### PR TITLE
add link to Slack to docs

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -67,6 +67,11 @@ const config = {
           },
           {to: 'blog', label: 'Blog', position: 'left'},
           {
+            href: 'https://join.slack.com/t/dlthub-community/shared_invite/zt-1slox199h-HAE7EQoXmstkP_bTqal65g',
+            label: 'Slack',
+            position: 'right',
+          },
+          {
             href: 'https://github.com/dlt-hub/dlt',
             label: 'GitHub',
             position: 'right',
@@ -80,14 +85,22 @@ const config = {
             title: 'Docs',
             items: [
               {
-                label: 'dlt',
+                label: 'data load tool',
                 to: '/intro',
               },
+              {
+                label: 'Blog',
+                to: '/blog',
+              }
             ],
           },
           {
             title: 'Community',
             items: [
+              {
+                label: 'Slack',
+                href: 'https://join.slack.com/t/dlthub-community/shared_invite/zt-1slox199h-HAE7EQoXmstkP_bTqal65g',
+              },
               {
                 label: 'Email',
                 href: 'mailto:community@dlthub.com',
@@ -101,6 +114,10 @@ const config = {
                 label: 'GitHub',
                 href: 'https://github.com/dlt-hub/dlt',
               },
+              {
+                label: 'Twitter',
+                href: 'https://twitter.com/dlthub',
+              }
             ],
           },
         ],


### PR DESCRIPTION
no matter where you are on the docs...

in the top right it will link to the Slack:
<img width="1440" alt="Screenshot 2023-04-05 at 14 54 30" src="https://user-images.githubusercontent.com/13314504/230086685-031e24ea-fade-4bb3-bd4b-1853e42fed43.png">

as well as the in the footer:
<img width="1440" alt="Screenshot 2023-04-05 at 14 54 39" src="https://user-images.githubusercontent.com/13314504/230086745-37dfa01b-d8fa-411f-a1b6-3632304d4b9c.png">