### PR TITLE
Feat: don't require AWS credentials for ext stage

### DIFF
--- a/dlt/destinations/snowflake/snowflake.py
+++ b/dlt/destinations/snowflake/snowflake.py
@@ -68,8 +68,11 @@ class SnowflakeLoadJob(LoadJob, FollowupJob):
         stage_file_path = ""
 
         if bucket_path:
-            # s3 credentials case
-            if bucket_path.startswith("s3://") and staging_credentials and isinstance(staging_credentials, AwsCredentialsWithoutDefaults):
+            # referencing an external s3 stage does not require explicit AWS credentials
+            if bucket_path.startswith("s3://") and stage_name:
+                from_clause = f"FROM '@{stage_name}'"
+            # referencing an staged files via a bucket URL requires explicit AWS credentials
+            elif bucket_path.startswith("s3://") and staging_credentials and isinstance(staging_credentials, AwsCredentialsWithoutDefaults):
                 credentials_clause = f"""CREDENTIALS=(AWS_KEY_ID='{staging_credentials.aws_access_key_id}' AWS_SECRET_KEY='{staging_credentials.aws_secret_access_key}')"""
                 from_clause = f"FROM '{bucket_path}'"
             else:

--- a/dlt/destinations/snowflake/snowflake.py
+++ b/dlt/destinations/snowflake/snowflake.py
@@ -71,6 +71,7 @@ class SnowflakeLoadJob(LoadJob, FollowupJob):
             # referencing an external s3 stage does not require explicit AWS credentials
             if bucket_path.startswith("s3://") and stage_name:
                 from_clause = f"FROM '@{stage_name}'"
+                files_clause = f"FILES = ('{urlparse(bucket_path).path.lstrip('/')}')"
             # referencing an staged files via a bucket URL requires explicit AWS credentials
             elif bucket_path.startswith("s3://") and staging_credentials and isinstance(staging_credentials, AwsCredentialsWithoutDefaults):
                 credentials_clause = f"""CREDENTIALS=(AWS_KEY_ID='{staging_credentials.aws_access_key_id}' AWS_SECRET_KEY='{staging_credentials.aws_secret_access_key}')"""

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -110,6 +110,7 @@ def destinations_configs(
             DestinationTestConfiguration(destination="redshift", staging="filesystem", file_format="parquet", bucket_url=AWS_BUCKET, staging_iam_role="arn:aws:iam::267388281016:role/redshift_s3_read", extra_info="s3-role"),
             DestinationTestConfiguration(destination="bigquery", staging="filesystem", file_format="parquet", bucket_url=GCS_BUCKET, extra_info="gcs-authorization"),
             DestinationTestConfiguration(destination="snowflake", staging="filesystem", file_format="jsonl", bucket_url=GCS_BUCKET, stage_name="PUBLIC.dlt_gcs_stage", extra_info="gcs-integration"),
+            DestinationTestConfiguration(destination="snowflake", staging="filesystem", file_format="jsonl", bucket_url=AWS_BUCKET, extra_info="s3-integration"),
             DestinationTestConfiguration(destination="snowflake", staging="filesystem", file_format="jsonl", bucket_url=AWS_BUCKET, stage_name="PUBLIC.dlt_s3_stage", extra_info="s3-integration")
         ]
 


### PR DESCRIPTION
Re-opening #580 as contributor

As special note on testing this "feature": I went down the pragmatic route by just having two s3-staged Snowflake destination configs in the tests, one with and one without a stage name.

For the config that contains a stage name, dlt will reference the staged data through the stage name and therefore, Snowflake will load the data through the underlying storage integration without requiring any explicit s3 credentials.

For the config that has NO stage name, dlt will reference the staged data through the s3 URL and therefore, Snowflake will rely on the access key and access key ID being provided explicitly in the loading statement.

A more "rigorous" way of testing it would have been the following, but I found it prohibitively complex to implement as pipelines don't have separate APIs for loading data into the staging location before loading it from there into the destination table.
1. Load the normalized data into the s3 stage
2. Remove the s3 credentials from the config
3. Load the data from the s3 stage into Snowflake

Please let me know how you feel about the testing approach @rudolfix @sh-rp 