### PR TITLE
Feat: add time to pua serde

### DIFF
--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -1,7 +1,7 @@
 import os
 import base64
 import dataclasses
-from datetime import date, datetime  # noqa: I251
+from datetime import date, datetime, time  # noqa: I251
 from typing import Any, Callable, List, Protocol, IO, Union
 from uuid import UUID
 from hexbytes import HexBytes
@@ -98,6 +98,7 @@ _UUIDT = '\uF029'
 _HEXBYTES = '\uF02A'
 _B64BYTES = '\uF02B'
 _WEI = '\uF02C'
+_TIME = '\uF02D'
 
 DECODERS: List[Callable[[Any], Any]] = [
     Decimal,
@@ -106,7 +107,8 @@ DECODERS: List[Callable[[Any], Any]] = [
     UUID,
     HexBytes,
     base64.b64decode,
-    Wei
+    Wei,
+    time.fromisoformat,
 ]
 
 
@@ -124,6 +126,8 @@ def custom_pua_encode(obj: Any) -> str:
         return _DATETIME + r
     elif isinstance(obj, date):
         return _DATE + obj.isoformat()
+    elif isinstance(obj, time):
+        return _TIME + obj.isoformat()
     elif isinstance(obj, UUID):
         return _UUIDT + str(obj)
     elif isinstance(obj, HexBytes):

--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -73,6 +73,8 @@ def custom_encode(obj: Any) -> str:
         return r
     elif isinstance(obj, date):
         return obj.isoformat()
+    elif isinstance(obj, time):
+        return obj.isoformat()
     elif isinstance(obj, UUID):
         return str(obj)
     elif isinstance(obj, HexBytes):
@@ -100,6 +102,8 @@ _B64BYTES = '\uF02B'
 _WEI = '\uF02C'
 _TIME = '\uF02D'
 
+
+# define decoder for each prefix
 DECODERS: List[Callable[[Any], Any]] = [
     Decimal,
     parse_iso_like_datetime,
@@ -108,8 +112,10 @@ DECODERS: List[Callable[[Any], Any]] = [
     HexBytes,
     base64.b64decode,
     Wei,
-    time.fromisoformat,
+    lambda s: s  # NOTE: we keep iso implementation until we have TIME, time.fromisoformat,
 ]
+# how many decoders?
+PUA_CHARACTER_MAX = len(DECODERS)
 
 
 def custom_pua_encode(obj: Any) -> str:
@@ -149,7 +155,7 @@ def custom_pua_decode(obj: Any) -> Any:
     if isinstance(obj, str) and len(obj) > 1:
         c = ord(obj[0]) - 0xF026
         # decode only the PUA space defined in DECODERS
-        if c >=0 and c <= 6:
+        if c >=0 and c <= PUA_CHARACTER_MAX:
             return DECODERS[c](obj[1:])
     return obj
 
@@ -167,7 +173,7 @@ def custom_pua_remove(obj: Any) -> Any:
     if isinstance(obj, str) and len(obj) > 1:
         c = ord(obj[0]) - 0xF026
         # decode only the PUA space defined in DECODERS
-        if c >=0 and c <= 6:
+        if c >=0 and c <= PUA_CHARACTER_MAX:
             return obj[1:]
     return obj
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dlt"
-version = "0.3.15"
+version = "0.3.16a0"
 description = "DLT is an open-source python-native scalable data loading framework that does not require any devops efforts to run."
 authors = ["dltHub Inc. <services@dlthub.com>"]
 maintainers = [ "Marcin Rudolf <marcin@dlthub.com>", "Adrian Brudaru <adrian@dlthub.com>", "Ty Dunn <ty@dlthub.com>"]

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -20,8 +20,12 @@ JSON_TYPED_DICT: StrAny = {
     # "uuid": UUID(_UUID),
     "hexbytes": HexBytes("0x2137"),
     "bytes": b'2137',
-    "wei": Wei.from_int256(2137, decimals=2)
+    "wei": Wei.from_int256(2137, decimals=2),
+    "time": pendulum.parse("2005-04-02T20:37:37.358236Z").time()
 }
+# TODO: a version after PUA decoder (time is not yet implemented end to end)
+JSON_TYPED_DICT_DECODED = dict(JSON_TYPED_DICT)
+JSON_TYPED_DICT_DECODED["time"] = JSON_TYPED_DICT["time"].isoformat()
 
 JSON_TYPED_DICT_TYPES: Dict[str, TDataType] = {
     "str": "text",
@@ -32,7 +36,8 @@ JSON_TYPED_DICT_TYPES: Dict[str, TDataType] = {
     # "uuid": "text",
     "hexbytes": "binary",
     "bytes": "binary",
-    "wei": "wei"
+    "wei": "wei",
+    "time": "text"
 }
 
 JSON_TYPED_DICT_NESTED = {
@@ -40,6 +45,12 @@ JSON_TYPED_DICT_NESTED = {
     "list_dicts": [dict(JSON_TYPED_DICT), dict(JSON_TYPED_DICT)],
     "list": list(JSON_TYPED_DICT.values()),
     **JSON_TYPED_DICT
+}
+JSON_TYPED_DICT_NESTED_DECODED = {
+    "dict": dict(JSON_TYPED_DICT_DECODED),
+    "list_dicts": [dict(JSON_TYPED_DICT_DECODED), dict(JSON_TYPED_DICT_DECODED)],
+    "list": list(JSON_TYPED_DICT_DECODED.values()),
+    **JSON_TYPED_DICT_DECODED
 }
 
 TABLE_UPDATE: List[TColumnSchema] = [

--- a/tests/common/test_json.py
+++ b/tests/common/test_json.py
@@ -9,7 +9,7 @@ from dlt.common.arithmetics import numeric_default_context
 from dlt.common.json import _DECIMAL, _WEI, custom_pua_decode, _orjson, _simplejson, SupportsJson
 
 from tests.utils import autouse_test_storage, TEST_STORAGE_ROOT
-from tests.cases import JSON_TYPED_DICT, JSON_TYPED_DICT_NESTED
+from tests.cases import JSON_TYPED_DICT, JSON_TYPED_DICT_DECODED, JSON_TYPED_DICT_NESTED, JSON_TYPED_DICT_NESTED_DECODED
 from tests.common.utils import json_case_path, load_json_case
 
 
@@ -188,6 +188,11 @@ def test_json_pendulum(json_impl: SupportsJson) -> None:
     # mock hh:mm (incorrect) TZ notation which must serialize to UTC as well
     s_r = json_impl.loads(s[:-3] + '+00:00"}')
     assert pendulum.parse(s_r["t"]) == now
+    # serialize date and time
+    s = json_impl.dumps(JSON_TYPED_DICT)
+    s_r = json_impl.loads(s)
+    assert s_r["date"] == "2022-02-02"
+    assert s_r["time"] == "20:37:37.358236"
 
 
 @pytest.mark.parametrize("json_impl", _JSON_IMPL)
@@ -219,8 +224,8 @@ def test_json_typed_dumps_loads(json_impl: SupportsJson) -> None:
     s = json_impl.typed_dumps(JSON_TYPED_DICT_NESTED)
     b = json_impl.typed_dumpb(JSON_TYPED_DICT_NESTED)
 
-    assert json_impl.typed_loads(s) == JSON_TYPED_DICT_NESTED
-    assert json_impl.typed_loadb(b) == JSON_TYPED_DICT_NESTED
+    assert json_impl.typed_loads(s) == JSON_TYPED_DICT_NESTED_DECODED
+    assert json_impl.typed_loadb(b) == JSON_TYPED_DICT_NESTED_DECODED
 
     # Test load/dump naked
     dt = pendulum.now()
@@ -240,7 +245,7 @@ def test_json_typed_encode(json_impl: SupportsJson) -> None:
     assert d["wei"][0] == _WEI
     # decode all
     d_d = {k: custom_pua_decode(v) for k,v in d.items()}
-    assert d_d == JSON_TYPED_DICT
+    assert d_d == JSON_TYPED_DICT_DECODED
 
 
 def test_load_and_compare_all_impls() -> None:

--- a/tests/load/pipeline/test_restore_state.py
+++ b/tests/load/pipeline/test_restore_state.py
@@ -81,11 +81,11 @@ def test_restore_state_utils(destination_config: DestinationTestConfiguration) -
         # extract state again
         with p.managed_state(extract_state=True) as managed_state:
             # this will be saved
-            managed_state["sources"] = {"source": dict(JSON_TYPED_DICT)}
+            managed_state["sources"] = {"source": dict(JSON_TYPED_DICT_DECODED)}
         p.normalize(loader_file_format=destination_config.file_format)
         p.load()
         stored_state = load_state_from_destination(p.pipeline_name, job_client.sql_client)
-        assert stored_state["sources"] == {"source": JSON_TYPED_DICT}
+        assert stored_state["sources"] == {"source": JSON_TYPED_DICT_DECODED}
         local_state = p._get_state()
         local_state.pop("_local")
         assert stored_state == local_state

--- a/tests/load/pipeline/test_restore_state.py
+++ b/tests/load/pipeline/test_restore_state.py
@@ -15,7 +15,7 @@ from dlt.pipeline.pipeline import Pipeline
 from dlt.pipeline.state_sync import STATE_TABLE_COLUMNS, STATE_TABLE_NAME, load_state_from_destination, state_resource
 
 from tests.utils import TEST_STORAGE_ROOT
-from tests.cases import JSON_TYPED_DICT
+from tests.cases import JSON_TYPED_DICT, JSON_TYPED_DICT_DECODED
 from tests.common.utils import IMPORTED_VERSION_HASH_ETH_V6, yml_case_path as common_yml_case_path
 from tests.common.configuration.utils import environment
 from tests.load.pipeline.utils import assert_query_data, drop_active_pipeline_data
@@ -241,7 +241,7 @@ def test_restore_state_pipeline(destination_config: DestinationTestConfiguration
     def source_four():
         @dlt.resource
         def some_data():
-            dlt.current.source_state()["state5"] = dict(JSON_TYPED_DICT)
+            dlt.current.source_state()["state5"] = dict(JSON_TYPED_DICT_DECODED)
             yield "four"
 
         return some_data()
@@ -280,7 +280,7 @@ def test_restore_state_pipeline(destination_config: DestinationTestConfiguration
     assert p.default_schema_name == "default"
     assert set(p.schema_names) == set(["default", "two", "three", "four"])
     assert p.state["sources"] == {
-        "default": {'state1': 'state1', 'state2': 'state2'}, "two": {'state3': 'state3'}, "three": {'state4': 'state4'}, "four": {"state5": JSON_TYPED_DICT}
+        "default": {'state1': 'state1', 'state2': 'state2'}, "two": {'state3': 'state3'}, "three": {'state4': 'state4'}, "four": {"state5": JSON_TYPED_DICT_DECODED}
     }
     for schema in p.schemas.values():
         assert "some_data" in schema.tables


### PR DESCRIPTION
### Description

`datetime.time` types are not included in PUA, as noted by someone on slack -- this adds it. Its a bigger conversation around making json serialization more robust. In cases like Zendesk and Mongo, we have to clean the object before yielding it. Ideally, we could just extend the serializer.
