### PR TITLE
Replace multiprocessing pool with futures executors

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           # path: ${{ steps.pip-cache.outputs.dir }}
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies + sentry
         run: poetry install --no-interaction  -E parquet -E pydantic && pip install sentry-sdk

--- a/.github/workflows/test_dbt_cloud.yml
+++ b/.github/workflows/test_dbt_cloud.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           # path: ${{ steps.pip-cache.outputs.dir }}
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-dbt-cloud
+          key: venv-${{ matrix.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-dbt-cloud
 
       - name: Install dependencies
         # install dlt with postgres support

--- a/dlt/common/runners/__init__.py
+++ b/dlt/common/runners/__init__.py
@@ -1,5 +1,5 @@
 from . import pool_runner
-from .pool_runner import run_pool
-from .runnable import Runnable, workermethod
+from .pool_runner import run_pool, NullExecutor
+from .runnable import Runnable, workermethod, TExecutor
 from .typing import TRunMetrics
 from .venv import Venv, VenvNotFound

--- a/dlt/common/runners/pool_runner.py
+++ b/dlt/common/runners/pool_runner.py
@@ -1,30 +1,56 @@
 import multiprocessing
-from typing import Callable, Union, cast
+from typing import Callable, Union, cast, Any, TypeVar
 from multiprocessing.pool import ThreadPool, Pool
+from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor, Future
+from typing_extensions import ParamSpec
 
 from dlt.common import logger, sleep
 from dlt.common.runtime import init
-from dlt.common.runners.runnable import Runnable, TPool
+from dlt.common.runners.runnable import Runnable, TExecutor
 from dlt.common.runners.configuration import PoolRunnerConfiguration
 from dlt.common.runners.typing import TRunMetrics
 from dlt.common.runtime import signals
 from dlt.common.exceptions import SignalReceivedException
 
 
-def create_pool(config: PoolRunnerConfiguration) -> Pool:
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class NullExecutor(Executor):
+    """Dummy executor that runs jobs single-threaded.
+
+    Provides a uniform interface for `None` pool type
+    """
+
+    def submit(self, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Future[T]:
+        """Run the job and return a Future"""
+        fut: Future[T] = Future()
+        try:
+            result = fn(*args, **kwargs)
+        except BaseException as exc:
+            fut.set_exception(exc)
+        else:
+            fut.set_result(result)
+        return fut
+
+
+def create_pool(config: PoolRunnerConfiguration) -> Executor:
     if config.pool_type == "process":
         # if not fork method, provide initializer for logs and configuration
         if multiprocessing.get_start_method() != "fork" and init._INITIALIZED:
-            return Pool(processes=config.workers, initializer=init.initialize_runtime, initargs=(init._RUN_CONFIGURATION, ))
+            return ProcessPoolExecutor(max_workers=config.workers, initializer=init.initialize_runtime, initargs=(init._RUN_CONFIGURATION,))
+            # return Pool(processes=config.workers, initializer=init.initialize_runtime, initargs=(init._RUN_CONFIGURATION, ))
         else:
-            return Pool(processes=config.workers)
+            return ProcessPoolExecutor(max_workers=config.workers)
+            # return Pool(processes=config.workers)
     elif config.pool_type == "thread":
-        return ThreadPool(processes=config.workers)
+        return ThreadPoolExecutor(max_workers=config.workers)
     # no pool - single threaded
-    return None
+    return NullExecutor()
 
 
-def run_pool(config: PoolRunnerConfiguration, run_f: Union[Runnable[TPool], Callable[[TPool], TRunMetrics]]) -> int:
+def run_pool(config: PoolRunnerConfiguration, run_f: Union[Runnable[TExecutor], Callable[[TExecutor], TRunMetrics]]) -> int:
     # validate the run function
     if not isinstance(run_f, Runnable) and not callable(run_f):
         raise ValueError(run_f, "Pool runner entry point must be a function f(pool: TPool) or Runnable")
@@ -36,9 +62,9 @@ def run_pool(config: PoolRunnerConfiguration, run_f: Union[Runnable[TPool], Call
 
     def _run_func() -> bool:
         if callable(run_f):
-            run_metrics = run_f(cast(TPool, pool))
+            run_metrics = run_f(cast(TExecutor, pool))
         elif isinstance(run_f, Runnable):
-            run_metrics = run_f.run(cast(TPool, pool))
+            run_metrics = run_f.run(cast(TExecutor, pool))
         else:
             raise SignalReceivedException(-1)
         return run_metrics.pending_items > 0
@@ -59,7 +85,7 @@ def run_pool(config: PoolRunnerConfiguration, run_f: Union[Runnable[TPool], Call
         if pool:
             logger.info("Closing processing pool")
             # terminate pool and do not join
-            pool.terminate()
+            pool.shutdown(wait=True)
             # in very rare cases process hangs here, even with starmap terminating earlier
             # pool.close()
             # pool.join()

--- a/dlt/common/runners/pool_runner.py
+++ b/dlt/common/runners/pool_runner.py
@@ -84,10 +84,6 @@ def run_pool(config: PoolRunnerConfiguration, run_f: Union[Runnable[TExecutor], 
     finally:
         if pool:
             logger.info("Closing processing pool")
-            # terminate pool and do not join
             pool.shutdown(wait=True)
-            # in very rare cases process hangs here, even with starmap terminating earlier
-            # pool.close()
-            # pool.join()
             pool = None
             logger.info("Processing pool closed")

--- a/dlt/common/runners/pool_runner.py
+++ b/dlt/common/runners/pool_runner.py
@@ -1,6 +1,6 @@
+from __future__ import annotations
 import multiprocessing
-from typing import Callable, Union, cast, Any, TypeVar
-from multiprocessing.pool import ThreadPool, Pool
+from typing import Callable, Union, cast, TypeVar
 from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor, Future
 from typing_extensions import ParamSpec
 
@@ -39,9 +39,17 @@ def create_pool(config: PoolRunnerConfiguration) -> Executor:
     if config.pool_type == "process":
         # if not fork method, provide initializer for logs and configuration
         if multiprocessing.get_start_method() != "fork" and init._INITIALIZED:
-            return ProcessPoolExecutor(max_workers=config.workers, initializer=init.initialize_runtime, initargs=(init._RUN_CONFIGURATION,))
+            return ProcessPoolExecutor(
+                max_workers=config.workers,
+                initializer=init.initialize_runtime,
+                initargs=(init._RUN_CONFIGURATION,),
+                mp_context=multiprocessing.get_context()
+                )
         else:
-            return ProcessPoolExecutor(max_workers=config.workers)
+            return ProcessPoolExecutor(
+                max_workers=config.workers,
+                mp_context=multiprocessing.get_context()
+            )
     elif config.pool_type == "thread":
         return ThreadPoolExecutor(max_workers=config.workers)
     # no pool - single threaded

--- a/dlt/common/runners/pool_runner.py
+++ b/dlt/common/runners/pool_runner.py
@@ -40,10 +40,8 @@ def create_pool(config: PoolRunnerConfiguration) -> Executor:
         # if not fork method, provide initializer for logs and configuration
         if multiprocessing.get_start_method() != "fork" and init._INITIALIZED:
             return ProcessPoolExecutor(max_workers=config.workers, initializer=init.initialize_runtime, initargs=(init._RUN_CONFIGURATION,))
-            # return Pool(processes=config.workers, initializer=init.initialize_runtime, initargs=(init._RUN_CONFIGURATION, ))
         else:
             return ProcessPoolExecutor(max_workers=config.workers)
-            # return Pool(processes=config.workers)
     elif config.pool_type == "thread":
         return ThreadPoolExecutor(max_workers=config.workers)
     # no pool - single threaded

--- a/dlt/common/runners/runnable.py
+++ b/dlt/common/runners/runnable.py
@@ -3,14 +3,15 @@ from functools import wraps
 from typing import Any, Dict, Type, TypeVar, TYPE_CHECKING, Union, Generic
 from multiprocessing.pool import Pool
 from weakref import WeakValueDictionary
+from concurrent.futures import Executor
 
 from dlt.common.typing import TFun
 from dlt.common.runners.typing import TRunMetrics
 
-TPool = TypeVar("TPool", bound=Pool)
+TExecutor = TypeVar("TExecutor", bound=Executor)
 
 
-class Runnable(ABC, Generic[TPool]):
+class Runnable(ABC, Generic[TExecutor]):
     if TYPE_CHECKING:
         TWeakValueDictionary = WeakValueDictionary[int, "Runnable[Any]"]
     else:
@@ -19,7 +20,7 @@ class Runnable(ABC, Generic[TPool]):
     # use weak reference container, once other references are dropped the referenced object is garbage collected
     RUNNING: TWeakValueDictionary = WeakValueDictionary({})
 
-    def __new__(cls: Type["Runnable[TPool]"], *args: Any, **kwargs: Any) -> "Runnable[TPool]":
+    def __new__(cls: Type["Runnable[TExecutor]"], *args: Any, **kwargs: Any) -> "Runnable[TExecutor]":
         """Registers Runnable instance as running for a time when context is active.
         Used with `~workermethod` decorator to pass a class instance to decorator function that must be static thus avoiding pickling such instance.
 
@@ -34,7 +35,7 @@ class Runnable(ABC, Generic[TPool]):
         return i
 
     @abstractmethod
-    def run(self, pool: TPool) -> TRunMetrics:
+    def run(self, pool: TExecutor) -> TRunMetrics:
         pass
 
 
@@ -50,7 +51,7 @@ def workermethod(f: TFun) -> TFun:
         TFun: wrapped worker function
     """
     @wraps(f)
-    def _wrap(rid: Union[int, Runnable[TPool]], *args: Any, **kwargs: Any) -> Any:
+    def _wrap(rid: Union[int, Runnable[TExecutor]], *args: Any, **kwargs: Any) -> Any:
         if isinstance(rid, int):
             rid = Runnable.RUNNING[rid]
         return f(rid, *args, **kwargs)

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -29,6 +29,7 @@ from dlt.load.exceptions import LoadClientJobFailed, LoadClientJobRetry, LoadCli
 
 
 class Load(Runnable[Executor]):
+    pool: Executor
 
     @with_config(spec=LoaderConfiguration, sections=(known_sections.LOAD,))
     def __init__(
@@ -48,7 +49,7 @@ class Load(Runnable[Executor]):
         self.destination = destination
         self.capabilities = destination.capabilities()
         self.staging_destination = staging_destination
-        self.pool: Executor = NullExecutor()
+        self.pool = NullExecutor()
         self.load_storage: LoadStorage = self.create_storage(is_storage_owner)
         self._processed_load_ids: Dict[str, str] = {}
         """Load ids to dataset name"""
@@ -380,9 +381,9 @@ class Load(Runnable[Executor]):
                 self.complete_package(load_id, schema, True)
                 raise
 
-    def run(self, pool: Executor) -> TRunMetrics:
+    def run(self, pool: Optional[Executor]) -> TRunMetrics:
         # store pool
-        self.pool = pool
+        self.pool = pool or NullExecutor()
 
         logger.info("Running file loading")
         # get list of loads and order by name ASC to execute schema updates

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -3,7 +3,7 @@ from copy import copy
 from functools import reduce
 import datetime  # noqa: 251
 from typing import Dict, List, Optional, Tuple, Set, Iterator, Iterable, Callable
-from multiprocessing.pool import ThreadPool
+from concurrent.futures import Executor
 import os
 
 from dlt.common import sleep, logger
@@ -13,7 +13,7 @@ from dlt.common.pipeline import LoadInfo, SupportsPipeline
 from dlt.common.schema.utils import get_child_tables, get_top_level_table
 from dlt.common.storages.load_storage import LoadPackageInfo, ParsedLoadJobFileName, TJobState
 from dlt.common.typing import StrAny
-from dlt.common.runners import TRunMetrics, Runnable, workermethod
+from dlt.common.runners import TRunMetrics, Runnable, workermethod, NullExecutor
 from dlt.common.runtime.collector import Collector, NULL_COLLECTOR
 from dlt.common.runtime.logger import pretty_format_exception
 from dlt.common.exceptions import TerminalValueError, DestinationTerminalException, DestinationTransientException
@@ -28,7 +28,7 @@ from dlt.load.configuration import LoaderConfiguration
 from dlt.load.exceptions import LoadClientJobFailed, LoadClientJobRetry, LoadClientUnsupportedWriteDisposition, LoadClientUnsupportedFileFormats
 
 
-class Load(Runnable[ThreadPool]):
+class Load(Runnable[Executor]):
 
     @with_config(spec=LoaderConfiguration, sections=(known_sections.LOAD,))
     def __init__(
@@ -48,7 +48,7 @@ class Load(Runnable[ThreadPool]):
         self.destination = destination
         self.capabilities = destination.capabilities()
         self.staging_destination = staging_destination
-        self.pool: ThreadPool = None
+        self.pool: Executor = NullExecutor()
         self.load_storage: LoadStorage = self.create_storage(is_storage_owner)
         self._processed_load_ids: Dict[str, str] = {}
         """Load ids to dataset name"""
@@ -137,11 +137,7 @@ class Load(Runnable[ThreadPool]):
         param_chunk = [(id(self), file, load_id, schema) for file in load_files]
         # exceptions should not be raised, None as job is a temporary failure
         # other jobs should not be affected
-        if self.pool:
-            jobs: List[LoadJob] = self.pool.starmap(Load.w_spool_job, param_chunk)
-        else:
-            # single-threaded loading
-            jobs = [Load.w_spool_job(self, file, load_id, schema) for file in load_files]
+        jobs = self.pool.map(Load.w_spool_job, *zip(*param_chunk))
         # remove None jobs and check the rest
         return file_count, [job for job in jobs if job is not None]
 
@@ -384,7 +380,7 @@ class Load(Runnable[ThreadPool]):
                 self.complete_package(load_id, schema, True)
                 raise
 
-    def run(self, pool: ThreadPool) -> TRunMetrics:
+    def run(self, pool: Executor) -> TRunMetrics:
         # store pool
         self.pool = pool
 

--- a/dlt/normalize/normalize.py
+++ b/dlt/normalize/normalize.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable, List, Dict, Sequence, Tuple, Set
+from typing import Any, Callable, List, Dict, Sequence, Tuple, Set, Optional
 from concurrent.futures import Future, ProcessPoolExecutor, Executor
 # from multiprocessing.pool import AsyncResult, Pool as ProcessPool
 
@@ -35,12 +35,13 @@ TWorkerRV = Tuple[List[TSchemaUpdate], int, List[str], TRowCount]
 
 
 class Normalize(Runnable[Executor]):
+    pool: Executor
     @with_config(spec=NormalizeConfiguration, sections=(known_sections.NORMALIZE,))
     def __init__(self, collector: Collector = NULL_COLLECTOR, schema_storage: SchemaStorage = None, config: NormalizeConfiguration = config.value) -> None:
         self.config = config
         self.collector = collector
         self.normalize_storage: NormalizeStorage = None
-        self.pool: Executor = NullExecutor()
+        self.pool = NullExecutor()
         self.load_storage: LoadStorage = None
         self.schema_storage: SchemaStorage = None
         self._row_counts: TRowCount = {}
@@ -279,9 +280,9 @@ class Normalize(Runnable[Executor]):
 
         return load_id
 
-    def run(self, pool: Executor) -> TRunMetrics:
+    def run(self, pool: Optional[Executor]) -> TRunMetrics:
         # keep the pool in class instance
-        self.pool = pool
+        self.pool = pool or NullExecutor()
         self._row_counts = {}
         logger.info("Running file normalizing")
         # list files and group by schema name, list must be sorted for group by to actually work

--- a/dlt/normalize/normalize.py
+++ b/dlt/normalize/normalize.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any, Callable, List, Dict, Sequence, Tuple, Set
-from multiprocessing.pool import AsyncResult, Pool as ProcessPool
+from concurrent.futures import Future, ProcessPoolExecutor, Executor
+# from multiprocessing.pool import AsyncResult, Pool as ProcessPool
 
 from dlt.common import pendulum, json, logger, sleep
 from dlt.common.configuration import with_config, known_sections
@@ -8,7 +9,7 @@ from dlt.common.configuration.accessors import config
 from dlt.common.configuration.container import Container
 from dlt.common.destination import DestinationCapabilitiesContext, TLoaderFileFormat
 from dlt.common.json import custom_pua_decode
-from dlt.common.runners import TRunMetrics, Runnable
+from dlt.common.runners import TRunMetrics, Runnable, NullExecutor
 from dlt.common.runtime import signals
 from dlt.common.runtime.collector import Collector, NULL_COLLECTOR
 from dlt.common.schema.typing import TStoredSchema, TTableSchemaColumns
@@ -33,14 +34,13 @@ TMapFuncType = Callable[[Schema, str, Sequence[str]], TMapFuncRV]  # input param
 TWorkerRV = Tuple[List[TSchemaUpdate], int, List[str], TRowCount]
 
 
-class Normalize(Runnable[ProcessPool]):
-
+class Normalize(Runnable[Executor]):
     @with_config(spec=NormalizeConfiguration, sections=(known_sections.NORMALIZE,))
     def __init__(self, collector: Collector = NULL_COLLECTOR, schema_storage: SchemaStorage = None, config: NormalizeConfiguration = config.value) -> None:
         self.config = config
         self.collector = collector
-        self.pool: ProcessPool = None
         self.normalize_storage: NormalizeStorage = None
+        self.pool: Executor = NullExecutor()
         self.load_storage: LoadStorage = None
         self.schema_storage: SchemaStorage = None
         self._row_counts: TRowCount = {}
@@ -174,57 +174,52 @@ class Normalize(Runnable[ProcessPool]):
         return chunk_files
 
     def map_parallel(self, schema: Schema, load_id: str, files: Sequence[str]) -> TMapFuncRV:
-        workers = self.pool._processes  # type: ignore
+        workers: int = getattr(self.pool, '_max_workers', 1)
         chunk_files = self.group_worker_files(files, workers)
         schema_dict: TStoredSchema = schema.to_dict()
-        config_tuple = (self.normalize_storage.config, self.load_storage.config, self.config.destination_capabilities, schema_dict)
-        param_chunk = [[*config_tuple, load_id, files] for files in chunk_files]
-        tasks: List[Tuple[AsyncResult[TWorkerRV], List[Any]]] = []
+        param_chunk = [(
+            self.normalize_storage.config, self.load_storage.config, self.config.destination_capabilities, schema_dict, load_id, files
+        ) for files in chunk_files]
         row_counts: TRowCount = {}
 
         # return stats
         schema_updates: List[TSchemaUpdate] = []
 
         # push all tasks to queue
-        for params in param_chunk:
-            pending: AsyncResult[TWorkerRV] = self.pool.apply_async(Normalize.w_normalize_files, params)
-            tasks.append((pending, params))
+        tasks = [
+            (self.pool.submit(Normalize.w_normalize_files, *params), params) for params in param_chunk
+        ]
 
         while len(tasks) > 0:
             sleep(0.3)
             # operate on copy of the list
             for task in list(tasks):
                 pending, params = task
-                if pending.ready():
-                    if pending.successful():
-                        result: TWorkerRV = pending.get()
-                        try:
-                            # gather schema from all manifests, validate consistency and combine
-                            self.update_table(schema, result[0])
-                            schema_updates.extend(result[0])
-                            # update metrics
-                            self.collector.update("Files", len(result[2]))
-                            self.collector.update("Items", result[1])
-                            # merge row counts
-                            merge_row_count(row_counts, result[3])
-                        except CannotCoerceColumnException as exc:
-                            # schema conflicts resulting from parallel executing
-                            logger.warning(f"Parallel schema update conflict, retrying task ({str(exc)}")
-                            # delete all files produced by the task
-                            for file in result[2]:
-                                os.remove(file)
-                            # schedule the task again
-                            schema_dict = schema.to_dict()
-                            # TODO: it's time for a named tuple
-                            params[3] = schema_dict
-                            retry_pending: AsyncResult[TWorkerRV] = self.pool.apply_async(Normalize.w_normalize_files, params)
-                            tasks.append((retry_pending, params))
-                        # remove finished tasks
-                        tasks.remove(task)
-                    else:
-                        # raise the exception
-                        pending.get()
-                        raise AssertionError("unreachable code: pending.get must raise")
+                if pending.done():
+                    result: TWorkerRV = pending.result()  # Exception in task (if any) is raised here
+                    try:
+                        # gather schema from all manifests, validate consistency and combine
+                        self.update_table(schema, result[0])
+                        schema_updates.extend(result[0])
+                        # update metrics
+                        self.collector.update("Files", len(result[2]))
+                        self.collector.update("Items", result[1])
+                        # merge row counts
+                        merge_row_count(row_counts, result[3])
+                    except CannotCoerceColumnException as exc:
+                        # schema conflicts resulting from parallel executing
+                        logger.warning(f"Parallel schema update conflict, retrying task ({str(exc)}")
+                        # delete all files produced by the task
+                        for file in result[2]:
+                            os.remove(file)
+                        # schedule the task again
+                        schema_dict = schema.to_dict()
+                        # TODO: it's time for a named tuple
+                        params = params[:3] + (schema_dict,) + params[4:]
+                        retry_pending: Future[TWorkerRV] = self.pool.submit(Normalize.w_normalize_files, *params)
+                        tasks.append((retry_pending, params))
+                    # remove finished tasks
+                    tasks.remove(task)
 
         return schema_updates, row_counts
 
@@ -272,12 +267,9 @@ class Normalize(Runnable[ProcessPool]):
 
         self.load_storage.create_temp_load_package(load_id)
         logger.info(f"Created temp load folder {load_id} on loading volume")
-
-        # if pool is not present use map_single method to run normalization in single process
-        map_parallel_f = self.map_parallel if self.pool else self.map_single
         try:
             # process parallel
-            self.spool_files(schema_name, load_id, map_parallel_f, files)
+            self.spool_files(schema_name, load_id, self.map_parallel, files)
         except CannotCoerceColumnException as exc:
             # schema conflicts resulting from parallel executing
             logger.warning(f"Parallel schema update conflict, switching to single thread ({str(exc)}")
@@ -287,7 +279,7 @@ class Normalize(Runnable[ProcessPool]):
 
         return load_id
 
-    def run(self, pool: ProcessPool) -> TRunMetrics:
+    def run(self, pool: Executor) -> TRunMetrics:
         # keep the pool in class instance
         self.pool = pool
         self._row_counts = {}

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from functools import wraps
 from collections.abc import Sequence as C_Sequence
 from typing import Any, Callable, ClassVar, List, Iterator, Optional, Sequence, Tuple, cast, get_type_hints, ContextManager
+from concurrent.futures import Executor
 
 from dlt import version
 from dlt.common import json, logger, pendulum

--- a/tests/common/runners/test_runnable.py
+++ b/tests/common/runners/test_runnable.py
@@ -46,12 +46,11 @@ def test_runnable_direct_worker_call() -> None:
     assert rv[0] == 199
 
 
-def test_fail_on_process_worker_started_early() -> None:
-    # process pool cannot be started before class instance is created: mapping not exist in worker
+def test_process_worker_started_early() -> None:
+    # ProcessPoolExecutor starts lazily so it can be created before tasks
     with ProcessPoolExecutor(4) as p:
         r = _TestRunnableWorkerMethod(4)
-        with pytest.raises(KeyError):
-            r._run(p)
+        r._run(p)
         p.shutdown(wait=True)
 
 

--- a/tests/common/runners/test_runnable.py
+++ b/tests/common/runners/test_runnable.py
@@ -1,8 +1,9 @@
 import gc
 import pytest
 import multiprocessing
-from multiprocessing.pool import Pool
-from multiprocessing.dummy import Pool as ThreadPool
+# from multiprocessing.pool import Pool
+# from multiprocessing.dummy import Pool as ThreadPool
+from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
 from typing import Any
 
 from dlt.normalize.configuration import SchemaStorageConfiguration
@@ -17,9 +18,9 @@ def test_runnable_process_pool(method: str) -> None:
     # 4 tasks
     r = _TestRunnableWorker(4)
     # create 4 workers
-    with Pool(4) as p:
+    with ProcessPoolExecutor(4) as p:
         rv = r._run(p)
-        p.close()
+        p.shutdown()
     assert len(rv) == 4
     assert [v[0] for v in rv] == list(range(4))
     # must contain 4 different pids (coming from 4 worker processes)
@@ -28,9 +29,9 @@ def test_runnable_process_pool(method: str) -> None:
 
 def test_runnable_thread_pool() -> None:
     r = _TestRunnableWorkerMethod(4)
-    with ThreadPool(4) as p:
+    with ThreadPoolExecutor(4) as p:
         rv = r._run(p)
-        p.close()
+        p.shutdown()
         assert len(rv) == 4
         assert [v[0] for v in rv] == list(range(4))
         # must contain 1 pid (all in single process)
@@ -47,11 +48,11 @@ def test_runnable_direct_worker_call() -> None:
 
 def test_fail_on_process_worker_started_early() -> None:
     # process pool cannot be started before class instance is created: mapping not exist in worker
-    with Pool(4) as p:
+    with ProcessPoolExecutor(4) as p:
         r = _TestRunnableWorkerMethod(4)
         with pytest.raises(KeyError):
             r._run(p)
-        p.close()
+        p.shutdown(wait=True)
 
 
 @pytest.mark.skip("Hangs on gc.collect")
@@ -74,8 +75,8 @@ def test_configuredworker() -> None:
     _worker_1(config, "PX1", par2="PX2")
 
     # must also work across process boundary
-    with Pool(1) as p:
-        p.starmap(_worker_1, [(config, "PX1", "PX2")])
+    with ProcessPoolExecutor(1) as p:
+        p.map(_worker_1, *zip(*[(config, "PX1", "PX2")]))
 
 
 def _worker_1(CONFIG: SchemaStorageConfiguration, par1: str, par2: str = "DEFAULT") -> None:

--- a/tests/normalize/test_normalize.py
+++ b/tests/normalize/test_normalize.py
@@ -1,8 +1,9 @@
 import pytest
 from fnmatch import fnmatch
 from typing import Dict, Iterator, List, Sequence, Tuple
-from multiprocessing import get_start_method, Pool
-from multiprocessing.dummy import Pool as ThreadPool
+# from multiprocessing import get_start_method, Pool
+# from multiprocessing.dummy import Pool as ThreadPool
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 from dlt.common import json
 from dlt.common.schema.schema import Schema
@@ -208,7 +209,7 @@ def test_multiprocess_row_counting(caps: DestinationCapabilitiesContext, raw_nor
         ["github.events.load_page_1_duck"]
     )
     # use real process pool in tests
-    with Pool(processes=4) as p:
+    with ProcessPoolExecutor(max_workers=4) as p:
         raw_normalize.run(p)
 
     assert raw_normalize._row_counts["events"] == 100
@@ -222,7 +223,7 @@ def test_normalize_many_schemas(caps: DestinationCapabilitiesContext, rasa_norma
         ["event.event.many_load_2", "event.event.user_load_1", "ethereum.blocks.9c1d9b504ea240a482b007788d5cd61c_2"]
     )
     # use real process pool in tests
-    with Pool(processes=4) as p:
+    with ProcessPoolExecutor(max_workers=4) as p:
         rasa_normalize.run(p)
     # must have two loading groups with model and event schemas
     loads = rasa_normalize.load_storage.list_packages()
@@ -244,7 +245,7 @@ def test_normalize_many_schemas(caps: DestinationCapabilitiesContext, rasa_norma
 @pytest.mark.parametrize("caps", ALL_CAPABILITIES, indirect=True)
 def test_normalize_typed_json(caps: DestinationCapabilitiesContext, raw_normalize: Normalize) -> None:
     extract_items(raw_normalize.normalize_storage, [JSON_TYPED_DICT], "special", "special")
-    with ThreadPool(processes=1) as pool:
+    with ThreadPoolExecutor(max_workers=1) as pool:
         raw_normalize.run(pool)
     loads = raw_normalize.load_storage.list_packages()
     assert len(loads) == 1


### PR DESCRIPTION
Resolves: https://github.com/dlt-hub/dlt/issues/699

Added `NullExecutor` fallback implementation as well which just runs the task in the same thread and wraps in a future. So we have the same interface in single-threaded mode and don't have to check whether a pool is there.