### PR TITLE
RESTClient: Import `Request` and `Response` directly from `requests`.

### DIFF
--- a/dlt/sources/helpers/rest_client/client.py
+++ b/dlt/sources/helpers/rest_client/client.py
@@ -12,11 +12,11 @@ import copy
 from urllib.parse import urlparse
 
 from requests import Session as BaseSession  # noqa: I251
+from requests import Response, Request
 
 from dlt.common import logger
 from dlt.common import jsonpath
 from dlt.sources.helpers.requests.retry import Client
-from dlt.sources.helpers.requests import Response, Request
 
 from .typing import HTTPMethodBasic, HTTPMethod, Hooks
 from .paginators import BasePaginator


### PR DESCRIPTION
Follow-up to #1210