### PR TITLE
Fix links to source code

### DIFF
--- a/docs/website/pydoc-markdown.yml
+++ b/docs/website/pydoc-markdown.yml
@@ -19,7 +19,7 @@ renderer:
     classdef_with_decorators: true
     signature_with_decorators: true
     format_code: true
-    source_linker:
-      type: github
-      repo: dlt-hub/dlt
-      root: ..
+#    source_linker:
+#      type: github
+#      repo: dlt-hub/dlt
+#      root: ..

--- a/docs/website/pydoc-markdown.yml
+++ b/docs/website/pydoc-markdown.yml
@@ -22,5 +22,3 @@ renderer:
     source_linker:
       type: github
       repo: dlt-hub/dlt
-      root: ..
-      use_branch: true

--- a/docs/website/pydoc-markdown.yml
+++ b/docs/website/pydoc-markdown.yml
@@ -19,7 +19,8 @@ renderer:
     classdef_with_decorators: true
     signature_with_decorators: true
     format_code: true
-#    source_linker:
-#      type: github
-#      repo: dlt-hub/dlt
-#      root: ..
+    source_linker:
+      type: github
+      repo: dlt-hub/dlt
+      root: ..
+      use_branch: true

--- a/docs/website/pydoc-markdown.yml
+++ b/docs/website/pydoc-markdown.yml
@@ -22,3 +22,4 @@ renderer:
     source_linker:
       type: github
       repo: dlt-hub/dlt
+      root: ../..


### PR DESCRIPTION
Fixed the problem with source code links in [API reference.](https://dlthub.com/docs/api_reference/common/time). 