### PR TITLE
SCD2 Experiment

### DIFF
--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -114,6 +114,8 @@ class DestinationClientDwhConfiguration(DestinationClientConfiguration):
     """How to handle replace disposition for this destination, can be classic or staging"""
     merge_strategy: TLoaderMergeStrategy = "merge"
     """How to handle merging, can be classic merge on primary key or merge keys, or scd2"""
+    load_timestamp: str = None
+    """Configurable timestamp for load strategies that record validity dates"""
 
     def normalize_dataset_name(self, schema: Schema) -> str:
         """Builds full db dataset (schema) name out of configured dataset name and schema name: {dataset_name}_{schema.name}. The resulting name is normalized.

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -48,6 +48,7 @@ from dlt.common.configuration.specs import GcpCredentials, AwsCredentialsWithout
 
 
 TLoaderReplaceStrategy = Literal["truncate-and-insert", "insert-from-staging", "staging-optimized"]
+TLoaderMergeStrategy = Literal["merge", "scd2"]
 TDestinationConfig = TypeVar("TDestinationConfig", bound="DestinationClientConfiguration")
 TDestinationClient = TypeVar("TDestinationClient", bound="JobClientBase")
 
@@ -111,6 +112,8 @@ class DestinationClientDwhConfiguration(DestinationClientConfiguration):
     """name of default schema to be used to name effective dataset to load data to"""
     replace_strategy: TLoaderReplaceStrategy = "truncate-and-insert"
     """How to handle replace disposition for this destination, can be classic or staging"""
+    merge_strategy: TLoaderMergeStrategy = "merge"
+    """How to handle merging, can be classic merge on primary key or merge keys, or scd2"""
 
     def normalize_dataset_name(self, schema: Schema) -> str:
         """Builds full db dataset (schema) name out of configured dataset name and schema name: {dataset_name}_{schema.name}. The resulting name is normalized.

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -240,6 +240,15 @@ class Schema:
                         updated_table_partial["columns"] = {}
                     updated_table_partial["columns"][new_col_name] = new_col_def
 
