### PR TITLE
Fix: make Load single-thread compatible

### DIFF
--- a/dlt/load/configuration.py
+++ b/dlt/load/configuration.py
@@ -16,6 +16,9 @@ class LoaderConfiguration(PoolRunnerConfiguration):
     """When gt 0 will raise when job reaches raise_on_max_retries"""
     _load_storage_config: LoadStorageConfiguration = None
 
+    def on_resolved(self) -> None:
+        self.pool_type = "none" if self.workers == 1 else "thread"
+
     if TYPE_CHECKING:
         def __init__(
             self,

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -137,7 +137,11 @@ class Load(Runnable[ThreadPool]):
         param_chunk = [(id(self), file, load_id, schema) for file in load_files]
         # exceptions should not be raised, None as job is a temporary failure
         # other jobs should not be affected
-        jobs: List[LoadJob] = self.pool.starmap(Load.w_spool_job, param_chunk)
+        if self.pool:
+            jobs: List[LoadJob] = self.pool.starmap(Load.w_spool_job, param_chunk)
+        else:
+            # single-threaded loading
+            jobs = [Load.w_spool_job(self, file, load_id, schema) for file in load_files]
         # remove None jobs and check the rest
         return file_count, [job for job in jobs if job is not None]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dlt"
-version = "0.3.21"
+version = "0.3.22a0"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 authors = ["dltHub Inc. <services@dlthub.com>"]
 maintainers = [ "Marcin Rudolf <marcin@dlthub.com>", "Adrian Brudaru <adrian@dlthub.com>", "Ty Dunn <ty@dlthub.com>"]

--- a/tests/load/test_dummy_client.py
+++ b/tests/load/test_dummy_client.py
@@ -370,6 +370,21 @@ def test_retry_exceptions() -> None:
         assert py_ex.value.max_retry_count * 2 == py_ex.value.retry_count == 10
 
 
+def test_load_single_thread() -> None:
+    os.environ["LOAD__WORKERS"] = "1"
+    load = setup_loader(client_config=DummyClientConfiguration(completed_prob=1.0))
+    assert load.config.pool_type == "none"
+    load_id, _ = prepare_load_package(
+        load.load_storage,
+        NORMALIZED_FILES
+    )
+    # we do not need pool to complete
+    metrics = load.run(None)
+    while metrics.pending_items > 0:
+        metrics = load.run(None)
+    assert not load.load_storage.storage.has_folder(load.load_storage.get_package_path(load_id))
+
+
 def test_wrong_writer_type() -> None:
     load = setup_loader()
     load_id, _ = prepare_load_package(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
`Load` class does currently fail if `dlt.config["load.pool_type"] = "none"`

### Additional Context
see https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1697550254041179
