### PR TITLE
Docs: Add preprocessor

### DIFF
--- a/docs/website/.gitignore
+++ b/docs/website/.gitignore
@@ -4,6 +4,9 @@
 # Production
 /build
 
+# preprocessed docs
+/docs_processed
+
 # Generated files
 .docusaurus
 .cache-loader

--- a/docs/website/docs/dlt-ecosystem/destinations/bigquery.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/bigquery.md
@@ -263,7 +263,7 @@ bigquery_adapter(my_resource, partition="partition_column_name")
 my_resource = bigquery_adapter(my_resource, partition="partition_column_name")
 ```
 
-Refer to the [full API specification](../../../docs/api_reference/destinations/impl/bigquery/bigquery_adapter.md) for more details.
+Refer to the [full API specification](../../api_reference/destinations/impl/bigquery/bigquery_adapter.md) for more details.
 
 <!--@@@DLT_SNIPPET_START tuba::bigquery-->
 ## Additional Setup guides

--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -38,6 +38,7 @@ const config = {
       ({
         docs: {
           routeBasePath: '/',
+          path: 'docs_processed',
           include: ['**/*.md', '**/*.mdx'],
           exclude: [
             // '**/_*.{js,jsx,ts,tsx,md,mdx}',

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "PYTHONPATH=. poetry run pydoc-markdown && node tools/update_snippets.js && node tools/update_version_env.js && docusaurus start",
+    "start": "node tools/preprocess_docs.js && PYTHONPATH=. poetry run pydoc-markdown && node tools/update_version_env.js && docusaurus start",
     "watch-snippets": "node tools/update_snippets.js --watch",
     "build": "PYTHONPATH=. poetry run pydoc-markdown && node tools/update_snippets.js && node tools/update_version_env.js && docusaurus build",
     "build:netlify": "PYTHONPATH=. pydoc-markdown && node tools/update_snippets.js && node tools/update_version_env.js && docusaurus build --out-dir build/docs",

--- a/docs/website/pydoc-markdown.yml
+++ b/docs/website/pydoc-markdown.yml
@@ -9,7 +9,7 @@ processors:
   - type: crossref
 renderer:
   type: docusaurus
-  docs_base_path: docs
+  docs_base_path: docs_processed
   relative_output_path: api_reference
   relative_sidebar_path: sidebar.json
   sidebar_top_level_label: API

--- a/docs/website/tools/preprocess_docs.js
+++ b/docs/website/tools/preprocess_docs.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+
+// constants
+const MD_SOURCE_DIR = "docs/";
+const MD_TARGET_DIR = "docs_processed/";
+
+const MOVE_FILES_EXTENSION = [".md", ".mdx", ".py", ".png", ".jpg", ".jpeg"];
+const DOCS_EXTENSIONS = [".md", ".mdx"];
+
+// yield all files in dir
+function *walkSync(dir) {
+    const files = fs.readdirSync(dir, { withFileTypes: true });
+    for (const file of files) {
+      if (file.isDirectory()) {
+        yield* walkSync(path.join(dir, file.name));
+      } else {
+        yield path.join(dir, file.name);
+      }
+    }
+  }
+
+
+function preprocess_docs() {
+    console.log("Updating Snippets");
+    let processedFiles = 0;
+    for (const fileName of walkSync(MD_SOURCE_DIR)) {
+        if (!MOVE_FILES_EXTENSION.includes(path.extname(fileName))) {
+            continue
+        }
+
+        // target name, where to copy the file
+        const targetFileName = fileName.replace(MD_SOURCE_DIR, MD_TARGET_DIR);
+        fs.mkdirSync(path.dirname(targetFileName), { recursive: true });
+        
+        // if not markdown file, just copy
+        if (!DOCS_EXTENSIONS.includes(path.extname(fileName))) {
+            fs.copyFileSync(fileName, targetFileName);
+            continue
+        }
+
+        
+        // copy docs to correct folder
+        const lines = fs.readFileSync(fileName, 'utf8').split(/\r?\n/);
+        const updatedLines = lines;
+
+        lines.splice(8, 0, "Generated")
+
+        fs.writeFileSync(targetFileName, updatedLines.join("\n"));
+    }
+    console.log(`Processed ${processedFiles} files.`);
+}
+
+
+
+preprocess_docs();

--- a/docs/website/tools/update_snippets.js
+++ b/docs/website/tools/update_snippets.js
@@ -48,8 +48,6 @@ function *listDirsSync(dir) {
     }
 }
 
-
-
 // extract the snippet name from a line
 const extractSnippetName = (tag, line) => {
     if (line && line.includes(tag)) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
We want to run all markdown pages through a preprocessor which injects snippets and other links. This will make snippets inserting easier and will remove code duplication for the most part. Re-organizing the snippets will come in a next step.