### PR TITLE
uses fsspec.rm_file instead of fsspec.rm

### DIFF
--- a/dlt/common/storages/transactional_file.py
+++ b/dlt/common/storages/transactional_file.py
@@ -115,7 +115,7 @@ class TransactionalFile:
             mtime = self.extract_mtime(lock)
             if now - mtime > timedelta(seconds=TransactionalFile.LOCK_TTL_SECONDS):
                 try: # Janitors can race, so we ignore errors
-                    self._fs.rm(name)
+                    self._fs.rm_file(name)
                 except OSError:
                     pass
                 continue
@@ -146,7 +146,7 @@ class TransactionalFile:
         if self._original_contents is not None:
             self.write(self._original_contents)
         elif self._fs.isfile(self.path):
-            self._fs.rm(self.path)
+            self._fs.rm_file(self.path)
 
     def acquire_lock(self, blocking: bool = True, timeout: float = -1, jitter_mean: float = 0) -> bool:
         """Acquires a lock on a path. Mimics the stdlib's `threading.Lock` interface.
@@ -185,7 +185,7 @@ class TransactionalFile:
 
         while active_lock != self.lock_path:
             if not blocking or (timeout > 0 and time.time() - start > timeout):
-                self._fs.rm(self.lock_path)
+                self._fs.rm_file(self.lock_path)
                 return False
 
             time.sleep(random.random() + TransactionalFile.POLLING_INTERVAL)
@@ -208,7 +208,7 @@ class TransactionalFile:
         """
         if self._is_locked:
             self._stop_heartbeat()
-            self._fs.rm(self.lock_path)
+            self._fs.rm_file(self.lock_path)
             self._is_locked = False
             self._original_contents = None
 

--- a/dlt/destinations/filesystem/filesystem.py
+++ b/dlt/destinations/filesystem/filesystem.py
@@ -44,8 +44,11 @@ class LoadFilesystemJob(LoadJob):
             # NOTE: glob implementation in fsspec does not look thread safe, way better is to use ls and then filter
             all_files: List[str] = fs_client.ls(dataset_path, detail=False, refresh=True)
             items = [item for item in all_files if item.startswith(search_prefix)]
-            if items:
-                fs_client.rm(items)
+            # NOTE: deleting in chunks on s3 does not raise on access denied, file non existing and probably other errors
+            # if items:
+            #     fs_client.rm(items[0])
+            for item in items:
+                fs_client.rm_file(item)
 
         destination_file_name = LoadFilesystemJob.make_destination_filename(file_name, schema_name, load_id)
         fs_client.put_file(local_path, posixpath.join(dataset_path, destination_file_name))

--- a/tests/load/filesystem/test_filesystem_client.py
+++ b/tests/load/filesystem/test_filesystem_client.py
@@ -8,6 +8,7 @@ from dlt.common.storages import LoadStorage, FileStorage
 from dlt.common.destination.reference import LoadJob
 from dlt.destinations.filesystem.filesystem import FilesystemClient, LoadFilesystemJob
 from dlt.load import Load
+from dlt.destinations.job_impl import EmptyLoadJob
 
 from tests.utils import clean_test_storage, init_test_logging, preserve_environ
 from tests.load.filesystem.utils import get_client_instance, setup_loader
@@ -110,6 +111,9 @@ def perform_load(
     jobs = []
     for f in files:
         job = Load.w_spool_job(load, f, load_id, schema)
+        # job execution failed
+        if isinstance(job, EmptyLoadJob):
+            raise RuntimeError(job.exception())
         jobs.append(job)
 
     return jobs, root_path, load_id


### PR DESCRIPTION
On s3 rm() does not raise exceptions if file cannot be deleted