### PR TITLE
Rfix/duck case

### DIFF
--- a/dlt/common/normalizers/naming/duck_case.py
+++ b/dlt/common/normalizers/naming/duck_case.py
@@ -1,26 +1,24 @@
 import re
 from functools import lru_cache
 
-from dlt.common.normalizers.naming.snake_case import NamingConvention as BaseNamingConvention
+from dlt.common.normalizers.naming.snake_case import NamingConvention as SnakeCaseNamingConvention
 
 
-class NamingConvention(BaseNamingConvention):
+class NamingConvention(SnakeCaseNamingConvention):
 
-    _RE_NON_ALPHANUMERIC = re.compile(r"[^a-zA-Z\d_+-]+")
-    _REDUCE_ALPHABET = ("*@|", "xal")
-    _TR_REDUCE_ALPHABET = str.maketrans(_REDUCE_ALPHABET[0], _REDUCE_ALPHABET[1])
+    _CLEANUP_TABLE = str.maketrans("\n\r\"", "___")
+    _RE_LEADING_DIGITS = None  # do not remove leading digits
 
     @staticmethod
     @lru_cache(maxsize=None)
     def _normalize_identifier(identifier: str, max_length: int) -> str:
         """Normalizes the identifier according to naming convention represented by this function"""
-        # all characters that are not letters digits or a few special chars are replaced with underscore
-        normalized_ident = identifier.translate(NamingConvention._TR_REDUCE_ALPHABET)
-        normalized_ident = NamingConvention._RE_NON_ALPHANUMERIC.sub("_", normalized_ident)
+
+        normalized_ident = identifier.translate(NamingConvention._CLEANUP_TABLE)
 
         # shorten identifier
         return NamingConvention.shorten_identifier(
-            NamingConvention._to_snake_case(normalized_ident),
+            NamingConvention._RE_UNDERSCORES.sub("_", normalized_ident),
             identifier,
             max_length
         )

--- a/dlt/common/normalizers/naming/snake_case.py
+++ b/dlt/common/normalizers/naming/snake_case.py
@@ -46,14 +46,14 @@ class NamingConvention(BaseNamingConvention):
             max_length
         )
 
-    @staticmethod
-    def _to_snake_case(identifier: str) -> str:
+    @classmethod
+    def _to_snake_case(cls, identifier: str) -> str:
         # then convert to snake case
-        identifier = NamingConvention._SNAKE_CASE_BREAK_1.sub(r'\1_\2', identifier)
-        identifier = NamingConvention._SNAKE_CASE_BREAK_2.sub(r'\1_\2', identifier).lower()
+        identifier = cls._SNAKE_CASE_BREAK_1.sub(r'\1_\2', identifier)
+        identifier = cls._SNAKE_CASE_BREAK_2.sub(r'\1_\2', identifier).lower()
 
-        # leading digits will be prefixed
-        if NamingConvention._RE_LEADING_DIGITS.match(identifier):
+        # leading digits will be prefixed (if regex is defined)
+        if cls._RE_LEADING_DIGITS and cls._RE_LEADING_DIGITS.match(identifier):
             identifier = "_" + identifier
 
         # replace trailing _ with x
@@ -61,6 +61,6 @@ class NamingConvention(BaseNamingConvention):
         strip_count = len(identifier) - len(stripped_ident)
         stripped_ident += "x" * strip_count
 
-        # identifier = NamingConvention._RE_ENDING_UNDERSCORES.sub("x", identifier)
+        # identifier = cls._RE_ENDING_UNDERSCORES.sub("x", identifier)
         # replace consecutive underscores with single one to prevent name clashes with PATH_SEPARATOR
-        return NamingConvention._RE_UNDERSCORES.sub("_", stripped_ident)
+        return cls._RE_UNDERSCORES.sub("_", stripped_ident)

--- a/dlt/common/storages/filesystem.py
+++ b/dlt/common/storages/filesystem.py
@@ -19,6 +19,7 @@ class FileItem(TypedDict):
     file_name: str
     mime_type: str
     modification_date: pendulum.DateTime
+    size_in_bytes: int
     file_content: Optional[Union[str, bytes]]
 
 

