### PR TITLE
Fix: Add extra guard to buffered writer

### DIFF
--- a/dlt/common/data_writers/buffered.py
+++ b/dlt/common/data_writers/buffered.py
@@ -50,7 +50,7 @@ class BufferedDataWriter:
         self._current_columns: TTableSchemaColumns = None
         self._file_name: str = None
         self._buffered_items: List[TDataItem] = []
-        self._writer: DataWriter = None
+        self._writer: Optional[DataWriter] = None
         self._file: IO[Any] = None
         self._closed = False
         try:
@@ -82,7 +82,7 @@ class BufferedDataWriter:
             if self.file_max_bytes and self._file.tell() >= self.file_max_bytes:
                 self._rotate_file()
             # rotate on max items
-            if self.file_max_items and self._writer.items_count >= self.file_max_items:
+            if self.file_max_items and self._writer and self._writer.items_count >= self.file_max_items:
                 self._rotate_file()
 
     def close(self) -> None:


### PR DESCRIPTION
I saw this error in prod, it was interesting -- hadn't seen it before:

```
Traceback (most recent call last):
File "/harness/.venv/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 272, in extract
self._extract_source(storage, source, max_parallel_items, workers)
File "/harness/.venv/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 818, in _extract_source
extract_id = extract_with_schema(storage, source, source_schema, self.collector, max_parallel_items, workers)
File "/harness/.venv/lib/python3.10/site-packages/dlt/extract/extract.py", line 171, in extract_with_schema
extractor = extract(extract_id, source, storage, collector, max_parallel_items=max_parallel_items, workers=workers)
File "/harness/.venv/lib/python3.10/site-packages/dlt/extract/extract.py", line 140, in extract
_write_item(table_name, pipe_item.item)
File "/harness/.venv/lib/python3.10/site-packages/dlt/extract/extract.py", line 81, in _write_item
storage.write_data_item(extract_id, schema.name, table_name, item, None)
File "/harness/.venv/lib/python3.10/site-packages/dlt/common/storages/data_item_storage.py", line 26, in write_data_item
writer.write_data_item(item, columns)
File "/harness/.venv/lib/python3.10/site-packages/dlt/common/data_writers/buffered.py", line 85, in write_data_item
if self.file_max_items and self._writer.items_count >= self.file_max_items:
AttributeError: 'NoneType' object has no attribute 'items_count'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
File "/harness/.venv/bin/revops", line 6, in &lt;module>
sys.exit(app())
File "/harness/.venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
return self.main(*args, **kwargs)
File "/harness/.venv/lib/python3.10/site-packages/typer/core.py", line 778, in main
return _main(
File "/harness/.venv/lib/python3.10/site-packages/typer/core.py", line 216, in _main
rv = self.invoke(ctx)
File "/harness/.venv/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/harness/.venv/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
rv.append(sub_ctx.command.invoke(sub_ctx))
File "/harness/.venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/harness/.venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
return __callback(*args, **kwargs)
File "/harness/.venv/lib/python3.10/site-packages/typer/main.py", line 683, in wrapper
return callback(**use_params) # type: ignore
File "/harness/revops/cli.py", line 134, in _
extract_stage(
File "/harness/revops/engine/execution.py", line 127, in extract_stage
info = pipeline.extract(data_source.source)
File "/harness/.venv/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 103, in _wrap
step_info = f(self, *args, **kwargs)
File "/harness/.venv/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 77, in _wrap
rv = f(self, *args, **kwargs)
File "/harness/.venv/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 63, in _wrap
return f(self, *args, **kwargs)
File "/harness/.venv/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 137, in _wrap
return f(self, *args, **kwargs)
File "/harness/.venv/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 281, in extract
raise PipelineStepFailed(self, "extract", exc, ExtractInfo()) from exc
dlt.pipeline.exceptions.PipelineStepFailed: Pipeline execution failed at stage extract with exception:
&lt;class 'AttributeError'>
'NoneType' object has no attribute 'items_count'
```