### PR TITLE
Fix: assert for test_coerce_type_to_text test

### DIFF
--- a/tests/common/schema/test_coercion.py
+++ b/tests/common/schema/test_coercion.py
@@ -32,7 +32,7 @@ def test_coerce_type_to_text() -> None:
     # bytes to text (base64)
     assert coerce_value("text", "binary", b'binary string') == "YmluYXJ5IHN0cmluZw=="
     # HexBytes to text (hex with prefix)
-    assert coerce_value("text", "binary", HexBytes(b'binary string')) == "0x62696e61727920737472696e67"
+    assert coerce_value("text", "binary", HexBytes(b'binary string')) == "62696e61727920737472696e67"
     # Str enum value
     class StrEnum(Enum):
         a = "a_value"


### PR DESCRIPTION
we have a problem with test `tests/common/schema/test_coercion.py` test_coerce_type_to_text:

```
    def test_coerce_type_to_text() -> None:
        assert coerce_value("text", "bool", False) == str(False)
        # double into text
        assert coerce_value("text", "double", -1726.1288) == "-1726.1288"
        # bytes to text (base64)
        assert coerce_value("text", "binary", b'binary string') == "YmluYXJ5IHN0cmluZw=="
        # HexBytes to text (hex with prefix)
>       assert coerce_value("text", "binary", HexBytes(b'binary string')) == "0x62696e61727920737472696e67"
E       AssertionError: assert '62696e61727920737472696e67' == '0x62696e61727920737472696e67'
E         - 0x62696e61727920737472696e67
E         ? --
E         + 62696e61727920737472696e67
```

HexBytes deleted prepend of `0x` from HexBytes().value. [PR](https://github.com/ethereum/hexbytes/pull/38)
