### PR TITLE
Normalize pipeline_name for Google secrets provider

### DIFF
--- a/dlt/common/configuration/providers/google_secrets.py
+++ b/dlt/common/configuration/providers/google_secrets.py
@@ -9,8 +9,9 @@ from dlt.common.exceptions import MissingDependencyException
 from .toml import VaultTomlProvider
 from .provider import get_key_name
 
-punctuation = "".join(set(string.punctuation) - {"-", "_"})
 # Create a translation table to replace punctuation with ""
+# since google secrets allow "-"" and "_" we need to exclude them
+punctuation = "".join(set(string.punctuation) - {"-", "_"})
 translator = str.maketrans("", "", punctuation)
 
 

--- a/dlt/common/configuration/providers/google_secrets.py
+++ b/dlt/common/configuration/providers/google_secrets.py
@@ -9,9 +9,13 @@ from dlt.common.exceptions import MissingDependencyException
 from .toml import VaultTomlProvider
 from .provider import get_key_name
 
+punctuation = "".join(set(string.punctuation) - {"-", "_"})
+# Create a translation table to replace punctuation with ""
+translator = str.maketrans("", "", punctuation)
 
-def strip_punctuation(in_string: str) -> str:
-    """Replace punctuation characters in a string
+
+def normalize_key(in_string: str) -> str:
+    """Replaces punctuation characters in a string
 
     Note: We exclude `_` and `-` from punctuation characters
 
@@ -21,14 +25,12 @@ def strip_punctuation(in_string: str) -> str:
     Returns:
         (str): a string without punctuatio characters and whitespaces
     """
-    whitespace = re.compile("\s+")
-    punctuation_chars = set(string.punctuation) - {"-", "_"}
-    for char in in_string:
-        if char in punctuation_chars:
-            in_string = in_string.replace(char, "")
 
-    in_string = in_string.strip()
-    return whitespace.sub("_", in_string)
+    # Strip punctuation from the string
+    stripped_text = in_string.translate(translator)
+    whitespace = re.compile("\s+")
+    stripped_whitespace = whitespace.sub("", stripped_text)
+    return stripped_whitespace
 
 
 class GoogleSecretsProvider(VaultTomlProvider):
@@ -52,9 +54,9 @@ class GoogleSecretsProvider(VaultTomlProvider):
             3. Hyphens,
             4. Underscores.
         """
-        key = strip_punctuation(key)
-        sections = [strip_punctuation(section) for section in sections if section]
-        key_name = get_key_name(key, "-", *sections)
+        key = normalize_key(key)
+        sections = [normalize_key(section) for section in sections if section]
+        key_name = get_key_name(normalize_key(key), "-", *sections)
         return key_name
 
     @property

--- a/dlt/common/configuration/providers/google_secrets.py
+++ b/dlt/common/configuration/providers/google_secrets.py
@@ -29,7 +29,7 @@ def normalize_key(in_string: str) -> str:
 
     # Strip punctuation from the string
     stripped_text = in_string.translate(translator)
-    whitespace = re.compile("\s+")
+    whitespace = re.compile(r"\s+")
     stripped_whitespace = whitespace.sub("", stripped_text)
     return stripped_whitespace
 

