### PR TITLE
Fix Windows lint issue and implement CI lint matrix strategy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,13 @@ jobs:
         #     os: "ubuntu-latest"
         #   - python-version: "3.10.x"
         #     os: "ubuntu-latest"
+        include:
+          - os: "windows-latest"
+            python-version: "3.8.x"
+          - os: "windows-latest"
+            python-version: "3.9.x"
+          - os: "windows-latest"            
+            python-version: "3.10.x"
 
     defaults:
       run:
@@ -72,14 +79,15 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
-          export PATH=$PATH:"C:/Program Files/Git/usr/bin"
-          echo $PATH
-          ls "C:/Program Files/Git/usr/bin"
-          echo $SHELL
-          echo 'all:;@echo $(SHELL)' | make -f-
-          poetry --version
-          make --version
-          echo $GITHUB_PATH
+          # export PATH=$PATH:"C:/Program Files/Git/usr/bin"
+          export PATH=$PATH:"/c/Program Files/usr/bin"
+          # echo $PATH
+          # ls "C:/Program Files/Git/usr/bin"
+          # echo $SHELL
+          # echo 'all:;@echo $(SHELL)' | make -f-
+          # poetry --version
+          # make --version
+          # echo $GITHUB_PATH
           make dev
 
       # - name: Install self

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,36 +13,19 @@ jobs:
   #   uses: ./.github/workflows/get_docs_changes.yml
 
   run_lint:
-    name: Runs make lint
+    name: Lint
     # needs: get_docs_changes
     # if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.11.x"]
-        # Test all python versions on ubuntu only
-        # include:
-        #   - python-version: "3.8.x"
-        #     os: "ubuntu-latest"
-        #   - python-version: "3.9.x"
-        #     os: "ubuntu-latest"
-        #   - python-version: "3.10.x"
-        #     os: "ubuntu-latest"
-        include:
-          - os: "windows-latest"
-            python-version: "3.8.x"
-          - os: "windows-latest"
-            python-version: "3.9.x"
-          - os: "windows-latest"            
-            python-version: "3.10.x"
+        python-version: ["3.8.x", "3.9.x", "3.10.x", "3.11.x"]
 
     defaults:
       run:
         shell: bash
     runs-on: ${{ matrix.os }}    
-
-    # runs-on: ubuntu-latest
 
     steps:
 
@@ -54,19 +37,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # - name: Install make     
-      #   if: runner.os == 'Windows'
-      #   run: choco install make
-
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
-          installer-parallel: true
-
-      - name: Check Poetry install     
-        run: poetry --version          
+          installer-parallel: true         
 
       - name: Load cached venv
         id: cached-poetry-dependencies
@@ -75,21 +51,15 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Install dependencies
+      - name: Extend path
+        run: echo "/c/Program Files/usr/bin" >> $GITHUB_PATH
+
+      - name: Run make dev
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
-        run: |
-          export PATH=$PATH:"/c/Program Files/usr/bin"
-          make dev
+        run: make dev
 
-      # - name: Install self
-      #   run: poetry install --no-interaction
-
-
-      - name: Run lint
-        run: |
-          export PATH=$PATH:"/c/Program Files/usr/bin"
-          make lint
+      - name: Run make lint
+        run: make lint
 
       # - name: print envs
       #   run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,15 +51,16 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Extend path
-        run: echo "/c/Program Files/usr/bin" >> $GITHUB_PATH
-
       - name: Run make dev
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: make dev
+        run: |
+          export PATH=$PATH:"/c/Program Files/usr/bin"        
+          make dev
 
       - name: Run make lint
-        run: make lint
+        run: |
+          export PATH=$PATH:"/c/Program Files/usr/bin"        
+          make lint
 
       # - name: print envs
       #   run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,6 +68,10 @@ jobs:
       # - name: Install self
       #   run: poetry install --no-interaction
 
+      - name: Install make     
+        if: runner.os == 'Windows'
+        run: choco install make
+
       - name: Run lint
         run: make lint
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
-          ls C:/Program Files/Git/usr/bin/
+          ls
           echo $SHELL
           echo 'all:;@echo $(SHELL)' | make -f-
           poetry --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,14 +21,17 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.11.x"]
-        # Test all python versions on ubuntu only
-        # include:
-        #   - python-version: "3.8.x"
-        #     os: "ubuntu-latest"
-        #   - python-version: "3.9.x"
-        #     os: "ubuntu-latest"
-        #   - python-version: "3.10.x"
-        #     os: "ubuntu-latest"
+        Test all python versions on ubuntu only
+        include:
+          - python-version: "3.8.x"
+            # os: "ubuntu-latest"
+            os: "windows-latest"
+          - python-version: "3.9.x"
+            # os: "ubuntu-latest"
+            os: "windows-latest"
+          - python-version: "3.10.x"
+            # os: "ubuntu-latest"
+            os: "windows-latest"
 
     defaults:
       run:
@@ -45,7 +48,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10.x"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install make     
         if: runner.os == 'Windows'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
