### PR TITLE
fix extract schema update

### DIFF
--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -265,9 +265,9 @@ class Schema:
         else:
             return self._schema_tables[table_name]["columns"]
 
-    def data_tables(self) -> List[TTableSchema]:
+    def data_tables(self, include_incomplete: bool = False) -> List[TTableSchema]:
         """Gets list of all tables, that hold the loaded data. Excludes dlt tables. Excludes incomplete tables (ie. without columns)"""
-        return [t for t in self._schema_tables.values() if not t["name"].startswith("_dlt") and len(t["columns"]) > 0]
+        return [t for t in self._schema_tables.values() if not t["name"].startswith("_dlt") and (len(t["columns"]) > 0 or include_incomplete)]
 
     def dlt_tables(self) -> List[TTableSchema]:
         """Gets dlt tables"""

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -373,11 +373,12 @@ WHERE """
 
         # get schema as string
         # TODO: Re-use decompress/compress_state() implementation from dlt.pipeline.state_sync
-        schema_str = row[5]
+        schema_str: str = row[5]
         try:
             schema_bytes = base64.b64decode(schema_str, validate=True)
             schema_str = zlib.decompress(schema_bytes).decode("utf-8")
-        except binascii.Error:
+        except ValueError:
+            # not a base64 string
             pass
 
         # make utc datetime

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -858,7 +858,7 @@ class Pipeline(SupportsPipeline):
 
         # get the current schema and merge tables from source_schema
         # note we are not merging props like max nesting or column propagation
-        for table in source_schema.data_tables():
+        for table in source_schema.data_tables(include_incomplete=True):
             pipeline_schema.update_schema(pipeline_schema.normalize_table_identifiers(table))
 
         return extract_id

--- a/tests/cli/test_deploy_command.py
+++ b/tests/cli/test_deploy_command.py
@@ -18,8 +18,7 @@ from dlt.cli import deploy_command, _dlt, echo
 from dlt.cli.exceptions import CliCommandException
 from dlt.pipeline.exceptions import CannotRestorePipelineException
 
-from tests.pipeline.utils import drop_pipeline
-from tests.utils import preserve_environ, autouse_test_storage, TEST_STORAGE_ROOT, test_storage
+from tests.utils import preserve_environ, autouse_test_storage, TEST_STORAGE_ROOT, test_storage, wipe_pipeline
 
 
 @pytest.mark.parametrize("deployment_method", [dm.value for dm in deploy_command.DeploymentMethods])

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -27,8 +27,7 @@ from dlt.reflection import names as n
 
 from tests.cli.utils import echo_default_choice, repo_dir, project_files, cloned_init_repo, get_repo_dir, get_project_files
 from tests.common.utils import modify_and_commit_file
-from tests.pipeline.utils import drop_pipeline
-from tests.utils import ALL_DESTINATIONS, preserve_environ, autouse_test_storage, clean_test_storage, unload_modules
+from tests.utils import ALL_DESTINATIONS, preserve_environ, autouse_test_storage, clean_test_storage, unload_modules, wipe_pipeline
 
 
 def get_verified_source_candidates(repo_dir: str) -> List[str]:

--- a/tests/cli/test_pipeline_command.py
+++ b/tests/cli/test_pipeline_command.py
@@ -10,8 +10,7 @@ from dlt.common.storages.file_storage import FileStorage
 from dlt.cli import echo, init_command, pipeline_command
 
 from tests.cli.utils import echo_default_choice, repo_dir, project_files, cloned_init_repo, get_repo_dir, get_project_files
-from tests.pipeline.utils import drop_pipeline
-from tests.utils import preserve_environ, autouse_test_storage, clean_test_storage, unload_modules
+from tests.utils import preserve_environ, autouse_test_storage, clean_test_storage, unload_modules, wipe_pipeline
 
 
 def test_pipeline_command_operations(repo_dir: str, project_files: FileStorage) -> None:

--- a/tests/extract/conftest.py
+++ b/tests/extract/conftest.py
@@ -1,0 +1,1 @@
+from tests.utils import duckdb_pipeline_location, autouse_test_storage, preserve_environ, patch_home_dir, wipe_pipeline

--- a/tests/extract/test_decorators.py
+++ b/tests/extract/test_decorators.py
@@ -17,7 +17,6 @@ from dlt.cli.source_detection import detect_source_configs
 from dlt.extract.exceptions import ExplicitSourceNameInvalid, InvalidResourceDataTypeFunctionNotAGenerator, InvalidResourceDataTypeIsNone, ParametrizedResourceUnbound, PipeNotBoundToData, ResourceFunctionExpected, ResourceInnerCallableConfigWrapDisallowed, SourceDataIsNone, SourceIsAClassTypeError, SourceNotAFunction, SourceSchemaNotAvailable
 from dlt.extract.source import DltResource, DltSource
 
-from tests.utils import preserve_environ
 from tests.common.utils import IMPORTED_VERSION_HASH_ETH_V5
 
 

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -4,7 +4,7 @@ from dlt.common.storages import NormalizeStorageConfiguration
 from dlt.extract.extract import ExtractorStorage, extract
 from dlt.extract.source import DltResource, DltSource
 
-from tests.utils import autouse_test_storage, clean_test_storage
+from tests.utils import clean_test_storage
 from tests.extract.utils import expect_extracted_file
 
 

--- a/tests/extract/test_extract_pipe.py
+++ b/tests/extract/test_extract_pipe.py
@@ -13,8 +13,6 @@ from dlt.extract.exceptions import CreatePipeException, ResourceExtractionError
 from dlt.extract.typing import DataItemWithMeta, FilterItem, MapItem, YieldMapItem
 from dlt.extract.pipe import ManagedPipeIterator, Pipe, PipeItem, PipeIterator
 
-# from tests.utils import preserve_environ
-
 
 def test_next_item_mode() -> None:
 

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -21,10 +21,6 @@ from dlt.extract.source import DltSource
 from dlt.sources.helpers.transform import take_first
 from dlt.extract.incremental import IncrementalCursorPathMissing, IncrementalPrimaryKeyMissing
 
-from tests.pipeline.utils import drop_pipeline
-# from tests.load.pipeline.utils import load_table_counts
-from tests.utils import preserve_environ, autouse_test_storage, patch_home_dir
-
 
 def test_single_items_last_value_state_is_updated() -> None:
     @dlt.resource

--- a/tests/extract/test_sources.py
+++ b/tests/extract/test_sources.py
@@ -12,8 +12,6 @@ from dlt.extract.pipe import Pipe
 from dlt.extract.typing import FilterItem, MapItem
 from dlt.extract.source import DltResource, DltSource
 
-from tests.pipeline.utils import drop_pipeline
-
 
 def test_call_data_resource() -> None:
     with pytest.raises(TypeError):

--- a/tests/load/pipeline/conftest.py
+++ b/tests/load/pipeline/conftest.py
@@ -1,3 +1,3 @@
-from tests.utils import patch_home_dir, preserve_environ, autouse_test_storage
+from tests.utils import patch_home_dir, preserve_environ, autouse_test_storage, duckdb_pipeline_location
 from tests.pipeline.utils import drop_dataset_from_env
 from tests.load.pipeline.utils import drop_pipeline

--- a/tests/load/pipeline/test_filesystem_pipeline.py
+++ b/tests/load/pipeline/test_filesystem_pipeline.py
@@ -9,9 +9,6 @@ from dlt.common.schema.typing import LOADS_TABLE_NAME
 
 import pyarrow.parquet as pq
 
-from tests.utils import init_test_logging
-
-
 
 def assert_file_matches(job: LoadJobInfo, load_id: str, client: FilesystemClient) -> None:
     """Verify file contents of load job are identical to the corresponding file in destination"""
@@ -85,7 +82,6 @@ def test_pipeline_merge_write_disposition(all_buckets_env: str) -> None:
     replace_files = client.fs_client.glob(replace_glob)
     assert len(append_files) == 1
     assert len(replace_files) == 1
-
 
 
 def test_pipeline_parquet_filesystem_destination() -> None:

--- a/tests/load/pipeline/test_pipelines.py
+++ b/tests/load/pipeline/test_pipelines.py
@@ -433,15 +433,13 @@ def test_pipeline_with_sources_sharing_schema(destination_name: str) -> None:
 
     p = dlt.pipeline(pipeline_name="multi", destination="duckdb", full_refresh=True)
     p.extract([source_1(), source_2()])
-    # tables without columns are not added after extract
     default_schema = p.default_schema
     gen1_table = default_schema.tables["gen1"]
     assert "user_id" in gen1_table["columns"]
     assert "id" in gen1_table["columns"]
     assert "conflict" in default_schema.tables
-    assert "gen2" not in default_schema.tables
+    assert "gen2" in default_schema.tables
     p.normalize()
-    # default schema is a live object and must contain gen2 now
     assert "gen2" in default_schema.tables
     p.load()
     table_names = [t["name"] for t in default_schema.data_tables()]

--- a/tests/load/pipeline/test_restore_state.py
+++ b/tests/load/pipeline/test_restore_state.py
@@ -8,7 +8,7 @@ import dlt
 from dlt.common import pendulum
 from dlt.common.schema.schema import Schema, utils
 from dlt.common.schema.typing import LOADS_TABLE_NAME, VERSION_TABLE_NAME
-from dlt.common.utils import uniq_id
+from dlt.common.utils import custom_environ, uniq_id
 from dlt.destinations.exceptions import DatabaseUndefinedRelation
 from dlt.pipeline.pipeline import Pipeline
 from dlt.pipeline.state_sync import STATE_TABLE_COLUMNS, STATE_TABLE_NAME, load_state_from_destination, state_resource
@@ -19,6 +19,13 @@ from tests.common.utils import IMPORTED_VERSION_HASH_ETH_V5, yml_case_path as co
 from tests.common.configuration.utils import environment
 from tests.load.pipeline.utils import assert_query_data, drop_active_pipeline_data
 from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration, set_destination_config_envs
+
+
+@pytest.fixture(autouse=True)
+def duckdb_pipeline_location() -> None:
+    # this will store duckdb in working folder so it survives pipeline wipe
+    if "DESTINATION__DUCKDB__CREDENTIALS" in os.environ:
+        del os.environ["DESTINATION__DUCKDB__CREDENTIALS"]
 
 
 @pytest.mark.parametrize("destination_config", destinations_configs(default_staging_configs=True, default_non_staging_configs=True), ids=lambda x: x.name)

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -1,2 +1,2 @@
-from tests.utils import preserve_environ, autouse_test_storage, patch_home_dir
-from tests.pipeline.utils import drop_dataset_from_env, drop_pipeline
+from tests.utils import preserve_environ, autouse_test_storage, patch_home_dir, wipe_pipeline, duckdb_pipeline_location
+from tests.pipeline.utils import drop_dataset_from_env

--- a/tests/pipeline/utils.py
+++ b/tests/pipeline/utils.py
@@ -1,10 +1,8 @@
-from typing import Iterator
 import pytest
 from os import environ
 
 import dlt
 from dlt.common import json
-from dlt.common.configuration.container import Container
 from dlt.common.pipeline import LoadInfo, PipelineContext
 
 from tests.utils import TEST_STORAGE_ROOT
@@ -16,20 +14,6 @@ PIPELINE_TEST_CASES_PATH = "./tests/pipeline/cases/"
 def drop_dataset_from_env() -> None:
     if "DATASET_NAME" in environ:
         del environ["DATASET_NAME"]
-
-
-@pytest.fixture(autouse=True)
-def drop_pipeline() -> Iterator[None]:
-    container = Container()
-    if container[PipelineContext].is_active():
-        container[PipelineContext].deactivate()
-    yield
-    if container[PipelineContext].is_active():
-        # take existing pipeline
-        p = dlt.pipeline()
-        p._wipe_working_folder()
-        # deactivate context
-        container[PipelineContext].deactivate()
 
 
 def assert_load_info(info: LoadInfo, expected_load_packages: int = 1) -> None:
@@ -48,3 +32,29 @@ def json_case_path(name: str) -> str:
 def load_json_case(name: str) -> dict:
     with open(json_case_path(name), "rb") as f:
         return json.load(f)
+
+
+@dlt.source
+def airtable_emojis():
+
+    @dlt.resource(name="📆 Schedule")
+    def schedule():
+
+        yield [1, 2, 3]
+
+    @dlt.resource(name="💰Budget", primary_key=("🔑book_id", "asset_id"))
+    def budget():
+        # return empty
+        yield
+
+    @dlt.resource(name="🦚Peacock", selected=False, primary_key="🔑id")
+    def peacock():
+        dlt.current.resource_state()["🦚🦚🦚"] = "🦚"
+        yield [{"peacock": [1, 2, 3], "🔑id": 1}]
+
+    @dlt.resource(name="🦚WidePeacock", selected=False)
+    def wide_peacock():
+        yield [{"peacock": [1, 2, 3]}]
+
+
+    return budget, schedule, peacock, wide_peacock


### PR DESCRIPTION
this fixes two compounding bugs:
1. too narrow exception used to catch base64 decoding errors that failed when source string contains non ascii characters
2. when writing test for the above it was discovered that in some cases the extract stage does not initialize the discovered tables in the schema which didn't preserve the original resource name (breaking lineage and resource state automation)