### PR TITLE
Add simple package installer

### DIFF
--- a/dlt/helpers/pypi.py
+++ b/dlt/helpers/pypi.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+
+from dlt.cli import echo as fmt
+
+
+class Installer:
+    @staticmethod
+    def install(package: str):
+        if package not in sys.modules:
+            if Installer.yes_please(package):
+                subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+
+    @staticmethod
+    def yes_please(package: str) -> bool:
+        return fmt.confirm(f"Required package {package} is missing, should we install it?")

--- a/dlt/helpers/pypi.py
+++ b/dlt/helpers/pypi.py
@@ -1,15 +1,22 @@
+import importlib
 import subprocess
 import sys
+from types import ModuleType
 
 from dlt.cli import echo as fmt
+from dlt.common.exceptions import MissingDependencyException
 
 
-class Installer:
+class Importer:
     @staticmethod
-    def install(package: str):
+    def import_module(caller: str, package: str) -> ModuleType:
         if package not in sys.modules:
-            if Installer.yes_please(package):
+            if Importer.yes_please(package):
                 subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+            else:
+                raise MissingDependencyException(caller, [package])
+
+        return importlib.import_module(package)
 
     @staticmethod
     def yes_please(package: str) -> bool:

--- a/dlt/helpers/streamlit_helper.py
+++ b/dlt/helpers/streamlit_helper.py
@@ -15,7 +15,6 @@ from dlt.pipeline import Pipeline
 from dlt.pipeline.exceptions import CannotRestorePipelineException, SqlClientNotAvailable
 from dlt.pipeline.state_sync import load_pipeline_state_from_destination
 
-# type: streamlit
 st = Importer.import_module("DLT Streamlit Helpers", "streamlit")
 
 

--- a/dlt/helpers/streamlit_helper.py
+++ b/dlt/helpers/streamlit_helper.py
@@ -10,20 +10,13 @@ from dlt.common.destination.reference import WithStateSync
 from dlt.common.utils import flatten_list_or_items
 
 from dlt.common.libs.pandas import pandas
+from dlt.helpers.pypi import Importer
 from dlt.pipeline import Pipeline
 from dlt.pipeline.exceptions import CannotRestorePipelineException, SqlClientNotAvailable
 from dlt.pipeline.state_sync import load_pipeline_state_from_destination
 
-try:
-    import streamlit as st
-
-    # from streamlit import SECRETS_FILE_LOC, secrets
-except ModuleNotFoundError:
-    raise MissingDependencyException(
-        "DLT Streamlit Helpers",
-        ["streamlit"],
-        "DLT Helpers for Streamlit should be run within a streamlit app.",
-    )
+# type: streamlit
+st = Importer.import_module("DLT Streamlit Helpers", "streamlit")
 
 
 # use right caching function to disable deprecation message


### PR DESCRIPTION
This PR is related to https://github.com/dlt-hub/dlt/issues/158 and implements package a simple installer with confirmation.

We can also put calls to it in `__init__py` files for modules if they require some optional package
```py
# __init__.py

Importer.import_module("streamlit")
```