### PR TITLE
Handle optional incremental arg with explicit spec

### DIFF
--- a/dlt/extract/incremental.py
+++ b/dlt/extract/incremental.py
@@ -180,13 +180,9 @@ class IncrementalResourceWrapper(FilterItem):
             elif isinstance(p.default, Incremental):
                 new_incremental = p.default.copy()
 
-            if new_incremental and not new_incremental.cursor_path:
-                # Workaround for optional arg in spec
-                new_incremental = None
-                bound_args.arguments[p.name] = None
-
-            if not new_incremental:
+            if not new_incremental or new_incremental.is_partial():
                 if is_optional_type(p.annotation):
+                    bound_args.arguments[p.name] = None  # Remove partial spec
                     return func(*bound_args.args, **bound_args.kwargs)
                 raise ValueError(f"{p.name} Incremental has no default")
             new_incremental.resource_name = self.resource_name

--- a/dlt/extract/incremental.py
+++ b/dlt/extract/incremental.py
@@ -180,9 +180,14 @@ class IncrementalResourceWrapper(FilterItem):
             elif isinstance(p.default, Incremental):
                 new_incremental = p.default.copy()
 
+            if new_incremental and not new_incremental.cursor_path:
+                # Workaround for optional arg in spec
+                new_incremental = None
+                bound_args.arguments[p.name] = None
+
             if not new_incremental:
                 if is_optional_type(p.annotation):
-                    return func(*args, **kwargs)
+                    return func(*bound_args.args, **bound_args.kwargs)
                 raise ValueError(f"{p.name} Incremental has no default")
             new_incremental.resource_name = self.resource_name
             # set initial value from last value, in case of a new state those are equal

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -1,6 +1,6 @@
 import os
 from time import sleep
-from typing import Optional
+from typing import Optional, Any
 
 import duckdb
 import pytest
@@ -192,9 +192,25 @@ def test_optional_incremental_not_passed() -> None:
 
     assert list(some_data()) == [1, 2, 3]
 
+from dlt.common.configuration.specs.base_configuration import BaseConfiguration, configspec
+
+@configspec
+class OptionalIncrementalConfig(BaseConfiguration):
+    incremental: Optional[dlt.sources.incremental] = None  # type: ignore[type-arg]
+
+
+@dlt.resource(spec=OptionalIncrementalConfig)
+def optional_incremental_arg_resource(incremental: Optional[dlt.sources.incremental[Any]] = None) -> Any:
+    assert incremental is None
+    yield [1, 2, 3]
+
+
+def test_optional_arg_from_spec_not_passed() -> None:
+    p = dlt.pipeline(pipeline_name=uniq_id())
+    p.extract(optional_incremental_arg_resource())
+
 
 def test_override_initial_value_from_config() -> None:
-
     # use the shortest possible config version
     # os.environ['SOURCES__TEST_INCREMENTAL__SOME_DATA_OVERRIDE_CONFIG__CREATED_AT__INITIAL_VALUE'] = '2000-02-03T00:00:00Z'
     os.environ['CREATED_AT__INITIAL_VALUE'] = '2000-02-03T00:00:00Z'

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -6,7 +6,7 @@ import duckdb
 import pytest
 
 import dlt
-from dlt.common.configuration.specs.base_configuration import configspec
+from dlt.common.configuration.specs.base_configuration import configspec, BaseConfiguration
 from dlt.common.pendulum import pendulum, timedelta
 from dlt.common.utils import uniq_id, digest128
 from dlt.common.json import json
@@ -192,7 +192,6 @@ def test_optional_incremental_not_passed() -> None:
 
     assert list(some_data()) == [1, 2, 3]
 
-from dlt.common.configuration.specs.base_configuration import BaseConfiguration, configspec
 
 @configspec
 class OptionalIncrementalConfig(BaseConfiguration):


### PR DESCRIPTION
@rudolfix this workaround due to (I think) https://github.com/dlt-hub/dlt/blob/ecd773057cd4c3de5d93b486839f2a66d8557a84/dlt/common/configuration/resolve.py#L238-L239  

SQL pipeline is working with it in this branch: https://github.com/dlt-hub/pipelines/compare/master...example-incremental#diff-52f3a49a9a78cdceaf9545d295067445ceb1b467436135d35227e84054b73841R14-R16  
Because of the embedded spec you get an empty `Incremental()` instance instead of `None` when there's nothing in config  

This fix is not that great cause you can explictly pass empty `incremental=Incremental()` and get no error, just silently disables incremental load.   
Do you know any better solution? If there is some support for this case already or maybe we could add an attribute to configspec to prevent partial for individual specs?