### PR TITLE
Fix: Ensure destination caps is picklable

### DIFF
--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -1,4 +1,6 @@
-from typing import Any, Callable, ClassVar, List, Literal
+import marshal
+import types
+from typing import Any, Callable, ClassVar, Dict, List, Literal
 
 from dlt.common.configuration.utils import serialize_value
 from dlt.common.configuration import configspec
@@ -48,3 +50,14 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
         caps.is_max_text_data_type_length_in_bytes = True
         caps.supports_ddl_transactions = True
         return caps
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["escape_identifier"] = marshal.dumps(self.escape_identifier.__code__)
+        state["escape_literal"] = marshal.dumps(self.escape_literal.__code__)
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self.escape_identifier = types.FunctionType(marshal.loads(state["escape_identifier"]), globals())
+        self.escape_literal = types.FunctionType(marshal.loads(state["escape_literal"]), globals())


### PR DESCRIPTION
I noticed that the `DestinationCapabilitiesContext` needs to be pickleable for the `filesystem` destination when using more than one process in the `normalizer`. Otherwise you see this:

```
Traceback (most recent call last):
  File "/.../.venv/lib/python3.10/site-packages/dlt/pipeline/pipeline.py", line 310, in normalize
    runner.run_pool(normalize.config, normalize)
  File "/.../.venv/lib/python3.10/site-packages/dlt/common/runners/pool_runner.py", line 48, in run_pool
    while _run_func():
  File "/.../.venv/lib/python3.10/site-packages/dlt/common/runners/pool_runner.py", line 41, in _run_func
    run_metrics = run_f.run(cast(TPool, pool))
  File "/.../.venv/lib/python3.10/site-packages/dlt/normalize/normalize.py", line 302, in run
    self.spool_schema_files(load_id, schema_name, schema_files)
  File "/.../.venv/lib/python3.10/site-packages/dlt/normalize/normalize.py", line 275, in spool_schema_files
    self.spool_files(schema_name, load_id, map_parallel_f, files)
  File "/.../.venv/lib/python3.10/site-packages/dlt/normalize/normalize.py", line 244, in spool_files
    schema_updates = map_f(schema, load_id, files)
  File "/.../.venv/lib/python3.10/site-packages/dlt/normalize/normalize.py", line 221, in map_parallel
    pending.get()
  File "/nix/store/m0fw0myf45rbsqkgvrnhm6dim036nqm3-python3-3.10.10/lib/python3.10/multiprocessing/pool.py", line 774, in get
    raise self._value
  File "/nix/store/m0fw0myf45rbsqkgvrnhm6dim036nqm3-python3-3.10.10/lib/python3.10/multiprocessing/pool.py", line 540, in _handle_tasks
    put(task)
  File "/nix/store/m0fw0myf45rbsqkgvrnhm6dim036nqm3-python3-3.10.10/lib/python3.10/multiprocessing/connection.py", line 206, in send
    self._send_bytes(_ForkingPickler.dumps(obj))
  File "/nix/store/m0fw0myf45rbsqkgvrnhm6dim036nqm3-python3-3.10.10/lib/python3.10/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
AttributeError: Can't pickle local object 'DestinationCapabilitiesContext.generic_capabilities.<locals>.<lambda>'
```

Even if there is something deeper here to look at, making this pickle-able probably isn't a bad idea. 