### PR TITLE
Change `raise_for_status` default to False

### DIFF
--- a/dlt/sources/helpers/requests/retry.py
+++ b/dlt/sources/helpers/requests/retry.py
@@ -177,7 +177,7 @@ class Client:
             Union[TimedeltaSeconds, Tuple[TimedeltaSeconds, TimedeltaSeconds]]
         ] = DEFAULT_TIMEOUT,
         max_connections: int = 50,
-        raise_for_status: bool = True,
+        raise_for_status: bool = False,
         status_codes: Sequence[int] = DEFAULT_RETRY_STATUS,
         exceptions: Sequence[Type[Exception]] = DEFAULT_RETRY_EXCEPTIONS,
         request_max_attempts: int = RunConfiguration.request_max_attempts,

--- a/dlt/sources/helpers/requests/session.py
+++ b/dlt/sources/helpers/requests/session.py
@@ -36,7 +36,7 @@ class Session(BaseSession):
         timeout: Optional[
             Union[TimedeltaSeconds, Tuple[TimedeltaSeconds, TimedeltaSeconds]]
         ] = DEFAULT_TIMEOUT,
-        raise_for_status: bool = True,
+        raise_for_status: bool = False,
     ) -> None:
         super().__init__()
         self.timeout = _timeout_to_seconds(timeout)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This PR changes the default behaviour of `dlt.sources.helpers.requests.retry.Client` and `dlt.sources.helpers.requests.session.Session` so instances of both classes do not [`raise_for_status()`](https://requests.readthedocs.io/en/latest/api/#requests.Response.raise_for_status) by default.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- https://github.com/dlt-hub/verified-sources/pull/313
