### PR TITLE
Remove a misleading subtitle in Pseudonymizing Columns docs

### DIFF
--- a/docs/website/docs/general-usage/customising-pipelines/pseudonymizing_columns.md
+++ b/docs/website/docs/general-usage/customising-pipelines/pseudonymizing_columns.md
@@ -6,8 +6,6 @@ keywords: [pseudonymize, anonymize, columns, special characters]
 
 # Pseudonymizing columns
 
-## Pseudonymizing (or anonymizing) columns by replacing the special characters
-
 Pseudonymization is a deterministic way to hide personally identifiable info (PII), enabling us to
 consistently achieve the same mapping. If instead you wish to anonymize, you can delete the data, or
 replace it with a constant. In the example below, we create a dummy source with a PII column called


### PR DESCRIPTION
This was most likely copied from an adjacent page 'Renaming columns'. I suggest removing the subtitle altogether, as it provides little additional information.