### PR TITLE
Docs: Add note about google secret name normalization

### DIFF
--- a/docs/website/docs/general-usage/credentials/config_providers.md
+++ b/docs/website/docs/general-usage/credentials/config_providers.md
@@ -102,7 +102,7 @@ the `private_key` for Google credentials. It will look
 
 :::info
 While using Google secrets provider please make sure your pipeline name
-contains no space or any other punctuation characters except "-" and "_".
+contains no whitespace or any other punctuation characters except "-" and "_".
 
 Per Google the secret name can contain
 

--- a/docs/website/docs/general-usage/credentials/config_providers.md
+++ b/docs/website/docs/general-usage/credentials/config_providers.md
@@ -99,6 +99,19 @@ the `private_key` for Google credentials. It will look
 1. first in env variable `MY_SECTION__GCP_CREDENTIALS__PRIVATE_KEY` and if not found,
 1. in `secrets.toml` with key `my_section.gcp_credentials.private_key`.
 
+
+:::info
+While using Google secrets provider please make sure your pipeline name
+contains no space or any other punctuation characters except "-" and "_".
+
+Per Google the secret name can contain
+
+    1. Uppercase and lowercase letters,
+    2. Numerals,
+    3. Hyphens,
+    4. Underscores.
+:::
+
 ### Environment provider
 
 Looks for the values in the environment variables.


### PR DESCRIPTION
Added a quick info section about expected secret name format for google secrets.
The exact page url: https://deploy-preview-1056--dlt-hub-docs.netlify.app/docs/general-usage/credentials/config_providers/#provider-key-formats

<img width="1020" alt="image" src="https://github.com/dlt-hub/dlt/assets/354868/c0216514-8c79-4693-b596-a4be0e953ea2">