### PR TITLE
Add __main__ entry point to support calling dlt as python module

### DIFF
--- a/dlt/__main__.py
+++ b/dlt/__main__.py
@@ -1,0 +1,4 @@
+from dlt.cli._dlt import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR allows invoke `dlt` as a Python module `python -m dlt` there are some use cases where you want to run `dlt` as a module

1. You are developing the core library and it is handy to have a module entrypoint,
2. Direct execution target as module for example in Dockerfile which has `ENTRYPOINT python -m dlt` and `CMD python -m dlt` for example always running the latest master branch snapshot

```sh
python -m dlt
usage: __main__.py [-h] [--version] [--disable-telemetry] [--enable-telemetry] [--non-interactive] [--debug] {init,deploy,schema,pipeline,telemetry} ...

Creates, adds, inspects and deploys dlt pipelines.

positional arguments:
  {init,deploy,schema,pipeline,telemetry}
    init                Creates a pipeline project in the current folder by adding existing verified source or creating a new one from template.
    deploy              Install additional dependencies with pip install "dlt[cli]" to create deployment packages
    schema              Shows, converts and upgrades schemas
    pipeline            Operations on pipelines that were ran locally
    telemetry           Shows telemetry status

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --disable-telemetry   Disables telemetry before command is executed
  --enable-telemetry    Enables telemetry before command is executed
  --non-interactive     Non interactive mode. Default choices are automatically made for confirmations and prompts.
  --debug               Displays full stack traces on exceptions.
```