### PR TITLE
Fix Broken image in Docs > Pipelines > Google Analytics

### DIFF
--- a/docs/website/docs/pipelines/google_analytics.md
+++ b/docs/website/docs/pipelines/google_analytics.md
@@ -76,9 +76,9 @@ directory
 ## Pass property_id and request parameters
 
 1. `property_id` is a unique number that identifies a particular property. You will need to explicity pass it to get data from the property that you're interested in. For example, if the property that you want to get data from is “GA4- Google Merch Shop” then you will need to pass its propery id 213025502.
-    
-    <img src="docs_images/GA4_Property_ID.png" alt="Admin Centre" width = "50%" />
-    
+
+    <img src="https://raw.githubusercontent.com/dlt-hub/dlt/devel/docs/website/docs/pipelines/docs_images/GA4_Property_ID.png" alt="Admin Centre" width = "50%" />
+
 2. You can also specify the parameters of the API requests such as dimensions and metrics to get your desired data.
 3. An example of how you can pass all of this in `dlt` is to simply insert it in the `.dlt/config.toml` file as below:
 


### PR DESCRIPTION
Fixes: #326
Analysis:
- The markdown file in our repo using relative path so it will not be break in the repo scope
- But once we render that markdown file elsewhere, the relative path might not exists on the server. So, it will not get the correct image source.

Solution:
- Using raw image content from Github URL: "https://raw.githubusercontent.com/dlt-hub/dlt/devel/docs/website/docs/pipelines/docs_images/GA4_Property_ID.png

Result from draft PR Deploy Preview:

  ![image](https://github.com/dlt-hub/dlt/assets/85242618/5ec9fef1-1c5d-4ad7-9a41-9a28f0749bb5)
