### PR TITLE
Add support for TIME data type

### DIFF
--- a/dlt/common/data_types/typing.py
+++ b/dlt/common/data_types/typing.py
@@ -1,5 +1,5 @@
 from typing import Literal, Set, get_args
 
 
-TDataType = Literal["text", "double", "bool", "timestamp", "bigint", "binary", "complex", "decimal", "wei", "date"]
+TDataType = Literal["text", "double", "bool", "timestamp", "bigint", "binary", "complex", "decimal", "wei", "date", "time"]
 DATA_TYPES: Set[TDataType] = set(get_args(TDataType))

--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -11,10 +11,11 @@ try:
 except ImportError:
     PydanticBaseModel = None  # type: ignore[misc]
 
+from dlt.common import pendulum
 from dlt.common.arithmetics import Decimal
 from dlt.common.wei import Wei
 from dlt.common.utils import map_nested_in_place
-from dlt.common.time import parse_iso_like_datetime
+from dlt.common.time import ensure_pendulum_date, ensure_pendulum_datetime, ensure_pendulum_time
 
 
 class SupportsJson(Protocol):
@@ -106,13 +107,13 @@ _TIME = '\uF02D'
 # define decoder for each prefix
 DECODERS: List[Callable[[Any], Any]] = [
     Decimal,
-    parse_iso_like_datetime,
-    lambda s: parse_iso_like_datetime(s),
+    ensure_pendulum_datetime,
+    ensure_pendulum_date,
     UUID,
     HexBytes,
     base64.b64decode,
     Wei,
-    lambda s: s  # NOTE: we keep iso implementation until we have TIME, time.fromisoformat,
+    ensure_pendulum_time,
 ]
 # how many decoders?
 PUA_CHARACTER_MAX = len(DECODERS)

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -33,6 +33,8 @@ def get_py_arrow_datatype(column_type: str, caps: DestinationCapabilitiesContext
         return get_py_arrow_numeric(caps.wei_precision)
     elif column_type == "date":
         return pyarrow.date32()
+    elif column_type == "time":
+        return get_py_arrow_time(caps.timestamp_precision)
     else:
         raise ValueError(column_type)
 
@@ -45,6 +47,16 @@ def get_py_arrow_timestamp(precision: int, tz: str) -> Any:
     if precision <= 6:
         return pyarrow.timestamp("us", tz=tz)
     return pyarrow.timestamp("ns", tz=tz)
+
+
+def get_py_arrow_time(precision: int) -> Any:
+    if precision == 0:
+        return pyarrow.time32("s")
+    elif precision <= 3:
+        return pyarrow.time32("ms")
+    elif precision <= 6:
+        return pyarrow.time64("us")
+    return pyarrow.time64("ns")
 
 
 def get_py_arrow_numeric(precision: Tuple[int, int]) -> Any:

--- a/dlt/common/time.py
+++ b/dlt/common/time.py
@@ -105,7 +105,7 @@ def ensure_pendulum_time(value: Union[TAnyDateTime, datetime.time]) -> pendulum.
         value: The value to coerce. Can be a pendulum.DateTime, pendulum.Date, datetime, date, time, or iso date/time str.
 
     Returns:
-        A timezone aware pendulum.Time object in UTC timezone.
+        A pendulum.Time object
     """
 
     if isinstance(value, datetime.time):

--- a/dlt/common/time.py
+++ b/dlt/common/time.py
@@ -7,6 +7,7 @@ from dlt.common.typing import TimedeltaSeconds, TAnyDateTime
 from pendulum.parsing import parse_iso8601, _parse_common as parse_datetime_common
 from pendulum.tz import UTC
 
+
 PAST_TIMESTAMP: float = 0.0
 FUTURE_TIMESTAMP: float = 9999999999.0
 DAY_DURATION_SEC: float = 24 * 60 * 60.0
@@ -98,11 +99,11 @@ def ensure_pendulum_datetime(value: TAnyDateTime) -> pendulum.DateTime:
     raise TypeError(f"Cannot coerce {value} to a pendulum.DateTime object.")
 
 
-def ensure_pendulum_time(value: Union[TAnyDateTime, datetime.time]) -> pendulum.Time:
-    """Coerce a date/time value to a `pendulum.Time` object.
+def ensure_pendulum_time(value: Union[str, datetime.time]) -> pendulum.Time:
+    """Coerce a time value to a `pendulum.Time` object.
 
     Args:
-        value: The value to coerce. Can be a pendulum.DateTime, pendulum.Date, datetime, date, time, or iso date/time str.
+        value: The value to coerce. Can be a `pendulum.Time` / `datetime.time` or an iso time string.
 
     Returns:
         A pendulum.Time object
@@ -112,20 +113,12 @@ def ensure_pendulum_time(value: Union[TAnyDateTime, datetime.time]) -> pendulum.
         if isinstance(value, pendulum.Time):
             return value
         return pendulum.time(value.hour, value.minute, value.second, value.microsecond)
-    elif isinstance(value, datetime.datetime):
-        # both py datetime and pendulum datetime are handled here
-        value = pendulum.instance(value)
-        return pendulum.instance(value).time()  # type: ignore[no-any-return]
-    elif isinstance(value, datetime.date):
-        return pendulum.datetime(value.year, value.month, value.day).time()  # type: ignore[no-any-return]
-    elif isinstance(value, (int, float, str)):
-        result = _datetime_from_ts_or_iso(value)
+    elif isinstance(value, str):
+        result = parse_iso_like_datetime(value)
         if isinstance(result, pendulum.Time):
             return result
-        elif isinstance(result, pendulum.DateTime):
-            return result.time()  # type: ignore[no-any-return]
-        elif isinstance(result, pendulum.Date):
-            return pendulum.datetime(result.year, result.month, result.day).time()  # type: ignore[no-any-return]
+        else:
+            raise ValueError(f"{value} is not a valid ISO time string.")
     raise TypeError(f"Cannot coerce {value} to a pendulum.Time object.")
 
 

--- a/dlt/common/time.py
+++ b/dlt/common/time.py
@@ -117,7 +117,7 @@ def ensure_pendulum_time(value: Union[TAnyDateTime, datetime.time]) -> pendulum.
         value = pendulum.instance(value)
         return pendulum.instance(value).time()  # type: ignore[no-any-return]
     elif isinstance(value, datetime.date):
-        return pendulum.datetime(value.year, value.month, value.day)
+        return pendulum.datetime(value.year, value.month, value.day).time()  # type: ignore[no-any-return]
     elif isinstance(value, (int, float, str)):
         result = _datetime_from_ts_or_iso(value)
         if isinstance(result, pendulum.Time):

--- a/dlt/destinations/athena/athena.py
+++ b/dlt/destinations/athena/athena.py
@@ -41,7 +41,8 @@ SCT_TO_HIVET: Dict[TDataType, str] = {
     "timestamp": "timestamp",
     "bigint": "bigint",
     "binary": "binary",
-    "decimal": "decimal(%i,%i)"
+    "decimal": "decimal(%i,%i)",
+    "time": "time"
 }
 
 HIVET_TO_SCT: Dict[str, TDataType] = {
@@ -53,7 +54,8 @@ HIVET_TO_SCT: Dict[str, TDataType] = {
     "bigint": "bigint",
     "binary": "binary",
     "varbinary": "binary",
-    "decimal": "decimal"
+    "decimal": "decimal",
+    "time": "time"
 }
 
 

--- a/dlt/destinations/bigquery/bigquery.py
+++ b/dlt/destinations/bigquery/bigquery.py
@@ -35,7 +35,8 @@ SCT_TO_BQT: Dict[TDataType, str] = {
     "bigint": "INTEGER",
     "binary": "BYTES",
     "decimal": "NUMERIC(%i,%i)",
-    "wei": "BIGNUMERIC"  # non parametrized should hold wei values
+    "wei": "BIGNUMERIC",  # non parametrized should hold wei values
+    "time": "TIME",
 }
 
 BQT_TO_SCT: Dict[str, TDataType] = {
@@ -48,7 +49,8 @@ BQT_TO_SCT: Dict[str, TDataType] = {
     "BYTES": "binary",
     "NUMERIC": "decimal",
     "BIGNUMERIC": "decimal",
-    "JSON": "complex"
+    "JSON": "complex",
+    "TIME": "time",
 }
 
 class BigQueryLoadJob(LoadJob, FollowupJob):

--- a/dlt/destinations/duckdb/duck.py
+++ b/dlt/destinations/duckdb/duck.py
@@ -23,7 +23,8 @@ SCT_TO_PGT: Dict[TDataType, str] = {
     "timestamp": "TIMESTAMP WITH TIME ZONE",
     "bigint": "BIGINT",
     "binary": "BLOB",
-    "decimal": "DECIMAL(%i,%i)"
+    "decimal": "DECIMAL(%i,%i)",
+    "time": "TIME"
 }
 
 PGT_TO_SCT: Dict[str, TDataType] = {
@@ -35,7 +36,8 @@ PGT_TO_SCT: Dict[str, TDataType] = {
     "TIMESTAMP WITH TIME ZONE": "timestamp",
     "BIGINT": "bigint",
     "BLOB": "binary",
-    "DECIMAL": "decimal"
+    "DECIMAL": "decimal",
+    "TIME": "time"
 }
 
 HINT_TO_POSTGRES_ATTR: Dict[TColumnHint, str] = {

--- a/dlt/destinations/postgres/postgres.py
+++ b/dlt/destinations/postgres/postgres.py
@@ -26,7 +26,8 @@ SCT_TO_PGT: Dict[TDataType, str] = {
     "date": "date",
     "bigint": "bigint",
     "binary": "bytea",
-    "decimal": "numeric(%i,%i)"
+    "decimal": "numeric(%i,%i)",
+    "time": "time"
 }
 
 PGT_TO_SCT: Dict[str, TDataType] = {
@@ -38,7 +39,8 @@ PGT_TO_SCT: Dict[str, TDataType] = {
     "date": "date",
     "bigint": "bigint",
     "bytea": "binary",
-    "numeric": "decimal"
+    "numeric": "decimal",
+    "time": "time"
 }
 
 HINT_TO_POSTGRES_ATTR: Dict[TColumnHint, str] = {

--- a/dlt/destinations/postgres/postgres.py
+++ b/dlt/destinations/postgres/postgres.py
@@ -27,7 +27,7 @@ SCT_TO_PGT: Dict[TDataType, str] = {
     "bigint": "bigint",
     "binary": "bytea",
     "decimal": "numeric(%i,%i)",
-    "time": "time"
+    "time": "time without time zone"
 }
 
 PGT_TO_SCT: Dict[str, TDataType] = {
@@ -40,7 +40,7 @@ PGT_TO_SCT: Dict[str, TDataType] = {
     "bigint": "bigint",
     "bytea": "binary",
     "numeric": "decimal",
-    "time": "time"
+    "time without time zone": "time"
 }
 
 HINT_TO_POSTGRES_ATTR: Dict[TColumnHint, str] = {

--- a/dlt/destinations/redshift/redshift.py
+++ b/dlt/destinations/redshift/redshift.py
@@ -108,6 +108,8 @@ class RedshiftCopyFileLoadJob(CopyRemoteFileLoadJob):
         file_type = ""
         dateformat = ""
         compression = ""
+        if table_schema_has_type(table, "time"):
+            raise LoadJobTerminalException(self.file_name(), "Redshift cannot load TIME columns from load files.")
         if ext == "jsonl":
             if table_schema_has_type(table, "binary"):
                 raise LoadJobTerminalException(self.file_name(), "Redshift cannot load VARBYTE columns from json files. Switch to parquet to load binaries.")

--- a/dlt/destinations/redshift/redshift.py
+++ b/dlt/destinations/redshift/redshift.py
@@ -42,7 +42,7 @@ SCT_TO_PGT: Dict[TDataType, str] = {
     "bigint": "bigint",
     "binary": "varbinary",
     "decimal": "numeric(%i,%i)",
-    "time": "time"
+    "time": "time without time zone"
 }
 
 PGT_TO_SCT: Dict[str, TDataType] = {
@@ -55,7 +55,7 @@ PGT_TO_SCT: Dict[str, TDataType] = {
     "bigint": "bigint",
     "binary varying": "binary",
     "numeric": "decimal",
-    "time": "time"
+    "time without time zone": "time"
 }
 
 HINT_TO_REDSHIFT_ATTR: Dict[TColumnHint, str] = {

--- a/dlt/destinations/redshift/redshift.py
+++ b/dlt/destinations/redshift/redshift.py
@@ -42,7 +42,7 @@ SCT_TO_PGT: Dict[TDataType, str] = {
     "bigint": "bigint",
     "binary": "varbinary",
     "decimal": "numeric(%i,%i)",
-    "time": "time without time zone"
+    "time": "time with time zone"
 }
 
 PGT_TO_SCT: Dict[str, TDataType] = {
@@ -55,7 +55,7 @@ PGT_TO_SCT: Dict[str, TDataType] = {
     "bigint": "bigint",
     "binary varying": "binary",
     "numeric": "decimal",
-    "time without time zone": "time"
+    "time with time zone": "time"
 }
 
 HINT_TO_REDSHIFT_ATTR: Dict[TColumnHint, str] = {
@@ -109,7 +109,9 @@ class RedshiftCopyFileLoadJob(CopyRemoteFileLoadJob):
         dateformat = ""
         compression = ""
         if table_schema_has_type(table, "time"):
-            raise LoadJobTerminalException(self.file_name(), "Redshift cannot load TIME columns from load files.")
+            raise LoadJobTerminalException(
+                self.file_name(), "Redshift cannot load TIME columns from staged files."
+            )
         if ext == "jsonl":
             if table_schema_has_type(table, "binary"):
                 raise LoadJobTerminalException(self.file_name(), "Redshift cannot load VARBYTE columns from json files. Switch to parquet to load binaries.")

--- a/dlt/destinations/redshift/redshift.py
+++ b/dlt/destinations/redshift/redshift.py
@@ -41,7 +41,8 @@ SCT_TO_PGT: Dict[TDataType, str] = {
     "timestamp": "timestamp with time zone",
     "bigint": "bigint",
     "binary": "varbinary",
-    "decimal": "numeric(%i,%i)"
+    "decimal": "numeric(%i,%i)",
+    "time": "time"
 }
 
 PGT_TO_SCT: Dict[str, TDataType] = {
@@ -53,7 +54,8 @@ PGT_TO_SCT: Dict[str, TDataType] = {
     "timestamp with time zone": "timestamp",
     "bigint": "bigint",
     "binary varying": "binary",
-    "numeric": "decimal"
+    "numeric": "decimal",
+    "time": "time"
 }
 
 HINT_TO_REDSHIFT_ATTR: Dict[TColumnHint, str] = {
@@ -192,4 +194,3 @@ class RedshiftClient(InsertValuesJobClient):
             if (precision, scale) == cls.capabilities.wei_precision:
                 return "wei"
         return PGT_TO_SCT.get(pq_t, "text")
-

--- a/dlt/destinations/redshift/redshift.py
+++ b/dlt/destinations/redshift/redshift.py
@@ -42,7 +42,7 @@ SCT_TO_PGT: Dict[TDataType, str] = {
     "bigint": "bigint",
     "binary": "varbinary",
     "decimal": "numeric(%i,%i)",
-    "time": "time with time zone"
+    "time": "time"
 }
 
 PGT_TO_SCT: Dict[str, TDataType] = {
@@ -55,7 +55,7 @@ PGT_TO_SCT: Dict[str, TDataType] = {
     "bigint": "bigint",
     "binary varying": "binary",
     "numeric": "decimal",
-    "time with time zone": "time"
+    "time": "time"
 }
 
 HINT_TO_REDSHIFT_ATTR: Dict[TColumnHint, str] = {

--- a/dlt/destinations/redshift/redshift.py
+++ b/dlt/destinations/redshift/redshift.py
@@ -110,7 +110,8 @@ class RedshiftCopyFileLoadJob(CopyRemoteFileLoadJob):
         compression = ""
         if table_schema_has_type(table, "time"):
             raise LoadJobTerminalException(
-                self.file_name(), "Redshift cannot load TIME columns from staged files."
+                self.file_name(),
+                f"Redshift cannot load TIME columns from {ext} files. Switch to direct INSERT file format or convert `datetime.time` objects in your data to `str` or `datetime.datetime`"
             )
         if ext == "jsonl":
             if table_schema_has_type(table, "binary"):

--- a/dlt/destinations/snowflake/snowflake.py
+++ b/dlt/destinations/snowflake/snowflake.py
@@ -36,6 +36,7 @@ SCT_TO_SNOW: Dict[TDataType, str] = {
     "bigint": f"NUMBER({BIGINT_PRECISION},0)",  # Snowflake has no integer types
     "binary": "BINARY",
     "decimal": "NUMBER(%i,%i)",
+    "time": "TIME",
 }
 
 SNOW_TO_SCT: Dict[str, TDataType] = {
@@ -45,7 +46,8 @@ SNOW_TO_SCT: Dict[str, TDataType] = {
     "DATE": "date",
     "TIMESTAMP_TZ": "timestamp",
     "BINARY": "binary",
-    "VARIANT": "complex"
+    "VARIANT": "complex",
+    "TIME": "time",
 }
 
 

--- a/dlt/destinations/weaviate/weaviate_client.py
+++ b/dlt/destinations/weaviate/weaviate_client.py
@@ -55,6 +55,7 @@ SCT_TO_WT: Dict[TDataType, str] = {
     "bool": "boolean",
     "timestamp": "date",
     "date": "date",
+    "time": "text",
     "bigint": "int",
     "binary": "blob",
     "decimal": "text",

--- a/docs/website/docs/dlt-ecosystem/destinations/athena.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/athena.md
@@ -92,7 +92,11 @@ scanning your bucket and reading all relevant parquet files in there.
 `dlt` internal tables are saved as Iceberg tables.
 
 ### Data types
-Athena tables store timestamps with millisecond precision and with that precision we generate parquet files. Mind that Iceberg tables have microsecond precision. Athena does not support JSON filed so JSON is stored as string.
+Athena tables store timestamps with millisecond precision and with that precision we generate parquet files. Mind that Iceberg tables have microsecond precision. 
+
+Athena does not support JSON fields so JSON is stored as string.
+
+> ❗**Athena does not support TIME columns in parquet files**. `dlt` will fail such jobs permanently. Convert `datetime.time` objects to `str` or `datetime.datetime` to load them.
 
 ### Naming Convention
 We follow our snake_case name convention. Mind the following:

--- a/docs/website/docs/dlt-ecosystem/destinations/redshift.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/redshift.md
@@ -72,7 +72,9 @@ When staging is enabled:
 * [jsonl](../file-formats/jsonl.md) is used by default
 * [parquet](../file-formats/parquet.md) is supported
 
-> ❗ **Redshift cannot load VARBYTE columns from `json` files**. `dlt` will fail such jobs permanently. Switch to `parquet` to load binaries.
+> ❗ **Redshift cannot load `VARBYTE` columns from `json` files**. `dlt` will fail such jobs permanently. Switch to `parquet` to load binaries.
+
+> ❗ **Redshift cannot load `TIME` columns from `json` or `parquet` files**. `dlt` will fail such jobs permanently. Switch to direct `insert_values` to load time columns.
 
 > ❗ **Redshift cannot detect compression type from `json` files**. `dlt` assumes that `jsonl` files are gzip compressed which is the default.
 

--- a/docs/website/docs/general-usage/schema.md
+++ b/docs/website/docs/general-usage/schema.md
@@ -126,18 +126,19 @@ coerced in existing column.
 
 ### Data types
 
-| dlt Data Type | Source Value Example |
-| --- | --- |
-| text | `'hello world'` |
-| double | `45.678` |
-| bool | `True` |
-| timestamp | `'2023-07-26T14:45:00Z'`, `datetime.datetime.now()` |
-| date | `datetime.date(2023, 7, 26)` |
-| bigint | `9876543210` |
-| binary | `b'\x00\x01\x02\x03'` |
-| complex | `[4, 5, 6]`, `{'a': 1}` |
-| decimal | `Decimal('4.56')` |
-| wei | `2**56` |
+| dlt Data Type | Source Value Example                                |
+|---------------|-----------------------------------------------------|
+| text          | `'hello world'`                                     |
+| double        | `45.678`                                            |
+| bool          | `True`                                              |
+| timestamp     | `'2023-07-26T14:45:00Z'`, `datetime.datetime.now()` |
+| date          | `datetime.date(2023, 7, 26)`                        |
+| time          | `'14:01:02'`, `datetime.time(14, 1, 2)`             |
+| bigint        | `9876543210`                                        |
+| binary        | `b'\x00\x01\x02\x03'`                               |
+| complex       | `[4, 5, 6]`, `{'a': 1}`                             |
+| decimal       | `Decimal('4.56')`                                   |
+| wei           | `2**56`                                             |
 
 
 > ⛔ You cannot specify scale and precision for bigint, binary, text and decimal.
@@ -148,6 +149,8 @@ precision.
 
 `complex` data type tells `dlt` to load that element as JSON or struct and do not attempt to flatten
 or create a child table out of it.
+
+`time` data type is saved in destination without timezone info, if timezone is included it is stripped. E.g. `'14:01:02+02:00` -> `'14:01:02'`.
 
 ## Schema settings
 

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -25,7 +25,7 @@ JSON_TYPED_DICT: StrAny = {
 }
 # TODO: a version after PUA decoder (time is not yet implemented end to end)
 JSON_TYPED_DICT_DECODED = dict(JSON_TYPED_DICT)
-JSON_TYPED_DICT_DECODED["time"] = JSON_TYPED_DICT["time"].isoformat()
+JSON_TYPED_DICT_DECODED["time"] = JSON_TYPED_DICT["time"]
 
 JSON_TYPED_DICT_TYPES: Dict[str, TDataType] = {
     "str": "text",
@@ -37,7 +37,7 @@ JSON_TYPED_DICT_TYPES: Dict[str, TDataType] = {
     "hexbytes": "binary",
     "bytes": "binary",
     "wei": "wei",
-    "time": "text"
+    "time": "time"
 }
 
 JSON_TYPED_DICT_NESTED = {

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -106,6 +106,11 @@ TABLE_UPDATE: List[TColumnSchema] = [
         "nullable": False
     },
     {
+        "name": "col11",
+        "data_type": "time",
+        "nullable": False
+    },
+    {
         "name": "col1_null",
         "data_type": "bigint",
         "nullable": True
@@ -155,7 +160,12 @@ TABLE_UPDATE: List[TColumnSchema] = [
         "name": "col10_null",
         "data_type": "date",
         "nullable": True
-    }
+    },
+    {
+        "name": "col11_null",
+        "data_type": "time",
+        "nullable": True
+    },
 ]
 TABLE_UPDATE_COLUMNS_SCHEMA: TTableSchemaColumns = {t["name"]:t for t in TABLE_UPDATE}
 
@@ -170,6 +180,7 @@ TABLE_ROW_ALL_DATA_TYPES  = {
     "col8": 2**56 + 92093890840,
     "col9": {"complex":[1,2,3,"a"], "link": "?commen\ntU\nrn=urn%3Ali%3Acomment%3A%28acti\012 \6 \\vity%3A69'08444473\n\n551163392%2C6n \r \x8e9085"},
     "col10": "2023-02-27",
+    "col11": "13:26:45.176451",
     "col1_null": None,
     "col2_null": None,
     "col3_null": None,
@@ -179,7 +190,8 @@ TABLE_ROW_ALL_DATA_TYPES  = {
     "col7_null": None,
     "col8_null": None,
     "col9_null": None,
-    "col10_null": None
+    "col10_null": None,
+    "col11_null": None,
 }
 
 
@@ -216,6 +228,7 @@ def assert_all_data_types_row(
         db_row[8] = json.loads(db_row[8])
 
     db_row[9] = db_row[9].isoformat()
+    db_row[10] = db_row[10].isoformat()
     # print(db_row)
     # print(expected_rows)
     for expected, actual in zip(expected_rows, db_row):

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -25,7 +25,6 @@ JSON_TYPED_DICT: StrAny = {
 }
 # TODO: a version after PUA decoder (time is not yet implemented end to end)
 JSON_TYPED_DICT_DECODED = dict(JSON_TYPED_DICT)
-JSON_TYPED_DICT_DECODED["time"] = JSON_TYPED_DICT["time"]
 
 JSON_TYPED_DICT_TYPES: Dict[str, TDataType] = {
     "str": "text",

--- a/tests/common/schema/test_coercion.py
+++ b/tests/common/schema/test_coercion.py
@@ -200,6 +200,26 @@ def test_coerce_type_to_date() -> None:
     assert coerce_value("date", "text", "2022-04-26 10:36") == pendulum.parse("2022-04-26", exact=True)
 
 
+def test_coerce_type_to_time() -> None:
+    # from ISO time string
+    assert coerce_value("time", "text", "03:41:31.466000") == pendulum.parse("03:41:31.466000", exact=True)
+    # from datetime object
+    assert coerce_value("time", "timestamp", pendulum.datetime(1995, 5, 6, 00, 1, 1, tz='EST')) == pendulum.parse("00:01:01", exact=True)
+    assert coerce_value("time", "timestamp", pendulum.datetime(1995, 5, 6, 00, 1, 1)) == pendulum.parse("00:01:01", exact=True)
+    # from unix timestamp
+    assert coerce_value("time", "double", 1677546399.494264) == pendulum.parse("01:06:39.494264", exact=True)
+    assert coerce_value("time", "text", " 1677546399 ") == pendulum.parse("01:06:39", exact=True)
+    # ISO date string
+    assert coerce_value("time", "text", "2023-02-27") == pendulum.parse("00:00:00", exact=True)
+    # ISO datetime string
+    assert coerce_value("time", "text", "2022-05-10T03:41:31.466000+00:00") == pendulum.parse("03:41:31.466000", exact=True)
+    assert coerce_value("time", "text", "2022-05-10T03:41:31.466+02:00") == pendulum.parse("03:41:31.466000", exact=True)
+    assert coerce_value("time", "text", "2022-05-10T03:41:31.466+0200") == pendulum.parse("03:41:31.466000", exact=True)
+    # almost ISO compliant string
+    assert coerce_value("time", "text", "2022-04-26 10:36+02") == pendulum.parse("10:36:00", exact=True)
+    assert coerce_value("time", "text", "2022-04-26 10:36") == pendulum.parse("10:36:00", exact=True)
+
+
 def test_coerce_type_to_binary() -> None:
     # from hex string
     assert coerce_value("binary", "text", "0x30") == b'0'
@@ -224,6 +244,7 @@ def test_py_type_to_sc_type() -> None:
     assert py_type_to_sc_type(type(datetime.datetime(1988, 12, 1))) == "timestamp"
     assert py_type_to_sc_type(type(pendulum.date(2023, 2, 27))) == "date"
     assert py_type_to_sc_type(type(datetime.date.today())) == "date"
+    assert py_type_to_sc_type(type(pendulum.time(1, 6, 39))) == "time"
     assert py_type_to_sc_type(type(Decimal(1))) == "decimal"
     assert py_type_to_sc_type(type(HexBytes("0xFF"))) == "binary"
     assert py_type_to_sc_type(type(Wei.from_int256(2137, decimals=2))) == "wei"

--- a/tests/common/schema/test_coercion.py
+++ b/tests/common/schema/test_coercion.py
@@ -182,6 +182,14 @@ def test_coerce_type_to_timestamp() -> None:
     with pytest.raises(ValueError):
         coerce_value("timestamp", "text", "x2022-05-10T03:41:31.466000X+00:00")
 
+    # iso time string fails
+    with pytest.raises(ValueError):
+        coerce_value("timestamp", "text", "03:41:31.466")
+
+    # time object fails
+    with pytest.raises(TypeError):
+        coerce_value("timestamp", "time", pendulum.Time(10, 36, 0, 0))
+
 
 def test_coerce_type_to_date() -> None:
     # from datetime object
@@ -199,25 +207,35 @@ def test_coerce_type_to_date() -> None:
     assert coerce_value("date", "text", "2022-04-26 10:36+02") == pendulum.parse("2022-04-26", exact=True)
     assert coerce_value("date", "text", "2022-04-26 10:36") == pendulum.parse("2022-04-26", exact=True)
 
+        # iso time string fails
+    with pytest.raises(ValueError):
+        coerce_value("timestamp", "text", "03:41:31.466")
+
+    # time object fails
+    with pytest.raises(TypeError):
+        coerce_value("timestamp", "time", pendulum.Time(10, 36, 0, 0))
+
 
 def test_coerce_type_to_time() -> None:
     # from ISO time string
     assert coerce_value("time", "text", "03:41:31.466000") == pendulum.parse("03:41:31.466000", exact=True)
-    # from datetime object
-    assert coerce_value("time", "timestamp", pendulum.datetime(1995, 5, 6, 00, 1, 1, tz='EST')) == pendulum.parse("00:01:01", exact=True)
-    assert coerce_value("time", "timestamp", pendulum.datetime(1995, 5, 6, 00, 1, 1)) == pendulum.parse("00:01:01", exact=True)
-    # from unix timestamp
-    assert coerce_value("time", "double", 1677546399.494264) == pendulum.parse("01:06:39.494264", exact=True)
-    assert coerce_value("time", "text", " 1677546399 ") == pendulum.parse("01:06:39", exact=True)
-    # ISO date string
-    assert coerce_value("time", "text", "2023-02-27") == pendulum.parse("00:00:00", exact=True)
-    # ISO datetime string
-    assert coerce_value("time", "text", "2022-05-10T03:41:31.466000+00:00") == pendulum.parse("03:41:31.466000", exact=True)
-    assert coerce_value("time", "text", "2022-05-10T03:41:31.466+02:00") == pendulum.parse("03:41:31.466000", exact=True)
-    assert coerce_value("time", "text", "2022-05-10T03:41:31.466+0200") == pendulum.parse("03:41:31.466000", exact=True)
-    # almost ISO compliant string
-    assert coerce_value("time", "text", "2022-04-26 10:36+02") == pendulum.parse("10:36:00", exact=True)
-    assert coerce_value("time", "text", "2022-04-26 10:36") == pendulum.parse("10:36:00", exact=True)
+    # time object returns same value
+    assert coerce_value("time", "time", pendulum.time(3, 41, 31, 466000)) == pendulum.time(3, 41, 31, 466000)
+    # from datetime object fails
+    with pytest.raises(TypeError):
+        coerce_value("time", "timestamp", pendulum.datetime(1995, 5, 6, 00, 1, 1, tz=UTC))
+
+    # from unix timestamp fails
+    with pytest.raises(TypeError):
+        assert coerce_value("time", "double", 1677546399.494264) == pendulum.parse("01:06:39.494264", exact=True)
+    with pytest.raises(ValueError):
+        assert coerce_value("time", "text", " 1677546399 ") == pendulum.parse("01:06:39", exact=True)
+    # ISO date string fails
+    with pytest.raises(ValueError):
+        assert coerce_value("time", "text", "2023-02-27") == pendulum.parse("00:00:00", exact=True)
+    # ISO datetime string fails
+    with pytest.raises(ValueError):
+        assert coerce_value("time", "text", "2022-05-10T03:41:31.466000+00:00")
 
 
 def test_coerce_type_to_binary() -> None:

--- a/tests/common/test_data_writers/test_parquet_writer.py
+++ b/tests/common/test_data_writers/test_parquet_writer.py
@@ -92,6 +92,7 @@ def test_parquet_writer_all_data_fields() -> None:
     # fix dates to use pendulum
     data["col4"] = ensure_pendulum_datetime(data["col4"])
     data["col10"] = ensure_pendulum_date(data["col10"])
+    data["col11"] = pendulum.Time.fromisoformat(data["col11"])
 
     with get_writer("parquet") as writer:
         writer.write_data_item([data], TABLE_UPDATE_COLUMNS_SCHEMA)

--- a/tests/common/test_pydantic.py
+++ b/tests/common/test_pydantic.py
@@ -1,7 +1,7 @@
 import pytest
 from typing import Union, Optional, List, Dict
 
-from datetime import datetime, date  # noqa: I251
+from datetime import datetime, date, time  # noqa: I251
 from dlt.common import Decimal
 
 from pydantic import BaseModel
@@ -19,6 +19,7 @@ class Model(BaseModel):
     date_field: date
     decimal_field: Decimal
     double_field: float
+    time_field: time
 
     nested_field: NestedModel
     list_field: List[str]
@@ -37,6 +38,7 @@ def test_pydantic_model_to_columns(instance: bool) -> None:
         model = Model(
             bigint_field=1, text_field="text", timestamp_field=datetime.now(),
             date_field=date.today(), decimal_field=Decimal(1.1), double_field=1.1,
+            time_field=time(1, 2, 3, 12345),
             nested_field=NestedModel(nested_field="nested"),
             list_field=["a", "b", "c"],
             union_field=1,
@@ -55,6 +57,7 @@ def test_pydantic_model_to_columns(instance: bool) -> None:
     assert result["date_field"]["data_type"] == "date"
     assert result["decimal_field"]["data_type"] == "decimal"
     assert result["double_field"]["data_type"] == "double"
+    assert result["time_field"]["data_type"] == "time"
     assert result["nested_field"]["data_type"] == "complex"
     assert result['list_field']['data_type'] == 'complex'
     assert result['union_field']['data_type'] == 'bigint'

--- a/tests/load/pipeline/test_athena.py
+++ b/tests/load/pipeline/test_athena.py
@@ -1,12 +1,13 @@
 import pytest
 from copy import deepcopy
 import datetime  # noqa: I251
+from typing import Iterator, Any
 
 import dlt
 from dlt.common import pendulum
 from dlt.common.utils import uniq_id
 from tests.load.pipeline.utils import  load_table_counts
-from tests.load.utils import TABLE_UPDATE_COLUMNS_SCHEMA, TABLE_ROW_ALL_DATA_TYPES, assert_all_data_types_row
+from tests.cases import table_update_and_row, assert_all_data_types_row
 from tests.pipeline.utils import assert_load_info
 
 from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
@@ -65,17 +66,18 @@ def test_athena_destinations(destination_config: DestinationTestConfiguration) -
 @pytest.mark.parametrize("destination_config", destinations_configs(default_sql_configs=True, subset=["athena"]), ids=lambda x: x.name)
 def test_athena_all_datatypes_and_timestamps(destination_config: DestinationTestConfiguration) -> None:
     pipeline = destination_config.setup_pipeline("athena_" + uniq_id(), full_refresh=True)
-    data_types = deepcopy(TABLE_ROW_ALL_DATA_TYPES)
-    column_schemas = deepcopy(TABLE_UPDATE_COLUMNS_SCHEMA)
+
+    # TIME is not supported
+    column_schemas, data_types = table_update_and_row(exclude_types=["time"])
 
     # apply the exact columns definitions so we process complex and wei types correctly!
     @dlt.resource(table_name="data_types", write_disposition="append", columns=column_schemas)
-    def my_resource():
+    def my_resource() -> Iterator[Any]:
         nonlocal data_types
         yield [data_types]*10
 
     @dlt.source(max_table_nesting=0)
-    def my_source():
+    def my_source() -> Any:
         return my_resource
 
     info = pipeline.run(my_source())
@@ -86,7 +88,9 @@ def test_athena_all_datatypes_and_timestamps(destination_config: DestinationTest
         assert len(db_rows) == 10
         db_row = list(db_rows[0])
         # content must equal
-        assert_all_data_types_row(db_row[:-2], parse_complex_strings=True, timestamp_precision=sql_client.capabilities.timestamp_precision)
+        assert_all_data_types_row(
+            db_row[:-2], parse_complex_strings=True, timestamp_precision=sql_client.capabilities.timestamp_precision, schema=column_schemas
+        )
 
         # now let's query the data with timestamps and dates.
         # https://docs.aws.amazon.com/athena/latest/ug/engine-versions-reference-0003.html#engine-versions-reference-0003-timestamp-changes

--- a/tests/load/pipeline/test_redshift.py
+++ b/tests/load/pipeline/test_redshift.py
@@ -1,0 +1,32 @@
+from typing import Any, Iterator
+
+import pytest
+
+import dlt
+from dlt.common.utils import uniq_id
+from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
+from tests.cases import table_update_and_row, assert_all_data_types_row
+from tests.pipeline.utils import assert_load_info
+
+
+@pytest.mark.parametrize("destination_config", destinations_configs(all_staging_configs=True, subset=["redshift"]), ids=lambda x: x.name)
+def test_redshift_blocks_time_column(destination_config: DestinationTestConfiguration) -> None:
+    pipeline = destination_config.setup_pipeline("athena_" + uniq_id(), full_refresh=True)
+
+    column_schemas, data_types = table_update_and_row()
+
+    # apply the exact columns definitions so we process complex and wei types correctly!
+    @dlt.resource(table_name="data_types", write_disposition="append", columns=column_schemas)
+    def my_resource() -> Iterator[Any]:
+        nonlocal data_types
+        yield [data_types]*10
+
+    @dlt.source(max_table_nesting=0)
+    def my_source() -> Any:
+        return my_resource
+
+    info = pipeline.run(my_source())
+
+    assert info.has_failed_jobs
+
+    assert "Redshift cannot load TIME columns from" in info.load_packages[0].jobs['failed_jobs'][0].failed_message

--- a/tests/load/pipeline/test_stage_loading.py
+++ b/tests/load/pipeline/test_stage_loading.py
@@ -94,7 +94,7 @@ def test_all_data_types(destination_config: DestinationTestConfiguration) -> Non
     pipeline = destination_config.setup_pipeline('test_stage_loading', dataset_name="test_all_data_types" + uniq_id())
 
     column_schemas = deepcopy(TABLE_UPDATE_COLUMNS_SCHEMA)
-    if destination_config.destination == "redshift" and destination_config.file_format in ('parquet', 'jsonl'):
+    if destination_config.destination in ("redshift", "athena") and destination_config.file_format in ('parquet', 'jsonl'):
         # Redshift copy doesn't support TIME column
         column_schemas, data_types = table_update_and_row(exclude_types=['time'])
     else:

--- a/tests/load/pipeline/test_stage_loading.py
+++ b/tests/load/pipeline/test_stage_loading.py
@@ -10,6 +10,7 @@ from tests.load.pipeline.test_merge_disposition import github
 from tests.load.pipeline.utils import  load_table_counts
 from tests.pipeline.utils import  assert_load_info
 from tests.load.utils import TABLE_ROW_ALL_DATA_TYPES, TABLE_UPDATE_COLUMNS_SCHEMA, assert_all_data_types_row
+from tests.cases import table_update_and_row
 from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
 
 
@@ -92,8 +93,12 @@ def test_all_data_types(destination_config: DestinationTestConfiguration) -> Non
 
     pipeline = destination_config.setup_pipeline('test_stage_loading', dataset_name="test_all_data_types" + uniq_id())
 
-    data_types = deepcopy(TABLE_ROW_ALL_DATA_TYPES)
     column_schemas = deepcopy(TABLE_UPDATE_COLUMNS_SCHEMA)
+    if destination_config.destination == "redshift" and destination_config.file_format in ('parquet', 'jsonl'):
+        # Redshift copy doesn't support TIME column
+        column_schemas, data_types = table_update_and_row(exclude_types=['time'])
+    else:
+        column_schemas, data_types = table_update_and_row()
 
     # bigquery cannot load into JSON fields from parquet
     if destination_config.file_format == "parquet":
@@ -105,8 +110,6 @@ def test_all_data_types(destination_config: DestinationTestConfiguration) -> Non
         if destination_config.destination == "redshift":
             # change the datatype to text which will result in inserting base64 (allow_base64_binary)
             column_schemas["col7_null"]["data_type"] = column_schemas["col7"]["data_type"] = "text"
-            # Redshift COPY doesn't support TIME column
-            column_schemas["col11_null"]["data_type"] = column_schemas["col11"]["data_type"] = "text"
 
     # apply the exact columns definitions so we process complex and wei types correctly!
     @dlt.resource(table_name="data_types", write_disposition="merge", columns=column_schemas)
@@ -118,7 +121,7 @@ def test_all_data_types(destination_config: DestinationTestConfiguration) -> Non
     def my_source():
         return my_resource
 
-    info = pipeline.run(my_source(), loader_file_format=destination_config.file_format)
+    info = pipeline.run(my_source(), loader_file_format=destination_config.file_format)  # type: ignore[arg-type]
     assert_load_info(info)
 
     with pipeline.sql_client() as sql_client:
@@ -133,5 +136,6 @@ def test_all_data_types(destination_config: DestinationTestConfiguration) -> Non
             db_row[:-2],
             parse_complex_strings=parse_complex_strings,
             allow_base64_binary=allow_base64_binary,
-            timestamp_precision=sql_client.capabilities.timestamp_precision
+            timestamp_precision=sql_client.capabilities.timestamp_precision,
+            schema=column_schemas
         )

--- a/tests/load/pipeline/test_stage_loading.py
+++ b/tests/load/pipeline/test_stage_loading.py
@@ -105,6 +105,8 @@ def test_all_data_types(destination_config: DestinationTestConfiguration) -> Non
         if destination_config.destination == "redshift":
             # change the datatype to text which will result in inserting base64 (allow_base64_binary)
             column_schemas["col7_null"]["data_type"] = column_schemas["col7"]["data_type"] = "text"
+            # Redshift COPY doesn't support TIME column
+            column_schemas["col11_null"]["data_type"] = column_schemas["col11"]["data_type"] = "text"
 
     # apply the exact columns definitions so we process complex and wei types correctly!
     @dlt.resource(table_name="data_types", write_disposition="merge", columns=column_schemas)

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -322,8 +322,8 @@ def test_get_storage_table_with_all_types(client: SqlJobClientBase) -> None:
         # print(c["name"])
         # print(c["data_type"])
         assert c["name"] == expected_c["name"]
-        # athena does not know wei data type and has no JSON type
-        if client.config.destination_name == "athena" and c["data_type"] in ("wei", "complex"):
+        # athena does not know wei data type and has no JSON type, time is not supported with parquet tables
+        if client.config.destination_name == "athena" and c["data_type"] in ("wei", "complex", "time"):
             continue
         assert c["data_type"] == expected_c["data_type"]
 


### PR DESCRIPTION
### Description

Implements support for "TIME" in all destinations

### Related Issues

Resolves #605 

### Additional Context

Not all destinations support "time with timezone" so I'm using db tz naive "time" types in all and the timezone gets stripped when value includes it.