### PR TITLE
Fix/requests error handling

### DIFF
--- a/dlt/common/configuration/specs/run_configuration.py
+++ b/dlt/common/configuration/specs/run_configuration.py
@@ -18,7 +18,14 @@ class RunConfiguration(BaseConfiguration):
     dlthub_telemetry_segment_write_key: str = "a1F2gc6cNYw2plyAt02sZouZcsRjG7TD"
     log_format: str = '{asctime}|[{levelname:<21}]|{process}|{name}|{filename}|{funcName}:{lineno}|{message}'
     log_level: str = "WARNING"
-    request_timeout: Tuple[int, int] = (15, 300)  # default request timeout for all http clients
+    request_timeout: float = 60
+    """Timeout for http requests"""
+    request_max_attempts: int = 5
+    """Max retry attempts for http clients"""
+    request_backoff_factor: float = 1
+    """Multiplier applied to exponential retry delay for http requests"""
+    request_max_retry_delay: float = 300
+    """Maximum delay between http request retries"""
     config_files_storage_path: str = "/run/config/"
 
     __section__ = "runtime"

--- a/dlt/common/runtime/init.py
+++ b/dlt/common/runtime/init.py
@@ -8,11 +8,15 @@ _RUN_CONFIGURATION: RunConfiguration = None
 def initialize_runtime(config: RunConfiguration) -> None:
     from dlt.common.runtime.logger import init_logging
     from dlt.common.runtime.telemetry import start_telemetry
+    from dlt.sources.helpers import requests
 
     global _INITIALIZED, _RUN_CONFIGURATION
 
     # initialize or re-initialize logging with new settings
     init_logging(config)
+
+    # Init or update default requests client config
+    requests.init(config)
 
     # initialize only once
     if not _INITIALIZED:

--- a/dlt/common/runtime/sentry.py
+++ b/dlt/common/runtime/sentry.py
@@ -13,7 +13,7 @@ def init_sentry(config: RunConfiguration) -> None:
     version = dlt_version_info(config.pipeline_name)
     sys_ver = version["dlt_version"]
     release = sys_ver + "_" + version.get("commit_sha", "")
