### PR TITLE
Feat/new add_limit method for resources

### DIFF
--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -229,11 +229,15 @@ class DltResource(Iterable[TDataItem], DltResourceSchema):
             count = 0
             if inspect.isfunction(gen):
                 gen = gen()
-            for i in gen:  # type: ignore # TODO: help me fix this later
-                yield i
-                count += 1
-                if count > max_items:
-                    return
+            try:
+                for i in gen:  # type: ignore # TODO: help me fix this later
+                    yield i
+                    count += 1
+                    if count > max_items:
+                        return
+            finally:
+                if inspect.isgenerator(gen):
+                    gen.close()
             return
         # transformers should be limited by their input, so we only limit non-transformers
         if not self.is_transformer:

--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -234,7 +234,9 @@ class DltResource(Iterable[TDataItem], DltResourceSchema):
                 if count > max_items:
                     return
             return
-        self._pipe.replace_gen(_gen_wrap(self._pipe.gen))
+        # transformers should be limited by their input, so we only limit non-transformers
+        if not self.is_transformer:
+            self._pipe.replace_gen(_gen_wrap(self._pipe.gen))
         return self
 
     def add_step(self, item_transform: ItemTransformFunctionWithMeta[TDataItems], insert_at: int = None) -> "DltResource":  # noqa: A003

--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -215,10 +215,11 @@ class DltResource(Iterable[TDataItem], DltResourceSchema):
     def add_limit(self, max_items: int) -> "DltResource":  # noqa: A003
         """Adds a limit `max_items` to the resource pipe
 
-        This mutates the encapsulated generator to stop after `max_items` items are yielded.
+        This mutates the encapsulated generator to stop after `max_items` items are yielded. This is useful for testing and debugging. It is
+        a no-op for transformers. Those should be limited by their input data.
 
         Args:
-            max_items (ItemTransformFunc[bool]): A function taking a single data item and optional meta argument. Returns bool. If True, item is kept
+            max_items (int): The maximum number of items to yield
         Returns:
             "DltResource": returns self
         """

--- a/tests/extract/test_sources.py
+++ b/tests/extract/test_sources.py
@@ -562,7 +562,7 @@ def test_source_dynamic_resource_attrs() -> None:
 def test_add_transform_steps() -> None:
     # add all step types, using indexes. final steps
     # gen -> map that converts to str and multiplies character -> filter str of len 2 -> yield all characters in str separately
-    r = dlt.resource([1, 2, 3], name="all").add_yield_map(lambda i: (yield from i)).add_map(lambda i: str(i) * i, 1).add_filter(lambda i: len(i) == 2, 2)
+    r = dlt.resource([1, 2, 3, 4], name="all").add_limit(3).add_yield_map(lambda i: (yield from i)).add_map(lambda i: str(i) * i, 1).add_filter(lambda i: len(i) == 2, 2)
     assert list(r) == ["2", "2"]
 
 


### PR DESCRIPTION
This method is incredibly useful for end to end integration testing where a user requires a limited subset of the data. `add_filter` is not sufficient as it will still exhaust the generator in my experience and follows a very different code path than offering a legitimate cap to the generator before `return`ing. This is not to say you won't find a better way in the future @rudolfix but this solves the near term well enough. 