### PR TITLE
small improvements to duckdb docs

### DIFF
--- a/docs/website/docs/destinations.md
+++ b/docs/website/docs/destinations.md
@@ -166,7 +166,7 @@ p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='ches
 p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='chess_data', full_refresh=False, credentials="/var/local/database.duckdb")
 ```
 
-The destination accepts a `duckdb` connection instance via `credentials`, so you are free to open database yourself and pass it to `dlt` for usage. `:memory:` databases are supported.
+The destination accepts a `duckdb` connection instance via `credentials`, so you can also open a database connection yourself and pass it to `dlt` to use. `:memory:` databases are supported.
 ```python
 import duckdb
 db = duckdb.connect()

--- a/docs/website/docs/destinations.md
+++ b/docs/website/docs/destinations.md
@@ -8,7 +8,7 @@ sidebar_position: 8
 - [Google BigQuery](./destinations#google-bigquery)
 - [Postgres](./destinations#postgres)
 - [Amazon Redshift](./destinations#amazon-redshift)
-- [Duckdb](./destinations#duckdb)
+- [DuckDB](./destinations#duckdb)
 
 Learn how to set up each of the supported destinations below.
 
@@ -136,26 +136,28 @@ pip install -r requirements.txt
 open .dlt/secrets.toml
 ```
 
-## Duckdb
+## DuckDB
 
-**1. Initialize a project with a pipeline that loads to Redshift by running**
+**1. Initialize a project with a pipeline that loads to DuckDB by running**
 ```
 dlt init chess duckdb
 ```
 
-**2. Install the necessary dependencies for Duckdb by running**
+**2. Install the necessary dependencies for DuckDB by running**
 ```
 pip install -r requirements.txt
 ```
 
-**3. Run the pipeline
+**3. Run the pipeline**
 ```
 python3 chess.py
 ```
 
 ### Destination Configuration
 
-By default, a `duckdb` database will be created inside the pipeline working directory with a name `quack.duckdb`. It is available in `read/write` mode via `pipeline.sql_client`. As the `duckdb` credentials do not require any secret values, you are free to pass the configuration explicitly via `credentials` parameter to `dlt.pipeline` or `pipeline.run` methods. Examples:
+By default, a DuckDB database will be created inside the pipeline working directory with a name `quack.duckdb`. It is available in `read/write` mode via `pipeline.sql_client`.
+
+As the `duckdb` credentials do not require any secret values, you are free to pass the configuration explicitly via the `credentials` parameter to `dlt.pipeline` or `pipeline.run` methods. For example:
 ```python
 # will load data to files/data.db database file
 p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='chess_data', full_refresh=False, credentials="files/data.db")
@@ -164,16 +166,16 @@ p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='ches
 p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='chess_data', full_refresh=False, credentials="/var/local/database.duckdb")
 ```
 
-The destination accepts `duckdb` connection instance via `credentials` so you are free to open database yourself and pass it to `dlt` for usage. `:memory:` databases are supported.
+The destination accepts a `duckdb` connection instance via `credentials`, so you are free to open database yourself and pass it to `dlt` for usage. `:memory:` databases are supported.
 ```python
 import duckdb
 db = duckdb.connect()
 p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='chess_data', full_refresh=False, credentials=db)
 ```
 
-The destinations, as with any other, accepts database connection strings in format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
+This destination accepts database connection strings in format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 
-Lastly, you are free to configure duckdb as any other [secret / config values](./customization/credentials.md), for example in `secrets.toml`
+You can configure a DuckDB destination with [secret / config values](./customization/credentials.md) (e.g. using a `secrets.toml` file)
 ```toml
 destination.duckdb.credentials=duckdb:///_storage/test_quack.duckdb
 ```


### PR DESCRIPTION
I am unable to load data from the `chess.com` API to DuckDB after following the instructions in the docs. I get the following error when I try to run it:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/dlt/destinations/sql_client.py", line 138, in _wrap
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/dlt/destinations/duckdb/sql_client.py", line 35, in open_connection
    self._conn.execute(f"SET {k} = '{v}'")
duckdb.BinderException: Binder Error: Catalog "chess_data" does not exist!

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ty/Documents/dlthub/test-duckdb/chess.py", line 111, in <module>
    info = p.run(
  File "/usr/local/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 99, in _wrap
    step_info = f(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 130, in _wrap
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 477, in run
    self.sync_destination(destination, dataset_name)
  File "/usr/local/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 73, in _wrap
    rv = f(self, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 519, in sync_destination
    remote_state = self._restore_state_from_destination()
  File "/usr/local/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 954, in _restore_state_from_destination
    job_client.sql_client.open_connection()
  File "/usr/local/lib/python3.10/site-packages/dlt/destinations/sql_client.py", line 140, in _wrap
    raise DestinationConnectionError(type(self).__name__, self.dataset_name, str(ex), ex)
dlt.destinations.exceptions.DestinationConnectionError: Connection with DuckDbSqlClient to dataset name chess_data failed. Please check if you configured the credentials at all and provided the right credentials values. You can be also denied access or your internet connection may be down. The actual reason given is: Binder Error: Catalog "chess_data" does not exist!
```