### PR TITLE
Pass options to parse iso like strings

### DIFF
--- a/dlt/common/time.py
+++ b/dlt/common/time.py
@@ -1,12 +1,16 @@
 import contextlib
-from typing import Any, Optional, Union, overload, TypeVar, Callable  # noqa
 import datetime  # noqa: I251
+from typing import Any, Optional, Union, overload, TypeVar, Callable  # noqa
+
+from pendulum.parsing import (
+    parse_iso8601,
+    DEFAULT_OPTIONS as pendulum_options,
+    _parse_common as parse_datetime_common,
+)
+from pendulum.tz import UTC
 
 from dlt.common.pendulum import pendulum, timedelta
 from dlt.common.typing import TimedeltaSeconds, TAnyDateTime
-from pendulum.parsing import parse_iso8601, _parse_common as parse_datetime_common
-from pendulum.tz import UTC
-
 
 PAST_TIMESTAMP: float = 0.0
 FUTURE_TIMESTAMP: float = 9999999999.0
@@ -45,7 +49,7 @@ def timestamp_before(timestamp: float, max_inclusive: Optional[float]) -> bool:
 
 def parse_iso_like_datetime(value: Any) -> Union[pendulum.DateTime, pendulum.Date, pendulum.Time]:
     """Parses ISO8601 string into pendulum datetime, date or time. Preserves timezone info.
-    Note: naive datetimes will generated from string without timezone
+    Note: naive datetimes will be generated from string without timezone
 
        we use internal pendulum parse function. the generic function, for example, parses string "now" as now()
        it also tries to parse ISO intervals but the code is very low quality
@@ -56,7 +60,7 @@ def parse_iso_like_datetime(value: Any) -> Union[pendulum.DateTime, pendulum.Dat
         dtv = parse_iso8601(value)
     # now try to parse a set of ISO like dates
     if not dtv:
-        dtv = parse_datetime_common(value)
+        dtv = parse_datetime_common(value, **pendulum_options)
     if isinstance(dtv, datetime.time):
         return pendulum.time(dtv.hour, dtv.minute, dtv.second, dtv.microsecond)
     if isinstance(dtv, datetime.datetime):

--- a/tests/common/schema/test_detections.py
+++ b/tests/common/schema/test_detections.py
@@ -52,6 +52,7 @@ def test_iso_date_detection() -> None:
     # ISO-8601 allows dates with reduced precision
     assert is_iso_date(str, "1975-05") == "date"
     assert is_iso_date(str, "1975") == "date"
+    assert is_iso_date(str, "1975/05/01") == "date"
 
     # dont auto-detect timestamps as dates
     assert is_iso_date(str, str(pendulum.now())) is None
@@ -68,7 +69,6 @@ def test_iso_date_detection() -> None:
     assert is_iso_date(str, "") is None
     assert is_iso_date(str, "75") is None
     assert is_iso_date(str, "01-12") is None
-    assert is_iso_date(str, "1975/05/01") is None
 
     # wrong type
     assert is_iso_date(float, str(pendulum.now().date())) is None

--- a/tests/common/test_time.py
+++ b/tests/common/test_time.py
@@ -80,6 +80,8 @@ test_params = [
 def test_parse_iso_like_datetime() -> None:
     # naive datetime is still naive
     assert parse_iso_like_datetime("2021-01-01T05:02:32") == pendulum.DateTime(2021, 1, 1, 5, 2, 32)
+    # test that _parse_common form pendulum parsing is not failing with KeyError
+    assert parse_iso_like_datetime("2021:01:01 05:02:32") == pendulum.DateTime(2021, 1, 1, 5, 2, 32)
 
 
 @pytest.mark.parametrize("date_value, expected", test_params)


### PR DESCRIPTION
Now if datetime cannot be parsed by `parse_iso8601` it will be parsed by `_parse_common` with default pendulum options.  
