### PR TITLE
791 test mssql credentialspy is odbc driver 18 dependent

### DIFF
--- a/dlt/destinations/impl/mssql/README.md
+++ b/dlt/destinations/impl/mssql/README.md
@@ -1,5 +1,5 @@
 # loader account setup
 
 1. Create new database `CREATE DATABASE dlt_data`
-2. Create new user, set password `CREATE USER loader WITH PASSWORD 'loader';`
+2. Create new user, set password `CREATE USER loader WITH PASSWORD = 'loader';`
 3. Set as database owner (we could set lower permission) `ALTER DATABASE dlt_data OWNER TO loader`

--- a/docs/website/docs/dlt-ecosystem/destinations/mssql.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/mssql.md
@@ -18,7 +18,8 @@ See instructions here to [install Microsoft ODBC Driver 18 for SQL Server on Win
 Following ODBC drivers are supported:
 * ODBC Driver 18 for SQL Server
 * ODBC Driver 17 for SQL Server
-[You configure driver name explicitly](#additional-destination-options) as well.
+
+[You can configure driver name explicitly](#additional-destination-options) as well.
 
 ### Create a pipeline
 
@@ -92,7 +93,14 @@ create_indexes=true
 You can explicitly set the ODBC driver name:
 ```toml
 [destination.mssql.credentials]
-odbc_driver="ODBC Driver 18 for SQL Server"
+driver="ODBC Driver 18 for SQL Server"
+```
+
+When using a SQLAlchemy connection string, replace spaces with `+`:
+
+```toml
+# keep it at the top of your toml file! before any section starts
+destination.mssql.credentials="mssql://loader:<password>@loader.database.windows.net/dlt_data?driver=ODBC+Driver+18+for+SQL+Server"
 ```
 
 ### dbt support

--- a/tests/load/mssql/test_mssql_credentials.py
+++ b/tests/load/mssql/test_mssql_credentials.py
@@ -1,19 +1,65 @@
+import pyodbc
+import pytest
+
 from dlt.common.configuration import resolve_configuration
+from dlt.common.exceptions import SystemConfigurationException
 
-from dlt.destinations.impl.mssql.configuration import MsSqlCredentials
+from dlt.destinations.impl.mssql.configuration import MsSqlCredentials, SUPPORTED_DRIVERS
 
 
-def test_to_odbc_dsn() -> None:
+def test_parse_native_representation_unsupported_driver_specified() -> None:
+    # Case: unsupported driver specified.
+    with pytest.raises(SystemConfigurationException):
+        resolve_configuration(
+            MsSqlCredentials(
+                "mssql://test_user:test_password@sql.example.com:12345/test_db?DRIVER=foo"
+            )
+        )
+
+
+def test_to_odbc_dsn_supported_driver_specified() -> None:
+    # Case: supported driver specified — ODBC Driver 18 for SQL Server.
     creds = resolve_configuration(
         MsSqlCredentials(
-            "mssql://test_user:test_password@sql.example.com:12345/test_db?FOO=a&BAR=b"
+            "mssql://test_user:test_password@sql.example.com:12345/test_db?DRIVER=ODBC+Driver+18+for+SQL+Server"
         )
     )
-
     dsn = creds.to_odbc_dsn()
-
     result = {k: v for k, v in (param.split("=") for param in dsn.split(";"))}
+    assert result == {
+        "DRIVER": "ODBC Driver 18 for SQL Server",
+        "SERVER": "sql.example.com,12345",
+        "DATABASE": "test_db",
+        "UID": "test_user",
+        "PWD": "test_password",
+    }
 
+    # Case: supported driver specified — ODBC Driver 17 for SQL Server.
+    creds = resolve_configuration(
+        MsSqlCredentials(
+            "mssql://test_user:test_password@sql.example.com:12345/test_db?DRIVER=ODBC+Driver+17+for+SQL+Server"
+        )
+    )
+    dsn = creds.to_odbc_dsn()
+    result = {k: v for k, v in (param.split("=") for param in dsn.split(";"))}
+    assert result == {
+        "DRIVER": "ODBC Driver 17 for SQL Server",
+        "SERVER": "sql.example.com,12345",
+        "DATABASE": "test_db",
+        "UID": "test_user",
+        "PWD": "test_password",
+    }
+
+
+def test_to_odbc_dsn_arbitrary_keys_specified() -> None:
+    # Case: arbitrary query keys (and supported driver) specified.
+    creds = resolve_configuration(
+        MsSqlCredentials(
+            "mssql://test_user:test_password@sql.example.com:12345/test_db?FOO=a&BAR=b&DRIVER=ODBC+Driver+18+for+SQL+Server"
+        )
+    )
+    dsn = creds.to_odbc_dsn()
+    result = {k: v for k, v in (param.split("=") for param in dsn.split(";"))}
     assert result == {
         "DRIVER": "ODBC Driver 18 for SQL Server",
         "SERVER": "sql.example.com,12345",
@@ -23,3 +69,44 @@ def test_to_odbc_dsn() -> None:
         "FOO": "a",
         "BAR": "b",
     }
+
+    # Case: arbitrary capitalization.
+    creds = resolve_configuration(
+        MsSqlCredentials(
+            "mssql://test_user:test_password@sql.example.com:12345/test_db?FOO=a&bar=b&Driver=ODBC+Driver+18+for+SQL+Server"
+        )
+    )
+    dsn = creds.to_odbc_dsn()
+    result = {k: v for k, v in (param.split("=") for param in dsn.split(";"))}
+    assert result == {
+        "DRIVER": "ODBC Driver 18 for SQL Server",
+        "SERVER": "sql.example.com,12345",
+        "DATABASE": "test_db",
+        "UID": "test_user",
+        "PWD": "test_password",
+        "FOO": "a",
+        "BAR": "b",
+    }
+
+
+available_drivers = [d for d in pyodbc.drivers() if d in SUPPORTED_DRIVERS]
+
+
+@pytest.mark.skipif(not available_drivers, reason="no supported driver available")
+def test_to_odbc_dsn_driver_not_specified() -> None:
+    # Case: driver not specified, but supported driver is available.
+    creds = resolve_configuration(
+        MsSqlCredentials("mssql://test_user:test_password@sql.example.com:12345/test_db")
+    )
+    dsn = creds.to_odbc_dsn()
+    result = {k: v for k, v in (param.split("=") for param in dsn.split(";"))}
+    assert result in [
+        {
+            "DRIVER": d,
+            "SERVER": "sql.example.com,12345",
+            "DATABASE": "test_db",
+            "UID": "test_user",
+            "PWD": "test_password",
+        }
+        for d in SUPPORTED_DRIVERS
+    ]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR improves MSSQL connection string handling by
- making it case-insensitive
- enabling driver specification

New tests are added to check this functionality.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #791 and #792

<!--
Provide any additional context about the PR here.
-->
### Additional Context
The old test `test_to_odbc_dsn` would only pass if `ODBC Driver 18 for SQL Server` was available on the machine:
- `ODBC Driver 18 for SQL Server` available ➜ pass
- `ODBC Driver 17 for SQL Server` available ➜ fail
- both not available ➜ fail

The replacing test `test_to_odbc_dsn_driver_not_specified()` behaves like this:
- `ODBC Driver 18 for SQL Server` available ➜ pass
- `ODBC Driver 17 for SQL Server` available ➜ pass
- both not available ➜ skip

`odbc_driver` was renamed to `driver` because that's the [keyword used in connection strings.](https://learn.microsoft.com/en-us/sql/connect/odbc/dsn-connection-string-attribute?view=sql-server-ver16)


<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
