### PR TITLE
corrected data type

### DIFF
--- a/dlt/destinations/impl/mssql/mssql.py
+++ b/dlt/destinations/impl/mssql/mssql.py
@@ -76,7 +76,7 @@ class MsSqlTypeMapper(TypeMapper):
     def from_db_type(
         self, db_type: str, precision: Optional[int], scale: Optional[int]
     ) -> TColumnType:
-        if db_type == "numeric":
+        if db_type == "decimal":
             if (precision, scale) == self.capabilities.wei_precision:
                 return dict(data_type="wei")
         return super().from_db_type(db_type, precision, scale)

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -387,7 +387,7 @@ def test_get_storage_table_with_all_types(client: SqlJobClientBase) -> None:
             "time",
         ):
             continue
-        if client.config.destination_type == "mssql" and c["data_type"] in ("wei", "complex"):
+        if client.config.destination_type == "mssql" and c["data_type"] in ("complex"):
             continue
         assert c["data_type"] == expected_c["data_type"]
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR corrects the data type used in the `from_db_type` method in class `MsSqlTypeMapper` which referred to a `numeric` data type that isn't used for `mssql`.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #862 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
I also removed the `wei` exclusion for `mssql` in `test_get_storage_table_with_all_types`. With the corrected data type, this test passes without the exclusion.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
