### PR TITLE
fix incremental hash growing endlessly when using max with desc sort

### DIFF
--- a/dlt/common/exceptions.py
+++ b/dlt/common/exceptions.py
@@ -162,3 +162,9 @@ class PipelineStateNotAvailable(PipelineException):
         msg += " Call dlt.pipeline(...) before you call the @dlt.source or  @dlt.resource decorated function."
         self.source_name = source_name
         super().__init__(None, msg)
+
+
+class SourceSectionNotAvailable(PipelineException):
+    def __init__(self) -> None:
+        msg = "Access to state was requested without source section active. State should be requested from within the @dlt.source and @dlt.resource decorated function."
+        super().__init__(None, msg)

--- a/dlt/common/pipeline.py
+++ b/dlt/common/pipeline.py
@@ -14,7 +14,7 @@ from dlt.common.configuration.specs.config_section_context import ConfigSectionC
 from dlt.common.configuration.paths import get_dlt_home_dir
 from dlt.common.configuration.specs import RunConfiguration
 from dlt.common.destination.reference import DestinationReference, TDestinationReferenceArg
-from dlt.common.exceptions import DestinationHasFailedJobs, PipelineStateNotAvailable
+from dlt.common.exceptions import DestinationHasFailedJobs, PipelineStateNotAvailable, SourceSectionNotAvailable
 from dlt.common.schema import Schema
 from dlt.common.schema.typing import TColumnKey, TColumnSchema, TWriteDisposition
 from dlt.common.storages.load_storage import LoadPackageInfo
@@ -295,6 +295,7 @@ def state() -> DictStrAny:
     global _last_full_state
 
     container = Container()
+
     # get the source name from the section context
     source_section: str = None
     with contextlib.suppress(ContextDefaultCannotBeCreated):
@@ -302,9 +303,12 @@ def state() -> DictStrAny:
         with contextlib.suppress(ValueError):
             source_section = sections_context.source_section()
 
