### PR TITLE
annotations experiment

### DIFF
--- a/dlt/__init__.py
+++ b/dlt/__init__.py
@@ -26,6 +26,7 @@ from dlt.common.typing import TSecretValue as _TSecretValue
 from dlt.common.configuration.specs import CredentialsConfiguration as _CredentialsConfiguration
 from dlt.common.pipeline import source_state as state
 from dlt.common.schema import Schema
+from dlt.common.schema import annotations
 
 from dlt import sources
 from dlt.extract.decorators import source, resource, transformer, defer
@@ -54,6 +55,7 @@ TCredentials = _CredentialsConfiguration
 
 __all__ = [
     "__version__",
+    "annotations",
     "config",
     "secrets",
     "state",

--- a/dlt/common/schema/annotations.py
+++ b/dlt/common/schema/annotations.py
@@ -1,0 +1,162 @@
+import inspect
+
+from typing import Type, List, Any, Tuple, Union, Dict
+from typing_extensions import Annotated, get_origin, get_args
+from decimal import Decimal
+
+from dataclasses import dataclass
+from dlt.common.schema.typing import TTableSchema, TColumnSchema, TWriteDisposition, TDataType
+from datetime import datetime, date
+
+
+#
+# base dataclasses used for hints
+#
+@dataclass
+class BoolValue:
+    value: bool
+
+
+@dataclass
+class StringValue:
+    value: str
+
+
+@dataclass
+class IntValue:
+    value: int
+
+
+@dataclass
+class StrListValue:
+    value: List[str]
+
+
+#
+# Column Hints
+#
+class PrimaryKey(BoolValue): ...
+
+
+class Unique(BoolValue): ...
+
+
+#
+# Table Hints
+#
+class TableName(StringValue): ...
+
+
+class Description(StringValue): ...
+
+
+class Classifiers(StringValue): ...
+
+
+@dataclass
+class WriteDisposition:
+    value: TWriteDisposition
+
+
+#
+# Converters
+#
+
+TypeMap: Dict[Any, TDataType] = {
+    str: "text",
+    int: "bigint",
+    float: "double",
+    date: "date",
+    datetime: "time",
+    bool: "bool",
+    Decimal: "decimal",
+}
+
+
+def unwrap(t: Type[Any]) -> Tuple[Any, List[Any]]:
+    """Returns python type info and wrapped types if this was annotated type"""
+    if get_origin(t) is Annotated:
+        args = get_args(t)
+        return args[0], list(args[1:])
+    return t, []
+
+
+def to_full_type(t: Type[Any]) -> TColumnSchema:
+    result: TColumnSchema = {}
+    if get_origin(t) is Union:
+        for arg in get_args(t):
+            if arg is type(None):
+                result["nullable"] = True
+            else:
+                result["data_type"] = TypeMap.get(arg, None)
+    else:
+        result["data_type"] = TypeMap.get(t, None)
+    return result
+
+
+def to_table_hints(h: List[Type[Any]]) -> TTableSchema:
+    result: TTableSchema = {}
+    for hint in h:
+        if isinstance(hint, TableName):
+            result["name"] = hint.value
+        elif isinstance(hint, WriteDisposition):
+            result["write_disposition"] = hint.value
+    return result
+
+
+def resolve_boolean_hint(column: TColumnSchema, hint: Type[Any], type: Type[Any], key: str) -> None:
+    """boolean hints may be instantiated with a value or just be present as a class, in that case they are assumed to be true"""
+    if isinstance(hint, type):
+        column[key] = hint.value  # type: ignore
+    if hint is type:
+        column[key] = True  # type: ignore
+
+
+def to_column_hints(h: List[Type[Any]]) -> TColumnSchema:
+    result: TColumnSchema = {}
+    for hint in h:
+        resolve_boolean_hint(result, hint, Unique, "unique")
+        resolve_boolean_hint(result, hint, PrimaryKey, "primary_key")
+        #
+        if isinstance(hint, Classifiers):
+            result["x-classifiers"] = hint.value # NOTE: classifiers not supported properly yet
+    return result
+
+
+def class_to_table(cls: Type[Any]) -> TTableSchema:
+    # initial checks
+    if not inspect.isclass(cls):
+        return {}
+
+    table: TTableSchema = {"columns": {}}
+
+    # return if there are no type annotations
+    if not (annotations := getattr(cls, "__annotations__", None)):
+        return table
+
+    # convert annotations to table schema
+    for name, value in annotations.items():
+        t, hints = unwrap(value)
+
+        # extract table hints
+        if name == "__table__":
+            table = {**table, **to_table_hints(hints)}
+            continue
+
+        # skip private attributes for now
+        if name.startswith("_"):
+            continue
+
+        # extract column hints
+        table["columns"][name] = {
+            "name": name,
+            **to_full_type(t),
+            **to_column_hints(hints),
+        }
+
+    return table
+
+
+def table_to_class(table: TTableSchema) -> str:
+    """TODO: do something with ast unparse"""
+    return ""

--- a/dlt/common/schema/annotations.py
+++ b/dlt/common/schema/annotations.py
@@ -63,16 +63,6 @@ class WriteDisposition:
 # Converters
 #
 
-TypeMap: Dict[Any, TDataType] = {
-    str: "text",
-    int: "bigint",
-    float: "double",
-    date: "date",
-    datetime: "time",
-    bool: "bool",
-    Decimal: "decimal",
-}
-
 
 def unwrap(t: Type[Any]) -> Tuple[Any, List[Any]]:
     """Returns python type info and wrapped types if this was annotated type"""

--- a/dlt/extract/utils.py
+++ b/dlt/extract/utils.py
@@ -21,6 +21,7 @@ from dlt.common.pipeline import reset_resource_state
 from dlt.common.schema.typing import TColumnNames, TAnySchemaColumns, TTableSchemaColumns
 from dlt.common.typing import AnyFun, DictStrAny, TDataItem, TDataItems
 from dlt.common.utils import get_callable_name
+from dlt.common.schema.annotations import class_to_table
 
 from dlt.extract.exceptions import (
     InvalidResourceDataTypeFunctionNotAGenerator,
@@ -65,6 +66,11 @@ def ensure_table_schema_columns(columns: TAnySchemaColumns) -> TTableSchemaColum
         isinstance(columns, pydantic.BaseModel) or issubclass(columns, pydantic.BaseModel)
     ):
         return pydantic.pydantic_to_table_schema_columns(columns)
+    elif isinstance(columns, type):
+        # try to build a table from class annotations
+        table_schema = class_to_table(columns)
+        if len(table_schema["columns"]) > 0:
+            return table_schema["columns"]
 
     raise ValueError(f"Unsupported columns type: {type(columns)}")
 

--- a/test_pipeline.py
+++ b/test_pipeline.py
@@ -1,0 +1,37 @@
+import dlt
+
+from dlt import annotations as a
+from dlt.common import json
+from typing_extensions import Annotated, Never, Optional
+
+
+class Items:
+
+    # metadata for the table, currently not picked up by the pipeline
+    __table__: Annotated[Never, a.TableName("my_items"), a.WriteDisposition("merge")]
+
+    # primary keys
+    id: Annotated[str, a.PrimaryKey, a.Unique]
+
+    # additional columns
+    name: Annotated[Optional[str], a.Classifiers(["pii.name"])]
+    email: Annotated[Optional[str], a.Unique, a.Classifiers(["pii.email"])]
+    likes_herring: Annotated[bool, a.Classifiers(["pii.food_preference"])]
+
+
+if __name__ == "__main__":
+    # print result of class_to_table
+    # print(json.dumps(a.class_to_table(Items), pretty=True))
+
+    p = dlt.pipeline("my_pipe", destination="duckdb", full_refresh=True)
+
+    data = [{
+        "id": "my_id"
+    }]
+
+    # run simple pipeline and see wether schema was used
+    load_info = p.run(data, columns=Items, table_name="blah")
+    print(load_info)
+    print(p.default_schema.to_pretty_yaml())
+
+

--- a/test_pipeline.py
+++ b/test_pipeline.py
@@ -7,9 +7,6 @@ from typing_extensions import Annotated, Never, Optional
 
 class Items:
 
-    # metadata for the table, currently not picked up by the pipeline
-    __table__: Annotated[Never, a.TableName("my_items"), a.WriteDisposition("merge")]
-
     # primary keys
     id: Annotated[str, a.PrimaryKey, a.Unique]
 
@@ -19,9 +16,12 @@ class Items:
     likes_herring: Annotated[bool, a.Classifiers(["pii.food_preference"])]
 
 
+AnnotatedItems = Annotated[Items, a.TableName("my_items"), a.WriteDisposition("merge")]
+
 if __name__ == "__main__":
+
     # print result of class_to_table
-    # print(json.dumps(a.class_to_table(Items), pretty=True))
+    print(json.dumps(a.class_to_table(AnnotatedItems), pretty=True))
 
     p = dlt.pipeline("my_pipe", destination="duckdb", full_refresh=True)
 
@@ -30,8 +30,7 @@ if __name__ == "__main__":
     }]
 
     # run simple pipeline and see wether schema was used
-    load_info = p.run(data, columns=Items, table_name="blah")
+    load_info = p.run(data, columns=AnnotatedItems, table_name="blah")
     print(load_info)
     print(p.default_schema.to_pretty_yaml())
-
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This PR has an example of how we could leverage python annotations to have a more universal and more readable format of our schema.

Check out test_pipeline.py on what the interface for the user would be in this example. It actually already works. Basically all you need to to is to put our annotations on class vars, and you can use any new or pre-existing class as a basis for our schema. Typehints that are unknown to us will be ignored (as defined per "Annotated" PEP)

#### Notes and Considerations:
* Not all hints and data_types are support here, this is a prototype, but one that is easy to extend
* There is a meta data attribute "__table__" on the class, we can use this to set table level hints, currently the dlt core is not set up to support this via the columns attribute, but I think it should be quite easy to do.
