### PR TITLE
Sthor/parallelize decorator

### DIFF
--- a/dlt/extract/concurrency.py
+++ b/dlt/extract/concurrency.py
@@ -1,0 +1,219 @@
+import asyncio
+from uuid import uuid4
+from asyncio import Future
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    as_completed,
+    wait as wait_for_futures,
+    FIRST_COMPLETED,
+)
+from threading import Thread
+from typing import List, Awaitable, Callable, Any, Dict, Set, Optional
+
+from dlt.common.exceptions import PipelineException
+from dlt.common.configuration.container import Container
+from dlt.common.runtime.signals import sleep
+from dlt.extract.typing import DataItemWithMeta, TItemFuture
+from dlt.extract.items import ResolvablePipeItem, FuturePipeItem
+
+from dlt.extract.exceptions import (
+    DltSourceException,
+    ExtractorException,
+    PipeException,
+    ResourceExtractionError,
+)
+
+
+class WorkerPool:
+    """Worker pool for pipe items that can be resolved asynchronously.
+
+    Items can be either asyncio coroutines or regular callables which will be executed in a thread pool.
+    """
+
+    def __init__(
+        self, workers: int = 5, poll_interval: float = 0.01, max_parallel_items: int = 20
+    ) -> None:
+        self.futures: Dict[TItemFuture, FuturePipeItem] = {}
+        self._thread_pool: ThreadPoolExecutor = None
+        self._async_pool: asyncio.AbstractEventLoop = None
+        self._async_pool_thread: Thread = None
+        self.workers = workers
+        self.poll_interval = poll_interval
+        self.max_parallel_items = max_parallel_items
+        self.used_slots: int = 0
+
+    def __len__(self) -> int:
+        return len(self.futures)
+
+    @property
+    def free_slots(self) -> int:
+        # Done futures don't count as slots, so we can still add futures
+        return self.max_parallel_items - self.used_slots
+
+    @property
+    def empty(self) -> bool:
+        return len(self.futures) == 0
+
+    def _ensure_thread_pool(self) -> ThreadPoolExecutor:
+        # lazily start or return thread pool
+        if self._thread_pool:
+            return self._thread_pool
+
+        self._thread_pool = ThreadPoolExecutor(
+            self.workers, thread_name_prefix=Container.thread_pool_prefix() + "threads"
+        )
+        return self._thread_pool
+
+    def _ensure_async_pool(self) -> asyncio.AbstractEventLoop:
+        # lazily create async pool is separate thread
+        if self._async_pool:
+            return self._async_pool
+
+        def start_background_loop(loop: asyncio.AbstractEventLoop) -> None:
+            asyncio.set_event_loop(loop)
+            loop.run_forever()
+
+        self._async_pool = asyncio.new_event_loop()
+        self._async_pool_thread = Thread(
+            target=start_background_loop,
+            args=(self._async_pool,),
+            daemon=True,
+            name=Container.thread_pool_prefix() + "futures",
+        )
+        self._async_pool_thread.start()
+
+        # start or return async pool
+        return self._async_pool
+
+    def _vacate_slot(self, _: TItemFuture) -> None:
+        # Used as callback to free up slot when future is done
+        self.used_slots -= 1
+
+    def submit(self, pipe_item: ResolvablePipeItem) -> Optional[TItemFuture]:
+        """Submit an item to the pool.
+
+        Args:
+            pipe_item: The item to submit.
+
+        Returns:
+            The future if the item was successfully submitted, otherwise None.
+        """
+        if self.free_slots == 0:
+            return None
+
+        if self.free_slots < 0:  # TODO: Sanity check during dev, should never happen
+            raise RuntimeError("Used more slots than max_parallel_items")
+
+        # submit to thread pool or async pool
+        item = pipe_item.item
+        if isinstance(item, Awaitable):
+            future = asyncio.run_coroutine_threadsafe(item, self._ensure_async_pool())
+        elif callable(item):
+            future = self._ensure_thread_pool().submit(item)
+        else:
+            raise ValueError(f"Unsupported item type: {type(item)}")
+
+        # Future is not removed from self.futures until it's been consumed by the
+        # pipe iterator. But we always want to vacate a slot so new jobs can be submitted
+        future.add_done_callback(self._vacate_slot)
+        self.used_slots += 1
+
+        self.futures[future] = FuturePipeItem(
+            future, pipe_item.step, pipe_item.pipe, pipe_item.meta
+        )
+        return future
+
+    def poll(self) -> None:
+        sleep(self.poll_interval)
+
+    def _resolve_future(self, future: TItemFuture) -> Optional[ResolvablePipeItem]:
+        future, step, pipe, meta = self.futures.pop(future)
+
+        if ex := future.exception():
+            if isinstance(ex, StopAsyncIteration):
+                return None
+            # Raise if any future fails
+            if isinstance(
+                ex, (PipelineException, ExtractorException, DltSourceException, PipeException)
+            ):
+                raise ex
+            raise ResourceExtractionError(pipe.name, future, str(ex), "future") from ex
+
+        item = future.result()
+
+        if item is None:
+            return None
+        elif isinstance(item, DataItemWithMeta):
+            return ResolvablePipeItem(item.data, step, pipe, item.meta)
+        else:
+            return ResolvablePipeItem(item, step, pipe, meta)
+
+    def resolve_next_future(self) -> Optional[ResolvablePipeItem]:
+        """Wait for the next future to be done. Returns None if no futures done."""
+        if not self.futures:
+            return None
+
+        if (item := self.resolve_next_future_no_wait()) is not None:
+            return item
+        for future in as_completed(self.futures):
+            if future.cancelled():
+                # Get the next not-cancelled future
+                continue
+
+            return self._resolve_future(future)
+
+        return None
+
+    def resolve_next_future_no_wait(self) -> Optional[ResolvablePipeItem]:
+        """Resolve the first done future in the pool.
+        This does not block and returns None if no future is done.
+        """
+        # Get next done future
+        future = next((fut for fut in self.futures if fut.done() and not fut.cancelled()), None)
+        if not future:
+            return None
+
+        return self._resolve_future(future)
+
+    def wait_for_free_slot(self) -> None:
+        """Wait until any future in the pool is completed to ensure there's a free slot."""
+        if self.free_slots >= 1:
+            self.poll()  # Just sleep a bit to give other threads a chance
+            return
+
+        for future in as_completed(self.futures):
+            if future.cancelled():
+                # Get the next not-cancelled future
+                continue
+            if self.free_slots == 0:
+                # Future was already completed so slot was not freed
+                continue
+            return  # Return when first future completes
+
+    def close(self) -> None:
+        # Cancel all futures
+        for f in self.futures:
+            if not f.done():
+                f.cancel()
+
+        def stop_background_loop(loop: asyncio.AbstractEventLoop) -> None:
+            loop.stop()
+
+        if self._async_pool:
+            # wait for all async generators to be closed
+            future = asyncio.run_coroutine_threadsafe(
+                self._async_pool.shutdown_asyncgens(), self._ensure_async_pool()
+            )
+
+            wait_for_futures([future])
+            self._async_pool.call_soon_threadsafe(stop_background_loop, self._async_pool)
+
+            self._async_pool_thread.join()
+            self._async_pool = None
+            self._async_pool_thread = None
+
+        if self._thread_pool:
+            self._thread_pool.shutdown(wait=True)
+            self._thread_pool = None
+
+        self.futures.clear()

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -456,7 +456,7 @@ def resource(
             raise DynamicNameNotStandaloneResource(get_callable_name(f))
 
         if parallelized:
-            f = parallel(f)
+            f = parallelize(f)
 
         # resource_section = name if name and not callable(name) else get_callable_name(f)
         resource_name = name if name and not callable(name) else get_callable_name(f)
@@ -758,9 +758,9 @@ def defer(
     return _wrap
 
 
-def parallel(f: Callable[TResourceFunParams, Any]) -> Callable[TResourceFunParams, Any]:
+def parallelize(f: Callable[TResourceFunParams, Any]) -> Callable[TResourceFunParams, Any]:
     @wraps(f)
-    def _wrap(*args, **kwargs):
+    def _wrap(*args: Any, **kwargs: Any) -> Any:  # TODO: Type correctly
         gen = f(*args, **kwargs)
         if inspect.isfunction(gen):
             gen = gen()
@@ -770,7 +770,7 @@ def parallel(f: Callable[TResourceFunParams, Any]) -> Callable[TResourceFunParam
         exhausted = False
         busy = False
 
-        def _parallel_gen():
+        def _parallel_gen() -> Any:  # TODO: Type correctly
             try:
                 return next(gen)
             except StopIteration:

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -277,6 +277,7 @@ def resource(
     table_format: TTableHintTemplate[TTableFormat] = None,
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
+    parallelized: bool = False,
 ) -> DltResource:
     ...
 
@@ -295,6 +296,7 @@ def resource(
     table_format: TTableHintTemplate[TTableFormat] = None,
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
+    parallelized: bool = False,
 ) -> Callable[[Callable[TResourceFunParams, Any]], DltResource]:
     ...
 
@@ -314,6 +316,7 @@ def resource(
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
     standalone: Literal[True] = True,
+    parallelized: bool = False,
 ) -> Callable[[Callable[TResourceFunParams, Any]], Callable[TResourceFunParams, DltResource]]:
     ...
 
@@ -332,6 +335,7 @@ def resource(
     table_format: TTableHintTemplate[TTableFormat] = None,
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
+    parallelized: bool = False,
 ) -> DltResource:
     ...
 
@@ -351,7 +355,7 @@ def resource(
     spec: Type[BaseConfiguration] = None,
     standalone: bool = False,
     data_from: TUnboundDltResource = None,
-    parallelize: bool = False,
+    parallelized: bool = False,
 ) -> Any:
     """When used as a decorator, transforms any generator (yielding) function into a `dlt resource`. When used as a function, it transforms data in `data` argument into a `dlt resource`.
 
@@ -451,7 +455,7 @@ def resource(
         if not standalone and callable(name):
             raise DynamicNameNotStandaloneResource(get_callable_name(f))
 
-        if parallelize:
+        if parallelized:
             f = parallel(f)
 
         # resource_section = name if name and not callable(name) else get_callable_name(f)
@@ -785,5 +789,6 @@ def parallel(f: Callable[TResourceFunParams, Any]) -> Callable[TResourceFunParam
                 yield _parallel_gen
             except GeneratorExit:
                 gen.close()
+                raise
 
     return _wrap

--- a/dlt/extract/items.py
+++ b/dlt/extract/items.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Iterator, NamedTuple, Union, Optional
+from concurrent.futures import Future
+
+from dlt.common.typing import TDataItems
+from dlt.extract.typing import TPipedDataItems, DataItemWithMeta, TItemFuture
+
+if TYPE_CHECKING:
+    from dlt.extract.pipe import Pipe
+
+
+class PipeItem(NamedTuple):
+    item: TDataItems
+    step: int
+    pipe: "Pipe"
+    meta: Any
+
+
+class ResolvablePipeItem(NamedTuple):
+    # mypy unable to handle recursive types, ResolvablePipeItem should take itself in "item"
+    item: Union[TPipedDataItems, Iterator[TPipedDataItems]]
+    step: int
+    pipe: "Pipe"
+    meta: Any
+
+
+class FuturePipeItem(NamedTuple):
+    item: TItemFuture
+    step: int
+    pipe: "Pipe"
+    meta: Any
+
+
+class SourcePipeItem(NamedTuple):
+    item: Union[Iterator[TPipedDataItems], Iterator[ResolvablePipeItem]]
+    step: int
+    pipe: "Pipe"
+    meta: Any

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -314,14 +314,12 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         def _gen_wrap(gen: TPipeStep) -> TPipeStep:
             """Wrap a generator to take the first `max_items` records"""
             count = 0
-            is_async_gen = False
             if inspect.isfunction(gen):
                 gen = gen()
 
             # wrap async gen already here
             if isinstance(gen, AsyncIterator):
                 gen = wrap_async_iterator(gen)
-                is_async_gen = True
 
             try:
                 for i in gen:  # type: ignore # TODO: help me fix this later
@@ -331,7 +329,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
                         # async gen yields awaitable so we must count one awaitable more
                         # so the previous one is evaluated and yielded.
                         # new awaitable will be cancelled
-                        if count == max_items + int(is_async_gen):
+                        if count == max_items:
                             return
             finally:
                 if inspect.isgenerator(gen):

--- a/dlt/extract/typing.py
+++ b/dlt/extract/typing.py
@@ -11,7 +11,9 @@ from typing import (
     TypeVar,
     Union,
     Awaitable,
+    TYPE_CHECKING,
 )
+from concurrent.futures import Future
 
 from dlt.common.typing import TAny, TDataItem, TDataItems
 
@@ -158,3 +160,9 @@ class ValidateItem(ItemTransform[TDataItem]):
     def bind(self, pipe: SupportsPipe) -> ItemTransform[TDataItem]:
         self.table_name = pipe.name
         return self
+
+
+if TYPE_CHECKING:
+    TItemFuture = Future[Union[TDataItems, DataItemWithMeta]]
+else:
+    TItemFuture = Future


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Implements #934 

Draft for now, may need to test more.

Added a `parallelized` argument to resource. For me that seems like a good interface.  
Under the hood it's basically the same decorator from the test implementation (maybe it makes sense to use it directly in some cases?) or we could integrate this more deeply in resource.

There was a lot of overhead coming from all the polling in `PipeIterator` when constantly yielding `None`, so I tried to implement more intelligent waiting for futures. Basically just block until some future completes when the pool is full instead of blindly polling and looping over the resources and that seems to make a big difference.   
+ pretty big refactor of `PipeIterator` -> the futures worker pool is a separate class   

Benchmark before and after optimizing: https://gist.github.com/steinitzu/671b47cdb7cbf61b2fab46cf1faefd86  
The original iterator had a lot of overhead, especially when number of resources is <= number of workers.