### PR TITLE
fixes column order and add hints table variants

### DIFF
--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -426,7 +426,7 @@ class Schema:
             self._schema_tables[table_name] = partial_table
         else:
             # merge tables performing additional checks
-            partial_table = utils.merge_tables(table, partial_table)
+            partial_table = utils.merge_table(table, partial_table)
 
         self.data_item_normalizer.extend_table(table_name)
         return partial_table
@@ -515,7 +515,7 @@ class Schema:
                 # re-index columns as the name changed, if name space was reduced then
                 # some columns now clash with each other. so make sure that we merge columns that are already there
                 if new_col_name in new_columns:
-                    new_columns[new_col_name] = utils.merge_columns(
+                    new_columns[new_col_name] = utils.merge_column(
                         new_columns[new_col_name], c, merge_defaults=False
                     )
                 else:
@@ -782,7 +782,7 @@ class Schema:
             # if there's incomplete new_column then merge it with inferred column
             if new_column:
                 # use all values present in incomplete column to override inferred column - also the defaults
-                new_column = utils.merge_columns(inferred_column, new_column)
+                new_column = utils.merge_column(inferred_column, new_column)
             else:
                 new_column = inferred_column
 

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -44,10 +44,7 @@ class TResourceHints(TypedDict, total=False):
 
 
 class HintsMeta:
-    __slots__ = ["hints", "create_table_variant"]
-
-    hints: TResourceHints
-    create_table_variant: bool
+    __slots__ = ("hints", "create_table_variant")
 
     def __init__(self, hints: TResourceHints, create_table_variant: bool) -> None:
         self.hints = hints
@@ -169,7 +166,6 @@ class DltResourceHints:
         table_template = self._clone_hints(table_template)
         if "name" not in table_template:
             table_template["name"] = self.name
-        # table_template["columns"] = copy(self._hints["columns"])
 
         # if table template present and has dynamic hints, the data item must be provided.
         if self._table_name_hint_fun and item is None:

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -12,7 +12,8 @@ from dlt.common.schema.typing import (
     TTableFormat,
     TSchemaContract,
 )
-from dlt.common.schema.utils import DEFAULT_WRITE_DISPOSITION, merge_columns, new_column, new_table
+from dlt.common import logger
+from dlt.common.schema.utils import DEFAULT_WRITE_DISPOSITION, merge_column, new_column, new_table
 from dlt.common.typing import TDataItem, DictStrAny, DictStrStr
 from dlt.common.utils import update_dict_nested
 from dlt.common.validation import validate_dict_ignoring_xkeys
@@ -21,7 +22,7 @@ from dlt.extract.exceptions import (
     InconsistentTableTemplate,
 )
 from dlt.extract.incremental import Incremental
-from dlt.extract.items import TFunHintTemplate, TTableHintTemplate, ValidateItem
+from dlt.extract.items import TFunHintTemplate, TTableHintTemplate, TableNameMeta, ValidateItem
 from dlt.extract.utils import ensure_table_schema_columns, ensure_table_schema_columns_hint
 from dlt.extract.validation import create_item_validator
 
@@ -43,12 +44,17 @@ class TResourceHints(TypedDict, total=False):
 
 
 class HintsMeta:
-    __slots__ = "hints"
+    __slots__ = ["hints", "create_table_variant"]
 
     hints: TResourceHints
+    create_table_variant: bool
 
-    def __init__(self, hints: TResourceHints) -> None:
+    def __init__(self, hints: TResourceHints, create_table_variant: bool) -> None:
         self.hints = hints
+        self.create_table_variant = create_table_variant
+
+
+NATURAL_CALLABLES = ["incremental", "validator", "original_columns"]
 
 
 def make_hints(
@@ -105,8 +111,11 @@ class DltResourceHints:
         self._table_name_hint_fun: TFunHintTemplate[str] = None
         self._table_has_other_dynamic_hints: bool = False
         self._hints: TResourceHints = None
+        """Hints for the resource"""
+        self._hints_variants: Dict[str, TResourceHints] = {}
+        """Hints for tables emitted from resources"""
         if table_schema_template:
-            self.set_hints(table_schema_template)
+            self._set_hints(table_schema_template)
 
     @property
     def name(self) -> str:
@@ -143,16 +152,24 @@ class DltResourceHints:
     def schema_contract(self) -> TTableHintTemplate[TSchemaContract]:
         return self._hints.get("schema_contract")
 
-    def compute_table_schema(self, item: TDataItem = None) -> TTableSchema:
-        """Computes the table schema based on hints and column definitions passed during resource creation. `item` parameter is used to resolve table hints based on data."""
-        if not self._hints:
+    def compute_table_schema(self, item: TDataItem = None, meta: Any = None) -> TTableSchema:
+        """Computes the table schema based on hints and column definitions passed during resource creation.
+        `item` parameter is used to resolve table hints based on data.
+        `meta` parameter is taken from Pipe and may further specify table name if variant is to be used
+        """
+        if isinstance(meta, TableNameMeta):
+            # look for variant
+            table_template = self._hints_variants.get(meta.table_name, self._hints)
+        else:
+            table_template = self._hints
+        if not table_template:
             return new_table(self.name, resource=self.name)
 
         # resolve a copy of a held template
-        table_template = copy(self._hints)
+        table_template = self._clone_hints(table_template)
         if "name" not in table_template:
             table_template["name"] = self.name
-        table_template["columns"] = copy(self._hints["columns"])
+        # table_template["columns"] = copy(self._hints["columns"])
 
         # if table template present and has dynamic hints, the data item must be provided.
         if self._table_name_hint_fun and item is None:
@@ -161,7 +178,7 @@ class DltResourceHints:
         resolved_template: TResourceHints = {
             k: self._resolve_hint(item, v)
             for k, v in table_template.items()
-            if k not in ["incremental", "validator", "original_columns"]
+            if k not in NATURAL_CALLABLES
         }  # type: ignore
         table_schema = self._merge_keys(resolved_template)
         table_schema["resource"] = self.name
@@ -184,8 +201,13 @@ class DltResourceHints:
         schema_contract: TTableHintTemplate[TSchemaContract] = None,
         additional_table_hints: Optional[Dict[str, TTableHintTemplate[Any]]] = None,
         table_format: TTableHintTemplate[TTableFormat] = None,
+        create_table_variant: bool = False,
     ) -> None:
         """Creates or modifies existing table schema by setting provided hints. Accepts both static and dynamic hints based on data.
+
+        If `create_table_variant` is specified, the `table_name` must be a string and hints will be used to create a separate set of hints
+        for a particular `table_name`. Such hints may be retrieved via compute_table_schema(meta=TableNameMeta(table_name)).
+        Table variant hints may not contain dynamic hints.
 
         This method accepts the same table hints arguments as `dlt.resource` decorator with the following additions.
         Skip the argument or pass None to leave the existing hint.
@@ -197,7 +219,24 @@ class DltResourceHints:
         Please note that for efficient incremental loading, the resource must be aware of the Incremental by accepting it as one if its arguments and then using are to skip already loaded data.
         In non-aware resources, `dlt` will filter out the loaded values, however, the resource will yield all the values again.
         """
-        if not self._hints:
+        if create_table_variant:
+            if not isinstance(table_name, str):
+                raise ValueError(
+                    "Please provide string table name if you want to create a table variant of"
+                    " hints"
+                )
+            # select hints variant
+            t = self._hints_variants.get(table_name, None)
+            if t is None:
+                # use resource hints as starting point
+                if self._hints:
+                    t = self._clone_hints(self._hints)
+                    # but remove callables
+                    t = {n: h for n, h in t.items() if not callable(h)}  # type: ignore[assignment]
+        else:
+            t = self._hints
+
+        if t is None:
             # if there is no template yet, create and set a new one.
             default_wd = None if parent_table_name else DEFAULT_WRITE_DISPOSITION
             t = make_hints(
@@ -211,8 +250,7 @@ class DltResourceHints:
                 table_format,
             )
         else:
-            # set single hints
-            t = self._clone_hints(self._hints)
+            t = self._clone_hints(t)
             if table_name is not None:
                 if table_name:
                     t["name"] = table_name
@@ -279,20 +317,46 @@ class DltResourceHints:
         if incremental is not None:
             t["incremental"] = None if incremental is Incremental.EMPTY else incremental
 
-        self.set_hints(t)
+        self._set_hints(t, create_table_variant)
 
-    def set_hints(self, hints_template: TResourceHints) -> None:
+    def _set_hints(
+        self, hints_template: TResourceHints, create_table_variant: bool = False
+    ) -> None:
         DltResourceHints.validate_dynamic_hints(hints_template)
-        # if "name" is callable in the template, then the table schema requires data item to be inferred.
-        name_hint = hints_template.get("name")
-        self._table_name_hint_fun = name_hint if callable(name_hint) else None
-        # check if any other hints in the table template should be inferred from data.
-        self._table_has_other_dynamic_hints = any(
-            callable(v) for k, v in hints_template.items() if k != "name"
-        )
-        self._hints = hints_template
+        if create_table_variant:
+            table_name: str = hints_template["name"]  # type: ignore[assignment]
+            # incremental cannot be specified in variant
+            if hints_template.get("incremental"):
+                raise InconsistentTableTemplate(
+                    f"You can specify incremental only for the resource `{self.name}` hints, not in"
+                    f" table `{table_name}` variant-"
+                )
+            if hints_template.get("validator"):
+                logger.warning(
+                    f"A data item validator was created from column schema in {self.name} for a"
+                    f" table `{table_name}` variant. Currently such validator is ignored."
+                )
+            # dynamic hints will be ignored
+            for name, hint in hints_template.items():
+                if callable(hint) and name not in NATURAL_CALLABLES:
+                    raise InconsistentTableTemplate(
+                        f"Table `{table_name}` variant hint is resource {self.name} cannot have"
+                        f" dynamic hint but {name} does."
+                    )
+            self._hints_variants[table_name] = hints_template
+        else:
+            # if "name" is callable in the template, then the table schema requires data item to be inferred.
+            name_hint = hints_template.get("name")
+            self._table_name_hint_fun = name_hint if callable(name_hint) else None
+            # check if any other hints in the table template should be inferred from data.
+            self._table_has_other_dynamic_hints = any(
+                callable(v) for k, v in hints_template.items() if k != "name"
+            )
+            self._hints = hints_template
 
-    def merge_hints(self, hints_template: TResourceHints) -> None:
+    def merge_hints(
+        self, hints_template: TResourceHints, create_table_variant: bool = False
+    ) -> None:
         self.apply_hints(
             table_name=hints_template.get("name"),
             parent_table_name=hints_template.get("parent"),
@@ -303,6 +367,7 @@ class DltResourceHints:
             incremental=hints_template.get("incremental"),
             schema_contract=hints_template.get("schema_contract"),
             table_format=hints_template.get("table_format"),
+            create_table_variant=create_table_variant,
         )
 
     @staticmethod
@@ -324,7 +389,7 @@ class DltResourceHints:
             keys = [keys]
         for key in keys:
             if key in partial["columns"]:
-                merge_columns(partial["columns"][key], {hint: True})  # type: ignore
+                merge_column(partial["columns"][key], {hint: True})  # type: ignore
             else:
                 partial["columns"][key] = new_column(key, nullable=False)
                 partial["columns"][key][hint] = True
@@ -347,9 +412,7 @@ class DltResourceHints:
         table_name = template.get("name")
         # if any of the hints is a function, then name must be as well.
         if any(
-            callable(v)
-            for k, v in template.items()
-            if k not in ["name", "incremental", "validator", "original_columns"]
+            callable(v) for k, v in template.items() if k not in ["name", *NATURAL_CALLABLES]
         ) and not callable(table_name):
             raise InconsistentTableTemplate(
                 f"Table name {table_name} must be a function if any other table hint is a function"

--- a/dlt/extract/items.py
+++ b/dlt/extract/items.py
@@ -81,10 +81,7 @@ TPipeStep = Union[
 
 
 class DataItemWithMeta:
-    __slots__ = ["meta", "data"]
-
-    # meta: Any
-    # data: TDataItems
+    __slots__ = ("meta", "data")
 
     def __init__(self, meta: Any, data: TDataItems) -> None:
         self.meta = meta
@@ -92,9 +89,7 @@ class DataItemWithMeta:
 
 
 class TableNameMeta:
-    __slots__ = ["table_name"]
-
-    # table_name: str
+    __slots__ = ("table_name",)
 
     def __init__(self, table_name: str) -> None:
         self.table_name = table_name

--- a/dlt/extract/items.py
+++ b/dlt/extract/items.py
@@ -81,10 +81,10 @@ TPipeStep = Union[
 
 
 class DataItemWithMeta:
-    __slots__ = "meta", "data"
+    __slots__ = ["meta", "data"]
 
-    meta: Any
-    data: TDataItems
+    # meta: Any
+    # data: TDataItems
 
     def __init__(self, meta: Any, data: TDataItems) -> None:
         self.meta = meta
@@ -92,9 +92,9 @@ class DataItemWithMeta:
 
 
 class TableNameMeta:
-    __slots__ = "table_name"
+    __slots__ = ["table_name"]
 
-    table_name: str
+    # table_name: str
 
     def __init__(self, table_name: str) -> None:
         self.table_name = table_name

--- a/dlt/helpers/streamlit_app/utils.py
+++ b/dlt/helpers/streamlit_app/utils.py
@@ -38,9 +38,7 @@ def render_with_pipeline(render_func: Callable[..., None]) -> None:
     render_func(pipeline)
 
 
-def query_using_cache(
-    pipeline: dlt.Pipeline, ttl: int
-) -> Callable[..., Optional[pd.DataFrame]]:
+def query_using_cache(pipeline: dlt.Pipeline, ttl: int) -> Callable[..., Optional[pd.DataFrame]]:
     @st.cache_data(ttl=ttl)
     def do_query(  # type: ignore[return]
         query: str,

--- a/docs/tools/fix_grammar_gpt.py
+++ b/docs/tools/fix_grammar_gpt.py
@@ -41,7 +41,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "-f",
         "--files",
-        help="Specify the file name. Grammar Checker will filter all .md files containing this string in the filepath.",
+        help=(
+            "Specify the file name. Grammar Checker will filter all .md files containing this"
+            " string in the filepath."
+        ),
         type=str,
     )
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -1090,7 +1090,7 @@ def test_preserve_fields_order_incomplete_columns() -> None:
     p.extract(items2)
     p.normalize()
     # c3 was first so goes first
-    assert list(p.default_schema.get_table_columns("items").keys()) == [
+    assert list(p.default_schema.get_table_columns("items2").keys()) == [
         "c3",
         "c1",
         "c2",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. fixes #1111 
2. fixes #1105 

docs tbd.

creation hints variant per table happens as follows:
```
def test_mark_hints_with_variant() -> None:
    @dlt.resource
    def with_table_hints():
        # create variant for table a,  item dispatch to table a
        yield dlt.mark.with_hints(
            {"id": 1, "pk": "A"},
            dlt.mark.make_hints(
                table_name="table_a", columns=[{"name": "id", "data_type": "bigint"}]
            ),
            create_table_variant=True,
        )
     # then you can dispatch subsequent items like
     yield dlt.mark.with_table_name({"id": 4, "pk": "D"}, "table_a")
```