### PR TITLE
Add a suffix to the default dataset name

### DIFF
--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -144,6 +144,7 @@ class Pipeline(SupportsPipeline):
     STATE_FILE: ClassVar[str] = "state.json"
     STATE_PROPS: ClassVar[List[str]] = list(get_type_hints(TPipelineState).keys())
     LOCAL_STATE_PROPS: ClassVar[List[str]] = list(get_type_hints(TPipelineLocalState).keys())
+    DEFAULT_DATASET_SUFFIX: ClassVar[str] = "_dataset"
 
     pipeline_name: str
     """Name of the pipeline"""
@@ -940,6 +941,7 @@ class Pipeline(SupportsPipeline):
             if not self.dataset_name:
                 # set default dataset name from pipeline name
                 dataset_name = self._default_naming.normalize_identifier(self.pipeline_name)
+                dataset_name += self.DEFAULT_DATASET_SUFFIX
             else:
                 return
 

--- a/tests/load/pipeline/test_pipelines.py
+++ b/tests/load/pipeline/test_pipelines.py
@@ -75,7 +75,7 @@ def test_default_pipeline_names(destination_name: str, use_single_dataset: bool)
 
 @pytest.mark.parametrize('destination_name,use_single_dataset', itertools.product(ALL_DESTINATIONS, [True, False]))
 def test_default_dataset_name(destination_name: str, use_single_dataset: bool) -> None:
-    # Check if dataset_name does not collide with pipeline_name 
+    # Check if dataset_name does not collide with pipeline_name
     data = ["a", "b", "c"]
     info = dlt.run(data, destination=destination_name, table_name="data")
     assert_table(info.pipeline, "data", data, info=info)

--- a/tests/load/pipeline/test_pipelines.py
+++ b/tests/load/pipeline/test_pipelines.py
@@ -27,9 +27,10 @@ def test_default_pipeline_names(destination_name: str, use_single_dataset: bool)
     p.config.use_single_dataset = use_single_dataset
     # this is a name of executing test harness or blank pipeline on windows
     possible_names = ["dlt_pytest", "dlt_pipeline"]
+    possible_dataset_names = ["dlt_pytest_dataset", "dlt_pipeline_dataset"]
     assert p.pipeline_name in possible_names
     assert p.pipelines_dir == os.path.abspath(os.path.join(TEST_STORAGE_ROOT, ".dlt", "pipelines"))
-    assert p.dataset_name in possible_names
+    assert p.dataset_name in possible_dataset_names
     assert p.destination is None
     assert p.default_schema_name is None
 
@@ -70,6 +71,14 @@ def test_default_pipeline_names(destination_name: str, use_single_dataset: bool)
         # loaded to separate data sets
         assert_table(p, "data_fun", data, info=info)
         assert_table(p, "data_fun", data, schema_name="names", info=info)
+
+
+@pytest.mark.parametrize('destination_name,use_single_dataset', itertools.product(ALL_DESTINATIONS, [True, False]))
+def test_default_dataset_name(destination_name: str, use_single_dataset: bool) -> None:
+    # Check if dataset_name does not collide with pipeline_name 
+    data = ["a", "b", "c"]
+    info = dlt.run(data, destination=destination_name, table_name="data")
+    assert_table(info.pipeline, "data", data, info=info)
 
 
 @pytest.mark.parametrize('destination_name', ALL_DESTINATIONS)

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -28,11 +28,12 @@ def test_default_pipeline() -> None:
     p = dlt.pipeline()
     # this is a name of executing test harness or blank pipeline on windows
     possible_names = ["dlt_pytest", "dlt_pipeline"]
+    possible_dataset_names = ["dlt_pytest_dataset", "dlt_pipeline_dataset"]
     assert p.pipeline_name in possible_names
     assert p.pipelines_dir == os.path.abspath(os.path.join(TEST_STORAGE_ROOT, ".dlt", "pipelines"))
     assert p.runtime_config.pipeline_name == p.pipeline_name
     # dataset that will be used to load data is the pipeline name
-    assert p.dataset_name in possible_names
+    assert p.dataset_name in possible_dataset_names
     assert p.destination is None
     assert p.default_schema_name is None
 
@@ -71,7 +72,7 @@ def test_pipeline_with_non_alpha_name() -> None:
     p = dlt.pipeline(pipeline_name=name)
     assert p.pipeline_name == name
     # default dataset is set
-    assert p.dataset_name == "another_pipeline_8329x"
+    assert p.dataset_name == "another_pipeline_8329x_dataset"
     # also pipeline name in runtime must be correct
     assert p.runtime_config.pipeline_name == p.pipeline_name
 


### PR DESCRIPTION
Resolves the linked issue by adding a  `_dataset` suffix to a dataset name derived from pipeline name.
 
Fixes #176