### PR TITLE
Refactor LoadInfo metrics layout schema

### DIFF
--- a/dlt/common/pipeline.py
+++ b/dlt/common/pipeline.py
@@ -421,12 +421,15 @@ class WithStepInfo(ABC, Generic[TStepMetrics, TStepInfo]):
         )
         metrics["started_at"] = ensure_pendulum_datetime(self._current_load_started)
         metrics["finished_at"] = ensure_pendulum_datetime(precise_time())
-        self._load_id_metrics[load_id].append(metrics)
+        metrics["load_id"] = load_id
+        self._load_id_metrics.append(metrics)
         self._current_load_id = None
         self._current_load_started = None
 
     def _step_info_metrics(self, load_id: str) -> List[TStepMetrics]:
-        return self._load_id_metrics[load_id]
+        metrics = [metric for metric in self._load_id_metrics if metric["load_id"] == load_id]
+
+        return metrics
 
     @property
     def current_load_id(self) -> str:

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -357,10 +357,10 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
         self.extract_storage.delete_empty_extract_folder()
 
     def get_step_info(self, pipeline: SupportsPipeline) -> ExtractInfo:
-        load_ids = list(self._load_id_metrics.keys())
+        load_ids = list({m["load_id"] for m in self._load_id_metrics})
         load_packages: List[LoadPackageInfo] = []
         metrics: Dict[str, List[ExtractMetrics]] = {}
-        for load_id in self._load_id_metrics.keys():
+        for load_id in load_ids:
             load_package = self.extract_storage.get_load_package_info(load_id)
             load_packages.append(load_package)
             metrics[load_id] = self._step_info_metrics(load_id)

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -466,7 +466,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         pipeline: SupportsPipeline,
     ) -> LoadInfo:
         # TODO: LoadInfo should hold many datasets
-        load_ids = list(self._load_id_metrics.keys())
+        load_ids = list({m["load_id"] for m in self._load_id_metrics})
         metrics: Dict[str, List[LoadMetrics]] = {}
         # get load packages and dataset_name from the last package
         _dataset_name: str = None
@@ -498,7 +498,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
             str(self.initial_staging_client_config) if self.initial_staging_client_config else None,
             self.initial_client_config.fingerprint(),
             _dataset_name,
-            list(load_ids),
+            load_ids,
             self._loaded_packages,
             pipeline.first_run,
         )

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -467,7 +467,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
     ) -> LoadInfo:
         # TODO: LoadInfo should hold many datasets
         load_ids = list({m["load_id"] for m in self._load_id_metrics})
-        metrics: Dict[str, List[LoadMetrics]] = {}
+        metrics: List[LoadMetrics] = []
         # get load packages and dataset_name from the last package
         _dataset_name: str = None
         for load_package in self._loaded_packages:
@@ -476,7 +476,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                 _dataset_name = self.initial_client_config.normalize_dataset_name(
                     load_package.schema
                 )
