### PR TITLE
uses jsonl format for filesystem default

### DIFF
--- a/dlt/destinations/filesystem/__init__.py
+++ b/dlt/destinations/filesystem/__init__.py
@@ -15,7 +15,7 @@ def _configure(config: FilesystemClientConfiguration = config.value) -> Filesyst
 
 
 def capabilities() -> DestinationCapabilitiesContext:
-    return DestinationCapabilitiesContext.generic_capabilities("parquet")
+    return DestinationCapabilitiesContext.generic_capabilities("jsonl")
 
 
 def client(schema: Schema, initial_config: DestinationClientDwhConfiguration = config.value) -> JobClientBase:

--- a/dlt/destinations/filesystem/filesystem.py
+++ b/dlt/destinations/filesystem/filesystem.py
@@ -15,7 +15,6 @@ from dlt.destinations.filesystem.configuration import FilesystemClientConfigurat
 from dlt.destinations.filesystem.filesystem_client import client_from_config
 from dlt.common.storages import LoadStorage
 
-lock = threading.Lock()
 
 class LoadFilesystemJob(LoadJob):
     def __init__(

--- a/dlt/destinations/snowflake/configuration.py
+++ b/dlt/destinations/snowflake/configuration.py
@@ -90,4 +90,4 @@ class SnowflakeClientConfiguration(DestinationClientDwhConfiguration):
     stage_name: Optional[str] = None
     """Use an existing named stage instead of the default. Default uses the implicit table stage per table"""
     keep_staged_files: bool = True
-    """Whether to keep or delete the staged files after COPY INTO succeeeds"""
+    """Whether to keep or delete the staged files after COPY INTO succeeds"""

--- a/tests/normalize/utils.py
+++ b/tests/normalize/utils.py
@@ -17,7 +17,7 @@ def filesystem_caps_jsonl_adapter():
 
 DEFAULT_CAPS = pg_insert_caps
 INSERT_CAPS = [duck_insert_caps, rd_insert_caps, pg_insert_caps]
-JSONL_CAPS = [jsonl_caps, filesystem_caps_jsonl_adapter]
+JSONL_CAPS = [jsonl_caps, filesystem_caps]
 ALL_CAPABILITIES = INSERT_CAPS + JSONL_CAPS
 
 


### PR DESCRIPTION
Why set the `jsonl` as filesystem default: it does not require heavy dependencies