### PR TITLE
Update example connection string

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database.md
@@ -62,7 +62,7 @@ The database above doesn't require a password.
 The connection URL can be broken down into:
 
 ```py
-connection_url = connection_string = f"{drivername}://{username}:{password}@{host}:{port}{database}"
+connection_url = f"{drivername}://{username}:{password}@{host}:{port}/{database}"
 ```
 
 `drivername`: Indicates both the database system and driver used.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This is a quick fix to the docs to update the example connection string, `{port}{database}` -> `{port}/{database}` and removes extra variable `connection_string`

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
