### PR TITLE
fixed attribute check: getuid -> geteuid

### DIFF
--- a/dlt/common/configuration/paths.py
+++ b/dlt/common/configuration/paths.py
@@ -36,8 +36,8 @@ def get_dlt_data_dir() -> str:
     if "DLT_DATA_DIR" in os.environ:
         return os.environ["DLT_DATA_DIR"]
 
-    # getuid not available on Windows
-    if hasattr(os, "getuid") and os.geteuid() == 0:
+    # geteuid not available on Windows
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
         # we are root so use standard /var
         return os.path.join("/var", "dlt")
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR fixes a bug related to `os.geteuid()` that surfaces when running `make lint` on a Windows machine. See #822 for details.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #822

<!--
Provide any additional context about the PR here.
-->
### Additional Context
Although this PR fixes an error, there are other errors that cause both `make lint` and `make test-common` to fail before finishing. Perhaps also Windows-related.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
