### PR TITLE
Re-export requests `Request`, `Response` and exception types

### DIFF
--- a/dlt/sources/helpers/requests/__init__.py
+++ b/dlt/sources/helpers/requests/__init__.py
@@ -16,3 +16,7 @@ from dlt.sources.helpers.requests.retry import Client
 from dlt.sources.helpers.requests.session import Session
 
 client = Client()
+
+get, post, put, patch, delete, options, head, request = (
+    client.get, client.post, client.put, client.patch, client.delete, client.options, client.head, client.request
+)

--- a/dlt/sources/helpers/requests/__init__.py
+++ b/dlt/sources/helpers/requests/__init__.py
@@ -1,4 +1,17 @@
 from tenacity import RetryError
+from requests import (
+    Request, Response,
+    ConnectionError,
+    ConnectTimeout,
+    FileModeWarning,
+    HTTPError,
+    JSONDecodeError,
+    ReadTimeout,
+    RequestException,
+    Timeout,
+    TooManyRedirects,
+    URLRequired,
+)
 from dlt.sources.helpers.requests.retry import Client
 from dlt.sources.helpers.requests.session import Session
 


### PR DESCRIPTION
https://github.com/dlt-hub/pipelines/issues/44
#147 

Importing all requests exceptions and `Request/Response` types in the helper module, so that direct import from requests can be blocked.

Edit: added also request methods from the default client to __init__, so this is now pretty much a drop in requests replacement