### PR TITLE
fix(core): validation error with TTableHintTemplate

### DIFF
--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -160,8 +160,11 @@ def validate_dict(
             pass
         else:
             if not validator_f(path, pk, pv, t):
+                # TODO: when Python 3.9 and earlier support is
+                # dropped, just __name__ can be used
+                type_name = getattr(t, "__name__", t.__class__)
                 raise DictValidationException(
-                    f"In {path}: field {pk} has expected type {t.__name__} which lacks validator",
+                    f"In {path}: field {pk} has expected type {type_name} which lacks validator",
                     path,
                     pk,
                 )

--- a/tests/common/test_validation.py
+++ b/tests/common/test_validation.py
@@ -263,8 +263,8 @@ def test_callable() -> None:
     class TTestRecordCallable(TypedDict):
         prop: t_table_hint_template  # type: ignore
 
-    def f(item: TDataItem) -> TDynHintType:
-        return TDynHintType("test")
+    def f(item: TDataItem) -> TDynHintType:  # type: ignore
+        return "test"
 
     test_item = {"prop": f}
     validate_dict(

--- a/tests/common/test_validation.py
+++ b/tests/common/test_validation.py
@@ -9,6 +9,7 @@ from dlt.common.schema.typing import TStoredSchema, TColumnSchema
 from dlt.common.schema.utils import simple_regex_validator
 from dlt.common.typing import DictStrStr, StrStr
 from dlt.common.validation import validate_dict, validate_dict_ignoring_xkeys
+from dlt.extract.typing import TTableHintTemplate
 
 
 TLiteral = Literal["uno", "dos", "tres"]
@@ -241,3 +242,14 @@ def test_nested_union(test_doc: TTestRecord) -> None:
         validate_dict(TTestRecord, test_doc, ".")
     assert e.value.field == "f_optional_union"
     assert e.value.value == "blah"
+
+
+def test_no_name() -> None:
+    class TTestRecordNoNoame(TypedDict):
+        name: TTableHintTemplate[str]
+
+    test_item = {"name": "test"}
+    try:
+        validate_dict(TTestRecordNoNoame, test_item, path=".")
+    except AttributeError:
+        pytest.fail("validate_dict raised AttributeError unexpectedly")

--- a/tests/common/test_validation.py
+++ b/tests/common/test_validation.py
@@ -263,8 +263,8 @@ def test_callable() -> None:
     class TTestRecordCallable(TypedDict):
         prop: t_table_hint_template  # type: ignore
 
-    def f(item: TDataItem) -> TDynHintType:  # type: ignore
-        return "test"
+    def f(item: Union[TDataItem, TDynHintType]) -> TDynHintType:
+        return item
 
     test_item = {"prop": f}
     validate_dict(

--- a/tests/common/test_validation.py
+++ b/tests/common/test_validation.py
@@ -1,8 +1,7 @@
-from collections.abc import Callable
 from copy import deepcopy
 import pytest
 import yaml
-from typing import List, Literal, Mapping, Sequence, TypedDict, TypeVar, Optional, Union
+from typing import Callable, List, Literal, Mapping, Sequence, TypedDict, TypeVar, Optional, Union
 
 from dlt.common.exceptions import DictValidationException
 from dlt.common.schema.typing import TStoredSchema, TColumnSchema


### PR DESCRIPTION
Fixes #999 

I don't have this error on Python 3.10 and Python 3.11. Both versions had some changes in `typing` and its generics, so it seems to be an error of older Python versions.