### PR TITLE
Use BIGNUMERIC for large decimals in bigquery

### DIFF
--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -54,7 +54,6 @@ class BigQueryTypeMapper(TypeMapper):
     sct_to_dbt = {
         "text": "STRING(%i)",
         "binary": "BYTES(%i)",
-        "decimal": "NUMERIC(%i,%i)",
     }
 
     dbt_to_sct = {
@@ -70,6 +69,13 @@ class BigQueryTypeMapper(TypeMapper):
         "JSON": "complex",
         "TIME": "time",
     }
+
+    def to_db_decimal_type(self, precision: Optional[int], scale: Optional[int]) -> str:
+        # Use BigQuery's BIGNUMERIC for large precision decimals
+        precision, scale = self.decimal_precision(precision, scale)
+        if precision > 38 or scale > 9:
+            return "BIGNUMERIC(%i,%i)" % (precision, scale)
+        return "NUMERIC(%i,%i)" % (precision, scale)
 
     # noinspection PyTypeChecker,PydanticTypeChecker
     def from_db_type(

--- a/dlt/destinations/type_mapping.py
+++ b/dlt/destinations/type_mapping.py
@@ -36,6 +36,10 @@ class TypeMapper:
         # Override in subclass if db supports other time types (e.g. with different time resolutions)
         return None
 
+    def to_db_decimal_type(self, precision: Optional[int], scale: Optional[int]) -> str:
+        precision, scale = self.decimal_precision(precision, scale)
+        return self.sct_to_dbt["decimal"] % (precision, scale)
+
     def to_db_type(self, column: TColumnSchema, table_format: TTableFormat = None) -> str:
         precision, scale = column.get("precision"), column.get("scale")
         sc_t = column["data_type"]
@@ -45,6 +49,8 @@ class TypeMapper:
             db_t = self.to_db_datetime_type(precision, table_format)
         elif sc_t == "time":
             db_t = self.to_db_time_type(precision, table_format)
+        elif sc_t == "decimal":
+            db_t = self.to_db_decimal_type(precision, scale)
         else:
             db_t = None
         if db_t:

--- a/dlt/destinations/type_mapping.py
+++ b/dlt/destinations/type_mapping.py
@@ -37,8 +37,10 @@ class TypeMapper:
         return None
 
     def to_db_decimal_type(self, precision: Optional[int], scale: Optional[int]) -> str:
-        precision, scale = self.decimal_precision(precision, scale)
-        return self.sct_to_dbt["decimal"] % (precision, scale)
+        precision_tup = self.decimal_precision(precision, scale)
+        if not precision_tup or "decimal" not in self.sct_to_dbt:
+            return self.sct_to_unbound_dbt["decimal"]
+        return self.sct_to_dbt["decimal"] % (precision_tup[0], precision_tup[1])
 
     def to_db_type(self, column: TColumnSchema, table_format: TTableFormat = None) -> str:
         precision, scale = column.get("precision"), column.get("scale")

--- a/tests/load/pipeline/test_bigquery.py
+++ b/tests/load/pipeline/test_bigquery.py
@@ -1,0 +1,38 @@
+import pytest
+
+from dlt.common import Decimal
+
+from tests.pipeline.utils import assert_load_info
+from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
+from tests.load.utils import delete_dataset
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["bigquery"]),
+    ids=lambda x: x.name,
+)
+def test_bigquery_numeric_types(destination_config: DestinationTestConfiguration) -> None:
+    pipeline = destination_config.setup_pipeline("test_bigquery_numeric_types")
+
+    columns = [
+        {"name": "col_big_numeric", "data_type": "decimal", "precision": 47, "scale": 9},
+        {"name": "col_numeric", "data_type": "decimal", "precision": 38, "scale": 9},
+    ]
+
+    data = [
+        {
+            # Valid BIGNUMERIC and NUMERIC values
+            "col_big_numeric": Decimal("12345678901234567890123456789012345678.123456789"),
+            "col_numeric": Decimal("12345678901234567890123456789.123456789"),
+        },
+    ]
+
+    info = pipeline.run(iter(data), table_name="big_numeric", columns=columns)  # type: ignore[arg-type]
+    assert_load_info(info)
+
+    with pipeline.sql_client() as client:
+        with client.execute_query("SELECT col_big_numeric, col_numeric FROM big_numeric;") as q:
+            row = q.fetchone()
+            assert row[0] == data[0]["col_big_numeric"]
+            assert row[1] == data[0]["col_numeric"]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
* Adjust type mapper to use BIGNUMERIC for decimals with `precision > 38 or scale > 9`
* Tests -> added big decimal to table builder unit test and one e2e test with pipeline

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
- Fixes #983 