--- a/dlt/destinations/duckdb/__init__.py
+++ b/dlt/destinations/duckdb/__init__.py
@@ -28,7 +28,6 @@ def capabilities() -> DestinationCapabilitiesContext:
     caps.wei_precision = (DEFAULT_NUMERIC_PRECISION, 0)
     caps.max_identifier_length = 65536
     caps.max_column_identifier_length = 65536
-    caps.naming_convention = "duck_case"
     caps.max_query_length = 32 * 1024 * 1024
     caps.is_max_query_length_in_bytes = True
     caps.max_text_data_type_length = 1024 * 1024 * 1024

--- a/dlt/destinations/duckdb/sql_client.py
+++ b/dlt/destinations/duckdb/sql_client.py
@@ -135,7 +135,10 @@ class DuckDbSqlClient(SqlClientBase[duckdb.DuckDBPyConnection], DBTransaction):
     @classmethod
     def _make_database_exception(cls, ex: Exception) -> Exception:
         if isinstance(ex, (duckdb.CatalogException)):
-            raise DatabaseUndefinedRelation(ex)
+            if "already exists" in str(ex):
+                raise DatabaseTerminalException(ex)
+            else:
+                raise DatabaseUndefinedRelation(ex)
         elif isinstance(ex, duckdb.InvalidInputException):
             if "Catalog Error" in str(ex):
                 raise DatabaseUndefinedRelation(ex)

--- a/dlt/destinations/motherduck/__init__.py
+++ b/dlt/destinations/motherduck/__init__.py
@@ -26,7 +26,6 @@ def capabilities() -> DestinationCapabilitiesContext:
     caps.wei_precision = (DEFAULT_NUMERIC_PRECISION, 0)
     caps.max_identifier_length = 65536
     caps.max_column_identifier_length = 65536
-    caps.naming_convention = "duck_case"
     caps.max_query_length = 512 * 1024
     caps.is_max_query_length_in_bytes = True
     caps.max_text_data_type_length = 1024 * 1024 * 1024

--- a/dlt/extract/pipe.py
+++ b/dlt/extract/pipe.py
@@ -401,9 +401,10 @@ class Pipe(SupportsPipe):
             else:
                 raise InvalidStepFunctionArguments(self.name, callable_name, sig, str(ty_ex))
 
-    def _clone(self, keep_pipe_id: bool = True) -> "Pipe":
-        """Clones the pipe steps, optionally keeping the pipe id. Used internally to clone a list of connected pipes."""
-        p = Pipe(self.name, [], self.parent)
+    def _clone(self, keep_pipe_id: bool = True, new_name: str = None) -> "Pipe":
+        """Clones the pipe steps, optionally keeping the pipe id or renaming the pipe. Used internally to clone a list of connected pipes."""
+        assert not (new_name and keep_pipe_id), "Cannot keep pipe id when renaming the pipe"
+        p = Pipe(new_name or self.name, [], self.parent)
         p._steps = self._steps.copy()
         # clone shares the id with the original
         if keep_pipe_id:

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -29,6 +29,27 @@ All write dispositions are supported
 ## Data loading
 `dlt` will load data using large INSERT VALUES statements by default. Loading is multithreaded (20 threads by default). If you are ok with installing `pyarrow` we suggest to switch to `parquet` as file format. Loading is faster (and also multithreaded).
 
+### Names normalization
+`dlt` uses standard **snake_case** naming convention to keep identical table and column identifiers across all destinations. If you want to use **duckdb** wide range of characters (ie. emojis) for table and column names, you can switch to **duck_case** naming convention which accepts almost any string as an identifier:
+* `\n` `\r`  and `" are translated to `_`
+* multiple `_` are translated to single `_`
+
+Switch the naming convention using `config.toml`:
+```toml
+[schema]
+naming="duck_case"
+```
+
+or via env variable `SCHEMA__NAMING` or directly in code:
+```python
+dlt.config["schema.naming"] = "duck_case"
+```
+:::caution
+**duckdb** identifiers are **case insensitive** but display names preserve case. This may create name clashes if for example you load json with
+`{"Column": 1, "column": 2}` will map data to a single column.
+:::
+
+
 ## Supported file formats
 You can configure the following file formats to load data to duckdb
 * [insert-values](../file-formats/insert-format.md) is used by default

--- a/docs/website/docs/dlt-ecosystem/destinations/weaviate.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/weaviate.md
@@ -252,7 +252,7 @@ it will be normalized to:
 so your best course of action is to clean up the data yourself before loading and use default naming convention. Nevertheless you can configure the alternative in `config.toml`:
 ```toml
 [schema]
