### PR TITLE
Rfix/fixes credentials instantiation

### DIFF
--- a/dlt/destinations/filesystem/configuration.py
+++ b/dlt/destinations/filesystem/configuration.py
@@ -20,7 +20,8 @@ PROTOCOL_CREDENTIALS = {
 @configspec(init=True)
 class FilesystemClientConfiguration(DestinationClientStagingConfiguration):
     destination_name: Final[str] = "filesystem"  # type: ignore
-    credentials: Union[AwsCredentials, GcpCredentials]
+    # should be an union of all possible credentials as found in PROTOCOL_CREDENTIALS
+    credentials: Union[AwsCredentials, GcpServiceAccountCredentials, GcpOAuthCredentials]
     bucket_url: str
 
     @property


### PR DESCRIPTION
Fixes two problems:
1. staging (typically `filesystem`) credentials were instantiated from `credentials` argument of `dlt.pipeline` which apply only to destination
2. tired to instantiate an union of credentials. (fix: heuristics are added to pick the right type)

(2) is half-baked temporary solution until we convert all destinations into callable modules taking credentials as argument (https://github.com/dlt-hub/dlt/issues/508)