### PR TITLE
Feat: parameterize pipeline class in the primary factory method

### DIFF
--- a/dlt/pipeline/__init__.py
+++ b/dlt/pipeline/__init__.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Type, cast, overload
+from typing import Sequence, Type, TypeVar, cast, overload
 
 from dlt.common.schema import Schema
 from dlt.common.schema.typing import TColumnSchema, TWriteDisposition, TSchemaContract
@@ -15,6 +15,8 @@ from dlt.pipeline.pipeline import Pipeline
 from dlt.pipeline.progress import _from_name as collector_from_name, TCollectorArg, _NULL_COLLECTOR
 from dlt.pipeline.warnings import credentials_argument_deprecated
 
+TPipeline = TypeVar("TPipeline", bound=Pipeline)
+
 
 @overload
 def pipeline(
@@ -29,7 +31,8 @@ def pipeline(
     full_refresh: bool = False,
     credentials: Any = None,
     progress: TCollectorArg = _NULL_COLLECTOR,
-) -> Pipeline:
+    _impl_cls: Type[TPipeline] = Pipeline,
+) -> TPipeline:
     """Creates a new instance of `dlt` pipeline, which moves the data from the source ie. a REST API to a destination ie. database or a data lake.
 
     #### Note:
@@ -97,9 +100,9 @@ def pipeline(
     full_refresh: bool = False,
     credentials: Any = None,
     progress: TCollectorArg = _NULL_COLLECTOR,
-    _impl_cls: Type[Pipeline] = Pipeline,
+    _impl_cls: Type[TPipeline] = Pipeline,
     **kwargs: Any,
-) -> Pipeline:
+) -> TPipeline:
     ensure_correct_pipeline_kwargs(pipeline, **kwargs)
     # call without arguments returns current pipeline
     orig_args = get_orig_args(**kwargs)  # original (*args, **kwargs)
@@ -112,7 +115,7 @@ def pipeline(
         context = Container()[PipelineContext]
         # if pipeline instance is already active then return it, otherwise create a new one
         if context.is_active():
-            return cast(Pipeline, context.pipeline())
+            return cast(TPipeline, context.pipeline())
         else:
             pass
 

--- a/dlt/pipeline/__init__.py
+++ b/dlt/pipeline/__init__.py
@@ -81,12 +81,6 @@ def pipeline(
     """
 
 
-@overload
-def pipeline() -> Pipeline:  # type: ignore
-    """When called without any arguments, returns the recently created `Pipeline` instance.
-    If not found, it creates a new instance with all the pipeline options set to defaults."""
-
-
 @with_config(spec=PipelineConfiguration, auto_pipeline_section=True)
 def pipeline(
     pipeline_name: str = None,

--- a/dlt/pipeline/__init__.py
+++ b/dlt/pipeline/__init__.py
@@ -1,4 +1,4 @@
-from typing import Sequence, cast, overload
+from typing import Sequence, Type, cast, overload
 
 from dlt.common.schema import Schema
 from dlt.common.schema.typing import TColumnSchema, TWriteDisposition, TSchemaContract
@@ -97,6 +97,7 @@ def pipeline(
     full_refresh: bool = False,
     credentials: Any = None,
     progress: TCollectorArg = _NULL_COLLECTOR,
+    _impl_cls: Type[Pipeline] = Pipeline,
     **kwargs: Any,
 ) -> Pipeline:
     ensure_correct_pipeline_kwargs(pipeline, **kwargs)
@@ -129,7 +130,7 @@ def pipeline(
 
     progress = collector_from_name(progress)
     # create new pipeline instance
-    p = Pipeline(
+    p = _impl_cls(
         pipeline_name,
         pipelines_dir,
         pipeline_salt,

--- a/dlt/pipeline/__init__.py
+++ b/dlt/pipeline/__init__.py
@@ -1,4 +1,5 @@
-from typing import Sequence, Type, TypeVar, cast, overload
+from typing import Sequence, Type, cast, overload
+from typing_extensions import TypeVar
 
 from dlt.common.schema import Schema
 from dlt.common.schema.typing import TColumnSchema, TWriteDisposition, TSchemaContract
@@ -15,7 +16,7 @@ from dlt.pipeline.pipeline import Pipeline
 from dlt.pipeline.progress import _from_name as collector_from_name, TCollectorArg, _NULL_COLLECTOR
 from dlt.pipeline.warnings import credentials_argument_deprecated
 
-TPipeline = TypeVar("TPipeline", bound=Pipeline)
+TPipeline = TypeVar("TPipeline", bound=Pipeline, default=Pipeline)
 
 
 @overload
@@ -31,7 +32,7 @@ def pipeline(
     full_refresh: bool = False,
     credentials: Any = None,
     progress: TCollectorArg = _NULL_COLLECTOR,
-    _impl_cls: Type[TPipeline] = Pipeline,
+    _impl_cls: Type[TPipeline] = Pipeline,  # type: ignore[assignment]
 ) -> TPipeline:
     """Creates a new instance of `dlt` pipeline, which moves the data from the source ie. a REST API to a destination ie. database or a data lake.
 
@@ -81,6 +82,12 @@ def pipeline(
     """
 
 
+@overload
+def pipeline() -> Pipeline:  # type: ignore
+    """When called without any arguments, returns the recently created `Pipeline` instance.
+    If not found, it creates a new instance with all the pipeline options set to defaults."""
+
+
 @with_config(spec=PipelineConfiguration, auto_pipeline_section=True)
 def pipeline(
     pipeline_name: str = None,
@@ -94,7 +101,7 @@ def pipeline(
     full_refresh: bool = False,
     credentials: Any = None,
     progress: TCollectorArg = _NULL_COLLECTOR,
-    _impl_cls: Type[TPipeline] = Pipeline,
+    _impl_cls: Type[TPipeline] = Pipeline,  # type: ignore[assignment]
     **kwargs: Any,
 ) -> TPipeline:
     ensure_correct_pipeline_kwargs(pipeline, **kwargs)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This is an  easy addition to parameterize and will simplify some hackery in `cdf`. Furthermore it makes the factory method significantly more flexible in possibilities since we can pass subclasses of Pipeline. 

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

In the future, it would be even simpler if this sort of factory method was a `classmethod` on the `Pipeline` class and simply aliased/exported like `pipeline = Pipeline.create` where `Pipeline.create` has a sig like `def create(cls, ...)` which also lets subclasses benefit from the "standard" setup procedure. 

For now, we make the simpler change though...