### PR TITLE
exclude docs group from poetry install in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,9 +53,7 @@ jobs:
 
       - name: Run make dev
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: |
-          export PATH=$PATH:"/c/Program Files/usr/bin" # needed for Windows      
-          make dev
+        run: poetry install --all-extras --with airflow,providers,pipeline,sentry-sdk
 
       - name: Run make lint
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
           path: .venv
           key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
-      - name: Run make dev
+      - name: Install dependencies
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --all-extras --with airflow,providers,pipeline,sentry-sdk
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR excludes the `docs` group from `poetry install` in the `lint` workflow because it fails on Python 3.11 due to incompatibility with `connectorx`.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #831 