### PR TITLE
Handle UnionType when checking is_union_type and is_optional_type

### DIFF
--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -140,7 +140,7 @@ def pydantic_to_table_schema_columns(
             # This case is for a single field schema/model
             # we need to generate snake_case field names
             # and return flattened field schemas
-            schema_hints = pydantic_to_table_schema_columns(field.annotation)
+            schema_hints = pydantic_to_table_schema_columns(inner_type)
 
             for field_name, hints in schema_hints.items():
                 schema_key = snake_case_naming_convention.make_path(name, field_name)

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping as C_Mapping, Sequence as C_Sequence
 from datetime import datetime, date  # noqa: I251
 import inspect
 import os
+import sys
 from re import Pattern as _REPattern
 from typing import (
     ForwardRef,
@@ -26,9 +27,9 @@ from typing import (
     IO,
 )
 
-try:
+if sys.version_info >= (3, 10):
     from types import UnionType
-except ImportError:
+else:
     # it is defined as type(int | str)
     UnionType = Union[int, str]
 

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -27,10 +27,13 @@ from typing import (
     IO,
 )
 
-if sys.version_info >= (3, 10):
+try:
     from types import UnionType
-else:
-    # it is defined as type(int | str)
+except ImportError:
+    # Since new Union syntax was introduced in Python 3.10
+    # we need to substitute it here for older versions.
+    # it is defined as type(int | str) but for us having it
+    # as shown here should suffice.
     UnionType = Union[int, str]
 
 from typing_extensions import TypeAlias, ParamSpec, Concatenate, Annotated, get_args, get_origin
@@ -121,6 +124,8 @@ def is_union_type(hint: Type[Any]) -> bool:
     # <class 'types.UnionType'>
     # >>> type(str | None)
     # <class 'types.UnionType'>
+    # type(Union[int, str])
+    # <class 'typing._GenericAlias'>
     if origin is Union or origin is UnionType:
         return True
 

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -121,12 +121,8 @@ def is_union_type(hint: Type[Any]) -> bool:
     # <class 'types.UnionType'>
     # >>> type(str | None)
     # <class 'types.UnionType'>
-    if sys.version_info >= (3, 10):
-        if origin is Union or origin is UnionType:
-            return True
-    else:
-        if origin is Union:
-            return True
+    if origin is Union or origin is UnionType:
+        return True
 
     if hint := extract_type_if_modifier(hint):
         return is_union_type(hint)

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -121,8 +121,12 @@ def is_union_type(hint: Type[Any]) -> bool:
     # <class 'types.UnionType'>
     # >>> type(str | None)
     # <class 'types.UnionType'>
-    if origin is Union or origin is UnionType:
-        return True
+    if sys.version_info >= (3, 10):
+        if origin is Union or origin is UnionType:
+            return True
+    else:
+        if origin is Union:
+            return True
 
     if hint := extract_type_if_modifier(hint):
         return is_union_type(hint)

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -46,7 +46,6 @@ except ImportError:
     # in versions higher than 3.9
     UnionType = Never
 
-
 from dlt.common.pendulum import timedelta, pendulum
 
 if TYPE_CHECKING:
@@ -99,7 +98,8 @@ class SupportsVariant(Protocol, Generic[TVariantBase]):
     See `Wei` type declaration which returns Decimal or str for values greater than supported by destination warehouse.
     """
 
-    def __call__(self) -> Union[TVariantBase, TVariantRV]: ...
+    def __call__(self) -> Union[TVariantBase, TVariantRV]:
+        ...
 
 
 class SupportsHumanize(Protocol):

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -29,7 +29,8 @@ from typing import (
 try:
     from types import UnionType
 except ImportError:
-    UnionType = Union[str, int]
+    # it is defined as type(int | str)
+    UnionType = Union[int, str]
 
 from typing_extensions import TypeAlias, ParamSpec, Concatenate, Annotated, get_args, get_origin
 

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -28,7 +28,7 @@ from typing import (
 )
 
 try:
-    from types import UnionType
+    from types import UnionType  # type: ignore[attr-defined]
 except ImportError:
     # Since new Union syntax was introduced in Python 3.10
     # we need to substitute it here for older versions.

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -98,8 +98,7 @@ class SupportsVariant(Protocol, Generic[TVariantBase]):
     See `Wei` type declaration which returns Decimal or str for values greater than supported by destination warehouse.
     """
 
-    def __call__(self) -> Union[TVariantBase, TVariantRV]:
-        ...
+    def __call__(self) -> Union[TVariantBase, TVariantRV]: ...
 
 
 class SupportsHumanize(Protocol):

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -131,10 +131,12 @@ def is_union_type(hint: Type[Any]) -> bool:
 
 
 def is_optional_type(t: Type[Any]) -> bool:
-    if is_union_type(t):
-        return type(None) in get_args(t)
+    if is_union_type(t) and type(None) in get_args(t):
+        return True
+
     if t := extract_type_if_modifier(t):
         return is_optional_type(t)
+
     return False
 
 

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -29,7 +29,7 @@ from typing import (
 try:
     from types import UnionType
 except ImportError:
-    UnionType = type(str | int)
+    UnionType = Union[str, int]
 
 from typing_extensions import TypeAlias, ParamSpec, Concatenate, Annotated, get_args, get_origin
 

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -123,7 +123,6 @@ def extract_type_if_modifier(t: Type[Any]) -> Type[Any]:
 
 
 def is_union_type(hint: Type[Any]) -> bool:
-    origin = get_origin(hint)
     # We need to handle UnionType because with Python>=3.10
     # new Optional syntax was introduced which treats Optionals
     # as unions and probably internally there is no additional
@@ -134,6 +133,7 @@ def is_union_type(hint: Type[Any]) -> bool:
     # <class 'types.UnionType'>
     # type(Union[int, str])
     # <class 'typing._GenericAlias'>
+    origin = get_origin(hint)
     if origin is Union or origin is UnionType:
         return True
 

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -43,7 +43,7 @@ except ImportError:
     # we need to substitute it here for older versions.
     # it is defined as type(int | str) but for us having it
     # as shown here should suffice because it is valid only
-    # in versions higher than 3.9
+    # in versions of Python>=3.10.
     UnionType = Never
 
 from dlt.common.pendulum import timedelta, pendulum

--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -351,7 +351,9 @@ class AthenaClient(SqlJobClientWithStaging, SupportsStagingDestination):
         return self.type_mapper.from_db_type(hive_t, precision, scale)
 
     def _get_column_def_sql(self, c: TColumnSchema, table_format: TTableFormat = None) -> str:
-        return f"{self.sql_client.escape_ddl_identifier(c['name'])} {self.type_mapper.to_db_type(c, table_format)}"
+        return (
+            f"{self.sql_client.escape_ddl_identifier(c['name'])} {self.type_mapper.to_db_type(c, table_format)}"
+        )
 
     def _get_table_update_sql(
         self, table_name: str, new_columns: Sequence[TColumnSchema], generate_alter: bool
@@ -376,19 +378,15 @@ class AthenaClient(SqlJobClientWithStaging, SupportsStagingDestination):
         # use qualified table names
         qualified_table_name = self.sql_client.make_qualified_ddl_table_name(table_name)
         if is_iceberg and not generate_alter:
-            sql.append(
-                f"""CREATE TABLE {qualified_table_name}
+            sql.append(f"""CREATE TABLE {qualified_table_name}
                     ({columns})
                     LOCATION '{location}'
-                    TBLPROPERTIES ('table_type'='ICEBERG', 'format'='parquet');"""
-            )
+                    TBLPROPERTIES ('table_type'='ICEBERG', 'format'='parquet');""")
         elif not generate_alter:
-            sql.append(
-                f"""CREATE EXTERNAL TABLE {qualified_table_name}
+            sql.append(f"""CREATE EXTERNAL TABLE {qualified_table_name}
                     ({columns})
                     STORED AS PARQUET
-                    LOCATION '{location}';"""
-            )
+                    LOCATION '{location}';""")
         # alter table to add new columns at the end
         else:
             sql.append(f"""ALTER TABLE {qualified_table_name} ADD COLUMNS ({columns});""")

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -252,9 +252,9 @@ class BigQueryClient(SqlJobClientWithStaging, SupportsStagingDestination):
             elif (c := partition_list[0])["data_type"] == "date":
                 sql[0] = f"{sql[0]}\nPARTITION BY {self.capabilities.escape_identifier(c['name'])}"
             elif (c := partition_list[0])["data_type"] == "timestamp":
-                sql[
-                    0
-                ] = f"{sql[0]}\nPARTITION BY DATE({self.capabilities.escape_identifier(c['name'])})"
+                sql[0] = (
+                    f"{sql[0]}\nPARTITION BY DATE({self.capabilities.escape_identifier(c['name'])})"
+                )
             # Automatic partitioning of an INT64 type requires us to be prescriptive - we treat the column as a UNIX timestamp.
             # This is due to the bounds requirement of GENERATE_ARRAY function for partitioning.
             # The 10,000 partitions limit makes it infeasible to cover the entire `bigint` range.
@@ -272,7 +272,9 @@ class BigQueryClient(SqlJobClientWithStaging, SupportsStagingDestination):
 
     def _get_column_def_sql(self, c: TColumnSchema, table_format: TTableFormat = None) -> str:
         name = self.capabilities.escape_identifier(c["name"])
-        return f"{name} {self.type_mapper.to_db_type(c, table_format)} {self._gen_not_null(c.get('nullable', True))}"
+        return (
+            f"{name} {self.type_mapper.to_db_type(c, table_format)} {self._gen_not_null(c.get('nullable', True))}"
+        )
 
     def get_storage_table(self, table_name: str) -> Tuple[bool, TTableSchemaColumns]:
         schema_table: TTableSchemaColumns = {}

--- a/dlt/destinations/impl/databricks/databricks.py
+++ b/dlt/destinations/impl/databricks/databricks.py
@@ -166,12 +166,14 @@ class DatabricksLoadJob(LoadJob, FollowupJob):
             else:
                 raise LoadJobTerminalException(
                     file_path,
-                    f"Databricks cannot load data from staging bucket {bucket_path}. Only s3 and azure buckets are supported",
+                    f"Databricks cannot load data from staging bucket {bucket_path}. Only s3 and"
+                    " azure buckets are supported",
                 )
         else:
             raise LoadJobTerminalException(
                 file_path,
-                "Cannot load from local file. Databricks does not support loading from local files. Configure staging with an s3 or azure storage bucket.",
+                "Cannot load from local file. Databricks does not support loading from local files."
+                " Configure staging with an s3 or azure storage bucket.",
             )
 
         # decide on source format, stage_file_path will either be a local file or a bucket path
@@ -181,27 +183,33 @@ class DatabricksLoadJob(LoadJob, FollowupJob):
             if not config.get("data_writer.disable_compression"):
                 raise LoadJobTerminalException(
                     file_path,
-                    "Databricks loader does not support gzip compressed JSON files. Please disable compression in the data writer configuration: https://dlthub.com/docs/reference/performance#disabling-and-enabling-file-compression",
+                    "Databricks loader does not support gzip compressed JSON files. Please disable"
+                    " compression in the data writer configuration:"
+                    " https://dlthub.com/docs/reference/performance#disabling-and-enabling-file-compression",
                 )
             if table_schema_has_type(table, "decimal"):
                 raise LoadJobTerminalException(
                     file_path,
-                    "Databricks loader cannot load DECIMAL type columns from json files. Switch to parquet format to load decimals.",
+                    "Databricks loader cannot load DECIMAL type columns from json files. Switch to"
+                    " parquet format to load decimals.",
                 )
             if table_schema_has_type(table, "binary"):
                 raise LoadJobTerminalException(
                     file_path,
-                    "Databricks loader cannot load BINARY type columns from json files. Switch to parquet format to load byte values.",
+                    "Databricks loader cannot load BINARY type columns from json files. Switch to"
+                    " parquet format to load byte values.",
                 )
             if table_schema_has_type(table, "complex"):
                 raise LoadJobTerminalException(
                     file_path,
-                    "Databricks loader cannot load complex columns (lists and dicts) from json files. Switch to parquet format to load complex types.",
+                    "Databricks loader cannot load complex columns (lists and dicts) from json"
+                    " files. Switch to parquet format to load complex types.",
                 )
             if table_schema_has_type(table, "date"):
                 raise LoadJobTerminalException(
                     file_path,
-                    "Databricks loader cannot load DATE type columns from json files. Switch to parquet format to load dates.",
+                    "Databricks loader cannot load DATE type columns from json files. Switch to"
+                    " parquet format to load dates.",
                 )
 
             source_format = "JSON"
@@ -311,7 +319,7 @@ class DatabricksClient(InsertValuesJobClient, SupportsStagingDestination):
 
     def _get_storage_table_query_columns(self) -> List[str]:
         fields = super()._get_storage_table_query_columns()
-        fields[
-            1
-        ] = "full_data_type"  # Override because this is the only way to get data type with precision
+        fields[1] = (  # Override because this is the only way to get data type with precision
+            "full_data_type"
+        )
         return fields

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -175,15 +175,13 @@ class SnowflakeLoadJob(LoadJob, FollowupJob):
                     f'PUT file://{file_path} @{stage_name}/"{load_id}" OVERWRITE = TRUE,'
                     " AUTO_COMPRESS = FALSE"
                 )
-            client.execute_sql(
-                f"""COPY INTO {qualified_table_name}
+            client.execute_sql(f"""COPY INTO {qualified_table_name}
                 {from_clause}
                 {files_clause}
                 {credentials_clause}
                 FILE_FORMAT = {source_format}
                 MATCH_BY_COLUMN_NAME='CASE_INSENSITIVE'
-                """
-            )
+                """)
             if stage_file_path and not keep_staged_files:
                 client.execute_sql(f"REMOVE {stage_file_path}")
 

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -1163,9 +1163,9 @@ class Pipeline(SupportsPipeline):
             # set destination context on activation
             if self.destination:
                 # inject capabilities context
-                self._container[
-                    DestinationCapabilitiesContext
-                ] = self._get_destination_capabilities()
+                self._container[DestinationCapabilitiesContext] = (
+                    self._get_destination_capabilities()
+                )
         else:
             # remove destination context on deactivation
             if DestinationCapabilitiesContext in self._container:

--- a/tests/common/test_typing.py
+++ b/tests/common/test_typing.py
@@ -79,6 +79,7 @@ def test_optional() -> None:
     assert is_optional_type(ClassVar[TOptionalLi]) is True  # type: ignore[arg-type]
     assert is_optional_type(Annotated[TOptionalLi, Optional]) is True  # type: ignore[arg-type]
     assert is_optional_type(Annotated[TOptionalLi, "random metadata string"]) is True  # type: ignore[arg-type]
+    assert is_optional_type(Optional[Annotated[str, "random metadata string"]]) is True  # type: ignore[arg-type]
     assert is_optional_type(TOptionalTyDi) is True  # type: ignore[arg-type]
     assert is_optional_type(TTestTyDi) is False
     assert extract_union_types(TOptionalLi) == [TTestLi, type(None)]  # type: ignore[arg-type]

--- a/tests/common/test_typing.py
+++ b/tests/common/test_typing.py
@@ -78,6 +78,7 @@ def test_optional() -> None:
     assert is_optional_type(TOptionalLi) is True  # type: ignore[arg-type]
     assert is_optional_type(ClassVar[TOptionalLi]) is True  # type: ignore[arg-type]
     assert is_optional_type(Annotated[TOptionalLi, Optional]) is True  # type: ignore[arg-type]
+    assert is_optional_type(Annotated[TOptionalLi, "random metadata string"]) is True  # type: ignore[arg-type]
     assert is_optional_type(TOptionalTyDi) is True  # type: ignore[arg-type]
     assert is_optional_type(TTestTyDi) is False
     assert extract_union_types(TOptionalLi) == [TTestLi, type(None)]  # type: ignore[arg-type]

--- a/tests/common/test_typing.py
+++ b/tests/common/test_typing.py
@@ -80,6 +80,10 @@ def test_optional() -> None:
     assert is_optional_type(Annotated[TOptionalLi, Optional]) is True  # type: ignore[arg-type]
     assert is_optional_type(Annotated[TOptionalLi, "random metadata string"]) is True  # type: ignore[arg-type]
     assert is_optional_type(Optional[Annotated[str, "random metadata string"]]) is True  # type: ignore[arg-type]
+    assert is_optional_type(Final[Annotated[Optional[str], "annotated metadata"]]) is True  # type: ignore[arg-type]
+    assert is_optional_type(Final[Annotated[Optional[str], None]]) is True  # type: ignore[arg-type]
+    assert is_optional_type(Final[Annotated[Union[str, int], None]]) is False  # type: ignore[arg-type]
+    assert is_optional_type(Annotated[Union[str, int], type(None)]) is False  # type: ignore[arg-type]
     assert is_optional_type(TOptionalTyDi) is True  # type: ignore[arg-type]
     assert is_optional_type(TTestTyDi) is False
     assert extract_union_types(TOptionalLi) == [TTestLi, type(None)]  # type: ignore[arg-type]

--- a/tests/common/test_typing.py
+++ b/tests/common/test_typing.py
@@ -77,6 +77,7 @@ def test_is_literal() -> None:
 def test_optional() -> None:
     assert is_optional_type(TOptionalLi) is True  # type: ignore[arg-type]
     assert is_optional_type(ClassVar[TOptionalLi]) is True  # type: ignore[arg-type]
+    assert is_optional_type(Annotated[TOptionalLi, Optional]) is True  # type: ignore[arg-type]
     assert is_optional_type(TOptionalTyDi) is True  # type: ignore[arg-type]
     assert is_optional_type(TTestTyDi) is False
     assert extract_union_types(TOptionalLi) == [TTestLi, type(None)]  # type: ignore[arg-type]

--- a/tests/libs/test_pydantic.py
+++ b/tests/libs/test_pydantic.py
@@ -325,7 +325,7 @@ def test_nested_model_config_propagation() -> None:
     # print(model_freeze.__fields__["address"].annotation)
 
 
-if sys.version_info > (3, 9):
+if sys.version_info >= (3, 10):
     # Run for Python>=3.10
     def test_nested_model_config_propagation_python_310():
         """We would like to test that using Optional and new | syntax works as expected

--- a/tests/libs/test_pydantic.py
+++ b/tests/libs/test_pydantic.py
@@ -252,10 +252,10 @@ def test_nested_model_config_propagation() -> None:
         user_labels: List[UserLabel]
         address: Annotated[UserAddress, "PII", "address"]
         unity: Union[UserAddress, UserLabel, Dict[str, UserAddress]]
-        location: Annotated[Optional[Union[str, list]], None]
-        final_location: Final[Annotated[Union[str, int], None]]
+        location: Annotated[Optional[Union[str, List[str]]], None]
         something_required: Annotated[Union[str, int], type(None)]
-        final_optional: Final[Annotated[Optional[str], None]]
+        final_location: Final[Annotated[Union[str, int], None]]  # type: ignore[misc]
+        final_optional: Final[Annotated[Optional[str], None]]  # type: ignore[misc]
 
         dlt_config: ClassVar[DltConfig] = {"skip_complex_types": True}
 
@@ -349,10 +349,10 @@ if sys.version_info > (3, 9):
             user_labels: List[UserLabel]
             address: Annotated[UserAddress, "PII", "address"]
             unity: Union[UserAddress, UserLabel, Dict[str, UserAddress]]
-            location: Annotated[Union[str, list] | None, None]
-            final_location: Final[Annotated[Union[str, int], None]]
+            location: Annotated[Union[str, List[str]] | None, None]
             something_required: Annotated[Union[str, int], type(None)]
-            final_optional: Final[Annotated[str | None, None]]
+            final_location: Final[Annotated[Union[str, int], None]]  # type: ignore[misc]
+            final_optional: Final[Annotated[str | None, None]]  # type: ignore[misc]
 
             dlt_config: ClassVar[DltConfig] = {"skip_complex_types": True}
 

--- a/tests/libs/test_pydantic.py
+++ b/tests/libs/test_pydantic.py
@@ -2,6 +2,7 @@ from copy import copy
 import pytest
 from typing import (
     ClassVar,
+    Final,
     Sequence,
     Mapping,
     Dict,
@@ -250,6 +251,10 @@ def test_nested_model_config_propagation() -> None:
         user_labels: List[UserLabel]
         address: Annotated[UserAddress, "PII", "address"]
         unity: Union[UserAddress, UserLabel, Dict[str, UserAddress]]
+        location: Annotated[Optional[Union[str, list]], None]
+        final_location: Final[Annotated[Union[str, int], None]]
+        something_required: Annotated[Union[str, int], type(None)]
+        final_optional: Final[Annotated[Optional[str], None]]
 
         dlt_config: ClassVar[DltConfig] = {"skip_complex_types": True}
 
@@ -299,10 +304,18 @@ def test_nested_model_config_propagation() -> None:
             ],
         ),
         unity=UserLabel(label="123"),
+        location="Florida keys",
+        final_location="Ginnie Springs",
+        something_required=123,
+        final_optional=None,
     )
     schema_from_user_class = pydantic_to_table_schema_columns(User)
     schema_from_user_instance = pydantic_to_table_schema_columns(user)
     assert schema_from_user_class == schema_from_user_instance
+    assert schema_from_user_class["location"]["nullable"] is True
+    assert schema_from_user_class["final_location"]["nullable"] is False
+    assert schema_from_user_class["something_required"]["nullable"] is False
+    assert schema_from_user_class["final_optional"]["nullable"] is True
     # print(User.__fields__)
     # print(User.__fields__["name"].annotation)
     # print(model_freeze.model_config)

--- a/tests/libs/test_pydantic.py
+++ b/tests/libs/test_pydantic.py
@@ -266,6 +266,43 @@ def test_nested_model_config_propagation() -> None:
     type_annotation = model_freeze.__fields__["address"].annotation  # type: ignore[index]
     assert type_annotation is get_args(model_freeze.__fields__["unity"].annotation)[0]  # type: ignore[index]
 
+    # We need to check if pydantic_to_table_schema_columns is idempotent
+    # and can generate the same schema from the class and from the class intance.
+    user = User(
+        user_id=1,
+        name="random name",
+        created_at=datetime.now(),
+        labels=["str"],
+        user_label=UserLabel(label="123"),
+        user_labels=[
+            UserLabel(label="123"),
+        ],
+        address=UserAddress(
+            street="random street",
+            zip_code=[1234566, 4567789],
+            label=UserLabel(label="123"),
+            ro_labels={
+                "x": UserLabel(label="123"),
+            },
+            wr_labels={
+                "y": [
+                    UserLabel(label="123"),
+                ]
+            },
+            ro_list=[
+                UserLabel(label="123"),
+            ],
+            wr_list=[
+                {
+                    "x": UserLabel(label="123"),
+                }
+            ],
+        ),
+        unity=UserLabel(label="123"),
+    )
+    schema_from_user_class = pydantic_to_table_schema_columns(User)
+    schema_from_user_instance = pydantic_to_table_schema_columns(user)
+    assert schema_from_user_class == schema_from_user_instance
     # print(User.__fields__)
     # print(User.__fields__["name"].annotation)
     # print(model_freeze.model_config)


### PR DESCRIPTION
We have `typing.Union` and `types.UnionType` and a new union and an optional syntax which came in Python 3.10.
So using for example `str | None` will return `UnionType` for which we don't check during schema hint extraction/generation

```py
>>> type(str | int)
<class 'types.UnionType'>
>>> type(str | None)
<class 'types.UnionType'>
>>> type(Union[int, str])
<class 'typing._GenericAlias'>
```

## TODO
* [x] Tests