### PR TITLE
custom destination fixes

### DIFF
--- a/dlt/destinations/decorators.py
+++ b/dlt/destinations/decorators.py
@@ -54,7 +54,7 @@ def destination(
         naming_convention: defines the name of the destination that gets created by the destination decorator. This controls how table and column names are normalized. The default is direct which will keep all names the same.
         max_nesting_level: defines how deep the normalizer will go to normalize complex fields on your data to create subtables. This overwrites any settings on your source and is set to zero to not create any nested tables by default.
         skip_dlt_columns_and_tables: defines wether internal tables and columns will be fed into the custom destination function. This is set to True by default.
-        spec: defines a base configuration spec that will be used to create the config spec for this destination.
+        spec: defines a configuration spec that will be used to to inject arguments into the decorated functions. Argument not in spec will not be injected
 
     Returns:
         A callable that can be used to create a dlt custom destination instance

--- a/dlt/destinations/decorators.py
+++ b/dlt/destinations/decorators.py
@@ -1,7 +1,8 @@
 import functools
 
-from typing import Any, Type, Optional, Callable, Union
+from typing import Any, Type, Optional, Callable, Union, cast
 from typing_extensions import Concatenate
+from dlt.common.typing import AnyFun
 
 from functools import wraps
 
@@ -18,7 +19,8 @@ from dlt.common.schema import TTableSchema
 
 
 def destination(
-    *,
+    func: Optional[AnyFun] = None,
+    /,
     loader_file_format: TLoaderFileFormat = None,
     batch_size: int = 10,
     name: str = None,
@@ -35,7 +37,7 @@ def destination(
 
     #### Example Usage with Configuration and Secrets:
 
-    >>> @dlt.destination()
+    >>> @dlt.destination(batch_size=100, loader_file_format="parquet")
     >>> def my_destination(items, table, api_url: str = dlt.config.value, api_secret = dlt.secrets.value):
     >>>     print(table["name"])
     >>>     print(items)
@@ -86,4 +88,9 @@ def destination(
 
         return wrapper
 
-    return decorator
+    if func is None:
+        # we're called with parens.
+        return decorator
+
+    # we're called as @source without parens.
+    return decorator(func)  # type: ignore

--- a/dlt/destinations/decorators.py
+++ b/dlt/destinations/decorators.py
@@ -9,7 +9,7 @@ from dlt.common import logger
 from dlt.destinations.impl.destination.factory import destination as _destination
 from dlt.destinations.impl.destination.configuration import (
     TDestinationCallableParams,
-    GenericDestinationClientConfiguration,
+    CustomDestinationClientConfiguration,
 )
 from dlt.common.destination import TLoaderFileFormat
 from dlt.common.destination.reference import Destination
@@ -25,11 +25,39 @@ def destination(
     naming_convention: str = "direct",
     skip_dlt_columns_and_tables: bool = True,
     max_table_nesting: int = 0,
-    spec: Type[GenericDestinationClientConfiguration] = None,
+    spec: Type[CustomDestinationClientConfiguration] = None,
 ) -> Callable[
     [Callable[Concatenate[Union[TDataItems, str], TTableSchema, TDestinationCallableParams], Any]],
     Callable[TDestinationCallableParams, _destination],
 ]:
+    """A decorator that transforms a function that takes two positional arguments "table" and "items" and any number of keyword arguments with defaults
+    into a callable that will create a custom destination. The function does not return anything, the keyword arguments can be configuration and secrets values.
+
+    #### Example Usage with Configuration and Secrets:
+
+    >>> @dlt.destination()
+    >>> def my_destination(items, table, api_url: str = dlt.config.value, api_secret = dlt.secrets.value):
+    >>>     print(table["name"])
+    >>>     print(items)
+    >>>
+    >>> p = dlt.pipeline("chess_pipeline", destination=my_destination)
+
+    Here all incoming data will be sent to the destination function with the items in the requested format and the dlt table schema.
+    The config and secret values will be resolved from the path destination.my_destination.api_url and destination.my_destination.api_secret.
+
+    #### Args:
+        batch_size: defines how many items per function call are batched together and sent as an array. If you set a batch-size of 0, instead of passing in actual dataitems, you will receive one call per load job with the path of the file as the items argument. You can then open and process that file in any way you like.
+        loader_file_format: defines in which format files are stored in the load package before being sent to the destination function, this can be puae-jsonl or parquet.
+        name: defines the name of the destination that get's created by the destination decorator, defaults to the name of the function
+        naming_convention: defines the name of the destination that gets created by the destination decorator. This controls how table and column names are normalized. The default is direct which will keep all names the same.
+        max_nesting_level: defines how deep the normalizer will go to normalize complex fields on your data to create subtables. This overwrites any settings on your source and is set to zero to not create any nested tables by default.
+        skip_dlt_columns_and_tables: defines wether internal tables and columns will be fed into the custom destination function. This is set to True by default.
+        spec: defines a base configuration spec that will be used to create the config spec for this destination.
+
+    Returns:
+        A callable that can be used to create a dlt custom destination instance
+    """
+
     def decorator(
         destination_callable: Callable[
             Concatenate[Union[TDataItems, str], TTableSchema, TDestinationCallableParams], Any

--- a/dlt/destinations/decorators.py
+++ b/dlt/destinations/decorators.py
@@ -25,7 +25,7 @@ def destination(
     naming_convention: str = "direct",
     skip_dlt_columns_and_tables: bool = True,
     max_table_nesting: int = 0,
-    spec: Type[GenericDestinationClientConfiguration] = GenericDestinationClientConfiguration,
+    spec: Type[GenericDestinationClientConfiguration] = None,
 ) -> Callable[
     [Callable[Concatenate[Union[TDataItems, str], TTableSchema, TDestinationCallableParams], Any]],
     Callable[TDestinationCallableParams, _destination],

--- a/dlt/destinations/impl/destination/configuration.py
+++ b/dlt/destinations/impl/destination/configuration.py
@@ -15,7 +15,7 @@ TDestinationCallableParams = ParamSpec("TDestinationCallableParams")
 
 
 @configspec
-class GenericDestinationClientConfiguration(DestinationClientConfiguration):
+class CustomDestinationClientConfiguration(DestinationClientConfiguration):
     destination_type: Final[str] = "destination"  # type: ignore
     destination_callable: Optional[Union[str, TDestinationCallable]] = None  # noqa: A003
     loader_file_format: TLoaderFileFormat = "puae-jsonl"

--- a/dlt/destinations/impl/destination/destination.py
+++ b/dlt/destinations/impl/destination/destination.py
@@ -26,7 +26,7 @@ from dlt.common.destination.reference import (
 
 from dlt.destinations.impl.destination import capabilities
 from dlt.destinations.impl.destination.configuration import (
-    GenericDestinationClientConfiguration,
+    CustomDestinationClientConfiguration,
     TDestinationCallable,
 )
 
@@ -36,7 +36,7 @@ class DestinationLoadJob(LoadJob, ABC):
         self,
         table: TTableSchema,
         file_path: str,
-        config: GenericDestinationClientConfiguration,
+        config: CustomDestinationClientConfiguration,
         schema: Schema,
         destination_state: Dict[str, int],
         destination_callable: TDestinationCallable,
@@ -140,9 +140,9 @@ class DestinationClient(JobClientBase):
 
     capabilities: ClassVar[DestinationCapabilitiesContext] = capabilities()
 
-    def __init__(self, schema: Schema, config: GenericDestinationClientConfiguration) -> None:
+    def __init__(self, schema: Schema, config: CustomDestinationClientConfiguration) -> None:
         super().__init__(schema, config)
-        self.config: GenericDestinationClientConfiguration = config
+        self.config: CustomDestinationClientConfiguration = config
         # create pre-resolved callable to avoid multiple config resolutions during execution of the jobs
         self.destination_callable = create_resolved_partial(
             cast(AnyFun, self.config.destination_callable), self.config

--- a/dlt/destinations/impl/destination/factory.py
+++ b/dlt/destinations/impl/destination/factory.py
@@ -12,7 +12,7 @@ from dlt.common.configuration.exceptions import ConfigurationValueError
 from dlt.common import logger
 
 from dlt.destinations.impl.destination.configuration import (
-    GenericDestinationClientConfiguration,
+    CustomDestinationClientConfiguration,
     TDestinationCallable,
 )
 from dlt.destinations.impl.destination import capabilities
@@ -26,7 +26,7 @@ if t.TYPE_CHECKING:
 class DestinationInfo(t.NamedTuple):
     """Runtime information on a discovered destination"""
 
-    SPEC: t.Type[GenericDestinationClientConfiguration]
+    SPEC: t.Type[CustomDestinationClientConfiguration]
     f: AnyFun
     module: ModuleType
 
@@ -35,7 +35,7 @@ _DESTINATIONS: t.Dict[str, DestinationInfo] = {}
 """A registry of all the decorated destinations"""
 
 
-class destination(Destination[GenericDestinationClientConfiguration, "DestinationClient"]):
+class destination(Destination[CustomDestinationClientConfiguration, "DestinationClient"]):
     def capabilities(self) -> DestinationCapabilitiesContext:
         return capabilities(
             preferred_loader_file_format=self.config_params.get("loader_file_format", "puae-jsonl"),
@@ -44,7 +44,7 @@ class destination(Destination[GenericDestinationClientConfiguration, "Destinatio
         )
 
     @property
-    def spec(self) -> t.Type[GenericDestinationClientConfiguration]:
+    def spec(self) -> t.Type[CustomDestinationClientConfiguration]:
         """A spec of destination configuration resolved from the sink function signature"""
         return self._spec
 
@@ -62,12 +62,12 @@ class destination(Destination[GenericDestinationClientConfiguration, "Destinatio
         loader_file_format: TLoaderFileFormat = None,
         batch_size: int = 10,
         naming_convention: str = "direct",
-        spec: t.Type[GenericDestinationClientConfiguration] = None,
+        spec: t.Type[CustomDestinationClientConfiguration] = None,
         **kwargs: t.Any,
     ) -> None:
-        if spec and not issubclass(spec, GenericDestinationClientConfiguration):
+        if spec and not issubclass(spec, CustomDestinationClientConfiguration):
             raise ValueError(
-                "A SPEC for a sink destination must use GenericDestinationClientConfiguration as a"
+                "A SPEC for a sink destination must use CustomDestinationClientConfiguration as a"
                 " base."
             )
         # resolve callable
@@ -118,12 +118,12 @@ class destination(Destination[GenericDestinationClientConfiguration, "Destinatio
             spec=spec,
             sections=destination_sections,
             include_defaults=True,
-            base=None if spec else GenericDestinationClientConfiguration,
+            base=None if spec else CustomDestinationClientConfiguration,
         )
 
         # save destination in registry
         resolved_spec = t.cast(
-            t.Type[GenericDestinationClientConfiguration], get_fun_spec(conf_callable)
+            t.Type[CustomDestinationClientConfiguration], get_fun_spec(conf_callable)
         )
         # register only standalone destinations, no inner
         if not is_inner_callable(destination_callable):

--- a/docs/examples/custom_destination_bigquery/custom_destination_bigquery.py
+++ b/docs/examples/custom_destination_bigquery/custom_destination_bigquery.py
@@ -15,6 +15,7 @@ OWID_DISASTERS_URL = (
 # format: "your-project.your_dataset.your_table"
 BIGQUERY_TABLE_ID = "chat-analytics-rasa-ci.ci_streaming_insert.natural-disasters"
 
+
 # dlt sources
 @dlt.resource(name="natural_disasters")
 def resource(url: str):
@@ -38,6 +39,7 @@ def resource(url: str):
     )
     yield table
 
+
 # dlt biquery custom destination
 # we can use the dlt provided credentials class
 # to retrieve the gcp credentials from the secrets
@@ -57,6 +59,7 @@ def bigquery_insert(
     with open(items, "rb") as f:
         load_job = client.load_table_from_file(f, BIGQUERY_TABLE_ID, job_config=job_config)
     load_job.result()  # Waits for the job to complete.
+
 
 if __name__ == "__main__":
     # run the pipeline and print load results

--- a/docs/website/docs/examples/custom_destination_bigquery/code/custom_destination_bigquery-snippets.py
+++ b/docs/website/docs/examples/custom_destination_bigquery/code/custom_destination_bigquery-snippets.py
@@ -79,4 +79,3 @@ def custom_destination_biquery_snippet() -> None:
         print(load_info)
         # @@@DLT_SNIPPET_END example
         assert_load_info(load_info)
-

--- a/tests/common/reflection/test_reflect_spec.py
+++ b/tests/common/reflection/test_reflect_spec.py
@@ -1,11 +1,12 @@
 import inspect
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import dlt
 from dlt.common import Decimal
 from dlt.common.typing import TSecretValue, is_optional_type
 from dlt.common.configuration.inject import get_fun_spec, with_config
 from dlt.common.configuration.specs import (
+    configspec,
     BaseConfiguration,
     RunConfiguration,
     ConnectionStringCredentials,
@@ -34,7 +35,8 @@ def test_synthesize_spec_from_sig() -> None:
     ) -> None:
         pass
 
-    SPEC: Any = spec_from_signature(f_typed, inspect.signature(f_typed))
+    SPEC: Any
+    SPEC, _ = spec_from_signature(f_typed, inspect.signature(f_typed))
     assert SPEC.p1 is None
     assert SPEC.p2 is None
     assert SPEC.p3 is None
@@ -60,7 +62,7 @@ def test_synthesize_spec_from_sig() -> None:
     ) -> None:
         pass
 
-    SPEC = spec_from_signature(f_typed_default, inspect.signature(f_typed_default))
+    SPEC, _ = spec_from_signature(f_typed_default, inspect.signature(f_typed_default))
     assert SPEC.t_p1 == "str"
     assert SPEC.t_p2 == _DECIMAL_DEFAULT
     assert SPEC.t_p3 == _SECRET_DEFAULT
@@ -82,7 +84,7 @@ def test_synthesize_spec_from_sig() -> None:
     def f_untyped(untyped_p1=None, untyped_p2=dlt.config.value) -> None:
         pass
 
-    SPEC = spec_from_signature(f_untyped, inspect.signature(f_untyped))
+    SPEC, _ = spec_from_signature(f_untyped, inspect.signature(f_untyped))
     assert SPEC.untyped_p1 is None
     assert SPEC.untyped_p2 is None
     fields = SPEC.get_resolvable_fields()
@@ -98,7 +100,7 @@ def test_synthesize_spec_from_sig() -> None:
     ) -> None:
         pass
 
-    SPEC = spec_from_signature(f_untyped_default, inspect.signature(f_untyped_default))
+    SPEC, _ = spec_from_signature(f_untyped_default, inspect.signature(f_untyped_default))
     assert SPEC.untyped_p1 == "str"
     assert SPEC.untyped_p2 == _DECIMAL_DEFAULT
     assert isinstance(SPEC().untyped_p3, ConnectionStringCredentials)
@@ -124,7 +126,7 @@ def test_synthesize_spec_from_sig() -> None:
     ) -> None:
         pass
 
-    SPEC = spec_from_signature(f_pos_kw_only, inspect.signature(f_pos_kw_only))
+    SPEC, _ = spec_from_signature(f_pos_kw_only, inspect.signature(f_pos_kw_only))
     assert SPEC.pos_only_1 is None
     assert SPEC.pos_only_2 == "default"
     assert SPEC.kw_only_1 is None
@@ -140,7 +142,7 @@ def test_synthesize_spec_from_sig() -> None:
     # skip arguments with defaults
     # deregister spec to disable cache
     del globals()[SPEC.__name__]
-    SPEC = spec_from_signature(
+    SPEC, _ = spec_from_signature(
         f_pos_kw_only, inspect.signature(f_pos_kw_only), include_defaults=False
     )
     assert not hasattr(SPEC, "kw_only_1")
@@ -153,7 +155,7 @@ def test_synthesize_spec_from_sig() -> None:
     def f_variadic(var_1: str = "A", *args, kw_var_1: str, **kwargs) -> None:
         print(locals())
 
-    SPEC = spec_from_signature(f_variadic, inspect.signature(f_variadic))
+    SPEC, _ = spec_from_signature(f_variadic, inspect.signature(f_variadic))
     assert SPEC.var_1 == "A"
     assert not hasattr(SPEC, "kw_var_1")  # kw parameters that must be explicitly passed are removed
     assert not hasattr(SPEC, "args")
@@ -161,24 +163,33 @@ def test_synthesize_spec_from_sig() -> None:
     assert fields == {"var_1": str}
 
 
-def test_spec_none_when_no_fields() -> None:
+def test_spec_when_no_fields() -> None:
     def f_default_only(arg1, arg2=None):
         pass
 
-    SPEC = spec_from_signature(f_default_only, inspect.signature(f_default_only))
-    assert SPEC is not None
+    SPEC, fields = spec_from_signature(f_default_only, inspect.signature(f_default_only))
+    assert len(fields) > 0
 
     del globals()[SPEC.__name__]
-    SPEC = spec_from_signature(
+    SPEC, fields = spec_from_signature(
         f_default_only, inspect.signature(f_default_only), include_defaults=False
     )
-    assert SPEC is None
+    assert len(fields) == 0
 
     def f_no_spec(arg1):
         pass
 
-    SPEC = spec_from_signature(f_no_spec, inspect.signature(f_no_spec))
-    assert SPEC is None
+    SPEC, fields = spec_from_signature(f_no_spec, inspect.signature(f_no_spec))
+    assert len(fields) == 0
+
+    def f_no_spec_non_injectable(args1: Callable[[str], str] = str.upper):
+        pass
+
+    # all params are non injectable
+    SPEC, fields = spec_from_signature(
+        f_no_spec_non_injectable, inspect.signature(f_no_spec_non_injectable)
+    )
+    assert len(fields) == 0
 
 
 def f_top_kw_defaults_args(
@@ -247,7 +258,7 @@ def test_argument_have_dlt_config_defaults() -> None:
         "secret_val": "dlt.secrets.value",
         "config_val": "dlt.config.value",
     }
-    SPEC = spec_from_signature(f_defaults, inspect.signature(f_defaults))
+    SPEC, _ = spec_from_signature(f_defaults, inspect.signature(f_defaults))
     fields = SPEC.get_resolvable_fields()
     # fields market with dlt config are not optional, same for required fields
     for arg in [
@@ -272,7 +283,7 @@ def test_argument_have_dlt_config_defaults() -> None:
         "kw_lit": "'12131'",
         "kw1": "dlt.config.value",
     }
-    SPEC = spec_from_signature(f_kw_defaults, inspect.signature(f_kw_defaults))
+    SPEC, _ = spec_from_signature(f_kw_defaults, inspect.signature(f_kw_defaults))
     fields = SPEC.get_resolvable_fields()
     assert not is_optional_type(fields["kw_lit"])
     assert not is_optional_type(fields["kw1"])
@@ -298,3 +309,52 @@ def test_argument_have_dlt_config_defaults() -> None:
         "arg3": "dlt.config.value",
         "arg2": "'top'",
     }
+
+
+def test_reflect_custom_base() -> None:
+    @configspec
+    class BaseParams(BaseConfiguration):
+        str_str: str
+
+    def _f_1(str_str=dlt.config.value, p_def: bool = True):
+        pass
+
+    SPEC, fields = spec_from_signature(_f_1, inspect.signature(_f_1), base=BaseParams)
+    assert issubclass(SPEC, BaseParams)
+    # base field type is preserved over function type
+    assert (
+        SPEC.get_resolvable_fields()["str_str"]
+        == fields["str_str"]
+        == BaseParams.get_resolvable_fields()["str_str"]
+    )
+    assert "p_def" in fields
+    assert "p_def" in SPEC.get_resolvable_fields()
+
+    def _f_2(req_arg):
+        pass
+
+    SPEC, fields = spec_from_signature(_f_2, inspect.signature(_f_2), base=BaseParams)
+    assert issubclass(SPEC, BaseParams)
+    # f does not take any args of interest and does not require any fields to be injected
+    assert len(fields) == 0
+    assert SPEC.get_resolvable_fields() == BaseParams().get_resolvable_fields()
+
+    def _f_3(str_str: int = dlt.config.value, p_def: bool = True):
+        pass
+
+    SPEC, fields = spec_from_signature(_f_3, inspect.signature(_f_3), base=BaseParams)
+    assert issubclass(SPEC, BaseParams)
+    # int overrides str_str
+    assert SPEC.get_resolvable_fields()["str_str"] == int
+    # default
+    assert fields["str_str"] is None
+
+    def _f_4(str_str=300, p_def: bool = True):
+        pass
+
+    SPEC, fields = spec_from_signature(_f_4, inspect.signature(_f_4), base=BaseParams)
+    assert issubclass(SPEC, BaseParams)
+    # int overrides str_str
+    assert SPEC.get_resolvable_fields()["str_str"] == int
+    # default
+    assert fields["str_str"] == 300

--- a/tests/destinations/test_custom_destination.py
+++ b/tests/destinations/test_custom_destination.py
@@ -169,16 +169,16 @@ def test_instantiation() -> None:
     p.run([1, 2, 3], table_name="items")
     assert len(global_calls) == 1
 
-    # pass None credentials reference
-    with pytest.raises(InvalidDestinationReference):
-        p = dlt.pipeline(
-            "sink_test",
-            destination=Destination.from_reference("destination", destination_callable=None),
-            full_refresh=True,
-        )
+    # pass None as callable arg will fail on load
+    p = dlt.pipeline(
+        "sink_test",
+        destination=Destination.from_reference("destination", destination_callable=None),
+        full_refresh=True,
+    )
+    with pytest.raises(PipelineStepFailed):
         p.run([1, 2, 3], table_name="items")
 
-    # pass invalid credentials module
+    # pass invalid string reference will fail on instantiation
     with pytest.raises(InvalidDestinationReference):
         p = dlt.pipeline(
             "sink_test",
@@ -187,7 +187,6 @@ def test_instantiation() -> None:
             ),
             full_refresh=True,
         )
-        p.run([1, 2, 3], table_name="items")
 
 
 @pytest.mark.parametrize("loader_file_format", SUPPORTED_LOADER_FORMATS)

--- a/tests/extract/test_decorators.py
+++ b/tests/extract/test_decorators.py
@@ -631,14 +631,14 @@ def test_sources_no_arguments() -> None:
     def no_args():
         return dlt.resource([1, 2], name="data")
 
-    # there is no spec if no arguments
+    # there is a spec even if no arguments
     SPEC = _SOURCES[no_args.__qualname__].SPEC
-    assert SPEC is None
+    assert SPEC
     _, _, checked = detect_source_configs(_SOURCES, "", ())
     assert no_args.__qualname__ in checked
 
     SPEC = _SOURCES[no_args.__qualname__].SPEC
-    assert SPEC is None
+    assert SPEC
     _, _, checked = detect_source_configs(_SOURCES, "", ())
     assert not_args_r.__qualname__ in checked
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
see commit list

@sh-rp you can take over this:
- sink decorator must work without parens
- add good docstrings to the decorators
- write tests for:
1. add test for _DESTINATIONS
2. passing SPEC in the decorator
3. do we have test for instantiated factory like pipeline.run(destination=my_gcp_sink(credentials=...)