### PR TITLE
retain schema hints order

### DIFF
--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -3,6 +3,7 @@ from copy import copy, deepcopy
 from typing import ClassVar, Dict, List, Mapping, Optional, Sequence, Tuple, Any, cast
 from dlt.common import json
 
+from dlt.common.utils import extend_list_deduplicated
 from dlt.common.typing import DictStrAny, StrAny, REPattern, SupportsVariant, VARIANT_FIELD_FORMAT, TDataItem
 from dlt.common.normalizers import TNormalizersConfig, explicit_normalizers, import_normalizers
 from dlt.common.normalizers.naming import NamingConvention
@@ -231,8 +232,7 @@ class Schema:
         # add `new_hints` to existing hints
         for h, l in new_hints.items():
             if h in default_hints:
-                # merge if hint of this type exist
-                default_hints[h] = list(set(default_hints[h] + list(l)))
+                extend_list_deduplicated(default_hints[h], l)
             else:
                 # set new hint type
                 default_hints[h] = l  # type: ignore

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -10,7 +10,7 @@ from os import environ
 from types import ModuleType
 import zlib
 
-from typing import Any, ContextManager, Dict, Iterator, Optional, Sequence, Set, Tuple, TypeVar, Mapping, List, Union, Counter
+from typing import Any, ContextManager, Dict, Iterator, Optional, Sequence, Set, Tuple, TypeVar, Mapping, List, Union, Counter, Iterable
 from collections.abc import Mapping as C_Mapping
 
 from dlt.common.typing import AnyFun, StrAny, DictStrAny, StrStr, TAny, TFun
@@ -425,3 +425,12 @@ def compressed_b64decode(value: str) -> bytes:
 
 def identity(x: TAny) -> TAny:
     return x
+
+
+def extend_list_deduplicated(original_list: List[Any], extending_list: Iterable[Any]) -> List[Any]:
+    """extends the first list by the second, but does not add duplicates"""
+    list_keys = set(original_list)
+    for item in extending_list:
+        if item not in list_keys:
+            original_list.append(item)
+    return original_list

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from dlt.common.runners import Venv
 from dlt.common.utils import (graph_find_scc_nodes, flatten_list_of_str_or_dicts, digest128, graph_edges_to_nodes, map_nested_in_place,
-                              reveal_pseudo_secret, obfuscate_pseudo_secret, get_module_name, concat_strings_with_limit)
+                              reveal_pseudo_secret, obfuscate_pseudo_secret, get_module_name, concat_strings_with_limit, extend_list_deduplicated)
 
 
 def test_flatten_list_of_str_or_dicts() -> None:
@@ -125,3 +125,10 @@ def test_graph_edges_to_nodes() -> None:
     assert graph_edges_to_nodes([]) == {}
     # ignores double edge
     assert graph_edges_to_nodes([('A', 'B'), ('A', 'B')]) == {'A': {'B'}, 'B': set()}
+
+
+def test_extend_list_deduplicated() -> None:
+    assert extend_list_deduplicated(["one", "two", "three"], ["four", "five", "six"]) == ["one", "two", "three", "four", "five", "six"]
+    assert extend_list_deduplicated(["one", "two", "three", "six"], ["two", "four", "five", "six"]) == ["one", "two", "three", "six", "four", "five"]
+    assert extend_list_deduplicated(["one", "two", "three"], ["one", "two", "three"]) == ["one", "two", "three"]
+    assert extend_list_deduplicated([], ["one", "two", "three"]) == ["one", "two", "three"]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR fixes a bug where the schema sometimes changed order of the hints resulting in unnecessary schema version updates.