### PR TITLE
Check for default schema and schema name in streamlit session

### DIFF
--- a/dlt/helpers/streamlit_app/blocks/load_info.py
+++ b/dlt/helpers/streamlit_app/blocks/load_info.py
@@ -8,33 +8,34 @@ from dlt.helpers.streamlit_app.widgets import stat
 
 
 def last_load_info(pipeline: dlt.Pipeline) -> None:
-    loads_df = query_data_live(
-        pipeline,
-        f"SELECT load_id, inserted_at FROM {pipeline.default_schema.loads_table_name} WHERE"
-        " status = 0 ORDER BY inserted_at DESC LIMIT 101 ",
-    )
-
-    if loads_df is None:
-        st.error(
-            "Load info is not available",
-            icon="🚨",
+    if pipeline.default_schema_name:
+        loads_df = query_data_live(
+            pipeline,
+            f"SELECT load_id, inserted_at FROM {pipeline.default_schema.loads_table_name} WHERE"
+            " status = 0 ORDER BY inserted_at DESC LIMIT 101 ",
         )
-    else:
-        loads_no = loads_df.shape[0]
-        if loads_df.shape[0] > 0:
-            rel_time = (
-                humanize.naturaldelta(
-                    pendulum.now() - pendulum.from_timestamp(loads_df.iloc[0, 1].timestamp())
-                )
-                + " ago"
-            )
-            last_load_id = loads_df.iloc[0, 0]
-            if loads_no > 100:
-                loads_no = "> " + str(loads_no)
-        else:
-            rel_time = "---"
-            last_load_id = "---"
 
-        stat("Last load time", rel_time, border_left_width=4)
-        stat("Last load id", last_load_id)
-        stat("Total number of loads", loads_no)
+        if loads_df is None:
+            st.error(
+                "Load info is not available",
+                icon="🚨",
+            )
+        else:
+            loads_no = loads_df.shape[0]
+            if loads_df.shape[0] > 0:
+                rel_time = (
+                    humanize.naturaldelta(
+                        pendulum.now() - pendulum.from_timestamp(loads_df.iloc[0, 1].timestamp())
+                    )
+                    + " ago"
+                )
+                last_load_id = loads_df.iloc[0, 0]
+                if loads_no > 100:
+                    loads_no = "> " + str(loads_no)
+            else:
+                rel_time = "---"
+                last_load_id = "---"
+
+            stat("Last load time", rel_time, border_left_width=4)
+            stat("Last load id", last_load_id)
+            stat("Total number of loads", loads_no)

--- a/dlt/helpers/streamlit_app/blocks/resource_state.py
+++ b/dlt/helpers/streamlit_app/blocks/resource_state.py
@@ -27,7 +27,6 @@ def resource_state_info(
 
     schema = sources_state.get(schema_name)
     if not schema:
-        st.error(f"Schema with name: {schema_name} is not found")
         return
 
     resource = schema["resources"].get(resource_name)

--- a/dlt/helpers/streamlit_app/blocks/resource_state.py
+++ b/dlt/helpers/streamlit_app/blocks/resource_state.py
@@ -22,15 +22,8 @@ def resource_state_info(
     resource_name: str,
 ) -> None:
     sources_state = pipeline.state.get("sources") or {}
-    if not sources_state:
-        return
-
-    schema = sources_state.get(schema_name)
-    if not schema:
-        return
-
-    resource = schema["resources"].get(resource_name)
-
+    schema = sources_state.get(schema_name, {})
+    resource = schema.get("resources", {}).get(resource_name)
     with st.expander("Resource state", expanded=(resource is None)):
         if not resource:
             st.info(f"{resource_name} is missing resource state")

--- a/dlt/helpers/streamlit_app/blocks/resource_state.py
+++ b/dlt/helpers/streamlit_app/blocks/resource_state.py
@@ -22,6 +22,9 @@ def resource_state_info(
     resource_name: str,
 ) -> None:
     sources_state = pipeline.state.get("sources") or {}
+    if not sources_state:
+        return
+
     schema = sources_state.get(schema_name)
     if not schema:
         st.error(f"Schema with name: {schema_name} is not found")

--- a/dlt/helpers/streamlit_app/pages/dashboard.py
+++ b/dlt/helpers/streamlit_app/pages/dashboard.py
@@ -29,12 +29,16 @@ def write_data_explorer_page(
 
     st.subheader("Schemas and tables", divider="rainbow")
     schema_picker(pipeline)
-    tables = sorted(
-        st.session_state["schema"].data_tables(),
-        key=lambda table: table["name"],
-    )
+    if schema := st.session_state["schema"]:
+        tables = sorted(
+            schema.data_tables(),
+            key=lambda table: table["name"],
+        )
 
-    list_table_hints(pipeline, tables)
+        list_table_hints(pipeline, tables)
+    else:
+        st.warning("No schemas found")
+
     maybe_run_query(
         pipeline,
         show_charts=show_charts,

--- a/dlt/helpers/streamlit_app/widgets/schema.py
+++ b/dlt/helpers/streamlit_app/widgets/schema.py
@@ -16,6 +16,6 @@ def schema_picker(pipeline: dlt.Pipeline) -> None:
         )
         schema = pipeline.schemas.get(selected_schema_name)
 
+    st.session_state["schema"] = schema
     if schema:
         st.subheader(f"Schema: {schema.name}")
-        st.session_state["schema"] = schema

--- a/tests/helpers/streamlit_tests/test_streamlit_show_resources.py
+++ b/tests/helpers/streamlit_tests/test_streamlit_show_resources.py
@@ -13,7 +13,7 @@ import pytest
 
 import dlt
 
-from streamlit.testing.v1 import AppTest  # type: ignore
+from streamlit.testing.v1 import AppTest
 
 from dlt.helpers.streamlit_app.utils import render_with_pipeline
 from dlt.pipeline.exceptions import CannotRestorePipelineException
@@ -102,8 +102,8 @@ def test_multiple_resources_pipeline():
     assert streamlit_app.session_state["color_mode"] == "dark"
 
     # Check page links in sidebar
-    assert "Explore data" in streamlit_app.sidebar[2].label
-    assert "Load info" in streamlit_app.sidebar[3].label
+    assert "Explore data" in streamlit_app.sidebar[2].label  # type: ignore[union-attr]
+    assert "Load info" in streamlit_app.sidebar[3].label  # type: ignore[union-attr]
 
     # Check that at leas 4 content sections rendered
     assert len(streamlit_app.subheader) > 4

--- a/tests/helpers/streamlit_tests/test_streamlit_show_resources.py
+++ b/tests/helpers/streamlit_tests/test_streamlit_show_resources.py
@@ -13,7 +13,7 @@ import pytest
 
 import dlt
 
-from streamlit.testing.v1 import AppTest
+from streamlit.testing.v1 import AppTest  # type: ignore[import-not-found]
 
 from dlt.helpers.streamlit_app.utils import render_with_pipeline
 from dlt.pipeline.exceptions import CannotRestorePipelineException
@@ -102,8 +102,8 @@ def test_multiple_resources_pipeline():
     assert streamlit_app.session_state["color_mode"] == "dark"
 
     # Check page links in sidebar
-    assert "Explore data" in streamlit_app.sidebar[2].label  # type: ignore[union-attr]
-    assert "Load info" in streamlit_app.sidebar[3].label  # type: ignore[union-attr]
+    assert "Explore data" in streamlit_app.sidebar[2].label
+    assert "Load info" in streamlit_app.sidebar[3].label
 
     # Check that at leas 4 content sections rendered
     assert len(streamlit_app.subheader) > 4


### PR DESCRIPTION
This PR adds additional checks in case if pipeline ran but no data was loaded so we can show better error messages instead of showing a stack trace.