-    _SentryHttpTransport.timeout = config.request_timeout[0]
+    _SentryHttpTransport.timeout = config.request_timeout
     # TODO: ignore certain loggers ie. dbt loggers
     # https://docs.sentry.io/platforms/python/guides/logging/
     sentry_sdk.init(
@@ -53,7 +53,7 @@ def before_send(event: DictStrAny, _unused_hint: Optional[StrAny] = None) -> Opt
 
 class _SentryHttpTransport(HttpTransport):
 
-    timeout: int = 0
+    timeout: float = 0
 
     def _get_pool_options(self, *a: Any, **kw: Any) -> DictStrAny:
         rv = HttpTransport._get_pool_options(self, *a, **kw)

--- a/dlt/sources/helpers/requests/__init__.py
+++ b/dlt/sources/helpers/requests/__init__.py
@@ -14,9 +14,15 @@ from requests import (
 )
 from dlt.sources.helpers.requests.retry import Client
 from dlt.sources.helpers.requests.session import Session
+from dlt.common.configuration.specs import RunConfiguration
 
 client = Client()
 
 get, post, put, patch, delete, options, head, request = (
     client.get, client.post, client.put, client.patch, client.delete, client.options, client.head, client.request
 )
+
+
+def init(config: RunConfiguration) -> None:
+    """Initialize the default requests client from config"""
+    client.update_from_config(config)

--- a/dlt/sources/helpers/requests/__init__.py
+++ b/dlt/sources/helpers/requests/__init__.py
@@ -12,6 +12,7 @@ from requests import (
     TooManyRedirects,
     URLRequired,
 )
+from requests.exceptions import ChunkedEncodingError
 from dlt.sources.helpers.requests.retry import Client
 from dlt.sources.helpers.requests.session import Session
 from dlt.common.configuration.specs import RunConfiguration

--- a/dlt/sources/helpers/requests/retry.py
+++ b/dlt/sources/helpers/requests/retry.py
@@ -4,7 +4,8 @@ import time
 from typing import Optional, cast, Callable, Type, Union, Sequence, Tuple, List, TYPE_CHECKING, Any
 from threading import local
 
-from requests import Response, HTTPError, ConnectionError, Timeout, Session as BaseSession
+from requests import Response, HTTPError, Session as BaseSession
+from requests.exceptions import ConnectionError, Timeout, ChunkedEncodingError
 from requests.adapters import HTTPAdapter
 from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, RetryCallState, retry_any, wait_exponential
 from tenacity.retry import retry_base
@@ -14,7 +15,7 @@ from dlt.common.typing import TimedeltaSeconds
 
 
 DEFAULT_RETRY_STATUS = (429, *range(500, 600))
-DEFAULT_RETRY_EXCEPTIONS = (ConnectionError, Timeout)
+DEFAULT_RETRY_EXCEPTIONS = (ConnectionError, Timeout, ChunkedEncodingError)
 DEFAULT_RETRY_ATTEMPTS = 5
 DEFAULT_BACKOFF_FACTOR = 1
 

--- a/dlt/sources/helpers/requests/session.py
+++ b/dlt/sources/helpers/requests/session.py
@@ -2,6 +2,7 @@ from requests import Session as BaseSession
 from tenacity import Retrying, retry_if_exception_type
 from typing import Optional, TYPE_CHECKING, Sequence, Union, Tuple, Type, TypeVar
 
+from dlt.sources.helpers.requests.typing import TRequestTimeout
 from dlt.common.typing import TimedeltaSeconds
 from dlt.common.time import to_seconds
 
@@ -12,20 +13,25 @@ TSession = TypeVar("TSession", bound=BaseSession)
 DEFAULT_TIMEOUT = 60
 
 
+def _timeout_to_seconds(timeout: TRequestTimeout) -> Optional[Union[Tuple[float, float], float]]:
+    return (to_seconds(timeout[0]), to_seconds(timeout[1])) if isinstance(timeout, tuple) else to_seconds(timeout)
+
+
 class Session(BaseSession):
     """Requests session which by default adds a timeout to all requests and calls `raise_for_status()` on response
 
     ### Args
         timeout: Timeout for requests in seconds. May be passed as `timedelta` or `float/int` number of seconds.
+            May be a single value or a tuple for separate (connect, read) timeout.
         raise_for_status: Whether to raise exception on error status codes (using `response.raise_for_status()`)
     """
     def __init__(
         self,
-        timeout: Optional[TimedeltaSeconds] = DEFAULT_TIMEOUT,
+        timeout: Optional[Union[TimedeltaSeconds, Tuple[TimedeltaSeconds, TimedeltaSeconds]]] = DEFAULT_TIMEOUT,
         raise_for_status: bool = True,
     ) -> None:
         super().__init__()
-        self.timeout = to_seconds(timeout)
+        self.timeout = _timeout_to_seconds(timeout)
         self.raise_for_status = raise_for_status
 
     if TYPE_CHECKING:

--- a/dlt/sources/helpers/requests/session.py
+++ b/dlt/sources/helpers/requests/session.py
@@ -9,7 +9,7 @@ from dlt.common.time import to_seconds
 TSession = TypeVar("TSession", bound=BaseSession)
 
 
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = 60
 
 
 class Session(BaseSession):

--- a/dlt/sources/helpers/requests/typing.py
+++ b/dlt/sources/helpers/requests/typing.py
@@ -1,0 +1,6 @@
+from typing import Tuple, Union, Optional
+
+from dlt.common.typing import TimedeltaSeconds
+
+# Either a single timeout or tuple (connect,read) timeout
+TRequestTimeout = Union[TimedeltaSeconds, Tuple[TimedeltaSeconds, TimedeltaSeconds]]

--- a/docs/website/docs/reference/performance.md
+++ b/docs/website/docs/reference/performance.md
@@ -96,3 +96,98 @@ next_item_mode=round_robin
 [sources.my_pipeline.extract] # setting for the "my_pipeline" pipeline
 next_item_mode=5
 ```
+
+## Using the built in requests client
+
+`dlt` provides a customized [requests](https://requests.readthedocs.io/en/latest/) client with automatic retries and configurable timeouts.
+
+We recommend using this to make API calls in your sources as it makes your pipeline more resilient to intermittent network errors and other random glitches which otherwise can cause the whole pipeline to fail.
+
+For most use cases this is a drop in replacement for `requests`, so:
+
+:heavy_multiplication_x: **Don't**
+
+```python
+import requests
+```
+:heavy_check_mark: **Do**
+
+```python
+from dlt.sources.helpers import requests
+```
+
+And use it just like you would use `requests`:
+
+```python
+response = requests.get('https://example.com/api/contacts', headers={'Authorization': MY_API_KEY})
+data = response.json()
+...
+```
+
+### Retry rules
+
+By default failing requests are retried up to 5 times with an exponentially increasing delay. That means the first retry will wait 1 second and the fifth retry will wait 16 seconds.
+
+If all retry attempts fail the corresponding requests exception is raised. E.g. `requests.HTTPError` or `requests.ConnectionTimeout`
+
+All standard HTTP server errors trigger a retry. This includes:
+
+* Error status codes:
+
+    All status codes in the `500` range and `429` (too many requests).
+    Commonly servers include a `Retry-After` header with `429` and `503` responses.
+    When detected this value supersedes the standard retry delay.
+
+* Connection and timeout errors
+
+    When the remote server is unreachable, connection is unexpectedly dropped or when the request takes longer than the configured `timeout`.
+
+### Customizing retry settings
+
+
+Many requests settings can be added to the runtime section in your `config.toml`. For example:
+
+```toml
+[runtime]
+request_max_attemts = 10  # Stop after 10 retry attempts instead of 5
+request_backoff_factor = 1.5  # Multiplier applied to the exponential delays. Default is 1
+request_timeout = 120  # Timeout in seconds
+request_max_retry_delay = 30  # Cap exponential delay to 30 seconds
+```
+
+For more control you can create your own instance of `dlt.sources.requests.Client` and use that instead of the global client.
+
+This lets you customize which status codes and exceptions to retry on:
+
+```python
+from dlt.sources.helpers import requests
+
+http_client = requests.Client(
+    status_codes=(403, 500, 502, 503),
+    exceptions=(requests.ConnectionError, requests.ChunkedEncodingError)
+)
+```
+
+and you may even supply a custom retry condition in the form of a predicate.
+This is sometimes needed when loading from non-standard APIs which don't use HTTP error codes.
+
+For example:
+
+```python
+from dlt.sources.helpers import requests
+
+def retry_if_error_key(response: Optional[requests.Response], exception: Optional[BaseException]) -> bool:
+    """Decide whether to retry the request based on whether
+    the json response contains an `error` key
+    """
+    if response is None:
+        # Fall back on the default exception predicate.
+        return False
+    data = response.json()
+    return 'error' in data
+
+http_client = Client(
+    retry_condition=retry_timeout=120
+)
+```
+

--- a/tests/common/configuration/test_configuration.py
+++ b/tests/common/configuration/test_configuration.py
@@ -444,7 +444,7 @@ def test_configuration_is_mutable_mapping(environment: Any, env_provider: Config
         'dlthub_telemetry_segment_write_key': 'TLJiyRkGVZGCi2TtjClamXpFcxAA1rSB',
         'log_format': '{asctime}|[{levelname:<21}]|{process}|{name}|{filename}|{funcName}:{lineno}|{message}',
         'log_level': 'WARNING',
-        'request_timeout': (15, 60),
+        'request_timeout': 60,
         'request_max_attempts': 5,
         'request_backoff_factor': 1,
         'request_max_retry_delay': 300,

--- a/tests/common/configuration/test_configuration.py
+++ b/tests/common/configuration/test_configuration.py
@@ -444,7 +444,10 @@ def test_configuration_is_mutable_mapping(environment: Any, env_provider: Config
         'dlthub_telemetry_segment_write_key': 'TLJiyRkGVZGCi2TtjClamXpFcxAA1rSB',
         'log_format': '{asctime}|[{levelname:<21}]|{process}|{name}|{filename}|{funcName}:{lineno}|{message}',
         'log_level': 'WARNING',
-        'request_timeout': (15, 300),
+        'request_timeout': (15, 60),
+        'request_max_attempts': 5,
+        'request_backoff_factor': 1,
+        'request_max_retry_delay': 300,
         'config_files_storage_path': 'storage',
         "secret_value": None
     }

--- a/tests/sources/helpers/test_requests.py
+++ b/tests/sources/helpers/test_requests.py
@@ -43,7 +43,7 @@ def test_custom_session_retry_settings(respect_retry_after_header: bool) -> None
 
     session = Client(
         request_max_attempts=14,
-        condition=custom_retry_cond,
+        retry_condition=custom_retry_cond,
         request_backoff_factor=2,
         respect_retry_after_header=False,
     ).session
@@ -114,7 +114,7 @@ def test_retry_on_custom_condition(mock_sleep: mock.MagicMock) -> None:
     def retry_on(response: requests.Response, exception: BaseException) -> bool:
         return response.text == 'error'
 
-    session = Client(condition=retry_on).session
+    session = Client(retry_condition=retry_on).session
     url = 'https://example.com/data'
 
     with requests_mock.mock(session=session) as m:
@@ -128,7 +128,7 @@ def test_retry_on_custom_condition_success_after_2(mock_sleep: mock.MagicMock) -
     def retry_on(response: requests.Response, exception: BaseException) -> bool:
         return response.text == 'error'
 
-    session = Client(condition=retry_on).session
+    session = Client(retry_condition=retry_on).session
     url = 'https://example.com/data'
     responses = [dict(text='error'), dict(text='error'), dict(text='success')]
 


### PR DESCRIPTION
Fixes https://github.com/dlt-hub/dlt/issues/473

* `ChunkedLoadingException` added to retry list. Seems this almost always due to some kind of dropped connection  
* requests `Timeout` and `ConnectionError` are already retried and all server errors inherit those
* Added some of the retry settings to `RunConfiguration`   