### PR TITLE
removes the unpickable lambdas from destination caps and updates tests

### DIFF
--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, ClassVar, List, Literal
 from dlt.common.configuration.utils import serialize_value
 from dlt.common.configuration import configspec
 from dlt.common.configuration.specs import ContainerInjectableContext
+from dlt.common.utils import identity
 
 
 # known loader file formats
@@ -38,8 +39,8 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
         caps = DestinationCapabilitiesContext()
         caps.preferred_loader_file_format = preferred_loader_file_format
         caps.supported_loader_file_formats = ["jsonl", "insert_values"]
-        caps.escape_identifier = lambda x: x
-        caps.escape_literal = lambda x: serialize_value(x)
+        caps.escape_identifier = identity
+        caps.escape_literal = serialize_value
         caps.max_identifier_length = 65536
         caps.max_column_identifier_length = 65536
         caps.max_query_length = 32 * 1024 * 1024

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -421,3 +421,7 @@ def compressed_b64decode(value: str) -> bytes:
     """Decode a bytestring encoded with `compressed_b64encode`"""
     value_bytes = base64.b64decode(value, validate=True)
     return zlib.decompress(value_bytes)
+
+
+def identity(x: TAny) -> TAny:
+    return x

--- a/tests/normalize/utils.py
+++ b/tests/normalize/utils.py
@@ -2,6 +2,17 @@ from typing import Mapping, cast
 
 from dlt.common import json
 
+from dlt.destinations.duckdb import capabilities as duck_insert_caps
+from dlt.destinations.redshift import capabilities as rd_insert_caps
+from dlt.destinations.postgres import capabilities as pg_insert_caps
+from dlt.destinations.bigquery import capabilities as jsonl_caps
+from dlt.destinations.filesystem import capabilities as filesystem_caps
+
+DEFAULT_CAPS = pg_insert_caps
+INSERT_CAPS = [duck_insert_caps, rd_insert_caps, pg_insert_caps]
+JSONL_CAPS = [jsonl_caps, filesystem_caps]
+ALL_CAPABILITIES = INSERT_CAPS + JSONL_CAPS
+
 
 def load_json_case(name: str) -> Mapping:
     with open(json_case_path(name), "br") as f:


### PR DESCRIPTION
follows #397 