-          poetry shell
+          echo "$$PATH"
           make dev
         # shell: bash
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          # key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Run make dev
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,7 +76,7 @@ jobs:
           make --version
           echo $GITHUB_PATH
           make dev
-        # shell: bash
+        shell: pwsh
 
       # - name: Install self
       #   run: poetry install --no-interaction

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,6 +69,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: make dev
+        shell: bash
 
       # - name: Install self
       #   run: poetry install --no-interaction
@@ -76,6 +77,7 @@ jobs:
 
       - name: Run lint
         run: make lint
+        shell: bash
 
       # - name: print envs
       #   run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
+          poetry --version
           make --version
           echo $GITHUB_PATH
           make dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,6 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          # key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
           key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Run make dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
+          export PATH=$PATH:"C:/Program Files/Git/usr/bin"
           echo $PATH
           ls "C:/Program Files/Git/usr/bin"
           echo $SHELL

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,12 +54,12 @@ jobs:
       - name: Run make dev
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
-          export PATH=$PATH:"/c/Program Files/usr/bin"        
+          export PATH=$PATH:"/c/Program Files/usr/bin" # needed for Windows      
           make dev
 
       - name: Run make lint
         run: |
-          export PATH=$PATH:"/c/Program Files/usr/bin"        
+          export PATH=$PATH:"/c/Program Files/usr/bin" # needed for Windows        
           make lint
 
       # - name: print envs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,13 +22,13 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.11.x"]
         # Test all python versions on ubuntu only
-        include:
-          - python-version: "3.8.x"
-            os: "ubuntu-latest"
-          - python-version: "3.9.x"
-            os: "ubuntu-latest"
-          - python-version: "3.10.x"
-            os: "ubuntu-latest"
+        # include:
+        #   - python-version: "3.8.x"
+        #     os: "ubuntu-latest"
+        #   - python-version: "3.9.x"
+        #     os: "ubuntu-latest"
+        #   - python-version: "3.10.x"
+        #     os: "ubuntu-latest"
 
     defaults:
       run:
@@ -47,6 +47,10 @@ jobs:
         with:
           python-version: "3.10.x"
 
+      - name: Install make     
+        if: runner.os == 'Windows'
+        run: choco install make
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
@@ -63,14 +67,12 @@ jobs:
 
       - name: Install dependencies
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
+        # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
+        run: make dev
 
       # - name: Install self
       #   run: poetry install --no-interaction
 
-      - name: Install make     
-        if: runner.os == 'Windows'
-        run: choco install make
 
       - name: Run lint
         run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
-          ls
+          ls "C:/Program Files/Git/usr/bin"
           echo $SHELL
           echo 'all:;@echo $(SHELL)' | make -f-
           poetry --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,11 +72,12 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
+          echo $SHELL
+          echo 'all:;@echo $(SHELL)' | make -f-
           poetry --version
           make --version
           echo $GITHUB_PATH
           make dev
-        shell: pwsh
 
       # - name: Install self
       #   run: poetry install --no-interaction

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,9 +47,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install make     
-        if: runner.os == 'Windows'
-        run: choco install make
+      # - name: Install make     
+      #   if: runner.os == 'Windows'
+      #   run: choco install make
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,15 +79,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
-          # export PATH=$PATH:"C:/Program Files/Git/usr/bin"
           export PATH=$PATH:"/c/Program Files/usr/bin"
-          # echo $PATH
-          # ls "C:/Program Files/Git/usr/bin"
-          # echo $SHELL
-          # echo 'all:;@echo $(SHELL)' | make -f-
-          # poetry --version
-          # make --version
-          # echo $GITHUB_PATH
           make dev
 
       # - name: Install self
@@ -95,8 +87,9 @@ jobs:
 
 
       - name: Run lint
-        run: make lint
-        shell: bash
+        run: |
+          export PATH=$PATH:"/c/Program Files/usr/bin"
+          make lint
 
       # - name: print envs
       #   run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,8 +71,10 @@ jobs:
       - name: Install dependencies
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
-        run: make dev
-        shell: bash
+        run: |
+          poetry shell
+          make dev
+        # shell: bash
 
       # - name: Install self
       #   run: poetry install --no-interaction

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
+          ls C:/Program Files/Git/usr/bin/
           echo $SHELL
           echo 'all:;@echo $(SHELL)' | make -f-
           poetry --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.11.x"]
-        Test all python versions on ubuntu only
+        # Test all python versions on ubuntu only
         include:
           - python-version: "3.8.x"
             # os: "ubuntu-latest"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,7 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
-          echo "$$PATH"
+          echo $GITHUB_PATH
           make dev
         # shell: bash
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,29 @@ jobs:
   #   uses: ./.github/workflows/get_docs_changes.yml
 
   run_lint:
-    name: Runs mypy, flake and bandit
+    name: Runs make lint
     # needs: get_docs_changes
     # if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.11.x"]
