### PR TITLE
Fix typo with switched column names in schema evolution docs page

### DIFF
--- a/docs/website/docs/general-usage/schema-evolution.md
+++ b/docs/website/docs/general-usage/schema-evolution.md
@@ -97,7 +97,7 @@ What happened?
 - Removed column stopped loading:
     - New data to column `room` is not loaded.
 - Column stopped loading and new one was added:
-    - A new column `address__building` was added and now data will be loaded to that and stop loading in the column `address__main_block`.
+    - A new column `address__main_block` was added and now data will be loaded to that and stop loading in the column `address__building`.
 
 ## Alert schema changes to curate new data
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Fixes a small typo in the docs on [the schema evolution page](https://dlthub.com/docs/general-usage/schema-evolution).
The new field is `main_block` and the old one is `building`

