### PR TITLE
Update Synapse workflow for PR

### DIFF
--- a/.github/workflows/test_destination_synapse.yml
+++ b/.github/workflows/test_destination_synapse.yml
@@ -1,6 +1,11 @@
 name: test synapse
 
 on:
+  pull_request:
+    branches:
+      - master
+      - devel
+      
   workflow_dispatch:
   
 env:
@@ -14,6 +19,16 @@ env:
   ALL_FILESYSTEM_DRIVERS: "[\"memory\"]"
 
 jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check source branch name
+      run: |
+        if [[ "${{ github.head_ref }}" != "synapse" ]]; then
+          exit 1
+        fi
 
   run_loader:
     name: Tests Synapse loader


### PR DESCRIPTION
### Description

Updates the Synapse Workflow to run on Pull Requests from the Synapse Branch

Uses the following function to only run if the PR is from the "synapse" branch:

```
  build:
    runs-on: ubuntu-latest

    steps:
    - name: Check source branch name
      run: |
        if [[ "${{ github.head_ref }}" != "synapse" ]]; then
          exit 1
        fi
```


### Related Issues

Resolves issue with Synapse tests not running in the dlt repo from Synapse destination fork
