### PR TITLE
Allow changing write_disposition in the resource without dropping dataset

### DIFF
--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -281,12 +281,6 @@ def diff_tables(tab_a: TTableSchema, tab_b: TTableSchema, ignore_table_name: boo
     # check if table properties can be merged
     if tab_a.get("parent") != tab_b.get("parent"):
         raise TablePropertiesConflictException(table_name, "parent", tab_a.get("parent"), tab_b.get("parent"))
-    # check if partial table has write disposition set
-    partial_w_d = tab_b.get("write_disposition")
-    if partial_w_d:
-        existing_w_d = tab_a.get("write_disposition")
-        if existing_w_d != partial_w_d:
-            raise TablePropertiesConflictException(table_name, "write_disposition", existing_w_d, partial_w_d)
 
     # get new columns, changes in the column data type or other properties are not allowed
     table_columns = tab_a["columns"]
@@ -321,6 +315,11 @@ def merge_tables(table: TTableSchema, partial_table: TPartialTableSchema) -> TTa
     diff_table = diff_tables(table, partial_table, ignore_table_name=True)
     # add new columns when all checks passed
     table["columns"].update(diff_table["columns"])
+
+    partial_w_d = partial_table.get("write_disposition")
+    if partial_w_d:
+        table["write_disposition"] = partial_w_d
+
     return table
 
 

--- a/tests/common/schema/test_inference.py
+++ b/tests/common/schema/test_inference.py
@@ -391,28 +391,6 @@ def test_update_schema_table_prop_conflict(schema: Schema) -> None:
     assert exc_val.value.val1 is None
     assert exc_val.value.val2 == "tab_parent"
 
-    # write disposition conflict
-    tab1_u2 = deepcopy(tab1)
-    tab1_u2["write_disposition"] = "merge"
-    with pytest.raises(TablePropertiesConflictException) as exc_val:
-        schema.update_schema(tab1_u2)
-    assert exc_val.value.table_name == "tab1"
-    assert exc_val.value.prop_name == "write_disposition"
-    assert exc_val.value.val1 == "append"
-    assert exc_val.value.val2 == "merge"
-    # without write disposition will merge
-    del tab1_u2["write_disposition"]
-    schema.update_schema(tab1_u2)
-    # tab1 no write disposition, table update has write disposition
-    tab1["write_disposition"] = None
-    tab1_u2["write_disposition"] = "merge"
-    # this will not merge
-    with pytest.raises(TablePropertiesConflictException) as exc_val:
-        schema.update_schema(tab1_u2)
-    # both write dispositions are None
-    tab1_u2["write_disposition"] = None
-    schema.update_schema(tab1_u2)
-
 
 def test_update_schema_column_conflict(schema: Schema) -> None:
     tab1 = utils.new_table("tab1", write_disposition="append", columns=[

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -449,3 +449,20 @@ def test_set_get_local_value() -> None:
 
     p.extract(_w_local_state)
     assert p.state["_local"][new_val] == new_val
+
+def test_changed_write_disposition():
+    pipeline_name = "pipe_" + uniq_id()
+    p = dlt.pipeline(pipeline_name=pipeline_name, destination="dummy")
+
+    @dlt.resource
+    def resource_1():
+        yield [1, 2, 3]
+
+    p.run(resource_1, write_disposition="append")
+    assert p.default_schema.get_table("resource_1")["write_disposition"] == "append"
+
+    p.run(resource_1, write_disposition="append")
+    assert p.default_schema.get_table("resource_1")["write_disposition"] == "append"
+
+    p.run(resource_1, write_disposition="replace")
+    assert p.default_schema.get_table("resource_1")["write_disposition"] == "replace"


### PR DESCRIPTION
1. Removes the check in `dlt.common.schema.utils.diff_table()`
2. Sets the new `write_disposition` value if present.
3. Adds and fixes tests

Resolves #193 