### PR TITLE
adds anonymous id to telemetry

### DIFF
--- a/dlt/cli/telemetry_command.py
+++ b/dlt/cli/telemetry_command.py
@@ -9,6 +9,7 @@ from dlt.cli import echo as fmt
 from dlt.cli.utils import get_telemetry_status
 from dlt.cli.config_toml_writer import WritableConfigValue, write_values
 from dlt.common.configuration.specs.config_providers_context import ConfigProvidersContext
+from dlt.common.runtime.segment import get_anonymous_id
 
 DLT_TELEMETRY_DOCS_URL = "https://dlthub.com/docs/reference/telemetry"
 
@@ -16,6 +17,7 @@ DLT_TELEMETRY_DOCS_URL = "https://dlthub.com/docs/reference/telemetry"
 def telemetry_status_command() -> None:
     if get_telemetry_status():
         fmt.echo("Telemetry is %s" % fmt.bold("ENABLED"))
+        fmt.echo("Anonymous id %s" % fmt.bold(get_anonymous_id()))
     else:
         fmt.echo("Telemetry is %s" % fmt.bold("DISABLED"))
 

--- a/docs/website/docs/reference/telemetry.md
+++ b/docs/website/docs/reference/telemetry.md
@@ -6,13 +6,13 @@ keywords: [telemetry, usage information, opt out]
 
 # Telemetry
 
-`dlt` collects and reports **anonymous** usage information. This information is essential to figure out how we should improve the library. Telemetry does not send any personal data. We do not create tracking cookies nor identify users, even anonymously. You can disable telemetry at any moment or send it to your own servers instead.
+`dlt` collects and reports **anonymous** usage information. This information is essential to figure out how we should improve the library. Telemetry does not send any personal data. We create random tracking cookie that is stored in your `~./dlt` directory. You can disable telemetry at any moment or send it to your own servers instead.
 
 ## How to opt-out
 
 You can disable telemetry by adding `--disable-telemetry` to any dlt [command](../reference/command-line-interface.md).
 
-This command will disable telemtry both in the current project and globally for the whole machine:
+This command will disable telemetry both in the current project and globally for the whole machine:
 
 ```shell
 $ dlt --disable-telemetry
@@ -111,7 +111,7 @@ Example for `load` pipeline run step.
 
 The message context contains the following information:
 
-- `anonymousId`: a random number different for each message. It is required by Segment.
+- `anonymousId`: a random tracking cookie stored in `~/.dlt/.anonymous_id`.
 - `ci_run`: a flag indicating if the message was sent from a CI environment (e.g. `Github Actions`, `Travis CI`)
 - `cpu`: contains number of cores
 - `exec_info`: contains a list of strings that identify execution environment: (e.g. `kubernetes`, `docker`, `airflow`)

--- a/tests/common/runtime/test_telemetry.py
+++ b/tests/common/runtime/test_telemetry.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from dlt.common import logger
 from dlt.common.runtime.sentry import _get_sentry_log_level
-from dlt.common.runtime.segment import track, disable_segment
+from dlt.common.runtime.segment import get_anonymous_id, track, disable_segment
 from dlt.common.typing import DictStrAny, StrStr
 from dlt.common.configuration import configspec
 from dlt.common.configuration.specs import RunConfiguration
@@ -68,6 +68,7 @@ def test_track_segment_event() -> None:
         # this will send stuff
         disable_segment()
     event = SENT_ITEMS[0]
+    assert event["anonymousId"] == get_anonymous_id()
     assert event["event"] == "pipeline_run"
     assert props.items() <= event["properties"].items()
     assert event["properties"]["event_category"] == "pipeline"

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -585,7 +585,7 @@ def test_apply_hints_incremental() -> None:
 def test_last_value_func_on_dict() -> None:
 
     """Test last value which is a dictionary"""
-    def by_type(event):
+    def by_event_type(event):
         last_value = None
         if len(event) == 1:
             item, = event
@@ -601,7 +601,7 @@ def test_last_value_func_on_dict() -> None:
         return last_value
 
     @dlt.resource(primary_key="id", table_name=lambda i: i['type'])
-    def _get_shuffled_events(last_created_at = dlt.sources.incremental("$", last_value_func=by_type)):
+    def _get_shuffled_events(last_created_at = dlt.sources.incremental("$", last_value_func=by_event_type)):
         with open("tests/normalize/cases/github.events.load_page_1_duck.json", "r", encoding="utf-8") as f:
             yield json.load(f)
 


### PR DESCRIPTION
closes #216 without `tracking of source name for loads if it is using an existing pipeline or custom if it is not` I could not find an easy way to do it. I want to push anonymous id quickly