### PR TITLE
add library usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ```python
 import dlt
-from chess import chess
+from chess import chess # a utility function that grabs data from the chess.com API
 
 # create a dlt pipeline that will load chess game data to the DuckDB destination
 pipeline = dlt.pipeline(pipeline_name="chess_pipeline", destination='duckdb', dataset_name="games_data")

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 # data load tool (dlt)
 
+**[Colab Demo](https://colab.research.google.com/drive/1BXvma_9R9MX8p_iSvHE4ebg90sUroty2)**
+
 ```python
 import dlt
 from chess import chess # a utility function that grabs data from the chess.com API
@@ -26,6 +28,8 @@ data = chess(['magnuscarlsen', 'rpragchess'], start_month="2022/11", end_month="
 
 # extract, normalize, and load the data
 pipeline.run(data)
+
+
 ```
 
 **data load tool (dlt)** is a simple, open source Python library that makes data loading easy

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ data = chess(['magnuscarlsen', 'rpragchess'], start_month="2022/11", end_month="
 # extract, normalize, and load the data
 pipeline.run(data)
 
-
 ```
 
 **data load tool (dlt)** is a simple, open source Python library that makes data loading easy

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ data = chess(['magnuscarlsen', 'rpragchess'], start_month="2022/11", end_month="
 
 # extract, normalize, and load the data
 pipeline.run(data)
-
 ```
 
 **data load tool (dlt)** is a simple, open source Python library that makes data loading easy

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@
 
 # data load tool (dlt)
 
+```python
+import dlt
+from chess import chess
+
+# create a dlt pipeline that will load chess game data to the DuckDB destination
+pipeline = dlt.pipeline(pipeline_name="chess_pipeline", destination='duckdb', dataset_name="games_data")
+
+# use chess.com source to grab data about a few players from their API
+data = chess(['magnuscarlsen', 'rpragchess'], start_month="2022/11", end_month="2022/12")
+
+# extract, normalize, and load the data
+pipeline.run(data)
+```
+
 **data load tool (dlt)** is a simple, open source Python library that makes data loading easy
 - Automatically turn the JSON returned by any API into a live dataset stored wherever you want it
 - `pip install python-dlt` and then include `import dlt` to use it in your Python loading script

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ from chess import chess # a utility function that grabs data from the chess.com 
 # create a dlt pipeline that will load chess game data to the DuckDB destination
 pipeline = dlt.pipeline(pipeline_name="chess_pipeline", destination='duckdb', dataset_name="games_data")
 
-# use chess.com source to grab data about a few players from their API
+# use chess.com API to grab data about a few players
 data = chess(['magnuscarlsen', 'rpragchess'], start_month="2022/11", end_month="2022/12")
 
 # extract, normalize, and load the data

--- a/docs/website/docs/intro.md
+++ b/docs/website/docs/intro.md
@@ -18,6 +18,23 @@ Once you set it up, it will then automatically turn JSON returned by any
 [source](general-usage/glossary.md#source) (e.g. an API) into a live dataset stored in the 
 [destination](general-usage/glossary.md#destination) of your choice (e.g. Google BigQuery).
 
+
+**[Colab Demo](https://colab.research.google.com/drive/1BXvma_9R9MX8p_iSvHE4ebg90sUroty2)**
+
+```python
+import dlt
+from chess import chess # a utility function that grabs data from the chess.com API
+
+# create a dlt pipeline that will load chess game data to the DuckDB destination
+pipeline = dlt.pipeline(pipeline_name="chess_pipeline", destination='duckdb', dataset_name="games_data")
+
+# use chess.com API to grab data about a few players
+data = chess(['magnuscarlsen', 'rpragchess'], start_month="2022/11", end_month="2022/12")
+
+# extract, normalize, and load the data
+pipeline.run(data)
+```
+
 ## What does `dlt` do?
 
 **`pip install python-dlt` and then include `import dlt` to use it in your loading script**


### PR DESCRIPTION
@burnash: @matthauskrzykowski and I will think through how to improve the docs + README introductions holistically in the next week or two, but I wanted to quickly address the problem that it was not obvious in the README that we are a library, where you could easily import dlt, dlt run, etc.