### PR TITLE
fixes airflow provider init sequence

### DIFF
--- a/dlt/common/configuration/providers/airflow.py
+++ b/dlt/common/configuration/providers/airflow.py
@@ -1,5 +1,3 @@
-from airflow.models import Variable
-
 from .toml import VaultTomlProvider
 
 
@@ -13,6 +11,7 @@ class AirflowSecretsTomlProvider(VaultTomlProvider):
 
     def _look_vault(self, full_key: str, hint: type) -> str:
         """Get Airflow Variable with given `full_key`, return None if not found"""
+        from airflow.models import Variable
         return Variable.get(full_key, default_var=None)  # type: ignore
 
     @property

--- a/tests/helpers/airflow_tests/test_airflow_provider.py
+++ b/tests/helpers/airflow_tests/test_airflow_provider.py
@@ -27,6 +27,9 @@ def test_airflow_secrets_toml_provider() -> None:
         from dlt.common.configuration.providers.airflow import AirflowSecretsTomlProvider
 
         Variable.set(SECRETS_TOML_KEY, SECRETS_TOML_CONTENT)
+        # make sure provider works while creating DAG
+        provider = AirflowSecretsTomlProvider()
+        assert provider.get_value("api_key", str, None, "sources")[0] == "test_value"
 
         @task()
         def test_task():
@@ -78,6 +81,7 @@ def test_airflow_secrets_toml_provider_import_dlt_dag() -> None:
 
         # this will initialize provider context
         api_key = secrets["sources.api_key"]
+        assert api_key == "test_value"
 
         @task()
         def test_task():


### PR DESCRIPTION
Fixes a problem reported by our users - when airflow dependency was installed and then their meta database got broken, dlt was failing on getting airflow Variable with dlt secrets.

that was due to initialization of the provider out of exception handler