-        state, _ = state_value(container)
-        if state is None:
-            raise PipelineStateNotAvailable(source_section)
+    if not source_section:
+        raise SourceSectionNotAvailable()
+
+    state, _ = state_value(container)
+    if state is None:
+        raise PipelineStateNotAvailable(source_section)
 
     source_state: DictStrAny = state.setdefault(known_sections.SOURCES, {})  # type: ignore
     if source_section:

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -301,7 +301,7 @@ def resource(
     Returns:
         DltResource instance which may be loaded, iterated or combined with other resources into a pipeline.
     """
-    def make_resource(_name: str, _data: Any, incremental: IncrementalResourceWrapper = None) -> DltResource:
+    def make_resource(_name: str, _section: str, _data: Any, incremental: IncrementalResourceWrapper = None) -> DltResource:
         table_template = DltResource.new_table_template(
             table_name or _name,
             write_disposition=write_disposition,
@@ -309,7 +309,7 @@ def resource(
             primary_key=primary_key,
             merge_key=merge_key
         )
-        return DltResource.from_data(_data, _name, table_template, selected, cast(DltResource, depends_on), incremental=incremental)
+        return DltResource.from_data(_data, _name, _section, table_template, selected, cast(DltResource, depends_on), incremental=incremental)
 
 
     def decorator(f: Callable[TResourceFunParams, Any]) -> Callable[TResourceFunParams, DltResource]:
@@ -352,7 +352,7 @@ def resource(
         if SPEC:
             _SOURCES[f.__qualname__] = SourceInfo(SPEC, f, func_module)
 
-        return make_resource(resource_name, conf_f, incremental)
+        return make_resource(resource_name, source_section, conf_f, incremental)
 
     # if data is callable or none use decorator
     if data is None:
@@ -365,7 +365,7 @@ def resource(
         # take name from the generator
         if inspect.isgenerator(data):
             name = name or get_callable_name(data)  # type: ignore
-        return make_resource(name, data)
+        return make_resource(name, None, data)
 
 
 def transformer(

--- a/dlt/extract/incremental.py
+++ b/dlt/extract/incremental.py
@@ -189,7 +189,8 @@ class IncrementalResourceWrapper:
         if last_value == new_value:
             if unique_value in state['unique_hashes']:
                 return False
-            state['unique_hashes'].append(unique_value)
+            if self._incremental.last_value_func([row_value]) == last_value:
+                state['unique_hashes'].append(unique_value)
             return True
         if new_value != last_value:
             state.update({'last_value': new_value, 'unique_hashes': [unique_value]})

--- a/dlt/extract/incremental.py
+++ b/dlt/extract/incremental.py
@@ -9,10 +9,11 @@ from dlt.common.typing import DictStrAny, TDataItem, TDataItems, TFun, extract_i
 from dlt.common.schema.typing import TColumnKey
 from dlt.common.configuration import configspec, known_sections, resolve_configuration, ConfigFieldMissingException
 from dlt.common.configuration.specs import BaseConfiguration
-from dlt.common.pipeline import _resource_state, state as _state
+from dlt.common.pipeline import _resource_state
 from dlt.common.utils import digest256
+from dlt.extract.exceptions import PipeException
 from dlt.extract.utils import resolve_column_value
-from dlt.extract.typing import TTableHintTemplate
+from dlt.extract.typing import FilterItem, TTableHintTemplate
 
 
 TCursorValue = TypeVar("TCursorValue", bound=Any)
@@ -24,14 +25,30 @@ class IncrementalColumnState(TypedDict):
     unique_hashes: List[str]
 
 
+class IncrementalCursorPathMissing(PipeException):
+    def __init__(self, pipe_name: str, json_path: str, item: TDataItem) -> None:
+        self.json_path = json_path
+        self.item = item
+        msg = f"Cursor element with JSON path {json_path} was not found in extracted data item. All data items must contain this path. Use the same names of fields as in your JSON document - if those are different from the names you see in database."
+        super().__init__(pipe_name, msg)
+
+
+class IncrementalPrimaryKeyMissing(PipeException):
+    def __init__(self, pipe_name: str, primary_key_column: str, item: TDataItem) -> None:
+        self.primary_key_column = primary_key_column
+        self.item = item
+        msg = f"Primary key column {primary_key_column} was not found in extracted data item. All data items must contain this column. Use the same names of fields as in your JSON document."
+        super().__init__(pipe_name, msg)
+
+
 @configspec
 class IncrementalConfigSpec(BaseConfiguration):
-    cursor_column: str = None
+    cursor_path: str = None
     initial_value: Optional[Any] = None
 
     def parse_native_representation(self, native_value: Any) -> None:
         if isinstance(native_value, Incremental):
-            self.cursor_column = native_value.cursor_column
+            self.cursor_path = native_value.cursor_path
             self.initial_value = native_value.initial_value
         else:  # TODO: Maybe check if callable(getattr(native_value, '__lt__', None))
             # Passing bare value `incremental=44` gets parsed as initial_value
@@ -54,7 +71,7 @@ class Incremental(Generic[TCursorValue]):
     When the resource has a `primary_key` specified this is used to deduplicate overlapping items with the same cursor value.
 
     Args:
-        cursor_column: The name of the cursor column. This can be a column name or any valid JSON path.
+        cursor_path: The name or a JSON path to an cursor field. Uses the same names of fields as in your JSON document, before they are normalized to store in the database.
         initial_value: Optional value used for `last_value` when no state is available, e.g. on the first run of the pipeline. If not provided `last_value` will be `None` on the first run.
         last_value_func: Callable used to determine which cursor value to save in state. It is called with a list of the stored state value and all cursor vals from currently processing items. Default is `max`
     """
@@ -62,30 +79,30 @@ class Incremental(Generic[TCursorValue]):
 
     def __init__(
             self,
-            cursor_column: str,
+            cursor_path: str,
             initial_value: Optional[TCursorValue]=None,
             last_value_func: Optional[LastValueFunc[TCursorValue]]=None,
     ) -> None:
-        assert cursor_column, "`cursor_column` must be a column name or json path"
-        self.cursor_column = cursor_column
-        self.cursor_column_p = JSONPath(cursor_column)
+        assert cursor_path, "`cursor_path` must be a column name or json path"
+        self.cursor_path = cursor_path
+        self.cursor_path_p = JSONPath(cursor_path)
         self.last_value_func = last_value_func or max
         self.initial_value =  initial_value
 
     def copy(self) -> "Incremental[TCursorValue]":
-        return self.__class__(self.cursor_column, initial_value=self.initial_value, last_value_func=self.last_value_func)
+        return self.__class__(self.cursor_path, initial_value=self.initial_value, last_value_func=self.last_value_func)
 
     @classmethod
     def from_config(cls, cfg: IncrementalConfigSpec, orig: Optional["Incremental[Any]"]) -> "Incremental[Any]":
         # TODO: last_value_func from name
-        kwargs = dict(cursor_column=cfg.cursor_column, initial_value=cfg.initial_value)
+        kwargs = dict(cursor_path=cfg.cursor_path, initial_value=cfg.initial_value)
         if orig:
             kwargs['last_value_func'] = orig.last_value_func
         return cls(**kwargs)
 
     def get_state(self, resource_state: DictStrAny) -> IncrementalColumnState:
         """Given resource state, returns a state fragment for particular cursor column"""
-        state_params: IncrementalColumnState = resource_state.setdefault('incremental', {}).setdefault(self.cursor_column, {})
+        state_params: IncrementalColumnState = resource_state.setdefault('incremental', {}).setdefault(self.cursor_path, {})
         # if state params is empty
         if len(state_params) == 0:
             # set the default like this, setdefault evaluates the default no matter if it is needed or not. and our default is heavy
@@ -103,7 +120,7 @@ class Incremental(Generic[TCursorValue]):
         return s['last_value']  # type: ignore
 
 
-class IncrementalResourceWrapper:
+class IncrementalResourceWrapper(FilterItem):
     _incremental: Optional[Incremental[Any]] = None
     """Keeps the injectable incremental"""
 
@@ -172,27 +189,40 @@ class IncrementalResourceWrapper:
 
         return _wrap  # type: ignore
 
-    def transform(self, state: IncrementalColumnState, row: TDataItem, primary_key: Optional[TTableHintTemplate[TColumnKey]]) -> bool:
+    def unique_value(self, row: TDataItem) -> str:
+        try:
+            if self.primary_key:
+                return digest256(json.dumps(resolve_column_value(self.primary_key, row), sort_keys=True))
+            else:
+                return digest256(json.dumps(row, sort_keys=True))
+        except KeyError as k_err:
+            raise IncrementalPrimaryKeyMissing(self.resource_name, k_err.args[0], row)
+
+    def transform(self, state: IncrementalColumnState, row: TDataItem) -> bool:
         if row is None:
             return True
 
+        row_values = self._incremental.cursor_path_p.parse(row)
+        if len(row_values) == 0:
+            raise IncrementalCursorPathMissing(self.resource_name, self._incremental.cursor_path, row)
+
         last_value = state['last_value']
-        row_value = json.loads(
-            json.dumps(self._incremental.cursor_column_p.parse(row)[0])
-        )  # For now the value needs to match deserialized presentation from state
+        row_value = json.loads(json.dumps(row_values[0]))  # For now the value needs to match deserialized presentation from state
         check_values = ([last_value] if last_value is not None else []) + [row_value]
         new_value = self._incremental.last_value_func(check_values)
-        if primary_key:
-            unique_value = digest256(json.dumps(resolve_column_value(primary_key, row), sort_keys=True))
-        else:
-            unique_value = digest256(json.dumps(row, sort_keys=True))
         if last_value == new_value:
-            if unique_value in state['unique_hashes']:
-                return False
+            # we store row id for all records with the current "last_value" in state and use it to deduplicate
             if self._incremental.last_value_func([row_value]) == last_value:
+                unique_value = self.unique_value(row)
+                if unique_value in state['unique_hashes']:
+                    return False
+                # add new hash only if the record row id is same as current last value
                 state['unique_hashes'].append(unique_value)
-            return True
+                return True
+            # skip the record that is not a last_value or new_value: that record was already processed
+            return False
         if new_value != last_value:
+            unique_value = self.unique_value(row)
             state.update({'last_value': new_value, 'unique_hashes': [unique_value]})
         return True
 
@@ -200,12 +230,10 @@ class IncrementalResourceWrapper:
         # get the state only once for the whole list
         # TODO: cache the state, this can be done if we are sure that each processing pipe has a separate instance of this class. which is hard to do now.
         incremental_state = self._incremental.get_state(_resource_state(self.resource_name))
-        # TODO: reuse FilterItem from typing.py does exactly the same
-        if isinstance(items, list):
-            filtered = [item for item in items if self.transform(incremental_state, item, self.primary_key) is True]
-            if not filtered:
-                return None
-            else:
-                return filtered
 
-        return items if self.transform(incremental_state, items, self.primary_key) is True else None
+        # TODO: if we could cache the state, this wrapper would not be needed as well as __call__ override
+        def _transform(_i: TDataItems) -> bool:
+            return self.transform(incremental_state, _i)
+
+        self._f = _transform  # type: ignore
+        return super().__call__(items, meta)

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -742,11 +742,12 @@ class Pipeline(SupportsPipeline):
             elif isinstance(data_item, DltResource):
                 # apply hints
                 apply_hint_args(data_item)
-                resources.append(data_item)
+                sources.append(DltSource(data_item.name, data_item.section or self.pipeline_name, effective_schema, [data_item]))
             else:
                 # iterator/iterable/generator
                 # create resource first without table template
-                resource = DltResource.from_data(data_item, name=table_name)
+                resource = DltResource.from_data(data_item, name=table_name, section=self.pipeline_name)
+                print(resource)
                 # apply hints
                 apply_hint_args(resource)
                 resources.append(resource)

--- a/tests/extract/test_decorators.py
+++ b/tests/extract/test_decorators.py
@@ -146,6 +146,7 @@ def test_resource_name_from_generator() -> None:
 
     r = dlt.resource(some_data())
     assert r.name == "some_data"
+    assert r.section is None
 
 
 def test_source_sections() -> None:
@@ -208,6 +209,24 @@ def test_source_explicit_section() -> None:
         assert list(with_section()) == [1]
         # state should be modified: in the custom section we put the value from custom config
         assert state["sources"]["custom_section"]["val"] == "CUSTOM"
+
+
+def test_resource_section() -> None:
+
+    r = dlt.resource([1, 2, 3], name="T")
+    assert r.name == "T"
+    assert r.section is None
+
+    def _inner_gen():
+        yield from [1, 2, 3]
+
+    r = dlt.resource(_inner_gen)()
+    assert r.name == "_inner_gen"
+    assert r.section == "test_decorators"
+
+    from tests.extract.cases.section_source.external_resources import init_resource_f_2
+    assert init_resource_f_2.name == "init_resource_f_2"
+    assert init_resource_f_2.section == "section_source"
 
 
 def test_resources_injected_sections() -> None:
@@ -344,7 +363,6 @@ def test_source_state_context() -> None:
 
     # must enumerate single resource
     assert list(feeding) == [2, 4, 6]
-
 
 
 def test_source_schema_modified() -> None:

--- a/tests/load/pipeline/test_restore_state.py
+++ b/tests/load/pipeline/test_restore_state.py
@@ -253,7 +253,7 @@ def test_restore_state_pipeline(destination_name: str) -> None:
     p.run()
     assert p.default_schema_name == "default"
     assert set(p.schema_names) == set(["default", "two", "three"])
-    assert p.state["sources"] == {pipeline_name: {'state1': 'state1', 'state2': 'state2'}, "two": {'state3': 'state3'}, "three": {'state4': 'state4'}}
+    assert p.state["sources"] == {"test_restore_state": {'state1': 'state1', 'state2': 'state2'}, "two": {'state3': 'state3'}, "three": {'state4': 'state4'}}
     for schema in p.schemas.values():
         assert "some_data" in schema.tables
     # state version must be the same as the original
@@ -400,7 +400,7 @@ def test_restore_state_parallel_changes(destination_name: str) -> None:
     production_p.sync_destination(destination=destination_name, dataset_name=dataset_name)
     assert production_p.default_schema_name == "default"
     prod_state = production_p.state
-    assert prod_state["sources"] == {pipeline_name: {'state1': 'state1', 'state2': 'state2'}}
+    assert prod_state["sources"] == {"test_restore_state": {'state1': 'state1', 'state2': 'state2'}}
     assert prod_state["_state_version"] == orig_state["_state_version"]
     # generate data on production that modifies the schema but not state
     data2 = some_data("state1")


### PR DESCRIPTION
https://github.com/dlt-hub/dlt/issues/194

on top of storing just the hashes needed:
1. items already processed are filtered out (not just duplicates)
2. specialized exceptions for missing keys
3. added a section to resource so it can be iterated outside of the pipeline like inside (same state and config sections)
4. based on that additional tests: ie. filtering of elements also outside of pipeline context