+        # insert columns defs for scd2 (TODO: where to do this properly, maybe in a step after the normalization?)
+        for col in ["_dlt_valid_from", "_dlt_valid_until"]:
+            if col not in table["columns"].keys():
+                updated_table_partial["columns"][col] = {
+                    "name": col,
+                    "data_type": "timestamp",
+                    "nullable": True,
+                }
+
         return new_row, updated_table_partial
 
     def apply_schema_contract(

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -60,7 +60,7 @@ TColumnHint = Literal[
     "merge_key",
 ]
 """Known hints of a column used to declare hint regexes."""
-TWriteDisposition = Literal["skip", "append", "replace", "merge"]
+TWriteDisposition = Literal["skip", "append", "replace", "merge", "scd2"]
 TTableFormat = Literal["iceberg"]
 TTypeDetections = Literal[
     "timestamp", "iso_timestamp", "iso_date", "large_integer", "hexbytes_to_text", "wei_to_double"

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -60,7 +60,7 @@ TColumnHint = Literal[
     "merge_key",
 ]
 """Known hints of a column used to declare hint regexes."""
-TWriteDisposition = Literal["skip", "append", "replace", "merge", "scd2"]
+TWriteDisposition = Literal["skip", "append", "replace", "merge"]
 TTableFormat = Literal["iceberg"]
 TTypeDetections = Literal[
     "timestamp", "iso_timestamp", "iso_date", "large_integer", "hexbytes_to_text", "wei_to_double"

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -224,7 +224,7 @@ class SqlJobClientBase(JobClientBase, WithStateSync):
         return []
 
     def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[NewLoadJob]:
-        now = pendulum.now()
+        now = self.config.load_timestamp or pendulum.now().to_iso8601_string()
         return [
             SqlMergeJob.from_table_chain(
                 table_chain,

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -224,7 +224,14 @@ class SqlJobClientBase(JobClientBase, WithStateSync):
         return []
 
     def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[NewLoadJob]:
-        return [SqlMergeJob.from_table_chain(table_chain, self.sql_client)]
+        now = pendulum.now()
+        return [
+            SqlMergeJob.from_table_chain(
+                table_chain,
+                self.sql_client,
+                {"merge_stragegy": self.config.merge_strategy, "validity_date": now},
+            )
+        ]
 
     def _create_replace_followup_jobs(
         self, table_chain: Sequence[TTableSchema]

--- a/docs/examples/chess_production/chess.py
+++ b/docs/examples/chess_production/chess.py
@@ -6,6 +6,7 @@ from dlt.common import sleep
 from dlt.common.typing import StrAny, TDataItems
 from dlt.sources.helpers.requests import client
 
+
 @dlt.source
 def chess(
     chess_url: str = dlt.config.value,
@@ -59,6 +60,7 @@ from dlt.pipeline.helpers import retry_load
 
 MAX_PLAYERS = 5
 
+
 def load_data_with_retry(pipeline, data):
     try:
         for attempt in Retrying(
@@ -68,9 +70,7 @@ def load_data_with_retry(pipeline, data):
             reraise=True,
         ):
             with attempt:
-                logger.info(
-                    f"Running the pipeline, attempt={attempt.retry_state.attempt_number}"
-                )
+                logger.info(f"Running the pipeline, attempt={attempt.retry_state.attempt_number}")
                 load_info = pipeline.run(data)
                 logger.info(str(load_info))
 
@@ -92,9 +92,7 @@ def load_data_with_retry(pipeline, data):
     # print the information on the first load package and all jobs inside
     logger.info(f"First load package info: {load_info.load_packages[0]}")
     # print the information on the first completed job in first load package
-    logger.info(
-        f"First completed job info: {load_info.load_packages[0].jobs['completed_jobs'][0]}"
-    )
+    logger.info(f"First completed job info: {load_info.load_packages[0].jobs['completed_jobs'][0]}")
 
     # check for schema updates:
     schema_updates = [p.schema_update for p in load_info.load_packages]

--- a/docs/examples/connector_x_arrow/load_arrow.py
+++ b/docs/examples/connector_x_arrow/load_arrow.py
@@ -3,6 +3,7 @@ import connectorx as cx
 import dlt
 from dlt.sources.credentials import ConnectionStringCredentials
 
+
 def read_sql_x(
     conn_str: ConnectionStringCredentials = dlt.secrets.value,
     query: str = dlt.config.value,
@@ -13,6 +14,7 @@ def read_sql_x(
         return_type="arrow2",
         protocol="binary",
     )
+
 
 def genome_resource():
     # create genome resource with merge on `upid` primary key

--- a/docs/examples/google_sheets/google_sheets.py
+++ b/docs/examples/google_sheets/google_sheets.py
@@ -9,12 +9,14 @@ from dlt.common.configuration.specs import (
 )
 from dlt.common.typing import DictStrAny, StrAny
 
+
 def _initialize_sheets(
     credentials: Union[GcpOAuthCredentials, GcpServiceAccountCredentials]
 ) -> Any:
     # Build the service object.
     service = build("sheets", "v4", credentials=credentials.to_native_credentials())
     return service
+
 
 @dlt.source
 def google_spreadsheet(
@@ -54,6 +56,7 @@ def google_spreadsheet(
         dlt.resource(get_sheet(name), name=name, write_disposition="replace")
         for name in sheet_names
     ]
+
 
 if __name__ == "__main__":
     pipeline = dlt.pipeline(destination="duckdb")

--- a/docs/examples/incremental_loading/zendesk.py
+++ b/docs/examples/incremental_loading/zendesk.py
@@ -6,12 +6,11 @@ from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.typing import TAnyDateTime
 from dlt.sources.helpers.requests import client
 
+
 @dlt.source(max_table_nesting=2)
 def zendesk_support(
     credentials: Dict[str, str] = dlt.secrets.value,
-    start_date: Optional[TAnyDateTime] = pendulum.datetime(  # noqa: B008
-        year=2000, month=1, day=1
-    ),
+    start_date: Optional[TAnyDateTime] = pendulum.datetime(year=2000, month=1, day=1),  # noqa: B008
     end_date: Optional[TAnyDateTime] = None,
 ):
     """
@@ -112,6 +111,7 @@ def get_pages(
         # See https://developer.zendesk.com/api-reference/ticketing/ticket-management/incremental_exports/#json-format
         if not response_json["end_of_stream"]:
             get_url = response_json["next_page"]
+
 
 if __name__ == "__main__":
     # create dlt pipeline

--- a/docs/examples/nested_data/nested_data.py
+++ b/docs/examples/nested_data/nested_data.py
@@ -13,6 +13,7 @@ from dlt.common.utils import map_nested_in_place
 
 CHUNK_SIZE = 10000
 
+
 # You can limit how deep dlt goes when generating child tables.
 # By default, the library will descend and generate child tables
 # for all nested lists, without a limit.
@@ -80,6 +81,7 @@ class CollectionLoader:
         cursor = self.collection.find(self._filter_op)
         while docs_slice := list(islice(cursor, CHUNK_SIZE)):
             yield map_nested_in_place(convert_mongo_objs, docs_slice)
+
 
 def convert_mongo_objs(value: Any) -> Any:
     if isinstance(value, (ObjectId, Decimal128)):

--- a/docs/examples/pdf_to_weaviate/pdf_to_weaviate.py
+++ b/docs/examples/pdf_to_weaviate/pdf_to_weaviate.py
@@ -4,6 +4,7 @@ import dlt
 from dlt.destinations.impl.weaviate import weaviate_adapter
 from PyPDF2 import PdfReader
 
+
 @dlt.resource(selected=False)
 def list_files(folder_path: str):
     folder_path = os.path.abspath(folder_path)
@@ -14,6 +15,7 @@ def list_files(folder_path: str):
             "file_path": file_path,
             "mtime": os.path.getmtime(file_path),
         }
+
 
 @dlt.transformer(primary_key="page_id", write_disposition="merge")
 def pdf_to_text(file_item, separate_pages: bool = False):
@@ -27,6 +29,7 @@ def pdf_to_text(file_item, separate_pages: bool = False):
         page_item["text"] = reader.pages[page_no].extract_text()
         page_item["page_id"] = file_item["file_name"] + "_" + str(page_no)
         yield page_item
+
 
 pipeline = dlt.pipeline(pipeline_name="pdf_to_text", destination="weaviate")
 

--- a/docs/examples/qdrant_zendesk/qdrant.py
+++ b/docs/examples/qdrant_zendesk/qdrant.py
@@ -10,13 +10,12 @@ from qdrant_client import QdrantClient
 
 from dlt.common.configuration.inject import with_config
 
+
 # function from: https://github.com/dlt-hub/verified-sources/tree/master/sources/zendesk
 @dlt.source(max_table_nesting=2)
 def zendesk_support(
     credentials: Dict[str, str] = dlt.secrets.value,
-    start_date: Optional[TAnyDateTime] = pendulum.datetime(  # noqa: B008
-        year=2000, month=1, day=1
-    ),
+    start_date: Optional[TAnyDateTime] = pendulum.datetime(year=2000, month=1, day=1),  # noqa: B008
     end_date: Optional[TAnyDateTime] = None,
 ):
     """
@@ -80,12 +79,14 @@ def _parse_date_or_none(value: Optional[str]) -> Optional[pendulum.DateTime]:
         return None
     return ensure_pendulum_datetime(value)
 
+
 # modify dates to return datetime objects instead
 def _fix_date(ticket):
     ticket["updated_at"] = _parse_date_or_none(ticket["updated_at"])
     ticket["created_at"] = _parse_date_or_none(ticket["created_at"])
     ticket["due_at"] = _parse_date_or_none(ticket["due_at"])
     return ticket
+
 
 # function from: https://github.com/dlt-hub/verified-sources/tree/master/sources/zendesk
 def get_pages(
@@ -127,6 +128,7 @@ def get_pages(
         if not response_json["end_of_stream"]:
             get_url = response_json["next_page"]
 
+
 if __name__ == "__main__":
     # create a pipeline with an appropriate name
     pipeline = dlt.pipeline(
@@ -145,7 +147,6 @@ if __name__ == "__main__":
     )
 
     print(load_info)
-
 
     # running the Qdrant client to connect to your Qdrant database
 

--- a/docs/examples/transformers/pokemon.py
+++ b/docs/examples/transformers/pokemon.py
@@ -1,6 +1,7 @@
 import dlt
 from dlt.sources.helpers import requests
 
+
 @dlt.source(max_table_nesting=2)
 def source(pokemon_api_url: str):
     """"""
@@ -45,6 +46,7 @@ def source(pokemon_api_url: str):
     # NOTE: dlt is smart enough to get data from pokemon_list and pokemon details once
 
     return (pokemon_list | pokemon, pokemon_list | pokemon | species)
+
 
 if __name__ == "__main__":
     # build duck db pipeline

--- a/tests/load/pipeline/test_scd2_disposition.py
+++ b/tests/load/pipeline/test_scd2_disposition.py
@@ -1,6 +1,9 @@
-import pytest, dlt, os
+import pytest, dlt, os, pendulum
 
 from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
+from tests.load.pipeline.utils import (
+    load_tables_to_dicts,
+)
 
 
 @pytest.mark.parametrize(
@@ -10,7 +13,9 @@ from tests.load.pipeline.utils import destinations_configs, DestinationTestConfi
 )
 def test_simple_scd2_load(destination_config: DestinationTestConfiguration) -> None:
     # use scd2
+    first_load = pendulum.now()
     os.environ["DESTINATION__MERGE_STRATEGY"] = "scd2"
+    os.environ["DESTINATION__LOAD_TIMESTAMP"] = first_load.to_iso8601_string()
 
     @dlt.resource(name="items", write_disposition="merge")
     def load_items():
@@ -46,6 +51,7 @@ def test_simple_scd2_load(destination_config: DestinationTestConfiguration) -> N
 
     # new version of item 1
     # item 3 deleted
+    # item 2 has a new child
     @dlt.resource(name="items", write_disposition="merge")
     def load_items_2():
         yield from [
@@ -65,26 +71,71 @@ def test_simple_scd2_load(destination_config: DestinationTestConfiguration) -> N
             },
         ]
 
+    second_load = pendulum.now()
+    os.environ["DESTINATION__LOAD_TIMESTAMP"] = second_load.to_iso8601_string()
+
     p.run(load_items_2())
 
-    with p.sql_client() as c:
-        with c.execute_query(
-            "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME = 'items' ORDER"
-            " BY ORDINAL_POSITION"
-        ) as cur:
-            print(cur.fetchall())
-        with c.execute_query("SELECT * FROM items") as cur:
-            for row in cur.fetchall():
-                print(row)
+    tables = load_tables_to_dicts(p, "items", "items__children")
+    # we should have 4 items in total (3 from the first load and an update of item 1 from the second load)
+    assert len(tables["items"]) == 4
+    # 2 should be active (1 and 2)
+    active_items = [item for item in tables["items"] if item["_dlt_valid_until"] is None]
+    inactive_items = [item for item in tables["items"] if item["_dlt_valid_until"] is not None]
+    active_items.sort(key=lambda i: i["id"])
+    inactive_items.sort(key=lambda i: i["id"])
+    assert len(active_items) == 2
 
-    with p.sql_client() as c:
-        with c.execute_query(
-            "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME ="
-            " 'items__children' ORDER BY ORDINAL_POSITION"
-        ) as cur:
-            print(cur.fetchall())
-        with c.execute_query("SELECT * FROM items__children") as cur:
-            for row in cur.fetchall():
-                print(row)
-    # print(p.default_schema.to_pretty_yaml())
-    assert False
+    # changed in the second load
+    assert active_items[0]["id"] == 1
+    assert active_items[0]["name"] == "one_new"
+    assert active_items[0]["_dlt_valid_from"] == second_load
+
+    # did not change in the second load
+    assert active_items[1]["id"] == 2
+    assert active_items[1]["name"] == "two"
+    assert active_items[1]["_dlt_valid_from"] == first_load
+
+    # was valid between first and second load
+    assert inactive_items[0]["id"] == 1
+    assert inactive_items[0]["name"] == "one"
+    assert inactive_items[0]["_dlt_valid_from"] == first_load
+    assert inactive_items[0]["_dlt_valid_until"] == second_load
+
+    # was valid between first and second load
+    assert inactive_items[1]["id"] == 3
+    assert inactive_items[1]["name"] == "three"
+    assert inactive_items[1]["_dlt_valid_from"] == first_load
+    assert inactive_items[1]["_dlt_valid_until"] == second_load
+
+    # child tables
+    assert len(tables["items__children"]) == 3
+    active_child_items = [
+        item for item in tables["items__children"] if item["_dlt_valid_until"] is None
+    ]
+    inactive_child_items = [
+        item for item in tables["items__children"] if item["_dlt_valid_until"] is not None
+    ]
+    active_child_items.sort(key=lambda i: i["id_of"])
+    inactive_child_items.sort(key=lambda i: i["id_of"])
+
+    assert len(active_child_items) == 1
+
+    # the one active child item should be linked to the right parent, was create during 2. load
+    assert active_child_items[0]["id_of"] == 2
+    assert active_child_items[0]["name"] == "child2_new"
+    assert active_child_items[0]["_dlt_parent_id"] == active_items[1]["_dlt_id"]
+    assert active_child_items[0]["_dlt_valid_from"] == second_load
+
+    # check inactive child items
+    assert inactive_child_items[0]["id_of"] == 2
+    assert inactive_child_items[0]["name"] == "child2"
+    assert inactive_child_items[0]["_dlt_parent_id"] == active_items[1]["_dlt_id"]
+    assert inactive_child_items[0]["_dlt_valid_from"] == first_load
+    assert inactive_child_items[0]["_dlt_valid_until"] == second_load
+
+    assert inactive_child_items[1]["id_of"] == 3
+    assert inactive_child_items[1]["name"] == "child3"
+    assert inactive_child_items[1]["_dlt_parent_id"] == inactive_items[1]["_dlt_id"]
+    assert inactive_child_items[1]["_dlt_valid_from"] == first_load
+    assert inactive_child_items[1]["_dlt_valid_until"] == second_load

--- a/tests/load/pipeline/test_scd2_disposition.py
+++ b/tests/load/pipeline/test_scd2_disposition.py
@@ -1,4 +1,4 @@
-import pytest, dlt
+import pytest, dlt, os
 
 from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
 
@@ -9,21 +9,82 @@ from tests.load.pipeline.utils import destinations_configs, DestinationTestConfi
     ids=lambda x: x.name,
 )
 def test_simple_scd2_load(destination_config: DestinationTestConfiguration) -> None:
-    @dlt.resource(name="items", write_disposition="scd2", primary_key="id")
+    # use scd2
+    os.environ["DESTINATION__MERGE_STRATEGY"] = "scd2"
+
+    @dlt.resource(name="items", write_disposition="merge")
     def load_items():
-        yield from [{
-            "id": 1,
-            "name": "one",
-        },
-        {
-            "id": 2,
-            "name": "two",
-        },
-        {
-            "id": 3,
-            "name": "three",
-        }]
+        yield from [
+            {
+                "id": 1,
+                "name": "one",
+            },
+            {
+                "id": 2,
+                "name": "two",
+                "children": [
+                    {
+                        "id_of": 2,
+                        "name": "child2",
+                    }
+                ],
+            },
+            {
+                "id": 3,
+                "name": "three",
+                "children": [
+                    {
+                        "id_of": 3,
+                        "name": "child3",
+                    }
+                ],
+            },
+        ]
+
     p = destination_config.setup_pipeline("test", full_refresh=True)
     p.run(load_items())
-    print(p.default_schema.to_pretty_yaml())
+
+    # new version of item 1
+    # item 3 deleted
+    @dlt.resource(name="items", write_disposition="merge")
+    def load_items_2():
+        yield from [
+            {
+                "id": 1,
+                "name": "one_new",
+            },
+            {
+                "id": 2,
+                "name": "two",
+                "children": [
+                    {
+                        "id_of": 2,
+                        "name": "child2_new",
+                    }
+                ],
+            },
+        ]
+
+    p.run(load_items_2())
+
+    with p.sql_client() as c:
+        with c.execute_query(
+            "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME = 'items' ORDER"
+            " BY ORDINAL_POSITION"
+        ) as cur:
+            print(cur.fetchall())
+        with c.execute_query("SELECT * FROM items") as cur:
+            for row in cur.fetchall():
+                print(row)
+
+    with p.sql_client() as c:
+        with c.execute_query(
+            "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS  WHERE TABLE_NAME ="
+            " 'items__children' ORDER BY ORDINAL_POSITION"
+        ) as cur:
+            print(cur.fetchall())
+        with c.execute_query("SELECT * FROM items__children") as cur:
+            for row in cur.fetchall():
+                print(row)
+    # print(p.default_schema.to_pretty_yaml())
     assert False

--- a/tests/load/pipeline/test_scd2_disposition.py
+++ b/tests/load/pipeline/test_scd2_disposition.py
@@ -1,0 +1,29 @@
+import pytest, dlt
+
+from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["duckdb"]),
+    ids=lambda x: x.name,
+)
+def test_simple_scd2_load(destination_config: DestinationTestConfiguration) -> None:
+    @dlt.resource(name="items", write_disposition="scd2", primary_key="id")
+    def load_items():
+        yield from [{
+            "id": 1,
+            "name": "one",
+        },
+        {
+            "id": 2,
+            "name": "two",
+        },
+        {
+            "id": 3,
+            "name": "three",
+        }]
+    p = destination_config.setup_pipeline("test", full_refresh=True)
+    p.run(load_items())
+    print(p.default_schema.to_pretty_yaml())
+    assert False


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Proof of concept for scd2 implementation. This is an implementation of scd2 as described here: https://en.wikipedia.org/wiki/Slowly_changing_dimension#Type_2:_add_new_row with a valid_from and valid_until column. In this prototype we treat scd2 as a merge_strategy rather than it's own write_disposition, given the similarities between scd2 and merge this might make sense, we could also introduce a new write disposition.

Loading with this strategy always assumes a full dataset sync from the source, this way we detect missing columns and mark them as not valid anymore. 

Child tables get handled the same way as their parents. All tables are retained but gain validity columns. This part still needs to be hammered out.

### Open questions and ideas
* Where is the right place to extend the schema if additional columns are needed as in this case?
* Is it safe to convert the _dlt_id into a hash of the row in this scenario? Since we merge on this key in the merge job, there will never be two of the same _dlt_ids.
* How do we integrate soft delete columns into this?
* We could also have a scd2 mode that does not need a full sync but will not mark tables as deleted if there is no new value as a compromise.