### PR TITLE
feat(csv_reader): separate a method for csv_reader

### DIFF
--- a/dlt/common/configuration/specs/gcp_credentials.py
+++ b/dlt/common/configuration/specs/gcp_credentials.py
@@ -27,7 +27,9 @@ class GcpCredentials(CredentialsConfiguration):
 
     project_id: str = None
 
-    location: str = (  # DEPRECATED! and present only for backward compatibility. please set bigquery location in BigQuery configuration
+    location: (
+        str
+    ) = (  # DEPRECATED! and present only for backward compatibility. please set bigquery location in BigQuery configuration
         "US"
     )
 


### PR DESCRIPTION
A PR additional to the https://github.com/dlt-hub/verified-sources/pull/319

Splits a method into two to allow auth of a DuckDB CSV reader.