### PR TITLE
Autodetector for ISO date strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help:
 	@echo "			runs flake and mypy"
 	@echo "		test"
 	@echo "			tests all the components including destinations"
-	@echo "		test-local"
+	@echo "		test-load-local"
 	@echo "			tests all components unsing local destinations: duckdb and postgres"
 	@echo "		test-common"
 	@echo "			tests common components"

--- a/dlt/common/schema/detections.py
+++ b/dlt/common/schema/detections.py
@@ -36,6 +36,25 @@ def is_iso_timestamp(t: Type[Any], v: Any) -> Optional[TDataType]:
     return None
 
 
+def is_iso_date(t: Type[Any], v: Any) -> Optional[TDataType]:
+    # only strings can be converted
+    if not issubclass(t, str):
+        return None
+    if not v:
+        return None
+    # don't cast iso timestamps as dates
+    if is_iso_timestamp(t,v):
+        return None
+    # strict autodetection of iso timestamps
+    try:
+        dtv = parse_iso_like_datetime(v)
+        if isinstance(dtv, datetime.date):
+            return "date"
+    except Exception:
+        pass
+    return None
+
+
 def is_large_integer(t: Type[Any], v: Any) -> Optional[TDataType]:
     # only ints can be converted
     if issubclass(t, int):

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -25,7 +25,7 @@ TColumnHint = Literal["not_null", "partition", "cluster", "primary_key", "foreig
 """Known hints of a column used to declare hint regexes."""
 TWriteDisposition = Literal["skip", "append", "replace", "merge"]
 TTableFormat = Literal["iceberg"]
-TTypeDetections = Literal["timestamp", "iso_timestamp", "large_integer", "hexbytes_to_text", "wei_to_double"]
+TTypeDetections = Literal["timestamp", "iso_timestamp", "iso_date", "large_integer", "hexbytes_to_text", "wei_to_double"]
 TTypeDetectionFunc = Callable[[Type[Any], Any], Optional[TDataType]]
 TColumnNames = Union[str, Sequence[str]]
 """A string representing a column name or a list of"""

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -698,4 +698,4 @@ def standard_hints() -> Dict[TColumnHint, List[TSimpleRegex]]:
 
 
 def standard_type_detections() -> List[TTypeDetections]:
-    return ["iso_timestamp", "iso_date"]
+    return ["iso_timestamp"]

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -698,4 +698,4 @@ def standard_hints() -> Dict[TColumnHint, List[TSimpleRegex]]:
 
 
 def standard_type_detections() -> List[TTypeDetections]:
-    return ["iso_timestamp"]
+    return ["iso_timestamp", "iso_date"]

--- a/docs/examples/archive/examples/schemas/dlt_quickstart.schema.yaml
+++ b/docs/examples/archive/examples/schemas/dlt_quickstart.schema.yaml
@@ -109,6 +109,7 @@ settings:
   detections:
   - timestamp
   - iso_timestamp
+  - iso_date
   default_hints:
     not_null:
     - _dlt_id

--- a/docs/examples/archive/schemas/dlt_quickstart.schema.yaml
+++ b/docs/examples/archive/schemas/dlt_quickstart.schema.yaml
@@ -84,6 +84,7 @@ normalizers:
   detections:
   - timestamp
   - iso_timestamp
+  - iso_date
   names: dlt.common.normalizers.names.snake_case
   json:
     module: dlt.common.normalizers.json.relational

--- a/docs/technical/working_with_schemas.md
+++ b/docs/technical/working_with_schemas.md
@@ -124,6 +124,7 @@ settings:
     detections:
     - timestamp
     - iso_timestamp
+    - iso_date
 ```
 
 ⛔ we may define `all_text` function that will generate string only schemas by telling `dlt` that all types should be coerced to strings.

--- a/docs/website/docs/general-usage/schema.md
+++ b/docs/website/docs/general-usage/schema.md
@@ -182,6 +182,7 @@ settings:
   detections:
     - timestamp
     - iso_timestamp
+    - iso_date
 ```
 
 ### Column hint rules

--- a/tests/common/cases/schemas/github/issues.schema.json
+++ b/tests/common/cases/schemas/github/issues.schema.json
@@ -1294,7 +1294,8 @@
   "settings": {
     "detections": [
       "timestamp",
-      "iso_timestamp"
+      "iso_timestamp",
+      "iso_date"
     ],
     "default_hints": {
       "not_null": [

--- a/tests/common/cases/schemas/sheets/google_spreadsheet_v4.schema.json
+++ b/tests/common/cases/schemas/sheets/google_spreadsheet_v4.schema.json
@@ -387,7 +387,8 @@
   "normalizers": {
     "detections": [
       "timestamp",
-      "iso_timestamp"
+      "iso_timestamp",
+      "iso_date"
     ],
     "names": "dlt.common.normalizers.names.snake_case",
     "json": {

--- a/tests/common/schema/test_detections.py
+++ b/tests/common/schema/test_detections.py
@@ -38,7 +38,7 @@ def test_iso_date_detection() -> None:
     assert is_iso_date(str, str(pendulum.now().date())) == "date"
     assert is_iso_date(str, "1975-05-21") == "date"
     assert is_iso_date(str, "19750521") == "date"
-    
+
     # ISO-8601 allows dates with reduced precision
     assert is_iso_date(str, "1975-05") == "date"
     assert is_iso_date(str, "1975") == "date"

--- a/tests/common/schema/test_detections.py
+++ b/tests/common/schema/test_detections.py
@@ -44,7 +44,7 @@ def test_iso_date_detection() -> None:
     assert is_iso_date(str, "2022-06-01T00:48:35.040Z") is None
     assert is_iso_date(str, "1975-0521T22:00:00Z") is None
     assert is_iso_date(str, "2021-07-24 10:51") is None
-    
+
     # times are not accepted
     assert is_iso_date(str, "22:00:00") is None
     # wrong formats

--- a/tests/common/schema/test_detections.py
+++ b/tests/common/schema/test_detections.py
@@ -37,6 +37,11 @@ def test_iso_timestamp_detection() -> None:
 def test_iso_date_detection() -> None:
     assert is_iso_date(str, str(pendulum.now().date())) == "date"
     assert is_iso_date(str, "1975-05-21") == "date"
+    assert is_iso_date(str, "19750521") == "date"
+    
+    # ISO-8601 allows dates with reduced precision
+    assert is_iso_date(str, "1975-05") == "date"
+    assert is_iso_date(str, "1975") == "date"
 
     # dont auto-detect timestamps as dates
     assert is_iso_date(str, str(pendulum.now())) is None
@@ -48,10 +53,10 @@ def test_iso_date_detection() -> None:
     # times are not accepted
     assert is_iso_date(str, "22:00:00") is None
     # wrong formats
+    assert is_iso_date(str, "197505") is None
     assert is_iso_date(str, "0-05-01") is None
     assert is_iso_date(str, "") is None
-    assert is_iso_date(str, "1975-05") is None
-    assert is_iso_date(str, "1975") is None
+    assert is_iso_date(str, "75") is None
     assert is_iso_date(str, "01-12") is None
     assert is_iso_date(str, "1975/05/01") is None
 

--- a/tests/common/schema/test_detections.py
+++ b/tests/common/schema/test_detections.py
@@ -2,7 +2,7 @@ from hexbytes import HexBytes
 
 from dlt.common import pendulum, Decimal, Wei
 from dlt.common.schema.utils import autodetect_sc_type
-from dlt.common.schema.detections import is_hexbytes_to_text, is_timestamp, is_iso_timestamp, is_large_integer, is_wei_to_double, _FLOAT_TS_RANGE, _NOW_TS
+from dlt.common.schema.detections import is_hexbytes_to_text, is_timestamp, is_iso_timestamp, is_iso_date, is_large_integer, is_wei_to_double, _FLOAT_TS_RANGE, _NOW_TS
 
 
 def test_timestamp_detection() -> None:
@@ -34,6 +34,31 @@ def test_iso_timestamp_detection() -> None:
     assert is_iso_timestamp(float, str(pendulum.now())) is None
 
 
+def test_iso_date_detection() -> None:
+    assert is_iso_date(str, str(pendulum.now().date())) == "date"
+    assert is_iso_date(str, "1975-05-21") == "date"
+
+    # dont auto-detect timestamps as dates
+    assert is_iso_date(str, str(pendulum.now())) is None
+    assert is_iso_date(str, "1975-05-21T22:00:00Z") is None
+    assert is_iso_date(str, "2022-06-01T00:48:35.040Z") is None
+    assert is_iso_date(str, "1975-0521T22:00:00Z") is None
+    assert is_iso_date(str, "2021-07-24 10:51") is None
+    
+    # times are not accepted
+    assert is_iso_date(str, "22:00:00") is None
+    # wrong formats
+    assert is_iso_date(str, "0-05-01") is None
+    assert is_iso_date(str, "") is None
+    assert is_iso_date(str, "1975-05") is None
+    assert is_iso_date(str, "1975") is None
+    assert is_iso_date(str, "01-12") is None
+    assert is_iso_date(str, "1975/05/01") is None
+
+    # wrong type
+    assert is_iso_date(float, str(pendulum.now().date())) is None
+
+
 def test_detection_large_integer() -> None:
     assert is_large_integer(str, "A") is None
     assert is_large_integer(int, 2**64 // 2) == "wei"
@@ -56,6 +81,8 @@ def test_detection_function() -> None:
     assert autodetect_sc_type(None, str, str(pendulum.now())) is None
     assert autodetect_sc_type(["iso_timestamp"], str, str(pendulum.now())) == "timestamp"
     assert autodetect_sc_type(["iso_timestamp"], float, str(pendulum.now())) is None
+    assert autodetect_sc_type(["iso_date"], str, str(pendulum.now().date())) == "date"
+    assert autodetect_sc_type(["iso_date"], float, str(pendulum.now().date())) is None
     assert autodetect_sc_type(["timestamp"], str, str(pendulum.now())) is None
     assert autodetect_sc_type(["timestamp", "iso_timestamp"], float, pendulum.now().timestamp()) == "timestamp"
     assert autodetect_sc_type(["timestamp", "large_integer"], int, 2**64) == "wei"


### PR DESCRIPTION
### Description
[ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) defines date strings as `YYYY-MM-DD`. We already have autodetection for ISO timestamp strings and detect ISO-compliant date strings like `2023-11-15` as date objects (see [here](https://github.com/dlt-hub/dlt/blob/63c18fed82ad2618ae5f95274ceadf13a9fbe03c/dlt/common/time.py#L30C21-L30C21)). However, neither does the `is_iso_timestamp` autodetection function pick date strings up as dates, nor is there a dedicated `is_iso_date` auto-detection function. 

As a result, sources that yield "native" date objects get loaded with data type `date`, whereas sources that yield ISO-compliant date strings get loaded with data type `text`

This PR adds an `iso_date` autodetection function to the list of default type detectors. This change is fully backward compatible with existing schemas, so that we don't need to bump the schema engine version.

### Related Issues

- Fixes [766](https://github.com/dlt-hub/dlt/issues/766)
