### PR TITLE
Clarifies create-a-pipeline docs

### DIFF
--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -19,8 +19,7 @@ steps below.
 Create a new empty directory for your `dlt` project by running:
 
 ```bash
-mkdir weatherapi_duckdb
-cd weatherapi_duckdb
+mkdir weatherapi_duckdb && cd weatherapi_duckdb
 ```
 
 Start a `dlt` project with a pipeline template that loads data to DuckDB by running:

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -22,6 +22,11 @@ Create a new empty directory for your `dlt` project by running:
 mkdir weatherapi_duckdb
 ```
 
+Change into your new directory by running:
+```bash
+cd weatherapi_duckdb
+```
+
 Start a `dlt` project with a pipeline template that loads data to DuckDB by running:
 
 ```bash

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -20,10 +20,6 @@ Create a new empty directory for your `dlt` project by running:
 
 ```bash
 mkdir weatherapi_duckdb
-```
-
-Change into your new directory by running:
-```bash
 cd weatherapi_duckdb
 ```
 


### PR DESCRIPTION
This PR addresses https://github.com/dlt-hub/dlt/issues/492

## Alternatives

Instead of asking the user to `cd my_new_directory` we could put:

```bash
mkdir weatherapi_duckdb && cd "$_"
```

However, because it's less known and a bit cryptic I decided to be explicit with a simple `cd`.