-            metrics[load_package.load_id] = self._step_info_metrics(load_package.load_id)
+            metrics.append(self._step_info_metrics(load_package.load_id))
 
         return LoadInfo(
             pipeline,

--- a/dlt/normalize/normalize.py
+++ b/dlt/normalize/normalize.py
@@ -402,11 +402,12 @@ class Normalize(Runnable[Executor], WithStepInfo[NormalizeMetrics, NormalizeInfo
         self,
         pipeline: SupportsPipeline,
     ) -> NormalizeInfo:
-        load_ids = list(self._load_id_metrics.keys())
+        load_ids = list({m["load_id"] for m in self._load_id_metrics})
         load_packages: List[LoadPackageInfo] = []
         metrics: Dict[str, List[NormalizeMetrics]] = {}
-        for load_id in self._load_id_metrics.keys():
+        for load_id in load_ids:
             load_package = self.get_load_package_info(load_id)
             load_packages.append(load_package)
             metrics[load_id] = self._step_info_metrics(load_id)
+
         return NormalizeInfo(pipeline, metrics, load_ids, load_packages, pipeline.first_run)

--- a/tests/pipeline/test_pipeline_load_info.py
+++ b/tests/pipeline/test_pipeline_load_info.py
@@ -1,0 +1,34 @@
+from typing import Dict, List
+
+import dlt
+
+
+def get_metrics_table(tables: List[Dict]) -> List[str]:
+    return [
+        table_name for table_name in tables if table_name["name"].startswith("_load_info__metrics")
+    ]
+
+
+def test_pipeline_load_info_metrics_is_always_a_single_table() -> None:
+    data = [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+    ]
+
+    pipeline = dlt.pipeline(
+        pipeline_name="quick_start",
+        destination="duckdb",
+        dataset_name="mydata",
+    )
+
+    load_info = pipeline.run(data, table_name="users")
+
+    pipeline.run([load_info], table_name="_load_info")
+    metrics_tables_first_run = get_metrics_table(pipeline.default_schema.data_tables())
+
+    load_info = pipeline.run(data, table_name="users")
+    pipeline.run([load_info], table_name="_load_info")
+    metrics_tables_second_run = get_metrics_table(pipeline.default_schema.data_tables())
+
+    assert len(metrics_tables_first_run) == len(metrics_tables_second_run)
+    assert metrics_tables_first_run == metrics_tables_second_run

--- a/tests/pipeline/test_pipeline_load_info.py
+++ b/tests/pipeline/test_pipeline_load_info.py
@@ -9,14 +9,15 @@ def get_metrics_table(tables: List[Dict]) -> List[str]:
     ]
 
 
-def test_pipeline_load_info_metrics_is_always_a_single_table() -> None:
-    data = [
-        {"id": 1, "name": "Alice"},
-        {"id": 2, "name": "Bob"},
-    ]
+data = [
+    {"id": 1, "name": "Alice"},
+    {"id": 2, "name": "Bob"},
+]
 
+
+def test_pipeline_load_info_metrics_is_always_a_single_table_e2e() -> None:
     pipeline = dlt.pipeline(
-        pipeline_name="quick_start",
+        pipeline_name="quick_start_e2e",
         destination="duckdb",
         dataset_name="mydata",
     )
@@ -32,3 +33,22 @@ def test_pipeline_load_info_metrics_is_always_a_single_table() -> None:
 
     assert len(metrics_tables_first_run) == len(metrics_tables_second_run)
     assert metrics_tables_first_run == metrics_tables_second_run
+
+
+def test_pipeline_load_info_metrics_schema_is_not_chaning() -> None:
+    pipeline = dlt.pipeline(
+        pipeline_name="quick_start",
+        destination="duckdb",
+        dataset_name="mydata",
+    )
+
+    load_info = pipeline.run(data, table_name="users")
+
+    pipeline.run([load_info], table_name="_load_info")
+    first_version_hash = pipeline.default_schema.version_hash
+
+    load_info = pipeline.run(data, table_name="users")
+    pipeline.run([load_info], table_name="_load_info")
+    second_version_hash = pipeline.default_schema.version_hash
+
+    assert first_version_hash == second_version_hash

--- a/tests/pipeline/test_pipeline_load_info.py
+++ b/tests/pipeline/test_pipeline_load_info.py
@@ -15,26 +15,6 @@ data = [
 ]
 
 
-def test_pipeline_load_info_metrics_is_always_a_single_table_e2e() -> None:
-    pipeline = dlt.pipeline(
-        pipeline_name="quick_start_e2e",
-        destination="duckdb",
-        dataset_name="mydata",
-    )
-
-    load_info = pipeline.run(data, table_name="users")
-
-    pipeline.run([load_info], table_name="_load_info")
-    metrics_tables_first_run = get_metrics_table(pipeline.default_schema.data_tables())
-
-    load_info = pipeline.run(data, table_name="users")
-    pipeline.run([load_info], table_name="_load_info")
-    metrics_tables_second_run = get_metrics_table(pipeline.default_schema.data_tables())
-
-    assert len(metrics_tables_first_run) == len(metrics_tables_second_run)
-    assert metrics_tables_first_run == metrics_tables_second_run
-
-
 def test_pipeline_load_info_metrics_schema_is_not_chaning() -> None:
     pipeline = dlt.pipeline(
         pipeline_name="quick_start",

--- a/tests/pipeline/test_pipeline_load_info.py
+++ b/tests/pipeline/test_pipeline_load_info.py
@@ -1,12 +1,4 @@
-from typing import Dict, List
-
 import dlt
-
-
-def get_metrics_table(tables: List[Dict]) -> List[str]:
-    return [
-        table_name for table_name in tables if table_name["name"].startswith("_load_info__metrics")
-    ]
 
 
 data = [


### PR DESCRIPTION
This issue was reported by a community member in [slack](https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1709412446163619) and related issue https://github.com/dlt-hub/dlt/issues/1043

When we capture load_info data in the destination database the following occurs:
* Pipeline execution slows down significantly after x number of incremental pipeline runs (it is back to the original speed when load_info is not captured in the database). My specific job (sourcing data from rest API capturing it in MotherDuck) slows down from 1.5 minutes to over 10 minutes (after a few hundred runs) and seems to keep getting slower.
* Each pipeline run creates a new table with one record (at least in my simple pipeline) with names like _load_info__metrics___1709356777_4431682.

## TODO
* [ ] Adjust `_ExtractInfo.metrics` from `Dict[str, List[ExtractMetrics]]` to just `List[ExtractMetrics]`,
* [ ] Add `load_id` field to `StepMetrics`,
* [ ] Adjust dependent code to use and extract information collection to lookup load ids etc.