### PR TITLE
Fix circular import in rest_client

### DIFF
--- a/dlt/sources/helpers/requests/__init__.py
+++ b/dlt/sources/helpers/requests/__init__.py
@@ -15,12 +15,11 @@ from requests import (
 from requests.exceptions import ChunkedEncodingError
 from dlt.sources.helpers.requests.retry import Client
 from dlt.sources.helpers.requests.session import Session
-from dlt.sources.helpers.rest_client import paginate
 from dlt.common.configuration.specs import RunConfiguration
 
 client = Client()
 
-get, post, put, patch, delete, options, head, request, paginate = (
+get, post, put, patch, delete, options, head, request = (
     client.get,
     client.post,
     client.put,
@@ -29,7 +28,6 @@ get, post, put, patch, delete, options, head, request, paginate = (
     client.options,
     client.head,
     client.request,
-    paginate,
 )
 
 

--- a/tests/sources/helpers/rest_client/test_requests_paginate.py
+++ b/tests/sources/helpers/rest_client/test_requests_paginate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dlt.sources.helpers.requests import paginate
+from dlt.sources.helpers.rest_client import paginate
 from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator
 from .conftest import assert_pagination
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Removes `paginate` from `dlt.sources.helpers.requests` to address circular import error.