### PR TITLE
Feat: Bigquery load performance increase

### DIFF
--- a/dlt/destinations/bigquery/bigquery.py
+++ b/dlt/destinations/bigquery/bigquery.py
@@ -242,7 +242,7 @@ class BigQueryClient(SqlJobClientBase):
                 max_bad_records=0)
             with open(file_path, "rb") as f:
                 return self.sql_client.native_connection.load_table_from_file(
-                        io.BytesIO(gzip.compress(f)),  # network latency is the bottleneck so compress the data here
+                        io.BytesIO(gzip.compress(f.read())),  # network latency is the bottleneck so compress the data here
                         self.sql_client.make_qualified_table_name(table_name, escape=False),
                         job_id=job_id,
                         job_config=job_config,

--- a/dlt/destinations/bigquery/bigquery.py
+++ b/dlt/destinations/bigquery/bigquery.py
@@ -1,3 +1,5 @@
+import gzip
+import io
 from pathlib import Path
 from typing import ClassVar, Dict, Optional, Sequence, Tuple, List, cast
 import google.cloud.bigquery as bigquery  # noqa: I250
@@ -240,7 +242,7 @@ class BigQueryClient(SqlJobClientBase):
                 max_bad_records=0)
             with open(file_path, "rb") as f:
                 return self.sql_client.native_connection.load_table_from_file(
-                        f,
+                        io.BytesIO(gzip.compress(f)),  # network latency is the bottleneck so compress the data here
                         self.sql_client.make_qualified_table_name(table_name, escape=False),
                         job_id=job_id,
                         job_config=job_config,


### PR DESCRIPTION
The largest latency is by far network related during BigQuery loads. Especially when spooling many workers. They compete over network. It is much more efficient to spend the cpu cycles to 1-shot compress data and then send over the network. The advantages of BigQuery being able to read non-compressed data in parallel are moot given the network latency. I have found huge speedups with this locally. There can be a deferred consideration down the line for how dlt can handle compression more holistically as on another big load, I overloaded the disk memory of a Pod during an atomic move with a lot of data which would have likely taken much less room compressed if it were an option. 