### PR TITLE
fixing:  module 'pyarrow' has no attribute 'compute'

### DIFF
--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -1,5 +1,6 @@
 from datetime import datetime, date  # noqa: I251
 from typing import Any, Optional, Tuple, List
+import pyarrow.compute as pc
 
 try:
     import pandas as pd


### PR DESCRIPTION

### Description

I got an error while using [connector_x example](https://dlthub.com/docs/examples/connector_x_arrow/):
```
❯ python delta-load-connector.x.py
15.0.0
Traceback (most recent call last):
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/extract/pipe.py", line 672, in __next__
    next_item = step(item, meta=pipe_item.meta)  # type: ignore
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/extract/incremental/__init__.py", line 417, in __call__
    return self._transform_item(transformer, rows)
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/extract/incremental/__init__.py", line 292, in _transform_item
    row, start_out_of_range, end_out_of_range = transformer(row)
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/extract/incremental/transform.py", line 232, in __call__
    compute = pa.compute.max
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/pyarrow/__init__.py", line 317, in __getattr__
    raise AttributeError(
AttributeError: module 'pyarrow' has no attribute 'compute'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/pipeline/pipeline.py", line 391, in extract
    self._extract_source(extract_step, source, max_parallel_items, workers)
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/pipeline/pipeline.py", line 1028, in _extract_source
    load_id = extract.extract(source, max_parallel_items, workers)
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/extract/extract.py", line 341, in extract
    self._extract_single_source(
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/extract/extract.py", line 271, in _extract_single_source
    for pipe_item in pipes:
  File "/Users/sspaeti/.venvs/dlt/lib/python3.9/site-packages/dlt/extract/pipe.py", line 687, in __next__
    raise ResourceExtractionError(
dlt.extract.exceptions.ResourceExtractionError: In processing pipe schild: extraction of resource schild in transform Incremental caused an exception: module 'pyarrow' has no attribute 'compute'
```


### Related Issues

Haven't seen

### Additional Context

I added the `import pyarrow.compute as pc` which solved the error for me. But maybe we should use compute in `incremental/transform.py` explicit. Atm it is `pa.compute.max`. Should it be `pc.compute.max`?

See also the discussion on [Slack](https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1708989407596309) for more context.