### PR TITLE
Don't set source.<resource_name> attributes

### DIFF
--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -779,8 +779,6 @@ class DltSource(Iterable[TDataItem]):
             self._resources[name].add_pipe(resource)
         else:
             self._resources[name] = resource
-            # remember that resource got cloned when set into dict
-            super().__setattr__(name, self._resources[name])
 
     def __getattr__(self, resource_name: str) -> DltResource:
         return self._resources[resource_name]


### PR DESCRIPTION
### Description

Fixes the bug when resource names conflict with other attributes on `DltSource`.  I just deleted the `setattr` line, `__getattr__` will already pull from the resources dict any attrs that don't exist on the object.

### Related Issues
Fixes https://github.com/dlt-hub/dlt/issues/652