### PR TITLE
gdrive fsspec

### DIFF
--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -60,7 +60,7 @@ class FilesystemConfiguration(BaseConfiguration):
     PROTOCOL_CREDENTIALS: ClassVar[Dict[str, Any]] = {
         "gs": Union[GcpServiceAccountCredentials, GcpOAuthCredentials],
         "gcs": Union[GcpServiceAccountCredentials, GcpOAuthCredentials],
-        "gdrive": GcpOAuthCredentials,
+        "gdrive": Union[GcpServiceAccountCredentials, GcpOAuthCredentials],
         "s3": AwsCredentials,
         "az": Union[AzureCredentialsWithoutDefaults, AzureCredentials],
         "abfs": Union[AzureCredentialsWithoutDefaults, AzureCredentials],

--- a/dlt/common/storages/fsspec_filesystem.py
+++ b/dlt/common/storages/fsspec_filesystem.py
@@ -199,12 +199,10 @@ def glob_files(
         bucket_url = pathlib.Path(bucket_url).absolute().as_uri()
         bucket_url_parsed = urlparse(bucket_url)
 
-    # not all filesystems use the host in list functions
-    if bucket_url_parsed.scheme in ["gdrive"]:
-        bucket_path = bucket_url_parsed.path
-    else:
-        bucket_path = bucket_url_parsed._replace(scheme='').geturl()
-        bucket_path = bucket_path[2:] if bucket_path.startswith("//") else bucket_path
+    bucket_path = bucket_url_parsed._replace(scheme='').geturl()
+    bucket_path = bucket_path[2:] if bucket_path.startswith("//") else bucket_path
+    bucket_path = bucket_path.split("?", 1)[0]
+    query = bucket_url_parsed.query 
     
     filter_url = posixpath.join(bucket_path, file_glob)
 
@@ -219,10 +217,7 @@ def glob_files(
         if bucket_url_parsed.scheme == "file" and not file.startswith("/"):
             file = "/" + file
         file_name = posixpath.relpath(file, bucket_path)
-        if bucket_url_parsed.scheme in ["gdrive"]:
-            file_url = bucket_url_parsed.scheme + "://" + bucket_url_parsed.netloc + "/" + file.lstrip("/")
-        else:
-            file_url = bucket_url_parsed.scheme + "://" + file
+        file_url = bucket_url_parsed.scheme + "://" + file + ("?" + query if query else "")
         yield FileItem(
             file_name=file_name,
             file_url=file_url,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This PR makes some changes to the filesystem module in order to support gdrive.

<!--
Provide any additional context about the PR here.
-->
### Additional Context

In gdrive when parsing a directory that is not the user root, eg. a directory that is shared with the user, you need to provide `root_file_id`, this PR adds support for it without changing `GcpCredentials`, it also removes the `netloc` that contains the `root_file_id` before requesting the data to fsspec.

For fetching a file using file_id the user will need to provide something like: `gdrive:///path?RootId=<file_id>`
If the user wants to get the root from the user gdrive account the netloc should not be provided: `gdrive:///path`

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->


depends on the [PR](https://github.com/fsspec/gdrivefs/pull/36)