### PR TITLE
ignore Windows mypy error

### DIFF
--- a/dlt/common/pendulum.py
+++ b/dlt/common/pendulum.py
@@ -2,7 +2,7 @@ from datetime import timedelta  # noqa: I251
 import pendulum  # noqa: I251
 
 # force UTC as the local timezone to prevent local dates to be written to dbs
-pendulum.set_local_timezone(pendulum.timezone("UTC"))
+pendulum.set_local_timezone(pendulum.timezone("UTC"))  # type: ignore
 
 
 def __utcnow() -> pendulum.DateTime:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR makes `make lint` run without errors on Windows+Git Bash by ignoring a `mypy` error that only seems to surface when using Git Bash on Windows.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #840 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
The `mypy` error did not show on Windows Github runners in the `lint` workflow, only in my local environment.
<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
