### PR TITLE
Fix: ensure accessor typing does not make static type checker error

### DIFF
--- a/dlt/common/configuration/accessors.py
+++ b/dlt/common/configuration/accessors.py
@@ -102,7 +102,7 @@ class _ConfigAccessor(_Accessor):
         """find first writable provider that does not support secrets - should be config.toml"""
         return next(p for p in self._get_providers_from_context() if p.is_writable and not p.supports_secrets)
 
-    value: ClassVar[None] = ConfigValue
+    value: ClassVar[Any] = ConfigValue
     "A placeholder that tells dlt to replace it with actual config value during the call to a source or resource decorated function."
 
 
@@ -123,7 +123,7 @@ class _SecretsAccessor(_Accessor):
         """find first writable provider that supports secrets - should be secrets.toml"""
         return next(p for p in self._get_providers_from_context() if p.is_writable and p.supports_secrets)
 
-    value: ClassVar[None] = ConfigValue
+    value: ClassVar[Any] = ConfigValue
     "A placeholder that tells dlt to replace it with actual secret during the call to a source or resource decorated function."
 
 


### PR DESCRIPTION
Another quick patch for one of the more common public APIs.

Anywhere you use `dlt.config.value` or `dlt.secrets.value` will throw an error with Pyright (possibly other checkers depending on settings but pyright is the defacto standard in vscode for example which a large number of users use) unless the value is marked optional. This is antithetical to the point of the sentinel value as its presence indicates that a value will in fact contain something. 

So we should use `Any` here. Using Any fixes the below errors.

<img width="1636" alt="image" src="https://github.com/dlt-hub/dlt/assets/41213451/ba618ef9-0e2a-48ad-aabb-692d867d3317">

<img width="1491" alt="image" src="https://github.com/dlt-hub/dlt/assets/41213451/6fce5583-b823-4ce6-8384-ac3f3102102a">