-naming="dlt.destinations.weaviate.naming"
+naming="dlt.destinations.weaviate.ci_naming"
 ```
 
 ## Additional destination options

--- a/tests/common/normalizers/test_naming_duck_case.py
+++ b/tests/common/normalizers/test_naming_duck_case.py
@@ -12,15 +12,13 @@ def naming_unlimited() -> NamingConvention:
 def test_normalize_identifier(naming_unlimited: NamingConvention) -> None:
     assert naming_unlimited.normalize_identifier("+1") == "+1"
     assert naming_unlimited.normalize_identifier("-1") == "-1"
+    assert naming_unlimited.normalize_identifier("1-1") == "1-1"
+    assert naming_unlimited.normalize_identifier("🦚Peacock") == "🦚Peacock"
+    assert naming_unlimited.normalize_identifier("🦚🦚Peacocks") == "🦚🦚Peacocks"
+    assert naming_unlimited.normalize_identifier("🦚🦚peacocks") == "🦚🦚peacocks"
+    # non latin alphabets
+    assert naming_unlimited.normalize_identifier("Ölübeµrsईउऊऋऌऍऎएc⇨usǁs⛔lÄnder") == "Ölübeµrsईउऊऋऌऍऎएc⇨usǁs⛔lÄnder"
 
 
 def test_alphabet_reduction(naming_unlimited: NamingConvention) -> None:
-    assert naming_unlimited.normalize_identifier(NamingConvention._REDUCE_ALPHABET[0]) == NamingConvention._REDUCE_ALPHABET[1]
-
-
-def test_duck_snake_case_compat(naming_unlimited: NamingConvention) -> None:
-    snake_unlimited = SnakeNamingConvention()
-    # same reduction duck -> snake
-    assert snake_unlimited.normalize_identifier(NamingConvention._REDUCE_ALPHABET[0]) == NamingConvention._REDUCE_ALPHABET[1]
-    # but there are differences in the reduction
-    assert naming_unlimited.normalize_identifier(SnakeNamingConvention._REDUCE_ALPHABET[0]) != snake_unlimited.normalize_identifier(SnakeNamingConvention._REDUCE_ALPHABET[0])
+    assert naming_unlimited.normalize_identifier("A\nB\"C\rD") == "A_B_C_D"

--- a/tests/load/mssql/test_mssql_table_builder.py
+++ b/tests/load/mssql/test_mssql_table_builder.py
@@ -5,6 +5,8 @@ import sqlfluff
 from dlt.common.utils import uniq_id
 from dlt.common.schema import Schema
 
+pytest.importorskip("dlt.destinations.mssql.mssql", reason="MSSQL ODBC driver not installed")
+
 from dlt.destinations.mssql.mssql import MsSqlClient
 from dlt.destinations.mssql.configuration import MsSqlClientConfiguration, MsSqlCredentials
 

--- a/tests/load/pipeline/test_athena.py
+++ b/tests/load/pipeline/test_athena.py
@@ -11,6 +11,7 @@ from tests.pipeline.utils import assert_load_info
 
 from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
 
+
 @pytest.mark.parametrize("destination_config", destinations_configs(default_sql_configs=True, subset=["athena"]), ids=lambda x: x.name)
 def test_athena_destinations(destination_config: DestinationTestConfiguration) -> None:
 

--- a/tests/load/pipeline/test_duckdb.py
+++ b/tests/load/pipeline/test_duckdb.py
@@ -1,0 +1,42 @@
+import pytest
+import os
+
+import dlt
+from dlt.destinations.exceptions import DatabaseTerminalException
+from dlt.pipeline.exceptions import PipelineStepFailed
+
+from tests.pipeline.utils import airtable_emojis
+from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration, load_table_counts
+
+
+@pytest.mark.parametrize("destination_config", destinations_configs(default_sql_configs=True, subset=["duckdb"]), ids=lambda x: x.name)
+def test_duck_case_names(destination_config: DestinationTestConfiguration) -> None:
+    # we want to have nice tables
+    # dlt.config["schema.naming"] = "duck_case"
+    os.environ["SCHEMA__NAMING"] = "duck_case"
+    pipeline = destination_config.setup_pipeline("test_duck_case_names")
+    # create tables and columns with emojis and other special characters
+    pipeline.run(airtable_emojis().with_resources("📆 Schedule", "🦚Peacock", "🦚WidePeacock"))
+    pipeline.run([{"🐾Feet": 2, "1+1": "two", "\nhey": "value"}], table_name="🦚Peacocks🦚")
+    table_counts = load_table_counts(pipeline, *[t["name"] for t in pipeline.default_schema.data_tables()])
+    assert table_counts == {
+        "📆 Schedule": 3,
+        "🦚Peacock": 1,
+        '🦚Peacock__peacock': 3,
+        '🦚Peacocks🦚': 1,
+        '🦚WidePeacock': 1,
+        '🦚WidePeacock__peacock': 3
+    }
+
+    # this will fail - duckdb preserves case but is case insensitive when comparing identifiers
+    with pytest.raises(PipelineStepFailed) as pip_ex:
+        pipeline.run([{"🐾Feet": 2, "1+1": "two", "🐾feet": "value"}], table_name="🦚peacocks🦚")
+    assert isinstance(pip_ex.value.__context__, DatabaseTerminalException)
+
+    # show tables and columns
+    with pipeline.sql_client() as client:
+        with client.execute_query("DESCRIBE 🦚peacocks🦚;") as q:
+            tables = q.df()
+    assert tables["column_name"].tolist() == ["🐾Feet", "1+1", "hey", "_dlt_load_id", "_dlt_id"]
+
+

--- a/tests/load/redshift/test_redshift_table_builder.py
+++ b/tests/load/redshift/test_redshift_table_builder.py
@@ -6,7 +6,6 @@ from dlt.common.utils import uniq_id, custom_environ, digest128
 from dlt.common.schema import Schema
 from dlt.common.configuration import resolve_configuration
 
-from dlt.destinations.exceptions import DestinationSchemaWillNotUpdate
 from dlt.destinations.redshift.redshift import RedshiftClient
 from dlt.destinations.redshift.configuration import RedshiftClientConfiguration, RedshiftCredentials
 

--- a/tests/normalize/test_normalize.py
+++ b/tests/normalize/test_normalize.py
@@ -312,16 +312,11 @@ def test_normalize_twice_with_flatten(caps: DestinationCapabilitiesContext, raw_
 
     # check if schema contains a few crucial tables
     def assert_schema(_schema: Schema):
-        convention = _schema._normalizers_config["names"]
-        if convention == "snake_case":
-            assert "reactions___1" in _schema.tables["issues"]["columns"]
-            assert "reactions__x1" in _schema.tables["issues"]["columns"]
-            assert "reactions__1" not in _schema.tables["issues"]["columns"]
-        elif convention == "duck_case":
-            assert "reactions__+1" in _schema.tables["issues"]["columns"]
-            assert "reactions__-1" in _schema.tables["issues"]["columns"]
-        else:
-            raise ValueError(f"convention {convention} cannot be checked")
+        # convention = _schema._normalizers_config["names"]
+        assert "reactions___1" in _schema.tables["issues"]["columns"]
+        assert "reactions__x1" in _schema.tables["issues"]["columns"]
+        assert "reactions__1" not in _schema.tables["issues"]["columns"]
+
 
     schema = raw_normalize.load_or_create_schema(raw_normalize.schema_storage, "github")
     assert_schema(schema)

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -146,7 +146,6 @@ def test_pipeline_context() -> None:
     assert ctx.pipeline() is p2
     assert p.is_active is False
     assert p2.is_active is True
-    assert Container()[DestinationCapabilitiesContext].naming_convention == "duck_case"
 
     p3 = dlt.pipeline(pipeline_name="more pipelines", destination="dummy")
     assert ctx.pipeline() is p3
@@ -159,7 +158,6 @@ def test_pipeline_context() -> None:
     assert ctx.pipeline() is p2
     assert p3.is_active is False
     assert p2.is_active is True
-    assert Container()[DestinationCapabilitiesContext].naming_convention == "duck_case"
 
 
 def test_import_unknown_destination() -> None:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
* Adds **duck_case** naming convention that preserves emojis, letter casing etc. to have fancy table and column names
* Adds `with_name` to DltResource that clones it with a name change.
* Some small changes and bug fixes - see commit list
