### PR TITLE
Fixes typo in Incremental-loading docs.

### DIFF
--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -23,7 +23,7 @@ achieve this, use `write_disposition='replace'` in your resources. Learn more in
 - **Append**: appends the new data to the destination. Use `write_disposition='append'`.
 
 - **Merge**: Merges new data to the destination using `merge_key` and/or deduplicates/upserts new data
-using `private_key`. Use `write_disposition='merge'`.
+using `primary_key`. Use `write_disposition='merge'`.
 
 ### Two simple questions determine the write disposition you use
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Very small change. `private_key` to `primary_key` in the description of the `merge` option for `write_disposition` in the [Incremental loading](https://dlthub.com/docs/general-usage/incremental-loading#the-3-write-dispositions) docs. 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

While working through the **Getting Started** exercise, I was curious about the other `write_disposition` options, started reading the [Incremental loading](https://dlthub.com/docs/general-usage/incremental-loading) docs, and the description of the `merge` option indicated it uses a `private_key` to determine which records are duplicates. I'm nearly certain that should be `primary_key` based on semantics and [exploring the codebase](https://github.com/search?q=repo%3Adlt-hub%2Fdlt+write_disposition+merge&type=code).

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
