### PR TITLE
Add yaml representer for pendulum datetime

### DIFF
--- a/dlt/helpers/streamlit_app/blocks/resource_state.py
+++ b/dlt/helpers/streamlit_app/blocks/resource_state.py
@@ -1,12 +1,17 @@
+from typing import Union
+
 import dlt
+import pendulum
 import streamlit as st
 import yaml
 
-from dlt.common import json
-from dlt.common.libs.pandas import pandas as pd
-from dlt.common.pipeline import resource_state, TSourceState
-from dlt.common.schema.utils import group_tables_by_resource
-from dlt.helpers.streamlit_app.widgets.tags import tag
+
+def date_to_iso(dumper: yaml.Dumper, data: Union[pendulum.Date, pendulum.DateTime]) -> str:
+    return dumper.represent_datetime(data)
+
+
+yaml.representer.SafeRepresenter.add_representer(pendulum.Date, date_to_iso)
+yaml.representer.SafeRepresenter.add_representer(pendulum.DateTime, date_to_iso)
 
 
 def resource_state_info(
@@ -21,6 +26,7 @@ def resource_state_info(
         return
 
     resource = schema["resources"].get(resource_name)
+
     with st.expander("Resource state", expanded=(resource is None)):
         if not resource:
             st.info(f"{resource_name} is missing resource state")

--- a/dlt/helpers/streamlit_app/blocks/resource_state.py
+++ b/dlt/helpers/streamlit_app/blocks/resource_state.py
@@ -6,12 +6,14 @@ import streamlit as st
 import yaml
 
 
-def date_to_iso(dumper: yaml.Dumper, data: Union[pendulum.Date, pendulum.DateTime]) -> str:
-    return dumper.represent_datetime(data)
+def date_to_iso(
+    dumper: yaml.SafeDumper, data: Union[pendulum.Date, pendulum.DateTime]
+) -> yaml.ScalarNode:
+    return dumper.represent_datetime(data)  # type: ignore[arg-type]
 
 
-yaml.representer.SafeRepresenter.add_representer(pendulum.Date, date_to_iso)
-yaml.representer.SafeRepresenter.add_representer(pendulum.DateTime, date_to_iso)
+yaml.representer.SafeRepresenter.add_representer(pendulum.Date, date_to_iso)  # type: ignore[arg-type]
+yaml.representer.SafeRepresenter.add_representer(pendulum.DateTime, date_to_iso)  # type: ignore[arg-type]
 
 
 def resource_state_info(


### PR DESCRIPTION
This PR fixes the bug reported in https://github.com/dlt-hub/dlt/issues/1189 where `yaml.safe_dump` is unable to serialize `pendulum.[Date|DateTime]` it aliases with yaml's builtin `Dumper.represent_datetime` which uses ISO format.