### PR TITLE
adjustment of pua start in typed json encoding

### DIFF
--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -80,14 +80,18 @@ def custom_encode(obj: Any) -> str:
 
 
 # use PUA range to encode additional types
-_DECIMAL = "\uf026"
-_DATETIME = "\uf027"
-_DATE = "\uf028"
-_UUIDT = "\uf029"
-_HEXBYTES = "\uf02a"
-_B64BYTES = "\uf02b"
-_WEI = "\uf02c"
-_TIME = "\uf02d"
+PUA_START = int(os.environ.get("DLT_JSON_TYPED_PUA_START", "0x0FA179"), 16)
+
+_DECIMAL = chr(PUA_START)
+_DATETIME = chr(PUA_START + 1)
+_DATE = chr(PUA_START + 2)
+_UUIDT = chr(PUA_START + 3)
+_HEXBYTES = chr(PUA_START + 4)
+_B64BYTES = chr(PUA_START + 5)
+_WEI = chr(PUA_START + 6)
+_TIME = chr(PUA_START + 7)
+
+PUA_START_UTF8_MAGIC = _DECIMAL.encode("utf-8")[:2]
 
 
 def _datetime_decoder(obj: str) -> datetime:
@@ -148,7 +152,7 @@ def custom_pua_encode(obj: Any) -> str:
 
 def custom_pua_decode(obj: Any) -> Any:
     if isinstance(obj, str) and len(obj) > 1:
-        c = ord(obj[0]) - 0xF026
+        c = ord(obj[0]) - PUA_START
         # decode only the PUA space defined in DECODERS
         if c >= 0 and c <= PUA_CHARACTER_MAX:
             return DECODERS[c](obj[1:])
@@ -166,7 +170,7 @@ def custom_pua_decode_nested(obj: Any) -> Any:
 def custom_pua_remove(obj: Any) -> Any:
     """Removes the PUA data type marker and leaves the correctly serialized type representation. Unmarked values are returned as-is."""
     if isinstance(obj, str) and len(obj) > 1:
-        c = ord(obj[0]) - 0xF026
+        c = ord(obj[0]) - PUA_START
         # decode only the PUA space defined in DECODERS
         if c >= 0 and c <= PUA_CHARACTER_MAX:
             return obj[1:]
@@ -175,7 +179,7 @@ def custom_pua_remove(obj: Any) -> Any:
 
 def may_have_pua(line: bytes) -> bool:
     """Checks if bytes string contains pua marker"""
-    return b"\xef\x80" in line
+    return PUA_START_UTF8_MAGIC in line
 
 
 # pick the right impl

--- a/dlt/common/normalizers/naming/direct.py
+++ b/dlt/common/normalizers/naming/direct.py
@@ -6,7 +6,7 @@ from dlt.common.normalizers.naming.naming import NamingConvention as BaseNamingC
 class NamingConvention(BaseNamingConvention):
     PATH_SEPARATOR = "▶"
 
-    _CLEANUP_TABLE = str.maketrans("\n\r'\"▶", "_____")
+    _CLEANUP_TABLE = str.maketrans(".\n\r'\"▶", "______")
 
     def normalize_identifier(self, identifier: str) -> str:
         identifier = super().normalize_identifier(identifier)

--- a/tests/common/test_json.py
+++ b/tests/common/test_json.py
@@ -222,7 +222,9 @@ def test_json_named_tuple(json_impl: SupportsJson) -> None:
     )
     with io.BytesIO() as b:
         json_impl.typed_dump(NamedTupleTest("STR", Decimal("1.3333")), b)
-        assert b.getvalue().decode("utf-8") == '{"str_field":"STR","dec_field":"\uf0261.3333"}'
+        assert (
+            b.getvalue().decode("utf-8") == '{"str_field":"STR","dec_field":"%s1.3333"}' % _DECIMAL
+        )
 
 
 @pytest.mark.parametrize("json_impl", _JSON_IMPL)
@@ -235,7 +237,7 @@ def test_data_class(json_impl: SupportsJson) -> None:
         json_impl.typed_dump(DataClassTest(str_field="AAA"), b)
         assert (
             b.getvalue().decode("utf-8")
-            == '{"str_field":"AAA","int_field":5,"dec_field":"\uf0260.5"}'
+            == '{"str_field":"AAA","int_field":5,"dec_field":"%s0.5"}' % _DECIMAL
         )
 
 
@@ -300,10 +302,3 @@ def test_load_and_compare_all_impls() -> None:
         assert docs[idx] == docs[idx + 1]
         assert dump_s[idx] == dump_s[idx + 1]
         assert dump_b[idx] == dump_b[idx + 1]
-
-
-def test_orjson_segfault() -> None:
-    import orjson
-
-    for _ in range(10000000):
-        orjson.dumps((b"\n" + b"x" * 4046).decode())


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
`dlt` uses private unicode areas to encode certain Python types in json. In rare cases users may want to change where such encoding is placed in PUA.

First character code may be changed by using `DLT_JSON_TYPED_PUA_START` env variable with contains hex value of such character.
ie. "0xf026"