### PR TITLE
Fix config dataclasses on python 3.11

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10.x"
+          python-version: "3.11.x"
 
       - name: Install Poetry
         # https://github.com/snok/install-poetry#running-on-windows

--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -23,6 +23,15 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.11.x"]
+        # Test all python versions on ubuntu only
+        include:
+          - os: "ubuntu-latest"
+            python-version: "3.8.x"
+          - os: "ubuntu-latest"
+            python-version: "3.9.x"
+          - os: "ubuntu-latest"
+            python-version: "3.10.x"
     defaults:
       run:
         shell: bash
@@ -35,7 +44,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11.x"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         # https://github.com/snok/install-poetry#running-on-windows

--- a/dlt/common/configuration/specs/base_configuration.py
+++ b/dlt/common/configuration/specs/base_configuration.py
@@ -210,7 +210,7 @@ class BaseConfiguration(MutableMapping[str, Any]):
     @classmethod
     def _get_resolvable_dataclass_fields(cls) -> Iterator[dataclasses.Field[Any]]:
         """Yields all resolvable dataclass fields in the order they should be resolved"""
-        # Sort dynamic type hint fields last because they depend on other values        
+        # Sort dynamic type hint fields last because they depend on other values
         yield from sorted(
             (f for f in cls.__dataclass_fields__.values() if not f.name.startswith("__")),
             key=lambda f: f.name in cls.__hint_resolvers__

--- a/dlt/common/configuration/specs/base_configuration.py
+++ b/dlt/common/configuration/specs/base_configuration.py
@@ -19,6 +19,8 @@ from dlt.common.configuration.exceptions import ConfigFieldMissingTypeHintExcept
 _F_BaseConfiguration: Any = type(object)
 _F_ContainerInjectableContext: Any = type(object)
 
+_T = TypeVar("_T", bound="BaseConfiguration")
+
 
 def is_base_configuration_inner_hint(inner_hint: Type[Any]) -> bool:
     return inspect.isclass(inner_hint) and issubclass(inner_hint, BaseConfiguration)
@@ -80,16 +82,16 @@ def is_secret_hint(hint: Type[Any]) -> bool:
 
 
 @overload
-def configspec(cls: Type[TAnyClass], /, *, init: bool = False) -> Type[TAnyClass]:
+def configspec(cls: Type[TAnyClass]) -> Type[TAnyClass]:
     ...
 
 
 @overload
-def configspec(cls: None = ..., /, *, init: bool = False) -> Callable[[Type[TAnyClass]], Type[TAnyClass]]:
+def configspec(cls: None = ...) -> Callable[[Type[TAnyClass]], Type[TAnyClass]]:
     ...
 
 
-def configspec(cls: Optional[Type[Any]] = None, /, *, init: bool = False) -> Union[Type[TAnyClass], Callable[[Type[TAnyClass]], Type[TAnyClass]]]:
+def configspec(cls: Optional[Type[Any]] = None) -> Union[Type[TAnyClass], Callable[[Type[TAnyClass]], Type[TAnyClass]]]:
     """Converts (via derivation) any decorated class to a Python dataclass that may be used as a spec to resolve configurations
 
     In comparison the Python dataclass, a spec implements full dictionary interface for its attributes, allows instance creation from ie. strings
@@ -103,27 +105,57 @@ def configspec(cls: Optional[Type[Any]] = None, /, *, init: bool = False) -> Uni
         # if type does not derive from BaseConfiguration then derive it
         with contextlib.suppress(NameError):
             if not issubclass(cls, BaseConfiguration):
-                # keep the original module
+                # keep the original module and keep defaults for fields listed in annotations
                 fields = {"__module__": cls.__module__, "__annotations__": getattr(cls, "__annotations__", {})}
+                for key in fields['__annotations__'].keys():  # type: ignore[union-attr]
+                    if key in cls.__dict__:
+                        fields[key] = cls.__dict__[key]
                 cls = type(cls.__name__, (cls, _F_BaseConfiguration), fields)
         # get all annotations without corresponding attributes and set them to None
         for ann in cls.__annotations__:
             if not hasattr(cls, ann) and not ann.startswith(("__", "_abc_impl")):
                 setattr(cls, ann, None)
         # get all attributes without corresponding annotations
-        for att_name, att_value in cls.__dict__.items():
+        for att_name, att_value in list(cls.__dict__.items()):
             # skip callables, dunder names, class variables and some special names
             if callable(att_value):
                 if hint_field_name := getattr(att_value, "__hint_for_field__", None):
                     cls.__hint_resolvers__[hint_field_name] = att_value  # type: ignore[attr-defined]
-                continue
+                    continue
+                try:
+                    # Allow callable config objects (e.g. Incremental)
+                    if not isinstance(att_value, BaseConfiguration):
+                        continue
+                except NameError:
+                    # Dealing with BaseConfiguration itself before it is defined
+                    continue
             if not att_name.startswith(("__", "_abc_impl")) and not isinstance(att_value, (staticmethod, classmethod, property)):
                 if att_name not in cls.__annotations__:
                     raise ConfigFieldMissingTypeHintException(att_name, cls)
                 hint = cls.__annotations__[att_name]
+
                 # context can have any type
                 if not is_valid_hint(hint) and not is_context:
                     raise ConfigFieldTypeHintNotSupported(att_name, cls, hint)
+                if isinstance(att_value, BaseConfiguration):
+                    # Wrap config defaults in default_factory to work around dataclass
+                    # blocking mutable defaults
+                    def default_factory(att_value=att_value):  # type: ignore[no-untyped-def]
+                        return att_value.copy()
+                    setattr(cls, att_name, dataclasses.field(default_factory=default_factory))
+
+
+        # We don't want to overwrite user's __init__ method
+        # Create dataclass init only when not defined in the class
+        # (never put init on BaseConfiguration itself)
+        try:
+            is_base = cls is BaseConfiguration
+        except NameError:
+            is_base = True
+        init = False
+        base_params = getattr(cls, "__dataclass_params__", None)
+        if not is_base and (base_params and base_params.init or cls.__init__ is object.__init__):
+            init = True
         # do not generate repr as it may contain secret values
         return dataclasses.dataclass(cls, init=init, eq=False, repr=False)  # type: ignore
 
@@ -150,6 +182,7 @@ class BaseConfiguration(MutableMapping[str, Any]):
     """Typing for dataclass fields"""
     __hint_resolvers__: ClassVar[Dict[str, Callable[["BaseConfiguration"], Type[Any]]]] = {}
 
+
     def parse_native_representation(self, native_value: Any) -> None:
         """Initialize the configuration fields by parsing the `native_value` which should be a native representation of the configuration
         or credentials, for example database connection string or JSON serialized GCP service credentials file.
@@ -175,14 +208,18 @@ class BaseConfiguration(MutableMapping[str, Any]):
         raise NotImplementedError()
 
     @classmethod
-    def get_resolvable_fields(cls) -> Dict[str, type]:
-        """Returns a mapping of fields to their type hints. Dunders should not be resolved and are not returned"""
-        # Sort dynamic type hint fields last because they depend on other values
-        fields = sorted(
+    def _get_resolvable_dataclass_fields(cls) -> Iterator[dataclasses.Field[Any]]:
+        """Yields all resolvable dataclass fields in the order they should be resolved"""
+        # Sort dynamic type hint fields last because they depend on other values        
+        yield from sorted(
             (f for f in cls.__dataclass_fields__.values() if not f.name.startswith("__")),
             key=lambda f: f.name in cls.__hint_resolvers__
         )
-        return {f.name: f.type for f in fields}
+
+    @classmethod
+    def get_resolvable_fields(cls) -> Dict[str, type]:
+        """Returns a mapping of fields to their type hints. Dunders should not be resolved and are not returned"""
+        return {f.name: f.type for f in cls._get_resolvable_dataclass_fields()}
 
     def is_resolved(self) -> bool:
         return self.__is_resolved__
@@ -199,6 +236,10 @@ class BaseConfiguration(MutableMapping[str, Any]):
     def resolve(self) -> None:
         self.call_method_in_mro("on_resolved")
         self.__is_resolved__ = True
+
+    def copy(self: _T) -> _T:
+        """Returns a (shallow) copy of the configuration instance"""
+        return self.__class__(**dict(self))
 
     # implement dictionary-compatible interface on top of dataclass
 

--- a/dlt/common/configuration/specs/config_section_context.py
+++ b/dlt/common/configuration/specs/config_section_context.py
@@ -3,7 +3,7 @@ from dlt.common.configuration.specs import known_sections
 
 from dlt.common.configuration.specs.base_configuration import ContainerInjectableContext, configspec
 
-@configspec(init=True)
+@configspec
 class ConfigSectionContext(ContainerInjectableContext):
 
     TMergeFunc = Callable[["ConfigSectionContext", "ConfigSectionContext"], None]

--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -21,7 +21,7 @@ INTERNAL_LOADER_FILE_FORMATS: Set[TLoaderFileFormat] = {"puae-jsonl", "sql", "re
 EXTERNAL_LOADER_FILE_FORMATS: Set[TLoaderFileFormat] = set(get_args(TLoaderFileFormat)) - INTERNAL_LOADER_FILE_FORMATS
 
 
-@configspec(init=True)
+@configspec
 class DestinationCapabilitiesContext(ContainerInjectableContext):
     """Injectable destination capabilities required for many Pipeline stages ie. normalize"""
     preferred_loader_file_format: TLoaderFileFormat

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -21,7 +21,7 @@ from dlt.common.configuration.specs import GcpCredentials, AwsCredentialsWithout
 
 TLoaderReplaceStrategy = Literal["truncate-and-insert", "insert-from-staging", "staging-optimized"]
 
-@configspec(init=True)
+@configspec
 class DestinationClientConfiguration(BaseConfiguration):
     destination_name: str = None  # which destination to load data to
     credentials: Optional[CredentialsConfiguration]
@@ -40,7 +40,7 @@ class DestinationClientConfiguration(BaseConfiguration):
             ...
 
 
-@configspec(init=True)
+@configspec
 class DestinationClientDwhConfiguration(DestinationClientConfiguration):
     # keep default/initial value if present
     dataset_name: Final[str] = None
@@ -62,7 +62,7 @@ class DestinationClientDwhConfiguration(DestinationClientConfiguration):
         ) -> None:
             ...
 
-@configspec(init=True)
+@configspec
 class DestinationClientStagingConfiguration(DestinationClientDwhConfiguration):
     as_staging: bool = False
 

--- a/dlt/common/normalizers/configuration.py
+++ b/dlt/common/normalizers/configuration.py
@@ -8,7 +8,7 @@ from dlt.common.normalizers.typing import TJSONNormalizer
 from dlt.common.typing import StrAny
 
 
-@configspec(init=True)
+@configspec
 class NormalizersConfiguration(BaseConfiguration):
     # always in section
     __section__: str = "schema"

--- a/dlt/common/pipeline.py
+++ b/dlt/common/pipeline.py
@@ -223,7 +223,7 @@ class SupportsPipelineRun(Protocol):
         ...
 
 
-@configspec(init=True)
+@configspec
 class PipelineContext(ContainerInjectableContext):
     _deferred_pipeline: Callable[[], SupportsPipeline]
     _pipeline: SupportsPipeline
@@ -258,7 +258,7 @@ class PipelineContext(ContainerInjectableContext):
         self._deferred_pipeline = deferred_pipeline
 
 
-@configspec(init=True)
+@configspec
 class StateInjectableContext(ContainerInjectableContext):
     state: TPipelineState
 

--- a/dlt/common/reflection/spec.py
+++ b/dlt/common/reflection/spec.py
@@ -103,7 +103,7 @@ def spec_from_signature(f: AnyFun, sig: Signature, include_defaults: bool = True
     fields["__annotations__"] = annotations
     # synthesize type
     T: Type[BaseConfiguration] = type(name, (BaseConfiguration,), fields)
-    SPEC = configspec(init=False)(T)
+    SPEC = configspec()(T)
     # add to the module
     setattr(module, spec_id, SPEC)
     return SPEC

--- a/dlt/common/runners/configuration.py
+++ b/dlt/common/runners/configuration.py
@@ -6,7 +6,7 @@ from dlt.common.configuration.specs import BaseConfiguration
 TPoolType = Literal["process", "thread", "none"]
 
 
-@configspec(init=True)
+@configspec
 class PoolRunnerConfiguration(BaseConfiguration):
     pool_type: TPoolType = None  # type of pool to run, must be set in derived configs
     workers: Optional[int] = None  # how many threads/processes in the pool

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -6,7 +6,7 @@ TSchemaFileFormat = Literal["json", "yaml"]
 SchemaFileExtensions = get_args(TSchemaFileFormat)
 
 
-@configspec(init=True)
+@configspec
 class SchemaStorageConfiguration(BaseConfiguration):
     schema_volume_path: str = None  # path to volume with default schemas
     import_schema_path: Optional[str] = None  # import schema from external location
@@ -19,7 +19,7 @@ class SchemaStorageConfiguration(BaseConfiguration):
             ...
 
 
-@configspec(init=True)
+@configspec
 class NormalizeStorageConfiguration(BaseConfiguration):
     normalize_volume_path: str = None  # path to volume where normalized loader files will be stored
 
@@ -28,7 +28,7 @@ class NormalizeStorageConfiguration(BaseConfiguration):
             ...
 
 
-@configspec(init=True)
+@configspec
 class LoadStorageConfiguration(BaseConfiguration):
     load_volume_path: str = None  # path to volume where files to be loaded to analytical storage are stored
     delete_completed_jobs: bool = False  # if set to true the folder with completed jobs will be deleted

--- a/dlt/destinations/bigquery/configuration.py
+++ b/dlt/destinations/bigquery/configuration.py
@@ -8,7 +8,7 @@ from dlt.common.utils import digest128
 from dlt.common.destination.reference import DestinationClientDwhConfiguration
 
 
-@configspec(init=True)
+@configspec
 class BigQueryClientConfiguration(DestinationClientDwhConfiguration):
     destination_name: str = "bigquery"
     credentials: GcpServiceAccountCredentials = None

--- a/dlt/destinations/duckdb/configuration.py
+++ b/dlt/destinations/duckdb/configuration.py
@@ -174,7 +174,7 @@ class DuckDbCredentials(DuckDbBaseCredentials):
         return default_path, True
 
 
-@configspec(init=True)
+@configspec
 class DuckDbClientConfiguration(DestinationClientDwhConfiguration):
     destination_name: Final[str] = "duckdb"  # type: ignore
     credentials: DuckDbCredentials

--- a/dlt/destinations/dummy/configuration.py
+++ b/dlt/destinations/dummy/configuration.py
@@ -10,7 +10,7 @@ class DummyClientCredentials(CredentialsConfiguration):
         return "/dev/null"
 
 
-@configspec(init=True)
+@configspec
 class DummyClientConfiguration(DestinationClientConfiguration):
     destination_name: str = "dummy"
     loader_file_format: TLoaderFileFormat = "jsonl"

--- a/dlt/destinations/filesystem/configuration.py
+++ b/dlt/destinations/filesystem/configuration.py
@@ -17,7 +17,7 @@ PROTOCOL_CREDENTIALS = {
 }
 
 
-@configspec(init=True)
+@configspec
 class FilesystemClientConfiguration(DestinationClientStagingConfiguration):
     destination_name: Final[str] = "filesystem"  # type: ignore
     # should be an union of all possible credentials as found in PROTOCOL_CREDENTIALS

--- a/dlt/destinations/motherduck/configuration.py
+++ b/dlt/destinations/motherduck/configuration.py
@@ -38,7 +38,7 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
             raise ConfigurationValueError("Motherduck schema 'md' was specified without corresponding token or password. The required format of connection string is: md:///<database_name>?token=<token>")
 
 
-@configspec(init=True)
+@configspec
 class MotherDuckClientConfiguration(DestinationClientDwhConfiguration):
     destination_name: Final[str] = "motherduck"  # type: ignore
     credentials: MotherDuckCredentials

--- a/dlt/destinations/postgres/configuration.py
+++ b/dlt/destinations/postgres/configuration.py
@@ -34,7 +34,7 @@ class PostgresCredentials(ConnectionStringCredentials):
         return url
 
 
-@configspec(init=True)
+@configspec
 class PostgresClientConfiguration(DestinationClientDwhConfiguration):
     destination_name: Final[str] = "postgres"  # type: ignore
     credentials: PostgresCredentials

--- a/dlt/destinations/redshift/configuration.py
+++ b/dlt/destinations/redshift/configuration.py
@@ -15,7 +15,7 @@ class RedshiftCredentials(PostgresCredentials):
     host: str = None
 
 
-@configspec(init=True)
+@configspec
 class RedshiftClientConfiguration(PostgresClientConfiguration):
     destination_name: Final[str] = "redshift"  # type: ignore
     credentials: RedshiftCredentials

--- a/dlt/destinations/snowflake/configuration.py
+++ b/dlt/destinations/snowflake/configuration.py
@@ -83,7 +83,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         )
 
 
-@configspec(init=True)
+@configspec
 class SnowflakeClientConfiguration(DestinationClientDwhConfiguration):
     destination_name: Final[str] = "snowflake"  # type: ignore[misc]
     credentials: SnowflakeCredentials

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -27,7 +27,7 @@ from dlt.extract.source import DltResource, DltSource, TUnboundDltResource
 
 
 
-@configspec(init=True)
+@configspec
 class SourceSchemaInjectableContext(ContainerInjectableContext):
     """A context containing the source schema, present when decorated function is executed"""
     schema: Schema

--- a/dlt/load/configuration.py
+++ b/dlt/load/configuration.py
@@ -5,7 +5,7 @@ from dlt.common.storages import LoadStorageConfiguration
 from dlt.common.runners.configuration import PoolRunnerConfiguration, TPoolType
 
 
-@configspec(init=True)
+@configspec
 class LoaderConfiguration(PoolRunnerConfiguration):
     workers: int = 20
     """how many parallel loads can be executed"""

--- a/dlt/normalize/configuration.py
+++ b/dlt/normalize/configuration.py
@@ -6,7 +6,7 @@ from dlt.common.runners.configuration import PoolRunnerConfiguration, TPoolType
 from dlt.common.storages import LoadStorageConfiguration, NormalizeStorageConfiguration, SchemaStorageConfiguration
 
 
-@configspec(init=True)
+@configspec
 class NormalizeConfiguration(PoolRunnerConfiguration):
     pool_type: TPoolType = "process"
     destination_capabilities: DestinationCapabilitiesContext = None  # injectable

--- a/tests/common/configuration/test_configuration.py
+++ b/tests/common/configuration/test_configuration.py
@@ -77,12 +77,12 @@ class MockProdConfiguration(RunConfiguration):
     pipeline_name: str = "comp"
 
 
-@configspec(init=True)
+@configspec
 class FieldWithNoDefaultConfiguration(RunConfiguration):
     no_default: str
 
 
-@configspec(init=True)
+@configspec
 class InstrumentedConfiguration(BaseConfiguration):
     head: str
     tube: List[str]
@@ -106,7 +106,7 @@ class InstrumentedConfiguration(BaseConfiguration):
             raise RuntimeError("Head over heels")
 
 
-@configspec(init=True)
+@configspec
 class EmbeddedConfiguration(BaseConfiguration):
     default: str
     instrumented: InstrumentedConfiguration
@@ -130,22 +130,22 @@ class NonTemplatedComplexTypesConfiguration(BaseConfiguration):
     dict_val: dict
 
 
-@configspec(init=True)
+@configspec
 class DynamicConfigA(BaseConfiguration):
     field_for_a: str
 
 
-@configspec(init=True)
+@configspec
 class DynamicConfigB(BaseConfiguration):
     field_for_b: str
 
 
-@configspec(init=True)
+@configspec
 class DynamicConfigC(BaseConfiguration):
     field_for_c: str
 
 
-@configspec(init=True)
+@configspec
 class ConfigWithDynamicType(BaseConfiguration):
     discriminator: str
     embedded_config: BaseConfiguration
@@ -159,7 +159,7 @@ class ConfigWithDynamicType(BaseConfiguration):
         return BaseConfiguration
 
 
-@configspec(init=True)
+@configspec
 class ConfigWithInvalidDynamicType(BaseConfiguration):
     @resolve_type('a')
     def resolve_a_type(self) -> Type[BaseConfiguration]:
@@ -174,7 +174,7 @@ class ConfigWithInvalidDynamicType(BaseConfiguration):
         return DynamicConfigC
 
 
-@configspec(init=True)
+@configspec
 class SubclassConfigWithDynamicType(ConfigWithDynamicType):
     is_number: bool
     dynamic_type_field: Any
@@ -767,7 +767,7 @@ def test_is_valid_hint() -> None:
 
 def test_configspec_auto_base_config_derivation() -> None:
 
-    @configspec(init=True)
+    @configspec
     class AutoBaseDerivationConfiguration:
         auto: str
 

--- a/tests/common/configuration/test_container.py
+++ b/tests/common/configuration/test_container.py
@@ -12,7 +12,7 @@ from tests.utils import preserve_environ
 from tests.common.configuration.utils import environment
 
 
-@configspec(init=True)
+@configspec
 class InjectableTestContext(ContainerInjectableContext):
     current_value: str
 

--- a/tests/common/configuration/utils.py
+++ b/tests/common/configuration/utils.py
@@ -57,7 +57,7 @@ class WithCredentialsConfiguration(BaseConfiguration):
     credentials: SecretCredentials
 
 
-@configspec(init=True)
+@configspec
 class SectionedConfiguration(BaseConfiguration):
     __section__ = "DLT_TEST"
 

--- a/tests/common/reflection/test_reflect_spec.py
+++ b/tests/common/reflection/test_reflect_spec.py
@@ -22,7 +22,7 @@ def test_synthesize_spec_from_sig() -> None:
     def f_typed(p1: str = None, p2: Decimal = None, p3: Any = None, p4: Optional[RunConfiguration] = None, p5: TSecretValue = dlt.secrets.value) -> None:
         pass
 
-    SPEC = spec_from_signature(f_typed, inspect.signature(f_typed))
+    SPEC = spec_from_signature(f_typed, inspect.signature(f_typed))()
     assert SPEC.p1 is None
     assert SPEC.p2 is None
     assert SPEC.p3 is None
@@ -36,7 +36,7 @@ def test_synthesize_spec_from_sig() -> None:
     def f_typed_default(t_p1: str = "str", t_p2: Decimal = _DECIMAL_DEFAULT, t_p3: Any = _SECRET_DEFAULT, t_p4: RunConfiguration = _CONFIG_DEFAULT, t_p5: str = None) -> None:
         pass
 
-    SPEC = spec_from_signature(f_typed_default, inspect.signature(f_typed_default))
+    SPEC = spec_from_signature(f_typed_default, inspect.signature(f_typed_default))()
     assert SPEC.t_p1 == "str"
     assert SPEC.t_p2 == _DECIMAL_DEFAULT
     assert SPEC.t_p3 == _SECRET_DEFAULT
@@ -52,7 +52,7 @@ def test_synthesize_spec_from_sig() -> None:
     def f_untyped(untyped_p1 = None, untyped_p2 = dlt.config.value) -> None:
         pass
 
-    SPEC = spec_from_signature(f_untyped, inspect.signature(f_untyped))
+    SPEC = spec_from_signature(f_untyped, inspect.signature(f_untyped))()
     assert SPEC.untyped_p1 is None
     assert SPEC.untyped_p2 is None
     fields = SPEC.get_resolvable_fields()
@@ -65,7 +65,7 @@ def test_synthesize_spec_from_sig() -> None:
         pass
 
 
-    SPEC = spec_from_signature(f_untyped_default, inspect.signature(f_untyped_default))
+    SPEC = spec_from_signature(f_untyped_default, inspect.signature(f_untyped_default))()
     assert SPEC.untyped_p1 == "str"
     assert SPEC.untyped_p2 == _DECIMAL_DEFAULT
     assert isinstance(SPEC.untyped_p3, RunConfiguration)
@@ -79,7 +79,7 @@ def test_synthesize_spec_from_sig() -> None:
     def f_pos_kw_only(pos_only_1=dlt.config.value, pos_only_2: str = "default", /, *, kw_only_1=None, kw_only_2: int = 2) -> None:
         pass
 
-    SPEC = spec_from_signature(f_pos_kw_only, inspect.signature(f_pos_kw_only))
+    SPEC = spec_from_signature(f_pos_kw_only, inspect.signature(f_pos_kw_only))()
     assert SPEC.pos_only_1 is None
     assert SPEC.pos_only_2 == "default"
     assert SPEC.kw_only_1 is None
@@ -89,8 +89,8 @@ def test_synthesize_spec_from_sig() -> None:
 
     # skip arguments with defaults
     # deregister spec to disable cache
-    del globals()[SPEC.__name__]
-    SPEC = spec_from_signature(f_pos_kw_only, inspect.signature(f_pos_kw_only), include_defaults=False)
+    del globals()[SPEC.__class__.__name__]
+    SPEC = spec_from_signature(f_pos_kw_only, inspect.signature(f_pos_kw_only), include_defaults=False)()
     assert not hasattr(SPEC, "kw_only_1")
     assert not hasattr(SPEC, "kw_only_2")
     assert not hasattr(SPEC, "pos_only_2")
@@ -101,7 +101,7 @@ def test_synthesize_spec_from_sig() -> None:
     def f_variadic(var_1: str = "A", *args, kw_var_1: str, **kwargs) -> None:
         print(locals())
 
-    SPEC = spec_from_signature(f_variadic, inspect.signature(f_variadic))
+    SPEC = spec_from_signature(f_variadic, inspect.signature(f_variadic))()
     assert SPEC.var_1 == "A"
     assert not hasattr(SPEC, "kw_var_1")  # kw parameters that must be explicitly passed are removed
     assert not hasattr(SPEC, "args")

--- a/tests/common/runners/test_runners.py
+++ b/tests/common/runners/test_runners.py
@@ -14,19 +14,19 @@ from tests.common.runners.utils import _TestRunnableWorkerMethod, _TestRunnableW
 from tests.utils import init_test_logging
 
 
-@configspec(init=True)
+@configspec
 class ModPoolRunnerConfiguration(PoolRunnerConfiguration):
     pipeline_name: str = "testrunners"
     pool_type: TPoolType = "none"
     run_sleep: float = 0.1
 
 
-@configspec(init=True)
+@configspec
 class ProcessPoolConfiguration(ModPoolRunnerConfiguration):
     pool_type: TPoolType = "process"
 
 
-@configspec(init=True)
+@configspec
 class ThreadPoolConfiguration(ModPoolRunnerConfiguration):
     pool_type: TPoolType = "thread"
 

--- a/tests/common/runtime/test_telemetry.py
+++ b/tests/common/runtime/test_telemetry.py
@@ -24,7 +24,7 @@ class SentryLoggerConfiguration(RunConfiguration):
     dlthub_telemetry_segment_write_key: str = "TLJiyRkGVZGCi2TtjClamXpFcxAA1rSB"
 
 
-@configspec(init=True)
+@configspec
 class SentryLoggerCriticalConfiguration(SentryLoggerConfiguration):
     log_level: str = "CRITICAL"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,10 @@ def pytest_configure(config):
 
     test_storage_root = "_storage"
     run_configuration.RunConfiguration.config_files_storage_path = os.path.join(test_storage_root, "config/")
-    # push telemetry to CI
     run_configuration.RunConfiguration.dlthub_telemetry_segment_write_key = "TLJiyRkGVZGCi2TtjClamXpFcxAA1rSB"
+    delattr(run_configuration.RunConfiguration, "__init__")
+    run_configuration.RunConfiguration = dataclasses.dataclass(run_configuration.RunConfiguration, init=True, repr=False)  # type: ignore
+    # push telemetry to CI
 
     storage_configuration.LoadStorageConfiguration.load_volume_path = os.path.join(test_storage_root, "load")
     delattr(storage_configuration.LoadStorageConfiguration, "__init__")


### PR DESCRIPTION
https://github.com/dlt-hub/dlt/issues/378

Modified the `@configspec` decorator to automatically wrap any default values which are `BaseConfiguration` instances.

So that:

```python
@configspec
class MyConfig:
    created_at: dlt.sources.incremental = dlt.sources.incremental('created_at', '2022-01-01')
```
Becomes equivalent to:

```python
default_incremental = dlt.sources.incremental('created_at', '2022-01-01')

@configspec
class MyConfig:
    created_at: dlt.sources.incremental = dataclasses.field(
        default_factory=lambda: default_incremental.copy()
    )
```

Note:

1. `@configspec` `init` argument is removed.
   Default factories are called in the generated `__init__`, so now the
   dataclass is always created with `init=True` EXCEPT when the class (or base class) defines a custom init.
   
2. Wrapped default attributes are only set on the instance
    
    `MyConfig.created_at` is an `AttributeError`
    but `MyConfig().created_at` has the default value.  
    
    That's just how dataclass fields work but may lead to confusing bugs.