### PR TITLE
add secrets format option to dlt deploy

### DIFF
--- a/dlt/cli/_dlt.py
+++ b/dlt/cli/_dlt.py
@@ -13,7 +13,7 @@ from dlt.common.runners import Venv
 import dlt.cli.echo as fmt
 from dlt.cli import utils
 from dlt.cli.init_command import init_command, list_verified_sources_command, DLT_INIT_DOCS_URL, DEFAULT_VERIFIED_SOURCES_REPO
-from dlt.cli.deploy_command import PipelineWasNotRun, deploy_command, DLT_DEPLOY_DOCS_URL, DeploymentMethods, COMMAND_DEPLOY_REPO_LOCATION
+from dlt.cli.deploy_command import PipelineWasNotRun, deploy_command, DLT_DEPLOY_DOCS_URL, DeploymentMethods, COMMAND_DEPLOY_REPO_LOCATION, SecretFormats
 from dlt.cli.pipeline_command import pipeline_command, DLT_PIPELINE_COMMAND_DOCS_URL
 from dlt.cli.telemetry_command import DLT_TELEMETRY_DOCS_URL, change_telemetry_status_command, telemetry_status_command
 from dlt.pipeline.exceptions import CannotRestorePipelineException
@@ -49,7 +49,8 @@ def deploy_command_wrapper(
     run_on_push: bool,
     run_on_dispatch: bool,
     repo_location: str,
-    branch: Optional[str]) -> int:
+    branch: Optional[str], 
+    secrets_format: Optional[str]) -> int:
     try:
         utils.ensure_git_command("deploy")
     except Exception as ex:
@@ -58,7 +59,7 @@ def deploy_command_wrapper(
 
     from git import InvalidGitRepositoryError, NoSuchPathError
     try:
-        deploy_command(pipeline_script_path, deployment_method, schedule, run_on_push, run_on_dispatch, repo_location, branch)
+        deploy_command(pipeline_script_path, deployment_method, schedule, run_on_push, run_on_dispatch, repo_location, branch, secrets_format)
     except (CannotRestorePipelineException, PipelineWasNotRun) as ex:
         click.secho(str(ex), err=True, fg="red")
         fmt.note("You must run the pipeline locally successfully at least once in order to deploy it.")
@@ -198,17 +199,17 @@ def main() -> int:
 
     deploy_cmd = subparsers.add_parser("deploy", help="Creates a deployment package for a selected pipeline script")
     deploy_cmd.add_argument("pipeline_script_path", metavar="pipeline-script-path", help="Path to a pipeline script")
-    deploy_cmd.add_argument(
-        "deployment_method",
-        metavar="deployment-method",
-        choices=list(map(lambda value: value.value, DeploymentMethods.__members__.values())),
-        default=DeploymentMethods.github_actions.value,
-        help="Deployment method: %s" % ", ".join(map(lambda value: value.value, DeploymentMethods.__members__.values())))
     deploy_cmd.add_argument("--schedule", required=False, help="A schedule with which to run the pipeline, in cron format. Example: '*/30 * * * *' will run the pipeline every 30 minutes.")
     deploy_cmd.add_argument("--run-manually", default=True, action="store_true", help="Allows the pipeline to be run manually form Github Actions UI.")
     deploy_cmd.add_argument("--run-on-push", default=False, action="store_true", help="Runs the pipeline with every push to the repository.")
     deploy_cmd.add_argument("--location", default=COMMAND_DEPLOY_REPO_LOCATION, help="Advanced. Uses a specific url or local path to pipelines repository.")
     deploy_cmd.add_argument("--branch", default=None, help="Advanced. Uses specific branch of the deploy repository to fetch the template.")
+    deploy_sub_parsers = deploy_cmd.add_subparsers(dest="deployment_method")
+
+    deploy_github_cmd = deploy_sub_parsers.add_parser(DeploymentMethods.github_actions.value, help="Deploys the pipeline to Github Actions")
+    deploy_airlow_cmd = deploy_sub_parsers.add_parser(DeploymentMethods.airflow_composer.value, help="Deploys the pipeline to Airflow")
+
+    deploy_airlow_cmd.add_argument("--secrets-format", default=SecretFormats.env, choices=[v.value for v in SecretFormats.__members__.values()], required=True, help="Format of the secrets")
 
     schema = subparsers.add_parser("schema", help="Shows, converts and upgrades schemas")
     schema.add_argument("file", help="Schema file name, in yaml or json format, will autodetect based on extension")
@@ -285,7 +286,7 @@ def main() -> int:
             else:
                 return init_command_wrapper(args.source, args.destination, args.generic, args.location, args.branch)
     elif args.command == "deploy":
-        return deploy_command_wrapper(args.pipeline_script_path, args.deployment_method, args.schedule, args.run_on_push, args.run_manually, args.location, args.branch)
+        return deploy_command_wrapper(args.pipeline_script_path, args.deployment_method, args.schedule, args.run_on_push, args.run_manually, args.location, args.branch, args.secrets_format)
     elif args.command == "telemetry":
         return telemetry_status_command_wrapper()
     else:

--- a/dlt/cli/_dlt.py
+++ b/dlt/cli/_dlt.py
@@ -49,7 +49,7 @@ def deploy_command_wrapper(
     run_on_push: bool,
     run_on_dispatch: bool,
     repo_location: str,
-    branch: Optional[str], 
+    branch: Optional[str],
     secrets_format: Optional[str]) -> int:
     try:
         utils.ensure_git_command("deploy")
@@ -206,7 +206,7 @@ def main() -> int:
     deploy_cmd.add_argument("--branch", default=None, help="Advanced. Uses specific branch of the deploy repository to fetch the template.")
     deploy_sub_parsers = deploy_cmd.add_subparsers(dest="deployment_method")
 
-    deploy_github_cmd = deploy_sub_parsers.add_parser(DeploymentMethods.github_actions.value, help="Deploys the pipeline to Github Actions")
+    deploy_sub_parsers.add_parser(DeploymentMethods.github_actions.value, help="Deploys the pipeline to Github Actions")
     deploy_airlow_cmd = deploy_sub_parsers.add_parser(DeploymentMethods.airflow_composer.value, help="Deploys the pipeline to Airflow")
 
     deploy_airlow_cmd.add_argument("--secrets-format", default=SecretFormats.env, choices=[v.value for v in SecretFormats.__members__.values()], required=True, help="Format of the secrets")

--- a/dlt/cli/_dlt.py
+++ b/dlt/cli/_dlt.py
@@ -42,15 +42,7 @@ def list_verified_sources_command_wrapper(repo_location: str, branch: str) -> in
 
 
 @utils.track_command("deploy", False, "deployment_method")
-def deploy_command_wrapper(
-    pipeline_script_path: str,
-    deployment_method: str,
-    schedule: Optional[str],
-    run_on_push: bool,
-    run_on_dispatch: bool,
-    repo_location: str,
-    branch: Optional[str],
-    secrets_format: Optional[str]) -> int:
+def deploy_command_wrapper(**kwargs: Any) -> int:
     try:
         utils.ensure_git_command("deploy")
     except Exception as ex:
@@ -59,7 +51,7 @@ def deploy_command_wrapper(
 
     from git import InvalidGitRepositoryError, NoSuchPathError
     try:
-        deploy_command(pipeline_script_path, deployment_method, schedule, run_on_push, run_on_dispatch, repo_location, branch, secrets_format)
+        deploy_command(**kwargs)
     except (CannotRestorePipelineException, PipelineWasNotRun) as ex:
         click.secho(str(ex), err=True, fg="red")
         fmt.note("You must run the pipeline locally successfully at least once in order to deploy it.")
@@ -67,7 +59,7 @@ def deploy_command_wrapper(
         return -1
     except InvalidGitRepositoryError:
         click.secho(
-            "No git repository found for pipeline script %s." % fmt.bold(pipeline_script_path),
+            "No git repository found for pipeline script %s." % fmt.bold(kwargs["pipeline_script_path"]),
             err=True,
             fg="red"
         )
@@ -197,19 +189,22 @@ def main() -> int:
     init_cmd.add_argument("--branch", default=None, help="Advanced. Uses specific branch of the init repository to fetch the template.")
     init_cmd.add_argument("--generic", default=False, action="store_true", help="When present uses a generic template with all the dlt loading code present will be used. Otherwise a debug template is used that can be immediately run to get familiar with the dlt sources.")
 
+    # deploy
     deploy_cmd = subparsers.add_parser("deploy", help="Creates a deployment package for a selected pipeline script")
     deploy_cmd.add_argument("pipeline_script_path", metavar="pipeline-script-path", help="Path to a pipeline script")
     deploy_cmd.add_argument("--schedule", required=False, help="A schedule with which to run the pipeline, in cron format. Example: '*/30 * * * *' will run the pipeline every 30 minutes.")
-    deploy_cmd.add_argument("--run-manually", default=True, action="store_true", help="Allows the pipeline to be run manually form Github Actions UI.")
-    deploy_cmd.add_argument("--run-on-push", default=False, action="store_true", help="Runs the pipeline with every push to the repository.")
     deploy_cmd.add_argument("--location", default=COMMAND_DEPLOY_REPO_LOCATION, help="Advanced. Uses a specific url or local path to pipelines repository.")
     deploy_cmd.add_argument("--branch", default=None, help="Advanced. Uses specific branch of the deploy repository to fetch the template.")
     deploy_sub_parsers = deploy_cmd.add_subparsers(dest="deployment_method")
 
-    deploy_sub_parsers.add_parser(DeploymentMethods.github_actions.value, help="Deploys the pipeline to Github Actions")
-    deploy_airlow_cmd = deploy_sub_parsers.add_parser(DeploymentMethods.airflow_composer.value, help="Deploys the pipeline to Airflow")
+    # deploy github actions
+    deploy_github_cmd = deploy_sub_parsers.add_parser(DeploymentMethods.github_actions.value, help="Deploys the pipeline to Github Actions")
+    deploy_github_cmd.add_argument("--run-manually", default=True, action="store_true", help="Allows the pipeline to be run manually form Github Actions UI.")
+    deploy_github_cmd.add_argument("--run-on-push", default=False, action="store_true", help="Runs the pipeline with every push to the repository.")
 
-    deploy_airlow_cmd.add_argument("--secrets-format", default=SecretFormats.env, choices=[v.value for v in SecretFormats.__members__.values()], required=True, help="Format of the secrets")
+    # deploy airflow composer
+    deploy_airlow_cmd = deploy_sub_parsers.add_parser(DeploymentMethods.airflow_composer.value, help="Deploys the pipeline to Airflow")
+    deploy_airlow_cmd.add_argument("--secrets-format", default=SecretFormats.env, choices=[v.value for v in SecretFormats.__members__.values()], required=False, help="Format of the secrets")
 
     schema = subparsers.add_parser("schema", help="Shows, converts and upgrades schemas")
     schema.add_argument("file", help="Schema file name, in yaml or json format, will autodetect based on extension")
@@ -286,7 +281,7 @@ def main() -> int:
             else:
                 return init_command_wrapper(args.source, args.destination, args.generic, args.location, args.branch)
     elif args.command == "deploy":
-        return deploy_command_wrapper(args.pipeline_script_path, args.deployment_method, args.schedule, args.run_on_push, args.run_manually, args.location, args.branch, args.secrets_format)
+        return deploy_command_wrapper(**vars(args))
     elif args.command == "telemetry":
         return telemetry_status_command_wrapper()
     else:

--- a/dlt/cli/deploy_command.py
+++ b/dlt/cli/deploy_command.py
@@ -19,8 +19,8 @@ from dlt.version import DLT_PKG_NAME
 from dlt.common.destination.reference import DestinationReference
 
 REQUIREMENTS_GITHUB_ACTION = "requirements_github_action.txt"
-DLT_DEPLOY_DOCS_URL = "https://dlthub.com/docs/walkthroughs/deploy-a-pipeline/deploy-with-github-actions"
-DLT_AIRFLOW_GCP_DOCS_URL = "https://dlthub.com/docs/running-in-production/orchestrators/airflow-gcp-cloud-composer"
+DLT_DEPLOY_DOCS_URL = "https://dlthub.com/docs/walkthroughs/deploy-a-pipeline"
+DLT_AIRFLOW_GCP_DOCS_URL = "https://dlthub.com/docs/walkthroughs/deploy-a-pipeline/deploy-with-airflow-composer"
 AIRFLOW_GETTING_STARTED = "https://airflow.apache.org/docs/apache-airflow/stable/start.html"
 AIRFLOW_DAG_TEMPLATE_SCRIPT = "dag_template.py"
 AIRFLOW_CLOUDBUILD_YAML = "cloudbuild.yaml"

--- a/dlt/cli/deploy_command.py
+++ b/dlt/cli/deploy_command.py
@@ -4,7 +4,7 @@ import yaml
 from enum import Enum
 from importlib.metadata import version as pkg_version
 
-from dlt.common.configuration.providers import SECRETS_TOML, SECRETS_TOML_KEY, MemoryTomlProvider
+from dlt.common.configuration.providers import SECRETS_TOML, SECRETS_TOML_KEY, StringTomlProvider
 from dlt.common.configuration.paths import make_dlt_settings_path
 from dlt.common.configuration.utils import serialize_value
 from dlt.common.git import is_dirty
@@ -36,7 +36,7 @@ class SecretFormats(Enum):
     env = "env"
     toml = "toml"
 
-def deploy_command(deployment_method: str, **kwargs: Any
+def deploy_command(pipeline_script_path: str, deployment_method: str, repo_location: str, branch: Optional[str] = None, **kwargs: Any
 ) -> None:
 
     # get current repo local folder
@@ -48,7 +48,7 @@ def deploy_command(deployment_method: str, **kwargs: Any
     else:
         raise ValueError(f"Deployment method '{deployment_method}' is not supported. Only {', '.join([m.value for m in DeploymentMethods])} are available.'")
 
-    deployment_class(**kwargs).run_deployment()
+    deployment_class(pipeline_script_path=pipeline_script_path, location=repo_location, branch=branch, **kwargs).run_deployment()
 
 
 class GithubActionDeployment(BaseDeployment):
@@ -243,9 +243,9 @@ class AirflowDeployment(BaseDeployment):
                 self._echo_envs()
             elif self.secrets_format == SecretFormats.toml.value:
                 # build toml
-                fmt.echo(f"3. Add the following toml-string to the Airflow UI as the {SECRETS_TOML_KEY} variable.")
+                fmt.echo(f"3. Add the following toml-string in the Google Composer UI as the {SECRETS_TOML_KEY} variable.")
                 fmt.echo()
-                toml_provider = MemoryTomlProvider("")
+                toml_provider = StringTomlProvider("")
                 for s_v in self.secret_envs:
                     toml_provider.set_value(s_v.key, s_v.value, *s_v.sections)
                 for s_v in self.envs:

--- a/dlt/cli/deploy_command.py
+++ b/dlt/cli/deploy_command.py
@@ -11,8 +11,8 @@ from dlt.common.git import is_dirty
 
 from dlt.cli import utils
 from dlt.cli import echo as fmt
-from dlt.cli.deploy_command_helpers import (BaseDeployment, ask_files_overwrite, generate_pip_freeze, github_origin_to_url, serialize_templated_yaml,
-                                            wrap_template_str, PipelineWasNotRun)
+from dlt.cli.deploy_command_helpers import (PipelineWasNotRun, BaseDeployment, ask_files_overwrite, generate_pip_freeze, github_origin_to_url, serialize_templated_yaml,
+                                            wrap_template_str)
 
 from dlt.version import DLT_PKG_NAME
 
@@ -32,9 +32,11 @@ class DeploymentMethods(Enum):
     github_actions = "github-action"
     airflow_composer = "airflow-composer"
 
+
 class SecretFormats(Enum):
     env = "env"
     toml = "toml"
+
 
 def deploy_command(pipeline_script_path: str, deployment_method: str, repo_location: str, branch: Optional[str] = None, **kwargs: Any
 ) -> None:
@@ -247,10 +249,12 @@ class AirflowDeployment(BaseDeployment):
                 fmt.echo()
                 toml_provider = StringTomlProvider("")
                 for s_v in self.secret_envs:
-                    toml_provider.set_value(s_v.key, s_v.value, *s_v.sections)
+                    toml_provider.set_value(s_v.key, s_v.value, None, *s_v.sections)
                 for s_v in self.envs:
-                    toml_provider.set_value(s_v.key, s_v.value, *s_v.sections)
+                    toml_provider.set_value(s_v.key, s_v.value, None, *s_v.sections)
                 fmt.echo(toml_provider.dumps())
+            else:
+                raise ValueError(self.secrets_format)
 
         fmt.echo("4. Add dlt package below using Google Composer UI.")
         fmt.echo(fmt.bold(self.artifacts["requirements_txt"]))

--- a/dlt/cli/deploy_command.py
+++ b/dlt/cli/deploy_command.py
@@ -36,15 +36,7 @@ class SecretFormats(Enum):
     env = "env"
     toml = "toml"
 
-def deploy_command(
-    pipeline_script_path: str,
-    deployment_method: str,
-    schedule: Optional[str],
-    run_on_push: bool,
-    run_on_dispatch: bool,
-    repo_location: str,
-    branch: Optional[str] = None,
-    secret_format: Optional[str] = None,
+def deploy_command(deployment_method: str, **kwargs: Any
 ) -> None:
 
     # get current repo local folder
@@ -56,13 +48,7 @@ def deploy_command(
     else:
         raise ValueError(f"Deployment method '{deployment_method}' is not supported. Only {', '.join([m.value for m in DeploymentMethods])} are available.'")
 
-    deployment_class(pipeline_script_path=pipeline_script_path,
-            schedule=schedule,
-            run_on_push=run_on_push,
-            run_on_dispatch=run_on_dispatch,
-            repo_location=repo_location,
-            branch=branch,
-            secrets_format=secret_format).run_deployment()
+    deployment_class(**kwargs).run_deployment()
 
 
 class GithubActionDeployment(BaseDeployment):

--- a/dlt/cli/deploy_command_helpers.py
+++ b/dlt/cli/deploy_command_helpers.py
@@ -37,18 +37,19 @@ class BaseDeployment(abc.ABC):
     def __init__(
         self,
         pipeline_script_path: str,
+        location: str,
         schedule: Optional[str],
-        run_on_push: bool,
-        run_on_dispatch: bool,
-        repo_location: str,
+        run_on_push: bool = False,
+        run_on_dispatch: bool = False,
         branch: Optional[str] = None,
         secrets_format: Optional[str] = None,
+        **_kwargs: Any
     ):
         self.pipeline_script_path = pipeline_script_path
         self.schedule = schedule
         self.run_on_push = run_on_push
         self.run_on_dispatch = run_on_dispatch
-        self.repo_location = repo_location
+        self.repo_location = location
         self.branch = branch
         self.secrets_format = secrets_format
 

--- a/dlt/cli/deploy_command_helpers.py
+++ b/dlt/cli/deploy_command_helpers.py
@@ -41,7 +41,8 @@ class BaseDeployment(abc.ABC):
         run_on_push: bool,
         run_on_dispatch: bool,
         repo_location: str,
-        branch: Optional[str] = None
+        branch: Optional[str] = None,
+        secrets_format: Optional[str] = None,
     ):
         self.pipeline_script_path = pipeline_script_path
         self.schedule = schedule
@@ -49,6 +50,7 @@ class BaseDeployment(abc.ABC):
         self.run_on_dispatch = run_on_dispatch
         self.repo_location = repo_location
         self.branch = branch
+        self.secrets_format = secrets_format
 
         self.pipelines_dir: Optional[str] = None
         self.pipeline_name: Optional[str] = None

--- a/dlt/common/configuration/providers/__init__.py
+++ b/dlt/common/configuration/providers/__init__.py
@@ -1,6 +1,6 @@
 from .provider import ConfigProvider
 from .environ import EnvironProvider
 from .dictionary import DictionaryProvider
-from .toml import SecretsTomlProvider, ConfigTomlProvider, TomlFileProvider, CONFIG_TOML, SECRETS_TOML
+from .toml import SecretsTomlProvider, ConfigTomlProvider, TomlFileProvider, CONFIG_TOML, SECRETS_TOML, MemoryTomlProvider, SECRETS_TOML_KEY
 from .google_secrets import GoogleSecretsProvider
 from .context import ContextProvider

--- a/dlt/common/configuration/providers/__init__.py
+++ b/dlt/common/configuration/providers/__init__.py
@@ -1,6 +1,6 @@
 from .provider import ConfigProvider
 from .environ import EnvironProvider
 from .dictionary import DictionaryProvider
-from .toml import SecretsTomlProvider, ConfigTomlProvider, TomlFileProvider, CONFIG_TOML, SECRETS_TOML, MemoryTomlProvider, SECRETS_TOML_KEY
+from .toml import SecretsTomlProvider, ConfigTomlProvider, TomlFileProvider, CONFIG_TOML, SECRETS_TOML, StringTomlProvider, SECRETS_TOML_KEY
 from .google_secrets import GoogleSecretsProvider
 from .context import ContextProvider

--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -84,10 +84,10 @@ class BaseTomlProvider(ConfigProvider):
         return len(self._toml.body) == 0
 
 
-class MemoryTomlProvider(BaseTomlProvider):
+class StringTomlProvider(BaseTomlProvider):
 
     def __init__(self, toml_string: str) -> None:
-        super().__init__(MemoryTomlProvider.loads(toml_string))
+        super().__init__(StringTomlProvider.loads(toml_string))
 
     def dumps(self) -> str:
         return tomlkit.dumps(self._toml)

--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -99,12 +99,12 @@ class MemoryTomlProvider(BaseTomlProvider):
     @property
     def supports_secrets(self) -> bool:
         return True
-    
+
     @property
     def name(self) -> str:
         return "memory"
 
-        
+
 class VaultTomlProvider(BaseTomlProvider):
     """A toml-backed Vault abstract config provider.
 

--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -84,6 +84,27 @@ class BaseTomlProvider(ConfigProvider):
         return len(self._toml.body) == 0
 
 
+class MemoryTomlProvider(BaseTomlProvider):
+
+    def __init__(self, toml_string: str) -> None:
+        super().__init__(MemoryTomlProvider.loads(toml_string))
+
+    def dumps(self) -> str:
+        return tomlkit.dumps(self._toml)
+
+    @staticmethod
+    def loads(toml_string: str) -> tomlkit.TOMLDocument:
+        return tomlkit.parse(toml_string)
+
+    @property
+    def supports_secrets(self) -> bool:
+        return True
+    
+    @property
+    def name(self) -> str:
+        return "memory"
+
+        
 class VaultTomlProvider(BaseTomlProvider):
     """A toml-backed Vault abstract config provider.
 

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -164,6 +164,12 @@ const sidebars = {
          {
           type: 'category',
           label: 'Deploy a pipeline',
+          link: {
+            type: 'generated-index',
+            title: 'Deploy a pipeline',
+            description: 'Deploy dlt pipelines with different methods.',
+            slug: 'walkthroughs/deploy-a-pipeline',
+          },
           items: [
             'walkthroughs/deploy-a-pipeline/deploy-with-github-actions',
             'walkthroughs/deploy-a-pipeline/deploy-with-airflow-composer'

--- a/tests/cli/test_deploy_command.py
+++ b/tests/cli/test_deploy_command.py
@@ -1,6 +1,10 @@
 import os
+import io
+import contextlib
 import shutil
+import tempfile
 from subprocess import CalledProcessError
+from git import InvalidGitRepositoryError, NoSuchPathError
 import pytest
 
 import dlt
@@ -10,7 +14,7 @@ from dlt.common.storages.file_storage import FileStorage
 
 from dlt.common.utils import set_working_dir
 
-from dlt.cli import deploy_command
+from dlt.cli import deploy_command, _dlt, echo
 from dlt.cli.exceptions import CliCommandException
 from dlt.pipeline.exceptions import CannotRestorePipelineException
 
@@ -19,7 +23,22 @@ from tests.utils import preserve_environ, autouse_test_storage, TEST_STORAGE_ROO
 
 
 @pytest.mark.parametrize("deployment_method", [dm.value for dm in deploy_command.DeploymentMethods])
-def test_deploy_command(test_storage: FileStorage, deployment_method) -> None:
+def test_deploy_command_no_repo(test_storage: FileStorage, deployment_method: str) -> None:
+    pipeline_wf = tempfile.mkdtemp()
+    shutil.copytree("tests/cli/cases/deploy_pipeline", pipeline_wf, dirs_exist_ok=True)
+
+    with set_working_dir(pipeline_wf):
+        # we do not have repo
+        with pytest.raises(InvalidGitRepositoryError):
+            deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
+
+        # test wrapper
+        rc = _dlt.deploy_command_wrapper("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *")
+        assert rc == -3
+
+
+@pytest.mark.parametrize("deployment_method", [dm.value for dm in deploy_command.DeploymentMethods])
+def test_deploy_command(test_storage: FileStorage, deployment_method: str) -> None:
     # drop pipeline
     p = dlt.pipeline(pipeline_name="debug_pipeline")
     p._wipe_working_folder()
@@ -31,14 +50,20 @@ def test_deploy_command(test_storage: FileStorage, deployment_method) -> None:
 
         # we have a repo without git origin
         with Repo.init(".") as repo:
-            # test_storage.atomic_rename("empty_git", ".git")
+            # test no origin
             with pytest.raises(CliCommandException) as py_ex:
                 deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
             assert "Your current repository has no origin set" in py_ex.value.args[0]
+            rc = _dlt.deploy_command_wrapper("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *")
+            assert rc == -5
+
             # we have a repo that was never run
             Remote.create(repo, "origin", "git@github.com:rudolfix/dlt-cmd-test-2.git")
             with pytest.raises(CannotRestorePipelineException):
                 deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
+            rc = _dlt.deploy_command_wrapper("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *")
+            assert rc == -2
+
             # run the script with wrong credentials (it is postgres there)
             venv = Venv.restore_current()
             # mod environ so wrong password is passed to override secrets.toml
@@ -50,10 +75,52 @@ def test_deploy_command(test_storage: FileStorage, deployment_method) -> None:
             with pytest.raises(deploy_command.PipelineWasNotRun) as py_ex:
                 deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
             assert "The last pipeline run ended with error" in py_ex.value.args[0]
+            rc = _dlt.deploy_command_wrapper("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *")
+            assert rc == -2
+
             os.environ["DESTINATION__POSTGRES__CREDENTIALS"] = pg_credentials
             # also delete secrets so credentials are not mixed up on CI
             test_storage.delete(".dlt/secrets.toml")
             test_storage.atomic_rename(".dlt/secrets.toml.ci", ".dlt/secrets.toml")
+
             # this time script will run
             venv.run_script("debug_pipeline.py")
-            deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
+            with echo.always_choose(False, always_choose_value=True):
+                with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+                    deploy_command.deploy_command(
+                        "debug_pipeline.py",
+                        deployment_method,
+                        deploy_command.COMMAND_DEPLOY_REPO_LOCATION,
+                        schedule="*/30 * * * *",
+                        run_on_push=True,
+                        run_on_dispatch=True,
+                        secrets_format="env"
+                    )
+                    _out = buf.getvalue()
+                assert "DESTINATION__POSTGRES__CREDENTIALS" in _out
+                assert "API_KEY" in _out and "api_key" in _out
+                if deployment_method == "airflow-composer":
+                    # TODO: better parametrized test
+                    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+                        deploy_command.deploy_command(
+                            "debug_pipeline.py",
+                            deployment_method,
+                            deploy_command.COMMAND_DEPLOY_REPO_LOCATION,
+                            schedule="*/30 * * * *",
+                            run_on_push=True,
+                            run_on_dispatch=True,
+                            secrets_format="toml"
+                        )
+                        _out = buf.getvalue()
+                        assert 'api_key = "api_key"' in _out
+                        assert 'credentials = "postgresql' in _out
+
+                rc = _dlt.deploy_command_wrapper("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", secrets_format="env")
+                assert rc == 0
+            # non existing script name
+            with pytest.raises(NoSuchPathError):
+                deploy_command.deploy_command("no_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
+            with echo.always_choose(False, always_choose_value=True):
+                rc = _dlt.deploy_command_wrapper("no_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *")
+                assert rc == -4
+

--- a/tests/cli/test_deploy_command.py
+++ b/tests/cli/test_deploy_command.py
@@ -33,12 +33,12 @@ def test_deploy_command(test_storage: FileStorage, deployment_method) -> None:
         with Repo.init(".") as repo:
             # test_storage.atomic_rename("empty_git", ".git")
             with pytest.raises(CliCommandException) as py_ex:
-                deploy_command.deploy_command("debug_pipeline.py", deployment_method, "*/30 * * * *", True, True, deploy_command.COMMAND_DEPLOY_REPO_LOCATION)
+                deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
             assert "Your current repository has no origin set" in py_ex.value.args[0]
             # we have a repo that was never run
             Remote.create(repo, "origin", "git@github.com:rudolfix/dlt-cmd-test-2.git")
             with pytest.raises(CannotRestorePipelineException):
-                deploy_command.deploy_command("debug_pipeline.py", deployment_method, "*/30 * * * *", True, True, deploy_command.COMMAND_DEPLOY_REPO_LOCATION)
+                deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
             # run the script with wrong credentials (it is postgres there)
             venv = Venv.restore_current()
             # mod environ so wrong password is passed to override secrets.toml
@@ -48,7 +48,7 @@ def test_deploy_command(test_storage: FileStorage, deployment_method) -> None:
                 venv.run_script("debug_pipeline.py")
             print(py_ex.value.output)
             with pytest.raises(deploy_command.PipelineWasNotRun) as py_ex:
-                deploy_command.deploy_command("debug_pipeline.py", deployment_method, "*/30 * * * *", True, True, deploy_command.COMMAND_DEPLOY_REPO_LOCATION)
+                deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)
             assert "The last pipeline run ended with error" in py_ex.value.args[0]
             os.environ["DESTINATION__POSTGRES__CREDENTIALS"] = pg_credentials
             # also delete secrets so credentials are not mixed up on CI
@@ -56,4 +56,4 @@ def test_deploy_command(test_storage: FileStorage, deployment_method) -> None:
             test_storage.atomic_rename(".dlt/secrets.toml.ci", ".dlt/secrets.toml")
             # this time script will run
             venv.run_script("debug_pipeline.py")
-            deploy_command.deploy_command("debug_pipeline.py", deployment_method, "*/30 * * * *", True, True, deploy_command.COMMAND_DEPLOY_REPO_LOCATION)
+            deploy_command.deploy_command("debug_pipeline.py", deployment_method, deploy_command.COMMAND_DEPLOY_REPO_LOCATION, schedule="*/30 * * * *", run_on_push=True, run_on_dispatch=True)

--- a/tests/cli/test_telemetry_command.py
+++ b/tests/cli/test_telemetry_command.py
@@ -153,7 +153,7 @@ def test_instrumentation_wrappers() -> None:
         # assert msg["properties"]["operation"] == "list"
 
         SENT_ITEMS.clear()
-        deploy_command_wrapper("list.py", DeploymentMethods.github_actions.value, "* * * * *", False, False, COMMAND_DEPLOY_REPO_LOCATION, None)
+        deploy_command_wrapper("list.py", DeploymentMethods.github_actions.value, COMMAND_DEPLOY_REPO_LOCATION, schedule="* * * * *")
         msg = SENT_ITEMS[0]
         assert msg["event"] == "command_deploy"
         assert msg["properties"]["deployment_method"] == DeploymentMethods.github_actions.value

--- a/tests/common/configuration/test_providers.py
+++ b/tests/common/configuration/test_providers.py
@@ -1,5 +1,4 @@
 import pytest
-from dlt.common.configuration.providers import StringTomlProvider
 
 @pytest.mark.skip("Not implemented")
 def test_providers_order() -> None:
@@ -22,39 +21,3 @@ def test_providers_autodetect_and_config() -> None:
 def test_providers_value_getter() -> None:
     # TODO: it should be possible to get a value from providers' chain via `config` and `secrets` objects via indexer (nested) or explicit key, *sections getter
     pass
-
-
-def test_toml_memory_provider() -> None:
-
-    # test basic reading
-    provider = StringTomlProvider("""
-[section1.subsection]
-key1 = "value1"
-
-[section2.subsection]
-key2 = "value2"
-""")
-
-    assert provider.get_value("key1", "", "section1", "subsection") ==  ("value1", "section1.subsection.key1")
-    assert provider.get_value("key2", "", "section2", "subsection") ==  ("value2", "section2.subsection.key2")
-
-    # test basic writing
-    provider = StringTomlProvider("")
-    assert provider.dumps() == ""
-
-    provider.set_value("key1", "value1", "section1", "subsection")
-    assert provider.dumps() == """[section1.subsection]
-key1 = \"value1\"
-"""
-
-    provider.set_value("key1", "other_value", "section1", "subsection")
-    assert provider.dumps() == """[section1.subsection]
-key1 = \"other_value\"
-"""
-    provider.set_value("key1", "other_value", "section2", "subsection")
-    assert provider.dumps() == """[section1.subsection]
-key1 = \"other_value\"
-
-[section2.subsection]
-key1 = \"other_value\"
-"""

--- a/tests/common/configuration/test_providers.py
+++ b/tests/common/configuration/test_providers.py
@@ -1,5 +1,5 @@
 import pytest
-
+from dlt.common.configuration.providers import MemoryTomlProvider
 
 @pytest.mark.skip("Not implemented")
 def test_providers_order() -> None:
@@ -22,3 +22,39 @@ def test_providers_autodetect_and_config() -> None:
 def test_providers_value_getter() -> None:
     # TODO: it should be possible to get a value from providers' chain via `config` and `secrets` objects via indexer (nested) or explicit key, *sections getter
     pass
+
+
+def test_toml_memory_provider() -> None:
+
+    # test basic reading
+    provider = MemoryTomlProvider("""
+[section1.subsection]
+key1 = "value1"
+
+[section2.subsection]
+key2 = "value2"
+""")
+                                  
+    assert provider.get_value("key1", "", "section1", "subsection") ==  ("value1", "section1.subsection.key1")
+    assert provider.get_value("key2", "", "section2", "subsection") ==  ("value2", "section2.subsection.key2")
+
+    # test basic writing
+    provider = MemoryTomlProvider("")
+    assert provider.dumps() == ""
+    
+    provider.set_value("key1", "value1", "section1", "subsection")
+    assert provider.dumps() == """[section1.subsection]
+key1 = \"value1\"
+"""
+
+    provider.set_value("key1", "other_value", "section1", "subsection")
+    assert provider.dumps() == """[section1.subsection]
+key1 = \"other_value\"
+"""
+    provider.set_value("key1", "other_value", "section2", "subsection")
+    assert provider.dumps() == """[section1.subsection]
+key1 = \"other_value\"
+
+[section2.subsection]
+key1 = \"other_value\"
+"""

--- a/tests/common/configuration/test_providers.py
+++ b/tests/common/configuration/test_providers.py
@@ -1,5 +1,5 @@
 import pytest
-from dlt.common.configuration.providers import MemoryTomlProvider
+from dlt.common.configuration.providers import StringTomlProvider
 
 @pytest.mark.skip("Not implemented")
 def test_providers_order() -> None:
@@ -27,7 +27,7 @@ def test_providers_value_getter() -> None:
 def test_toml_memory_provider() -> None:
 
     # test basic reading
-    provider = MemoryTomlProvider("""
+    provider = StringTomlProvider("""
 [section1.subsection]
 key1 = "value1"
 
@@ -39,7 +39,7 @@ key2 = "value2"
     assert provider.get_value("key2", "", "section2", "subsection") ==  ("value2", "section2.subsection.key2")
 
     # test basic writing
-    provider = MemoryTomlProvider("")
+    provider = StringTomlProvider("")
     assert provider.dumps() == ""
 
     provider.set_value("key1", "value1", "section1", "subsection")

--- a/tests/common/configuration/test_providers.py
+++ b/tests/common/configuration/test_providers.py
@@ -34,14 +34,14 @@ key1 = "value1"
 [section2.subsection]
 key2 = "value2"
 """)
-                                  
+
     assert provider.get_value("key1", "", "section1", "subsection") ==  ("value1", "section1.subsection.key1")
     assert provider.get_value("key2", "", "section2", "subsection") ==  ("value2", "section2.subsection.key2")
 
     # test basic writing
     provider = MemoryTomlProvider("")
     assert provider.dumps() == ""
-    
+
     provider.set_value("key1", "value1", "section1", "subsection")
     assert provider.dumps() == """[section1.subsection]
 key1 = \"value1\"

--- a/tests/common/storages/test_transactional_file.py
+++ b/tests/common/storages/test_transactional_file.py
@@ -114,7 +114,8 @@ def test_file_transaction_multiple_writers_with_races(fs: fsspec.AbstractFileSys
 
     # writer 2 acquires lock
     assert writer_2.acquire_lock() is True
-
+    # a small gap required on windows which has a timer resolution of ~16ms
+    time.sleep(0.02)
     # Test that we cannot acquire a lock if it is already held
     assert not writer_1.acquire_lock(blocking=False)
     writer_2.release_lock()


### PR DESCRIPTION
Partly implements: https://github.com/dlt-hub/dlt/issues/368

the deploy command for airflow-composer now includes a secrets-format option: 
`dlt deploy stripe_analytics_pipeline.py airflow-composer --secrets-format toml`

which will result in a env output of the following if env or secrets are present:

```
3. Add the following toml-string to the Airflow UI as the dlt_secrets_toml variable.

[sources.stripe_analytics]
stripe_secret_key = "sk_test_51N0..."

```