### PR TITLE
replace child table handling

### DIFF
--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -163,8 +163,8 @@ class InsertValuesWriter(DataWriter):
         self._chunks_written += 1
 
     def write_footer(self) -> None:
-        assert self._chunks_written > 0
-        self._f.write(";")
+        if self._chunks_written > 0:
+            self._f.write(";")
 
     @classmethod
     def data_format(cls) -> TFileFormatSpec:

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -181,7 +181,7 @@ class JobClientBase(ABC):
         pass
 
     def get_truncate_destination_table_dispositions(self) -> List[TWriteDisposition]:
-        return []
+        return ["replace"]
 
     @abstractmethod
     def create_table_chain_completed_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[NewLoadJob]:

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -180,6 +180,9 @@ class JobClientBase(ABC):
     def restore_file_load(self, file_path: str) -> LoadJob:
         pass
 
+    def get_truncate_destination_table_dispositions(self) -> List[TWriteDisposition]:
+        return []
+
     @abstractmethod
     def create_table_chain_completed_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[NewLoadJob]:
         """Creates a list of followup jobs that should be executed after a table chain is completed"""

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -181,6 +181,7 @@ class JobClientBase(ABC):
         pass
 
     def get_truncate_destination_table_dispositions(self) -> List[TWriteDisposition]:
+        # in the base job, all replace strategies are treated the same, see filesystem for example
         return ["replace"]
 
     @abstractmethod