--- a/dlt/common/configuration/providers/google_secrets.py
+++ b/dlt/common/configuration/providers/google_secrets.py
@@ -56,8 +56,8 @@ class GoogleSecretsProvider(VaultTomlProvider):
             4. Underscores.
         """
         key = normalize_key(key)
-        sections = [normalize_key(section) for section in sections if section]
-        key_name = get_key_name(normalize_key(key), "-", *sections)
+        normalized_sections = [normalize_key(section) for section in sections if section]
+        key_name = get_key_name(normalize_key(key), "-", *normalized_sections)
         return key_name
 
     @property

--- a/dlt/common/normalizers/utils.py
+++ b/dlt/common/normalizers/utils.py
@@ -1,3 +1,4 @@
+import string
 from importlib import import_module
 from typing import Any, Type, Tuple, cast, List
 
@@ -76,3 +77,24 @@ def generate_dlt_ids(n_ids: int) -> List[str]:
 
 def generate_dlt_id() -> str:
     return uniq_id_base64(DLT_ID_LENGTH_BYTES)
+
+
+def has_punctuation_characters(in_string: str) -> bool:
+    """Check if the given string has any punctuation character
+
+    Note: We exclude `_` and `-` from punctuation characters
+
+    Args:
+        in_string(str): input string
+
+    Returns:
+        (bool): the result of check for punctuation characters
+    """
+    for char in in_string:
+        if char in ["-", "_"]:
+            continue
+
+        if char in string.punctuation:
+            return True
+
+    return False

--- a/dlt/common/normalizers/utils.py
+++ b/dlt/common/normalizers/utils.py
@@ -1,4 +1,3 @@
-import string
 from importlib import import_module
 from typing import Any, Type, Tuple, cast, List
 
@@ -77,24 +76,3 @@ def generate_dlt_ids(n_ids: int) -> List[str]:
 
 def generate_dlt_id() -> str:
     return uniq_id_base64(DLT_ID_LENGTH_BYTES)
-
-
-def has_punctuation_characters(in_string: str) -> bool:
-    """Check if the given string has any punctuation character
-
-    Note: We exclude `_` and `-` from punctuation characters
-
-    Args:
-        in_string(str): input string
-
-    Returns:
-        (bool): the result of check for punctuation characters
-    """
-    for char in in_string:
-        if char in ["-", "_"]:
-            continue
-
-        if char in string.punctuation:
-            return True
-
-    return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import dataclasses
 import logging
+from pathlib import Path
 from typing import List
 
 # patch which providers to enable
@@ -16,12 +17,15 @@ from dlt.common.configuration.specs.config_providers_context import (
 )
 
 
+TESTS_ROOT = Path(__file__).parent.absolute()
+
+
 def initial_providers() -> List[ConfigProvider]:
     # do not read the global config
     return [
         EnvironProvider(),
-        SecretsTomlProvider(project_dir="tests/.dlt", add_global_config=False),
-        ConfigTomlProvider(project_dir="tests/.dlt", add_global_config=False),
+        SecretsTomlProvider(project_dir=str(TESTS_ROOT / ".dlt"), add_global_config=False),
+        ConfigTomlProvider(project_dir=str(TESTS_ROOT / ".dlt"), add_global_config=False),
     ]
 
 
@@ -47,27 +51,35 @@ def pytest_configure(config):
         "TLJiyRkGVZGCi2TtjClamXpFcxAA1rSB"
     )
     delattr(run_configuration.RunConfiguration, "__init__")
-    run_configuration.RunConfiguration = dataclasses.dataclass(run_configuration.RunConfiguration, init=True, repr=False)  # type: ignore
+    run_configuration.RunConfiguration = dataclasses.dataclass(
+        run_configuration.RunConfiguration, init=True, repr=False
+    )  # type: ignore
     # push telemetry to CI
 
     storage_configuration.LoadStorageConfiguration.load_volume_path = os.path.join(
         test_storage_root, "load"
     )
     delattr(storage_configuration.LoadStorageConfiguration, "__init__")
-    storage_configuration.LoadStorageConfiguration = dataclasses.dataclass(storage_configuration.LoadStorageConfiguration, init=True, repr=False)  # type: ignore[misc, call-overload]
+    storage_configuration.LoadStorageConfiguration = dataclasses.dataclass(
+        storage_configuration.LoadStorageConfiguration, init=True, repr=False
+    )  # type: ignore[misc, call-overload]
 
     storage_configuration.NormalizeStorageConfiguration.normalize_volume_path = os.path.join(
         test_storage_root, "normalize"
     )
     # delete __init__, otherwise it will not be recreated by dataclass
     delattr(storage_configuration.NormalizeStorageConfiguration, "__init__")
-    storage_configuration.NormalizeStorageConfiguration = dataclasses.dataclass(storage_configuration.NormalizeStorageConfiguration, init=True, repr=False)  # type: ignore[misc, call-overload]
+    storage_configuration.NormalizeStorageConfiguration = dataclasses.dataclass(
+        storage_configuration.NormalizeStorageConfiguration, init=True, repr=False
+    )  # type: ignore[misc, call-overload]
 
     storage_configuration.SchemaStorageConfiguration.schema_volume_path = os.path.join(
         test_storage_root, "schemas"
     )
     delattr(storage_configuration.SchemaStorageConfiguration, "__init__")
-    storage_configuration.SchemaStorageConfiguration = dataclasses.dataclass(storage_configuration.SchemaStorageConfiguration, init=True, repr=False)  # type: ignore[misc, call-overload]
+    storage_configuration.SchemaStorageConfiguration = dataclasses.dataclass(
+        storage_configuration.SchemaStorageConfiguration, init=True, repr=False
+    )  # type: ignore[misc, call-overload]
 
     assert run_configuration.RunConfiguration.config_files_storage_path == os.path.join(
         test_storage_root, "config/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def pytest_configure(config):
         test_storage_root, "load"
     )
     delattr(storage_configuration.LoadStorageConfiguration, "__init__")
-    storage_configuration.LoadStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc]
+    storage_configuration.LoadStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc,call-overload]
         storage_configuration.LoadStorageConfiguration, init=True, repr=False
     )
 
@@ -69,7 +69,7 @@ def pytest_configure(config):
     )
     # delete __init__, otherwise it will not be recreated by dataclass
     delattr(storage_configuration.NormalizeStorageConfiguration, "__init__")
-    storage_configuration.NormalizeStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc]
+    storage_configuration.NormalizeStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc,call-overload]
         storage_configuration.NormalizeStorageConfiguration, init=True, repr=False
     )
 
@@ -77,7 +77,7 @@ def pytest_configure(config):
         test_storage_root, "schemas"
     )
     delattr(storage_configuration.SchemaStorageConfiguration, "__init__")
-    storage_configuration.SchemaStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc]
+    storage_configuration.SchemaStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc,call-overload]
         storage_configuration.SchemaStorageConfiguration, init=True, repr=False
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def pytest_configure(config):
         "TLJiyRkGVZGCi2TtjClamXpFcxAA1rSB"
     )
     delattr(run_configuration.RunConfiguration, "__init__")
-    run_configuration.RunConfiguration = dataclasses.dataclass(
+    run_configuration.RunConfiguration = dataclasses.dataclass(  # type: ignore[misc]
         run_configuration.RunConfiguration, init=True, repr=False
     )  # type: ignore
     # push telemetry to CI
@@ -60,26 +60,26 @@ def pytest_configure(config):
         test_storage_root, "load"
     )
     delattr(storage_configuration.LoadStorageConfiguration, "__init__")
-    storage_configuration.LoadStorageConfiguration = dataclasses.dataclass(
+    storage_configuration.LoadStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc]
         storage_configuration.LoadStorageConfiguration, init=True, repr=False
-    )  # type: ignore[misc, call-overload]
+    )
 
     storage_configuration.NormalizeStorageConfiguration.normalize_volume_path = os.path.join(
         test_storage_root, "normalize"
     )
     # delete __init__, otherwise it will not be recreated by dataclass
     delattr(storage_configuration.NormalizeStorageConfiguration, "__init__")
-    storage_configuration.NormalizeStorageConfiguration = dataclasses.dataclass(
+    storage_configuration.NormalizeStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc]
         storage_configuration.NormalizeStorageConfiguration, init=True, repr=False
-    )  # type: ignore[misc, call-overload]
+    )
 
     storage_configuration.SchemaStorageConfiguration.schema_volume_path = os.path.join(
         test_storage_root, "schemas"
     )
     delattr(storage_configuration.SchemaStorageConfiguration, "__init__")
-    storage_configuration.SchemaStorageConfiguration = dataclasses.dataclass(
+    storage_configuration.SchemaStorageConfiguration = dataclasses.dataclass(   # type: ignore[misc]
         storage_configuration.SchemaStorageConfiguration, init=True, repr=False
-    )  # type: ignore[misc, call-overload]
+    )
 
     assert run_configuration.RunConfiguration.config_files_storage_path == os.path.join(
         test_storage_root, "config/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def pytest_configure(config):
         test_storage_root, "schemas"
     )
     delattr(storage_configuration.SchemaStorageConfiguration, "__init__")
-    storage_configuration.SchemaStorageConfiguration = dataclasses.dataclass(   # type: ignore[misc]
+    storage_configuration.SchemaStorageConfiguration = dataclasses.dataclass(  # type: ignore[misc]
         storage_configuration.SchemaStorageConfiguration, init=True, repr=False
     )
 

--- a/tests/helpers/providers/test_google_secrets_provider.py
+++ b/tests/helpers/providers/test_google_secrets_provider.py
@@ -34,6 +34,10 @@ def test_regular_keys() -> None:
     # print(c)
     provider: GoogleSecretsProvider = _google_secrets_provider()  # type: ignore[assignment]
     assert provider._toml.as_string().strip() == DLT_SECRETS_TOML_CONTENT.strip()
+    assert provider.get_value("secret_value", AnyType, "pipeline x !!") == (
+        None,
+        "pipeline_x-secret_value",
+    )
     assert provider.get_value("secret_value", AnyType, None) == (2137, "secret_value")
     assert provider.get_value("secret_key", AnyType, None, "api") == ("ABCD", "api-secret_key")
 

--- a/tests/helpers/providers/test_google_secrets_provider.py
+++ b/tests/helpers/providers/test_google_secrets_provider.py
@@ -36,7 +36,7 @@ def test_regular_keys() -> None:
     assert provider._toml.as_string().strip() == DLT_SECRETS_TOML_CONTENT.strip()
     assert provider.get_value("secret_value", AnyType, "pipeline x !!") == (
         None,
-        "pipeline_x-secret_value",
+        "pipelinex-secret_value",
     )
     assert provider.get_value("secret_value", AnyType, None) == (2137, "secret_value")
     assert provider.get_value("secret_key", AnyType, None, "api") == ("ABCD", "api-secret_key")


### PR DESCRIPTION
This PR addresses the issue https://github.com/dlt-hub/dlt/issues/880 by stripping whitespaces then removing punctuation characters in `pipeline_name` before calling `get_key_name` which builds the final key name