+        # Test all python versions on ubuntu only
+        include:
+          - python-version: "3.8.x"
+            os: "ubuntu-latest"
+          - python-version: "3.9.x"
+            os: "ubuntu-latest"
+          - python-version: "3.10.x"
+            os: "ubuntu-latest"
 
-    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}    
+
+    # runs-on: ubuntu-latest
 
     steps:
 
@@ -58,3 +76,14 @@ jobs:
       #     echo "The GitHub Actor's username is: $GITHUB_ACTOR"
       #     echo "The GitHub repo owner is: $GITHUB_REPOSITORY_OWNER"
       #     echo "The GitHub repo is: $GITHUB_REPOSITORY"
+
+  matrix_job_required_check:
+    name: Lint results
+    needs: run_lint
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix job results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One or more matrix job tests failed or were cancelled. You may need to re-run them." && exit 1      

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,13 +9,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  # get_docs_changes:
-  #   uses: ./.github/workflows/get_docs_changes.yml
+  get_docs_changes:
+    uses: ./.github/workflows/get_docs_changes.yml
 
   run_lint:
     name: Lint
-    # needs: get_docs_changes
-    # if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    needs: get_docs_changes
+    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
+          make --version
           echo $GITHUB_PATH
           make dev
         # shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,7 @@ jobs:
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         # run: poetry install --no-interaction --all-extras --with airflow --with docs --with providers --with sentry-sdk --with pipeline
         run: |
+          echo $PATH
           ls "C:/Program Files/Git/usr/bin"
           echo $SHELL
           echo 'all:;@echo $(SHELL)' | make -f-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,13 +9,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  get_docs_changes:
-    uses: ./.github/workflows/get_docs_changes.yml
+  # get_docs_changes:
+  #   uses: ./.github/workflows/get_docs_changes.yml
 
   run_lint:
     name: Runs mypy, flake and bandit
-    needs: get_docs_changes
-    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    # needs: get_docs_changes
+    # if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,16 +22,13 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.11.x"]
         # Test all python versions on ubuntu only
-        include:
-          - python-version: "3.8.x"
-            # os: "ubuntu-latest"
-            os: "windows-latest"
-          - python-version: "3.9.x"
-            # os: "ubuntu-latest"
-            os: "windows-latest"
-          - python-version: "3.10.x"
-            # os: "ubuntu-latest"
-            os: "windows-latest"
+        # include:
+        #   - python-version: "3.8.x"
+        #     os: "ubuntu-latest"
+        #   - python-version: "3.9.x"
+        #     os: "ubuntu-latest"
+        #   - python-version: "3.10.x"
+        #     os: "ubuntu-latest"
 
     defaults:
       run:
@@ -60,6 +57,9 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+
+      - name: Check Poetry install     
+        run: poetry --version          
 
       - name: Load cached venv
         id: cached-poetry-dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+$(info $(SHELL))
+
 .PHONY: install-poetry build-library-prerelease has-poetry dev lint test test-common reset-test-storage recreate-compiled-deps build-library-prerelease publish-library
 
 PYV=$(shell python3 -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)")

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-$(info $(SHELL))
-
 .PHONY: install-poetry build-library-prerelease has-poetry dev lint test test-common reset-test-storage recreate-compiled-deps build-library-prerelease publish-library
 
 PYV=$(shell python3 -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)")

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint:
 	poetry run mypy --config-file mypy.ini dlt tests
 	poetry run flake8 --max-line-length=200 dlt
 	poetry run flake8 --max-line-length=200 tests --exclude tests/reflection/module_cases
-	poetry run black dlt docs tests --diff --exclude=".*syntax_error.py|\.venv.*|_storage/.*"
+	poetry run black dlt docs tests --diff --extend-exclude=".*syntax_error.py"
 	# poetry run isort ./ --diff
 	# $(MAKE) lint-security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ optional = true
 pymysql = "^1.1.0"
 pypdf2 = "^3.0.1"
 pydoc-markdown = "^4.8.2"
-connectorx="0.3.1"
+connectorx="0.3.2"
 dbt-core=">=1.2.0"
 dbt-duckdb=">=1.2.0"
 pymongo = ">=4.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ optional = true
 pymysql = "^1.1.0"
 pypdf2 = "^3.0.1"
 pydoc-markdown = "^4.8.2"
-connectorx="0.3.2"
+connectorx="0.3.1"
 dbt-core=">=1.2.0"
 dbt-duckdb=">=1.2.0"
 pymongo = ">=4.3.3"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. Fix for issue with `black` command when running `make lint` on Windows: #826 
2. Implementation of matrix strategy for linting CI: #830 

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #826
- Implements #830 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
The issue seems to be caused by the boolean ORs (`|`) in the regex for `--exclude`. These ORs can be circumvented when using `--extend-exclude` instead of `--extend`, because `.venv` and `_storage` are included in `.gitignore`, and everything in `.gitignore` is excluded by default ([link](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#exclude)).

> Note: `--exclude` overrides all default exclusions (such as `.gitignore`), while `--extend-exclude` adds on top of the default values. So this new solution potentially excludes more.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
