### PR TITLE
RESTClient: ensure total count is an integer in OffsetPaginator

### DIFF
--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -87,6 +87,14 @@ class OffsetPaginator(BasePaginator):
                 f"Total count not found in response for {self.__class__.__name__}"
             )
 
+        try:
+            total = int(total)
+        except ValueError:
+            raise ValueError(
+                f"Total count is not an integer in response for {self.__class__.__name__}. "
+                f"Expected an integer, got {total}"
+            )
+
         self.offset += self.limit
 
         if self.offset >= total:

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -75,6 +75,19 @@ class TestOffsetPaginator:
         paginator.update_state(response)
         assert paginator.has_next_page is False
 
+    def test_update_state_with_string_total(self):
+        paginator = OffsetPaginator(0, 10)
+        response = Mock(Response, json=lambda: {"total": "20"})
+        paginator.update_state(response)
+        assert paginator.offset == 10
+        assert paginator.has_next_page is True
+
+    def test_update_state_with_invalid_total(self):
+        paginator = OffsetPaginator(0, 10)
+        response = Mock(Response, json=lambda: {"total": "invalid"})
+        with pytest.raises(ValueError):
+            paginator.update_state(response)
+
     def test_update_state_without_total(self):
         paginator = OffsetPaginator(0, 10)
         response = Mock(Response, json=lambda: {})


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR adds conversion to `int` for the value extracted by `OffsetPaginator`.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related PRs

- #1141 