--- a/dlt/destinations/duckdb/duck.py
+++ b/dlt/destinations/duckdb/duck.py
@@ -44,14 +44,12 @@ HINT_TO_POSTGRES_ATTR: Dict[TColumnHint, str] = {
 
 
 class DuckDbCopyJob(LoadJob, FollowupJob):
-    def __init__(self, table_name: str, use_staging_table: bool, _should_truncate_destination_table: bool, file_path: str, sql_client: DuckDbSqlClient) -> None:
+    def __init__(self, table_name: str, use_staging_table: bool, file_path: str, sql_client: DuckDbSqlClient) -> None:
         super().__init__(FileStorage.get_file_name_from_file_path(file_path))
 
         with sql_client.with_staging_dataset(use_staging_table):
             qualified_table_name = sql_client.make_qualified_table_name(table_name)
             with sql_client.begin_transaction():
-                if _should_truncate_destination_table:
-                    sql_client.execute_sql(f"TRUNCATE TABLE {qualified_table_name}")
                 sql_client.execute_sql(f"COPY {qualified_table_name} FROM '{file_path}' ( FORMAT PARQUET );")
 
 
@@ -78,7 +76,7 @@ class DuckDbClient(InsertValuesJobClient):
     def start_file_load(self, table: TTableSchema, file_path: str, load_id: str) -> LoadJob:
         if file_path.endswith("parquet"):
             disposition = table["write_disposition"]
-            return DuckDbCopyJob(table["name"], disposition in self.get_stage_dispositions(), self._should_truncate_destination_table(disposition), file_path, self.sql_client)
+            return DuckDbCopyJob(table["name"], disposition in self.get_stage_dispositions(),  file_path, self.sql_client)
         return super().start_file_load(table, file_path, load_id)
 
     def _get_column_def_sql(self, c: TColumnSchema) -> str:

--- a/dlt/destinations/filesystem/filesystem.py
+++ b/dlt/destinations/filesystem/filesystem.py
@@ -88,7 +88,9 @@ class FilesystemClient(JobClientBase):
             for table in truncate_tables:
                 search_prefix = posixpath.join(self.dataset_path, f"{self.schema.name}.{table}.")
                 for item in all_files:
+                    # NOTE: glob implementation in fsspec does not look thread safe, way better is to use ls and then filter
                     if item.startswith(search_prefix):
+                        # NOTE: deleting in chunks on s3 does not raise on access denied, file non existing and probably other errors
                         self.fs_client.rm_file(item)
 
         # create destination dir

--- a/dlt/destinations/insert_job_client.py
+++ b/dlt/destinations/insert_job_client.py
@@ -12,13 +12,13 @@ from dlt.destinations.job_client_impl import SqlJobClientBase
 
 
 class InsertValuesLoadJob(LoadJob, FollowupJob):
-    def __init__(self, table_name: str, use_staging_table: bool, _should_truncate_destination_table: bool, file_path: str, sql_client: SqlClientBase[Any]) -> None:
+    def __init__(self, table_name: str, use_staging_table: bool, file_path: str, sql_client: SqlClientBase[Any]) -> None:
         super().__init__(FileStorage.get_file_name_from_file_path(file_path))
         self._sql_client = sql_client
         # insert file content immediately
         with self._sql_client.with_staging_dataset(use_staging_table):
             with self._sql_client.begin_transaction():
-                for fragments in self._insert(sql_client.make_qualified_table_name(table_name), _should_truncate_destination_table, file_path):
+                for fragments in self._insert(sql_client.make_qualified_table_name(table_name), file_path):
                     self._sql_client.execute_fragments(fragments)
 
     def state(self) -> TLoadJobState:
@@ -29,7 +29,7 @@ class InsertValuesLoadJob(LoadJob, FollowupJob):
         # this part of code should be never reached
         raise NotImplementedError()
 
-    def _insert(self, qualified_table_name: str, _should_truncate_destination_table: bool, file_path: str) -> Iterator[List[str]]:
+    def _insert(self, qualified_table_name: str, file_path: str) -> Iterator[List[str]]:
         # WARNING: maximum redshift statement is 16MB https://docs.aws.amazon.com/redshift/latest/dg/c_redshift-sql.html
         # the procedure below will split the inserts into max_query_length // 2 packs
         with FileStorage.open_zipsafe_ro(file_path, "r", encoding="utf-8") as f:
@@ -39,8 +39,6 @@ class InsertValuesLoadJob(LoadJob, FollowupJob):
             assert values_mark == "VALUES\n"
 
             insert_sql = []
-            if _should_truncate_destination_table:
-                insert_sql.append("DELETE FROM {};".format(qualified_table_name))
             while content := f.read(self._sql_client.capabilities.max_query_length // 2):
                 # write INSERT
                 insert_sql.extend([header.format(qualified_table_name), values_mark, content])
@@ -93,7 +91,7 @@ class InsertValuesJobClient(SqlJobClientBase):
         if not job:
             # this is using sql_client internally and will raise a right exception
             disposition = table["write_disposition"]
-            job = InsertValuesLoadJob(table["name"], disposition in self.get_stage_dispositions(), self._should_truncate_destination_table(disposition), file_path, self.sql_client)
+            job = InsertValuesLoadJob(table["name"], disposition in self.get_stage_dispositions(), file_path, self.sql_client)
         return job
 
     # TODO: implement indexes and primary keys for postgres

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -157,7 +157,7 @@ class SqlJobClientBase(StagingJobClientBase):
         return dispositions
 
     def get_truncate_destination_table_dispositions(self) -> List[TWriteDisposition]:
-        if self.config.replace_strategy:
+        if self.config.replace_strategy == "truncate-and-insert":
             return ["replace"]
         return []
 

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -156,8 +156,10 @@ class SqlJobClientBase(StagingJobClientBase):
             dispositions.append("replace")
         return dispositions
 
-    def _should_truncate_destination_table(self, disposition: TWriteDisposition) -> bool:
-        return disposition == "replace" and self.config.replace_strategy == "truncate-and-insert"
+    def get_truncate_destination_table_dispositions(self) -> List[TWriteDisposition]:
+        if self.config.replace_strategy:
+            return ["replace"]
+        return []
 
     def _create_merge_job(self, table_chain: Sequence[TTableSchema]) -> NewLoadJob:
         return SqlMergeJob.from_table_chain(table_chain, self.sql_client)

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -1,6 +1,6 @@
 import contextlib
 import os
-from typing import ClassVar, List
+from typing import ClassVar, List, Set
 
 from dlt.common.configuration.container import Container
 from dlt.common.configuration.resolve import inject_section
@@ -72,6 +72,11 @@ def extract(
 
     with collector(f"Extract {source.name}"):
 
+        def _write_empty_file(table_name: str) -> None:
+            table_name = schema.naming.normalize_identifier(table_name)
+            collector.update(table_name)
+            storage.write_empty_file(extract_id, schema.name, table_name, None)
+
         def _write_item(table_name: str, item: TDataItems) -> None:
             # normalize table name before writing so the name match the name in schema
             # note: normalize function should be cached so there's almost no penalty on frequent calling
@@ -80,8 +85,7 @@ def extract(
             collector.update(table_name)
             storage.write_data_item(extract_id, schema.name, table_name, item, None)
 
-        def _write_dynamic_table(resource: DltResource, item: TDataItem) -> None:
-            table_name = resource._table_name_hint_fun(item)
+        def _write_dynamic_table(table_name: str, resource: DltResource, item: TDataItem) -> None:
             existing_table = dynamic_tables.get(table_name)
             if existing_table is None:
                 dynamic_tables[table_name] = [resource.table_schema(item)]
@@ -105,6 +109,7 @@ def extract(
                 dynamic_tables[table_name] = [static_table]
 
         # yield from all selected pipes
+        populated_tables: Set[str] = set()
         with PipeIterator.from_pipes(source.resources.selected_pipes, max_parallel_items=max_parallel_items, workers=workers, futures_poll_interval=futures_poll_interval) as pipes:
             left_gens = total_gens = len(pipes._sources)
             collector.update("Resources", 0, total_gens)
@@ -121,8 +126,10 @@ def extract(
                 # TODO: many resources may be returned. if that happens the item meta must be present with table name and this name must match one of resources
                 # if meta contains table name
                 resource = source.resources.find_by_pipe(pipe_item.pipe)
+                table_name: str = None
                 if isinstance(pipe_item.meta, TableNameMeta):
                     table_name = pipe_item.meta.table_name
+                    populated_tables.add(table_name)
                     _write_static_table(resource, table_name)
                     _write_item(table_name, pipe_item.item)
                 else:
@@ -130,14 +137,31 @@ def extract(
                     if resource._table_name_hint_fun:
                         if isinstance(pipe_item.item, List):
                             for item in pipe_item.item:
-                                _write_dynamic_table(resource, item)
+                                table_name = resource._table_name_hint_fun(item)
+                                populated_tables.add(table_name)
+                                _write_dynamic_table(table_name, resource, item)
                         else:
-                            _write_dynamic_table(resource, pipe_item.item)
+                            table_name = resource._table_name_hint_fun(pipe_item.item)
+                            populated_tables.add(table_name)
+                            _write_dynamic_table(table_name, resource, pipe_item.item)
                     else:
                         # write item belonging to table with static name
                         table_name = resource.table_name
+                        populated_tables.add(table_name)
                         _write_static_table(resource, table_name)
                         _write_item(table_name, pipe_item.item)
+
+            # find defined resources that did not yield any pipeitems and create empty jobs for them
+            for resource in source.resources.selected.values():
+                if resource.write_disposition != "replace" or resource._table_name_hint_fun:
+                    continue
+                table_name = resource.table_name
+                # if table does not exist in schema, there is no need to create empty jobs
+                if table_name not in schema.tables:
+                    continue
+                if table_name and table_name not in populated_tables:
+                    _write_empty_file(resource.table_name)
+
             if left_gens > 0:
                 # go to 100%
                 collector.update("Resources", left_gens)

--- a/dlt/normalize/normalize.py
+++ b/dlt/normalize/normalize.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable, List, Dict, Sequence, Tuple
+from typing import Any, Callable, List, Dict, Sequence, Tuple, Set
 from multiprocessing.pool import AsyncResult, Pool as ProcessPool
 
 from dlt.common import pendulum, json, logger, sleep
@@ -52,7 +52,6 @@ class Normalize(Runnable[ProcessPool]):
         # normalize saves in preferred format but can read all supported formats
         self.load_storage = LoadStorage(True, self.config.destination_capabilities.preferred_loader_file_format, LoadStorage.ALL_SUPPORTED_FILE_FORMATS, config=self.config._load_storage_config)
 
-
     @staticmethod
     def load_or_create_schema(schema_storage: SchemaStorage, schema_name: str) -> Schema:
         try:
@@ -82,12 +81,16 @@ class Normalize(Runnable[ProcessPool]):
             normalize_storage = NormalizeStorage(False, normalize_storage_config)
 
             try:
+                root_tables: Set[str] = set()
+                populated_root_tables: Set[str] = set()
                 for extracted_items_file in extracted_items_files:
                     line_no: int = 0
                     root_table_name = NormalizeStorage.parse_normalize_file_name(extracted_items_file).table_name
+                    root_tables.add(root_table_name)
                     logger.debug(f"Processing extracted items in {extracted_items_file} in load_id {load_id} with table name {root_table_name} and schema {schema.name}")
                     with normalize_storage.storage.open_file(extracted_items_file) as f:
                         # enumerate jsonl file line by line
+                        items_count = 0
                         for line_no, line in enumerate(f):
                             items: List[TDataItem] = json.loads(line)
                             partial_update, items_count = Normalize._w_normalize_chunk(load_storage, schema, load_id, root_table_name, items)
@@ -96,7 +99,15 @@ class Normalize(Runnable[ProcessPool]):
                             logger.debug(f"Processed {line_no} items from file {extracted_items_file}, items {items_count} of total {total_items}")
                         # if any item found in the file
                         if items_count > 0:
+                            populated_root_tables.add(root_table_name)
                             logger.debug(f"Processed total {line_no + 1} lines from file {extracted_items_file}, total items {total_items}")
+                # write empty jobs for tables without items if table exists in schema
+                for table_name in root_tables - populated_root_tables:
+                    if table_name not in schema.tables:
+                        continue
+                    logger.debug(f"Writing empty job for table {table_name}")
+                    columns = schema.get_table_columns(table_name, only_complete=True)
+                    load_storage.write_empty_file(load_id, schema.name, table_name, columns)
             except Exception:
                 logger.exception(f"Exception when processing file {extracted_items_file}, line {line_no}")
                 raise

--- a/docs/website/docs/dlt-ecosystem/visualizations/understanding-the-tables.md
+++ b/docs/website/docs/dlt-ecosystem/visualizations/understanding-the-tables.md
@@ -47,22 +47,22 @@ case the primary key or other unique columns are defined.
 
 ## Load IDs
 
-Load IDs are important and present in all the top tables (`_dlt_loads`, `load_id`, etc.). Each
-pipeline run creates one or more load packages, which can be identified by their `load_id`. A load
+Each pipeline run creates one or more load packages, which can be identified by their `load_id`. A load
 package typically contains data from all [resources](../../general-usage/glossary.md#resource) of a
 particular [source](../../general-usage/glossary.md#source). The `load_id` of a particular package
-is added to the top data tables and to the `_dlt_loads` table with a status 0 (when the load process
+is added to the top data tables (`_dlt_load_id` column) and to the `_dlt_loads` table with a status 0 (when the load process
 is fully completed).
+
+The `_dlt_loads` table tracks complete loads and allows chaining transformations on top of them.
+Many destinations do not support distributed and long-running transactions (e.g. Amazon Redshift).
+In that case, the user may see the partially loaded data. It is possible to filter such data out—any
+row with a `load_id` that does not exist in `_dlt_loads` is not yet completed. The same procedure may be used to delete and identify
+and delete data for packages that never got completed.
 
 For each load, you can test and [alert](../../running-in-production/alerting.md) on anomalies (e.g.
 no data, too much loaded to a table). There are also some useful load stats in the `Load info` tab
 of the [Streamlit app](understanding-the-tables.md#show-tables-and-data-in-the-destination)
 mentioned above.
-
-The `_dlt_loads` table tracks complete loads and allows chaining transformations on top of them.
-Many destinations do not support distributed and long-running transactions (e.g. Amazon Redshift).
-In that case, the user may see the partially loaded data. It is possible to filter such data out—any
-row with a `load_id` that does not exist in `_dlt_loads` is not yet completed.
 
 You can add [transformations](../transformations) and chain them together
 using the `status` column. You start the transformation for all the data with a particular

--- a/docs/website/docs/general-usage/full-loading.md
+++ b/docs/website/docs/general-usage/full-loading.md
@@ -42,8 +42,8 @@ replace_strategy = "staging-optimized"
 The `truncate-and-insert` replace strategy is the default and the fastest of all three strategies. If you load data with this setting, then the
 destination tables will be truncated at the beginning of the load and the new data will be inserted consecutively but not within the same transaction. 
 The downside of this strategy is, that your tables will have no data for a while until the load is completed. You
-may end up with new data in some tables and no data in other tables if the load fails during the run. 
-If you prefer to have no data downtime, please use one of the other strategies.
+may end up with new data in some tables and no data in other tables if the load fails during the run. Such incomplete load may be however detected by checking if the 
+[_dlt_loads table contains load id](../dlt-ecosystem/visualizations/understanding-the-tables.md#load-ids) from _dlt_load_id of the replaced tables. If you prefer to have no data downtime, please use one of the other strategies.
 
 ### The `insert-from-staging` strategy
 

--- a/docs/website/docs/general-usage/full-loading.md
+++ b/docs/website/docs/general-usage/full-loading.md
@@ -40,18 +40,16 @@ replace_strategy = "staging-optimized"
 ### The `truncate-and-insert` strategy
 
 The `truncate-and-insert` replace strategy is the default and the fastest of all three strategies. If you load data with this setting, then the
-destination tables will be truncated and the new data will be inserted. The downside of this strategy is, that there is no transaction safety
-that ensures that parent tables and child tables will be in a consistent state if your pipeline run fails at some point during the loading. You
-may end up with new data in the main table and stale data in the its child tables. Furthermore on large loads, there is a possibility that not
-all data present in the resource will actually end up in the destination table, as `dlt` chunks data into predefined (and configurable) filesizes
-before loading into the destination, and there is no mechnism to ensure that chunked data will be appended back together. If you have large loads
-or consistently failing pipeline runs, it is better to choose one of the other two strategies. This strategy behaves the same way across all
-destinations.
+destination tables will be truncated at the beginning of the load and the new data will be inserted consecutively but not within the same transaction. 
+The downside of this strategy is, that your tables will have no data for a while until the load is completed. You
+may end up with new data in some tables and no data in other tables if the load fails during the run. 
+If you prefer to have no data downtime, please use one of the other strategies.
 
 ### The `insert-from-staging` strategy
 
-The `insert-from-staging` is the slowest of all three strategies. It will load all new data into staging tables away from your final destination tables and will then truncate and insert the new data in one transaction. It also maintains a consistent state between child and parent tables.
-Use this strategy if you have large loads or the requirement for consistent destination datasets with zero downtime and the `optimized` strategy does not work for you. This strategy behaves the same way across all destinations.
+The `insert-from-staging` is the slowest of all three strategies. It will load all new data into staging tables away from your final destination tables and will then truncate and insert the new data in one transaction. 
+It also maintains a consistent state between child and parent tables at all times. Use this strategy if you have the requirement for consistent destination datasets with zero downtime and the `optimized` strategy does not work for you. 
+This strategy behaves the same way across all destinations.
 
 ### The `staging-optimized` strategy
 

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -490,9 +490,9 @@ def test_replace_resets_state() -> None:
     info = p.run(s)
     # state was reset
     assert 'child' not in s.state['resources']
-    # there's a load package but it contains 1 job to reset state
-    assert len(info.load_packages[0].jobs['completed_jobs']) == 1
-    assert info.load_packages[0].jobs['completed_jobs'][0].job_file_info.table_name == "_dlt_pipeline_state"
+    # there will be a load package to reset the state but also a load package to update the child table
+    assert len(info.load_packages[0].jobs['completed_jobs']) == 2
+    assert {job.job_file_info.table_name for job in info.load_packages[0].jobs['completed_jobs'] } == {"_dlt_pipeline_state", "child"}
 
 
 def test_incremental_as_transform() -> None:

--- a/tests/load/filesystem/test_filesystem_client.py
+++ b/tests/load/filesystem/test_filesystem_client.py
@@ -110,7 +110,15 @@ def perform_load(
     load_id, schema = prepare_load_package(load.load_storage, cases, write_disposition)
 
     client.schema = schema
-    client.initialize_storage()
+
+    # for the replace disposition in the loader we truncate the tables, so do this here
+    truncate_tables = []
+    if write_disposition == 'replace':
+        for item in cases:
+            parts = item.split('.')
+            truncate_tables.append(parts[0])
+
+    client.initialize_storage(truncate_tables=truncate_tables)
     root_path = posixpath.join(client.fs_path, client.config.dataset_name)
 
     files = load.load_storage.list_new_jobs(load_id)

--- a/tests/load/pipeline/test_filesystem_pipeline.py
+++ b/tests/load/pipeline/test_filesystem_pipeline.py
@@ -58,9 +58,10 @@ def test_pipeline_merge_write_disposition(all_buckets_env: str) -> None:
     assert any(load_id1 in fn for fn in append_files)
     assert any(load_id2 in fn for fn in append_files)
 
-    # resource without pk is replaced and has 1 copy from second load
-    assert len(replace_files) == 1
-    assert load_id2 in replace_files[0]
+    # resource without pk is treated as append disposition
+    assert len(replace_files) == 2
+    assert any(load_id1 in fn for fn in replace_files)
+    assert any(load_id2 in fn for fn in replace_files)
 
     # Verify file contents
     assert info2.load_packages

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -232,9 +232,9 @@ def test_pipeline_load_parquet(destination_name: str) -> None:
     github_data.max_table_nesting = 2
     info = p.run(github_data, loader_file_format="parquet", write_disposition="replace")
     assert_load_info(info)
-    # make sure it was parquet only
+    # make sure it was parquet or sql inserts
     files = p.get_load_package_info(p.list_completed_load_packages()[1]).jobs["completed_jobs"]
-    assert all(f.job_file_info.file_format == "parquet" for f in files)
+    assert all(f.job_file_info.file_format in ["parquet", "sql"] for f in files)
 
     github_1_counts = load_table_counts(p, *[t["name"] for t in p.default_schema.data_tables()])
     assert github_1_counts["issues"] == 100

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -234,7 +234,7 @@ def test_pipeline_load_parquet(destination_name: str) -> None:
     assert_load_info(info)
     # make sure it was parquet or sql inserts
     files = p.get_load_package_info(p.list_completed_load_packages()[1]).jobs["completed_jobs"]
-    assert all(f.job_file_info.file_format in ["parquet", "sql"] for f in files)
+    assert all(f.job_file_info.file_format in ["parquet"] for f in files)
 
     github_1_counts = load_table_counts(p, *[t["name"] for t in p.default_schema.data_tables()])
     assert github_1_counts["issues"] == 100

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -17,7 +17,7 @@ def test_replace_disposition(destination_config: DestinationTestConfiguration, r
     # use staging tables for replace
     os.environ['DESTINATION__REPLACE_STRATEGY'] = replace_strategy
 
-    pipeline = destination_config.setup_pipeline("test_replace_strategies", full_refresh=True)
+    pipeline = destination_config.setup_pipeline("test_replace_strategies")
 
     global offset
     offset = 1000
@@ -88,7 +88,7 @@ def test_replace_table_clearing(destination_config: DestinationTestConfiguration
     # use staging tables for replace
     os.environ['DESTINATION__REPLACE_STRATEGY'] = replace_strategy
 
-    pipeline = destination_config.setup_pipeline("test_replace_table_clearing", full_refresh=True)
+    pipeline = destination_config.setup_pipeline("test_replace_table_clearing")
 
     @dlt.resource(name="main_resource", write_disposition="replace", primary_key="id")
     def items_with_subitems():

--- a/tests/load/pipeline/test_restore_state.py
+++ b/tests/load/pipeline/test_restore_state.py
@@ -30,9 +30,9 @@ def duckdb_pipeline_location() -> None:
 
 @pytest.mark.parametrize("destination_config", destinations_configs(default_staging_configs=True, default_non_staging_configs=True), ids=lambda x: x.name)
 def test_restore_state_utils(destination_config: DestinationTestConfiguration) -> None:
-    destination_config.setup()
 
-    p = dlt.pipeline(pipeline_name="pipe_" + uniq_id(), destination=destination_config.destination, staging=destination_config.staging, dataset_name="state_test_" + uniq_id())
+    p = destination_config.setup_pipeline(pipeline_name="pipe_" + uniq_id(), dataset_name="state_test_" + uniq_id())
+
     schema = Schema("state")
     # inject schema into pipeline, don't do it in production
     p._inject_schema(schema)

--- a/tests/load/pipeline/test_restore_state.py
+++ b/tests/load/pipeline/test_restore_state.py
@@ -18,7 +18,7 @@ from tests.cases import JSON_TYPED_DICT
 from tests.common.utils import IMPORTED_VERSION_HASH_ETH_V5, yml_case_path as common_yml_case_path
 from tests.common.configuration.utils import environment
 from tests.load.pipeline.utils import assert_query_data, drop_active_pipeline_data
-from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration, set_destination_config_envs
+from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
 
 
 @pytest.fixture(autouse=True)
@@ -30,7 +30,7 @@ def duckdb_pipeline_location() -> None:
 
 @pytest.mark.parametrize("destination_config", destinations_configs(default_staging_configs=True, default_non_staging_configs=True), ids=lambda x: x.name)
 def test_restore_state_utils(destination_config: DestinationTestConfiguration) -> None:
-    set_destination_config_envs(destination_config)
+    destination_config.setup()
 
     p = dlt.pipeline(pipeline_name="pipe_" + uniq_id(), destination=destination_config.destination, staging=destination_config.staging, dataset_name="state_test_" + uniq_id())
     schema = Schema("state")

--- a/tests/load/pipeline/test_stage_loading.py
+++ b/tests/load/pipeline/test_stage_loading.py
@@ -29,9 +29,8 @@ def load_modified_issues():
 
 @pytest.mark.parametrize("destination_config", destinations_configs(all_staging_configs=True), ids=lambda x: x.name)
 def test_staging_load(destination_config: DestinationTestConfiguration) -> None:
-    destination_config.setup()
 
-    pipeline = dlt.pipeline(pipeline_name='test_stage_loading_5', destination=destination_config.destination, staging=destination_config.staging, dataset_name='staging_test', full_refresh=True)
+    pipeline = destination_config.setup_pipeline(pipeline_name='test_stage_loading_5')
 
     info = pipeline.run(github(), loader_file_format=destination_config.file_format)
     assert_load_info(info)
@@ -86,9 +85,8 @@ def test_staging_load(destination_config: DestinationTestConfiguration) -> None:
 
 @pytest.mark.parametrize("destination_config", destinations_configs(all_staging_configs=True), ids=lambda x: x.name)
 def test_all_data_types(destination_config: DestinationTestConfiguration) -> None:
-    destination_config.setup()
 
-    pipeline = dlt.pipeline(pipeline_name='test_stage_loading', destination=destination_config.destination, dataset_name='staging_test', full_refresh=True, staging=destination_config.staging)
+    pipeline = destination_config.setup_pipeline('test_stage_loading')
 
     data_types = deepcopy(TABLE_ROW_ALL_DATA_TYPES)
     column_schemas = deepcopy(TABLE_UPDATE_COLUMNS_SCHEMA)

--- a/tests/load/pipeline/test_stage_loading.py
+++ b/tests/load/pipeline/test_stage_loading.py
@@ -9,7 +9,7 @@ from tests.load.pipeline.test_merge_disposition import github
 from tests.load.pipeline.utils import  load_table_counts
 from tests.pipeline.utils import  assert_load_info
 from tests.load.utils import TABLE_ROW_ALL_DATA_TYPES, TABLE_UPDATE_COLUMNS_SCHEMA, assert_all_data_types_row
-from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration, set_destination_config_envs
+from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
 
 
 @dlt.resource(table_name="issues", write_disposition="merge", primary_key="id", merge_key=("node_id", "url"))
@@ -29,7 +29,7 @@ def load_modified_issues():
 
 @pytest.mark.parametrize("destination_config", destinations_configs(all_staging_configs=True), ids=lambda x: x.name)
 def test_staging_load(destination_config: DestinationTestConfiguration) -> None:
-    set_destination_config_envs(destination_config)
+    destination_config.setup()
 
     pipeline = dlt.pipeline(pipeline_name='test_stage_loading_5', destination=destination_config.destination, staging=destination_config.staging, dataset_name='staging_test', full_refresh=True)
 
@@ -86,7 +86,7 @@ def test_staging_load(destination_config: DestinationTestConfiguration) -> None:
 
 @pytest.mark.parametrize("destination_config", destinations_configs(all_staging_configs=True), ids=lambda x: x.name)
 def test_all_data_types(destination_config: DestinationTestConfiguration) -> None:
-    set_destination_config_envs(destination_config)
+    destination_config.setup()
 
     pipeline = dlt.pipeline(pipeline_name='test_stage_loading', destination=destination_config.destination, dataset_name='staging_test', full_refresh=True, staging=destination_config.staging)
 

--- a/tests/load/pipeline/utils.py
+++ b/tests/load/pipeline/utils.py
@@ -67,7 +67,7 @@ def destinations_configs(
 
     # filter out non active destinations
     destination_configs = [conf for conf in destination_configs if conf.destination in ALL_DESTINATIONS]
-
+    return [DestinationTestConfiguration(destination="bigquery")]
     return destination_configs
 
 def set_destination_config_envs(conf: DestinationTestConfiguration) -> None:

--- a/tests/load/pipeline/utils.py
+++ b/tests/load/pipeline/utils.py
@@ -67,7 +67,7 @@ def destinations_configs(
 
     # filter out non active destinations
     destination_configs = [conf for conf in destination_configs if conf.destination in ALL_DESTINATIONS]
-    return [DestinationTestConfiguration(destination="bigquery")]
+
     return destination_configs
 
 def set_destination_config_envs(conf: DestinationTestConfiguration) -> None:

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -499,7 +499,6 @@ def test_write_dispositions(client: SqlJobClientBase, write_disposition: str, re
                 assert len(db_rows) == idx + 1
             elif write_disposition == "replace":
                 # we overwrite with the same row. merge fallbacks to replace when no keys specified
-                print(db_rows)
                 assert len(db_rows) == 1
             else:
                 # merge on client level, without loader, loads to staging dataset. so this table is empty

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -469,6 +469,7 @@ def test_write_dispositions(client: SqlJobClientBase, write_disposition: str, re
         )
     client.schema.bump_version()
     client.update_storage_schema()
+
     if write_disposition == "merge":
         # add root key
         client.schema.tables[table_name]["columns"]["col1"]["root_key"] = True
@@ -477,13 +478,19 @@ def test_write_dispositions(client: SqlJobClientBase, write_disposition: str, re
             client.initialize_storage()
             client.update_storage_schema()
     for idx in range(2):
+        # in the replace strategies, tables get truncated between loads
+        truncate_tables = [table_name, child_table]
+        if write_disposition == "replace":
+            client.initialize_storage(truncate_tables=truncate_tables)
+
         for t in [table_name, child_table]:
             # write row, use col1 (INT) as row number
-            table_row = deepcopy(TABLE_ROW_ALL_DATA_TYPES )
+            table_row = deepcopy(TABLE_ROW_ALL_DATA_TYPES)
             table_row["col1"] = idx
             with io.BytesIO() as f:
                 write_dataset(client, f, [table_row], TABLE_UPDATE_COLUMNS_SCHEMA)
                 query = f.getvalue().decode()
+
             expect_load_file(client, file_storage, query, t)
             db_rows = list(client.sql_client.execute_sql(f"SELECT * FROM {client.sql_client.make_qualified_table_name(t)} ORDER BY col1 ASC"))
             # in case of merge
@@ -492,6 +499,7 @@ def test_write_dispositions(client: SqlJobClientBase, write_disposition: str, re
                 assert len(db_rows) == idx + 1
             elif write_disposition == "replace":
                 # we overwrite with the same row. merge fallbacks to replace when no keys specified
+                print(db_rows)
                 assert len(db_rows) == 1
             else:
                 # merge on client level, without loader, loads to staging dataset. so this table is empty

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,6 +29,7 @@ TEST_STORAGE_ROOT = "_storage"
 ALL_DESTINATIONS = dlt.config.get("ALL_DESTINATIONS", list) or ["bigquery", "redshift", "postgres", "duckdb", "snowflake"]
 ALL_LOCAL_DESTINATIONS = set(ALL_DESTINATIONS).intersection("postgres", "duckdb")
 
+
 def TEST_DICT_CONFIG_PROVIDER():
     # add test dictionary provider
     providers_context = Container()[ConfigProvidersContext]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,7 +26,7 @@ from dlt.common.pipeline import PipelineContext
 TEST_STORAGE_ROOT = "_storage"
 
 # destination configs
-ALL_DESTINATIONS = dlt.config.get("ALL_DESTINATIONS", list) or ["bigquery", "redshift", "postgres", "duckdb", "snowflake"]
+ALL_DESTINATIONS = dlt.config.get("ALL_DESTINATIONS", list) or ["duckdb", "bigquery", "redshift", "postgres", "snowflake"]
 ALL_LOCAL_DESTINATIONS = set(ALL_DESTINATIONS).intersection("postgres", "duckdb")
 
 


### PR DESCRIPTION
One important note: This PR only handles propers child table clearing for the staging replace strategy. There are more changes needed if we also want to clear child tables on the classic strategy.

The one test that is always failing is: tests/load/pipeline/test_merge_disposition.py::test_merge_on_keys_in_schema. The problem here is, that the test makes sure that if there are tables defined in the schema but no data is coming for them they don't get created. But in this PR all the child tables of any table that has data are created on staging and cleared, so that the child table replacing works. The way to solve this is to look at the destination and see which tables are present already and prevent creation of tables that are not present, but that part I took out again.