### PR TITLE
Fix: check for typeddict before class or subclass checks which fail

### DIFF
--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -243,7 +243,7 @@ def get_all_types_of_class_in_union(hint: Type[Any], cls: Type[TAny]) -> List[Ty
     return [
         t
         for t in get_args(hint)
-        if inspect.isclass(t) and (issubclass(t, cls) or issubclass(cls, t))
+        if not is_typeddict(t) and inspect.isclass(t) and (issubclass(t, cls) or issubclass(cls, t))
     ]
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Just a small fix to ensure union types containing TypedDicts don't fail as they currently do. 

Reproducible Example:

```python

class NoopProviderOptions(t.TypedDict): ...


@t.overload
def load_feature_flag_provider(
    provider: None = None,
    options: t.Optional[NoopProviderOptions] = None,
) -> SupportsFFs: ...


@t.overload
def load_feature_flag_provider(
    provider: t.Literal["noop"] = "noop",
    options: t.Optional[NoopProviderOptions] = None,
) -> SupportsFFs: ...


class FileProviderOptions(t.TypedDict):
    path: str


@t.overload
def load_feature_flag_provider(
    provider: t.Literal["file"] = "file",
    options: t.Optional[FileProviderOptions] = None,
) -> SupportsFFs: ...


class HarnessProviderOptions(t.TypedDict):
    api_key: str
    sdk_key: str
    account: str
    organization: str
    project: str


@t.overload
def load_feature_flag_provider(
    provider: t.Literal["harness"] = "harness",
    options: t.Optional[HarnessProviderOptions] = None,
) -> SupportsFFs: ...


class LaunchDarklyProviderOptions(t.TypedDict):
    sdk_key: str


@t.overload
def load_feature_flag_provider(
    provider: t.Literal["launchdarkly"] = "launchdarkly",
    options: t.Optional[LaunchDarklyProviderOptions] = None,
) -> SupportsFFs: ...


@with_config(sections=("feature_flags",))
def load_feature_flag_provider(
    provider: t.Optional[t.Literal["file", "harness", "launchdarkly", "noop"]] = None,
    options: t.Optional[
        t.Union[
            NoopProviderOptions,
            FileProviderOptions,
            HarnessProviderOptions,
            LaunchDarklyProviderOptions,
        ]
    ] = None,
) -> SupportsFFs: ...

```

The `load_feature_flag_provider` will fail without my fix because you cannot do isclass or issubclass on a TypedDict...

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
