### PR TITLE
Snowflake & Motherduck partner identifier params

### DIFF
--- a/dlt/destinations/impl/motherduck/configuration.py
+++ b/dlt/destinations/impl/motherduck/configuration.py
@@ -6,11 +6,11 @@ from dlt.common.destination.reference import DestinationClientDwhWithStagingConf
 from dlt.common.destination.exceptions import DestinationTerminalException
 from dlt.common.typing import TSecretValue
 from dlt.common.utils import digest128
-from dlt.common.configuration.exceptions import ConfigurationValueError
 
 from dlt.destinations.impl.duckdb.configuration import DuckDbBaseCredentials
 
 MOTHERDUCK_DRIVERNAME = "md"
+MOTHERDUCK_PARTNER_ID: str = "dltHub_dlt"
 
 
 @configspec(init=False)
@@ -25,7 +25,7 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
     __config_gen_annotations__: ClassVar[List[str]] = ["password", "database"]
 
     def _conn_str(self) -> str:
-        return f"{MOTHERDUCK_DRIVERNAME}:{self.database}?token={self.password}"
+        return f"{MOTHERDUCK_DRIVERNAME}:{self.database}?token={self.password}&application={MOTHERDUCK_PARTNER_ID}"
 
     def _token_to_password(self) -> None:
         # could be motherduck connection

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -1,6 +1,7 @@
-import dataclasses
 import base64
-from typing import Final, Optional, Any, Dict, ClassVar, List, TYPE_CHECKING, Union
+import dataclasses
+
+from typing import Final, Optional, Any, Dict, ClassVar, List
 
 from dlt import version
 from dlt.common.libs.sql_alchemy import URL
@@ -11,6 +12,8 @@ from dlt.common.configuration.exceptions import ConfigurationValueError
 from dlt.common.configuration import configspec
 from dlt.common.destination.reference import DestinationClientDwhWithStagingConfiguration
 from dlt.common.utils import digest128
+
+snowflake_partner_id: str = "dltHub_dlt"
 
 
 def _read_private_key(private_key: str, password: Optional[str] = None) -> bytes:
@@ -85,6 +88,8 @@ class SnowflakeCredentials(ConnectionStringCredentials):
             query["warehouse"] = self.warehouse
         if self.role and "role" not in query:
             query["role"] = self.role
+        query["application"] = snowflake_partner_id
+
         return URL.create(
             self.drivername,
             self.username,

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -113,6 +113,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
             warehouse=self.warehouse,
             role=self.role,
             private_key=private_key,
+            application=snowflake_partner_id,
         )
         if self.authenticator:
             conn_params["authenticator"] = self.authenticator

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -65,7 +65,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
     authenticator: Optional[str] = None
     private_key: Optional[TSecretStrValue] = None
     private_key_passphrase: Optional[TSecretStrValue] = None
-    partner_integration_params: Dict[str, Any] = None
+    partner_integration_params: Optional[Dict[str, Any]] = None
 
     __config_gen_annotations__: ClassVar[List[str]] = ["password", "warehouse", "role"]
 
@@ -111,6 +111,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         private_key: Optional[bytes] = None
         if self.private_key:
             private_key = _read_private_key(self.private_key, self.private_key_passphrase)
+
         conn_params = dict(
             self.query or {},
             user=self.username,

--- a/tests/load/duckdb/test_motherduck_client.py
+++ b/tests/load/duckdb/test_motherduck_client.py
@@ -13,6 +13,7 @@ from tests.utils import patch_home_dir, preserve_environ, skip_if_not_active
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
+motherduck_partner_id = "dltHub_dlt"
 
 skip_if_not_active("motherduck")
 
@@ -24,6 +25,7 @@ def test_motherduck_configuration() -> None:
     assert cred.database == "dlt_data"
     assert cred.is_partial() is False
     assert cred.is_resolved() is True
+    assert f"application={motherduck_partner_id}" in str(cred._conn_str())
 
     cred = MotherDuckCredentials()
     cred.parse_native_representation("md:///?token=TOKEN")
@@ -31,6 +33,7 @@ def test_motherduck_configuration() -> None:
     assert cred.database == ""
     assert cred.is_partial() is False
     assert cred.is_resolved() is False
+    assert f"application={motherduck_partner_id}" in str(cred._conn_str())
 
     # password or token are mandatory
     with pytest.raises(ConfigFieldMissingException) as conf_ex:
@@ -55,6 +58,9 @@ def test_motherduck_connect() -> None:
         MotherDuckClientConfiguration()._bind_dataset_name(dataset_name="test"),
         sections=("destination", "motherduck"),
     )
+
+    assert f"application={motherduck_partner_id}" in config.credentials._conn_str()
+
     # connect
     con = config.credentials.borrow_conn(read_only=False)
     con.sql("SHOW DATABASES")

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -18,10 +18,10 @@ from tests.common.configuration.utils import environment
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
-
+snowflake_partner_id = "dltHub_dlt"
 
 def test_connection_string_with_all_params() -> None:
-    url = "snowflake://user1:pass1@host1/db1?warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr"
+    url = "snowflake://user1:pass1@host1/db1?warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr&application=dltHub_dlt"
 
     creds = SnowflakeCredentials()
     creds.parse_native_representation(url)
@@ -66,6 +66,7 @@ def test_to_connector_params() -> None:
         password=None,
         warehouse="warehouse1",
         role="role1",
+        application=snowflake_partner_id,
     )
 
     # base64 encoded DER key
@@ -92,6 +93,7 @@ def test_to_connector_params() -> None:
         password=None,
         warehouse="warehouse1",
         role="role1",
+        application=snowflake_partner_id,
     )
 
 

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -36,8 +36,10 @@ def test_connection_string_with_all_params() -> None:
     assert creds.private_key_passphrase == "paphr"
 
     expected = make_url(url)
+    creds_url = creds.to_url()
 
     # Test URL components regardless of query param order
+    assert creds_url == expected
     assert make_url(creds.to_native_representation()) == expected
 
 
@@ -109,8 +111,10 @@ def test_snowflake_credentials_native_value(environment) -> None:
         SnowflakeCredentials(),
         explicit_value="snowflake://user1@host1/db1?warehouse=warehouse1&role=role1",
     )
+
     assert c.is_resolved()
     assert c.password == "pass"
+    assert f"application={snowflake_partner_id}" in str(c.to_url())
     # # but if password is specified - it is final
     c = resolve_configuration(
         SnowflakeCredentials(),
@@ -118,6 +122,7 @@ def test_snowflake_credentials_native_value(environment) -> None:
     )
     assert c.is_resolved()
     assert c.password == "pass1"
+    assert f"application={snowflake_partner_id}" in str(c.to_url())
 
     # set PK via env
     del os.environ["CREDENTIALS__PASSWORD"]


### PR DESCRIPTION
This PR adds query parameters to connection strings of Snowflake and Motherduck destinations to allow them to discover dlt users.

Ticket: https://github.com/dlt-hub/dlt/issues/1257

## TODO

* [ ] Update Snowflake and Motherduck client configuration to include configurable integration params,
* [x] Waiting for DuckDb about their partner and integration identifiers,
* [x] Adjust tests,