### PR TITLE
docs(hubspot): add particular properties reading example

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
@@ -152,7 +152,9 @@ web analytics events data into the destination.
 ```python
 @dlt.source(name="hubspot")
 def hubspot(
-    api_key: str = dlt.secrets.value, include_history: bool = False
+    api_key: str = dlt.secrets.value,
+    include_history: bool = False,
+    global_props: Sequence[str] = None,
 ) -> Sequence[DltResource]:
 ```
 
@@ -160,6 +162,8 @@ def hubspot(
 
 `include_history`: This parameter, when set to "True", loads the history of property changes for the
 specified entities.
+
+`global_props`: A list of CRM object properties to extract. Applied to every included resource.
 
 ### Resource `companies`
 
@@ -248,6 +252,9 @@ verified source.
    load_data.contacts.bind(props=["date_of_birth", "degree"])
    load_info = pipeline.run(load_data.with_resources("contacts"))
    ```
+
+    1. `props` argument is supported by every Hubspot resource. By default, equals to the default returned properties
+    of [Hubspot search](https://developers.hubspot.com/docs/api/crm/search#crm-objects)
 
 1. To load the web analytics events of a given object type.
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
@@ -257,6 +257,18 @@ verified source.
     1. `props` argument is supported by every Hubspot resource. By default, equals to the default returned properties
     of [Hubspot search](https://developers.hubspot.com/docs/api/crm/search#crm-objects).
 
+1. To load all the custom properties of a single resource contacts.
+
+   ```python
+   from sources.hubspot.settings import ALL, CUSTON_ONLY
+   
+   load_data = hubspot()
+   load_data.contacts.bind(props=CUSTOM_ONLY)
+   load_info = pipeline.run(load_data.with_resources("contacts"))
+   ```
+    1. `CUSTOM_ONLY` filters out all the properties with the `hs_` prefix.
+    2. The `ALL` constant includes all the available properties of the CRM object.
+
 1. To load the web analytics events of a given object type.
 
    ```python

--- a/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
@@ -241,6 +241,13 @@ verified source.
    ```
     1. `include_history` loads property change history and entities as separate tables. By default set as False.
 
+1. To load particular properties of a single resource contacts.
+
+   ```python
+   load_data = hubspot()
+   load_data.contacts.bind(props=["date_of_birth", "degree"])
+   load_info = pipeline.run(load_data.with_resources("contacts"))
+   ```
 
 1. To load the web analytics events of a given object type.
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
@@ -164,6 +164,7 @@ def hubspot(
 specified entities.
 
 `global_props`: A list of CRM object properties to extract. Applied to every included resource.
+See the example of requesting properties for particular resources below.
 
 ### Resource `companies`
 
@@ -254,7 +255,7 @@ verified source.
    ```
 
     1. `props` argument is supported by every Hubspot resource. By default, equals to the default returned properties
-    of [Hubspot search](https://developers.hubspot.com/docs/api/crm/search#crm-objects)
+    of [Hubspot search](https://developers.hubspot.com/docs/api/crm/search#crm-objects).
 
 1. To load the web analytics events of a given object type.
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
@@ -154,7 +154,6 @@ web analytics events data into the destination.
 def hubspot(
     api_key: str = dlt.secrets.value,
     include_history: bool = False,
-    global_props: Sequence[str] = None,
 ) -> Sequence[DltResource]:
 ```
 
@@ -162,9 +161,6 @@ def hubspot(
 
 `include_history`: This parameter, when set to "True", loads the history of property changes for the
 specified entities.
-
-`global_props`: A list of CRM object properties to extract. Applied to every included resource.
-See the example of requesting properties for particular resources below.
 
 ### Resource `companies`
 
@@ -177,7 +173,7 @@ def companies(
       api_key: str = dlt.secrets.value, include_history: bool = False
 ) ->  Iterator[TDataItems]:
       """Hubspot companies resource"""
-      yield from crm_objects("company", api_key, include_history=False)
+      yield from crm_objects("company", api_key, include_history=include_history)
 ```
 
 This resource function takes the same arguments, `api_key` and `include_history` as the "husbpot"
@@ -246,28 +242,23 @@ verified source.
    ```
     1. `include_history` loads property change history and entities as separate tables. By default set as False.
 
-1. To load particular properties of a single resource contacts.
+1. By default, all the custom properties of a CRM object are extracted. If you want only particular fields,
+    set the flag `include_custom_props=False` and add a list of properties with the `props` arg.
 
    ```python
    load_data = hubspot()
-   load_data.contacts.bind(props=["date_of_birth", "degree"])
+   load_data.contacts.bind(props=["date_of_birth", "degree"], include_custom_props=False)
    load_info = pipeline.run(load_data.with_resources("contacts"))
    ```
 
-    1. `props` argument is supported by every Hubspot resource. By default, equals to the default returned properties
-    of [Hubspot search](https://developers.hubspot.com/docs/api/crm/search#crm-objects).
-
-1. To load all the custom properties of a single resource contacts.
+1. If you want to read all the custom properties of CRM objects and some additional (e.g. Hubspot driven) properties.
 
    ```python
-   from sources.hubspot.settings import ALL, CUSTON_ONLY
-   
    load_data = hubspot()
-   load_data.contacts.bind(props=CUSTOM_ONLY)
+   load_data.contacts.bind(props=["hs_content_membership_email", "hs_content_membership_email_confirmed"])
    load_info = pipeline.run(load_data.with_resources("contacts"))
    ```
-    1. `CUSTOM_ONLY` filters out all the properties with the `hs_` prefix.
-    2. The `ALL` constant includes all the available properties of the CRM object.
+
 
 1. To load the web analytics events of a given object type.
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/hubspot.md
@@ -170,14 +170,26 @@ the destination, replacing any existing data.
 ```python
 @dlt.resource(name="companies", write_disposition="replace")
 def companies(
-      api_key: str = dlt.secrets.value, include_history: bool = False
-) ->  Iterator[TDataItems]:
-      """Hubspot companies resource"""
-      yield from crm_objects("company", api_key, include_history=include_history)
+   api_key: str = api_key,
+   include_history: bool = include_history,
+   props: Sequence[str] = DEFAULT_COMPANY_PROPS,
+   include_custom_props: bool = True,
+) -> Iterator[TDataItems]:
+   """Hubspot companies resource"""
+   yield from crm_objects(
+      "company",
+      api_key,
+      include_history=include_history,
+      props=props,
+      include_custom_props=include_custom_props,
+   )
 ```
 
 This resource function takes the same arguments, `api_key` and `include_history` as the "husbpot"
-source described [above](hubspot.md#source-hubspot). Similar to this, resource functions "contacts",
+source described [above](hubspot.md#source-hubspot), but also supports two additional.
+`include_custom_props` - indicates if all the properties of CRM objects, except Hubspot driven
+(prefixed with `hs_`), are to be extracted. `props` - the list of properties to extract
+in addition to the custom properties. Similar to this, resource functions "contacts",
 "deals", "tickets", "products", and "quotes" retrieve data from the Hubspot API.
 
 ### Resource `hubspot_events_for_objects`


### PR DESCRIPTION
Into the Hubspot docs add a snippet, which shows how to extract particular properties of CRM objects.

Towards: https://github.com/dlt-hub/verified-sources/pull/311