### PR TITLE
Add snowflake to application parameter to configuration

### DIFF
--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -93,7 +93,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         if "application" not in query:
             if self.application is None:
                 query["application"] = snowflake_application_id
-            elif self.application and self.application != "skip":
+            elif self.application and self.application != "":
                 query["application"] = self.application
 
         return URL.create(
@@ -127,7 +127,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
 
         if self.application is None:
             conn_params["application"] = snowflake_application_id
-        elif self.application and self.application != "skip":
+        elif self.application and self.application != "":
             conn_params["application"] = self.application
 
         return conn_params

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -110,6 +110,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         private_key: Optional[bytes] = None
         if self.private_key:
             private_key = _read_private_key(self.private_key, self.private_key_passphrase)
+
         conn_params = dict(
             self.query or {},
             user=self.username,

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -63,7 +63,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
     authenticator: Optional[str] = None
     private_key: Optional[TSecretStrValue] = None
     private_key_passphrase: Optional[TSecretStrValue] = None
-    application: Optional[str] = None
+    application: Optional[str] = snowflake_application_id
 
     __config_gen_annotations__: ClassVar[List[str]] = ["password", "warehouse", "role"]
 
@@ -90,11 +90,8 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         if self.role and "role" not in query:
             query["role"] = self.role
 
-        if "application" not in query:
-            if self.application is None:
-                query["application"] = snowflake_application_id
-            elif self.application and self.application != "":
-                query["application"] = self.application
+        if self.application != "" and "application" not in query:
+            query["application"] = self.application
 
         return URL.create(
             self.drivername,
@@ -125,9 +122,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         if self.authenticator:
             conn_params["authenticator"] = self.authenticator
 
-        if self.application is None:
-            conn_params["application"] = snowflake_application_id
-        elif self.application and self.application != "":
+        if self.application != "" and self.application != "":
             conn_params["application"] = self.application
 
         return conn_params

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -122,7 +122,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         if self.authenticator:
             conn_params["authenticator"] = self.authenticator
 
-        if self.application != "" and self.application != "":
+        if self.application != "" and "application" not in conn_params:
             conn_params["application"] = self.application
 
         return conn_params

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -49,6 +49,9 @@ def _read_private_key(private_key: str, password: Optional[str] = None) -> bytes
     )
 
 
+snowflake_application_id = "dltHub_dlt"
+
+
 @configspec(init=False)
 class SnowflakeCredentials(ConnectionStringCredentials):
     drivername: Final[str] = dataclasses.field(default="snowflake", init=False, repr=False, compare=False)  # type: ignore[misc]
@@ -60,6 +63,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
     authenticator: Optional[str] = None
     private_key: Optional[TSecretStrValue] = None
     private_key_passphrase: Optional[TSecretStrValue] = None
+    application: Optional[str] = None
 
     __config_gen_annotations__: ClassVar[List[str]] = ["password", "warehouse", "role"]
 
@@ -85,6 +89,9 @@ class SnowflakeCredentials(ConnectionStringCredentials):
             query["warehouse"] = self.warehouse
         if self.role and "role" not in query:
             query["role"] = self.role
+        if self.application and self.application != "skip" and "application" not in query:
+            query["application"] = self.application
+
         return URL.create(
             self.drivername,
             self.username,
@@ -109,8 +116,13 @@ class SnowflakeCredentials(ConnectionStringCredentials):
             role=self.role,
             private_key=private_key,
         )
+
         if self.authenticator:
             conn_params["authenticator"] = self.authenticator
+
+        if self.application and self.application != "skip":
+            conn_params["application"] = snowflake_application_id
+
         return conn_params
 
 

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -89,8 +89,12 @@ class SnowflakeCredentials(ConnectionStringCredentials):
             query["warehouse"] = self.warehouse
         if self.role and "role" not in query:
             query["role"] = self.role
-        if self.application and self.application != "skip" and "application" not in query:
-            query["application"] = self.application
+
+        if "application" not in query:
+            if self.application is None:
+                query["application"] = snowflake_application_id
+            elif self.application and self.application != "skip":
+                query["application"] = self.application
 
         return URL.create(
             self.drivername,
@@ -120,8 +124,10 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         if self.authenticator:
             conn_params["authenticator"] = self.authenticator
 
-        if self.application and self.application != "skip":
+        if self.application is None:
             conn_params["application"] = snowflake_application_id
+        elif self.application and self.application != "skip":
+            conn_params["application"] = self.application
 
         return conn_params
 

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -49,7 +49,7 @@ def _read_private_key(private_key: str, password: Optional[str] = None) -> bytes
     )
 
 
-snowflake_application_id = "dltHub_dlt"
+SNOWFLAKE_APPLICATION_ID = "dltHub_dlt"
 
 
 @configspec(init=False)
@@ -63,7 +63,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
     authenticator: Optional[str] = None
     private_key: Optional[TSecretStrValue] = None
     private_key_passphrase: Optional[TSecretStrValue] = None
-    application: Optional[str] = snowflake_application_id
+    application: Optional[str] = SNOWFLAKE_APPLICATION_ID
 
     __config_gen_annotations__: ClassVar[List[str]] = ["password", "warehouse", "role"]
 

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -46,11 +46,6 @@ In the case of Snowflake, the **host** is your [Account Identifier](https://docs
 The **warehouse** and **role** are optional if you assign defaults to your user. In the example below, we do not do that, so we set them explicitly.
 
 :::note
-The `application` field enables Snowflake Support Engineers (SE) to offer targeted customer support.
-It is set to `dltHub_dlt` by default, if you prefer not to share the application ID for privacy or other reasons,
-just set `application` to an empty string (`""`) will prevent this information from being sent to Snowflake
-or simply you can take advantage of this as well by setting your own value.
-:::note
 The `application` field enables Snowflake to identify details about connections made to
 Snowflake instances. Snowflake will use this identifier to better understand the usage patterns
 associated with specific partner integrations. It is set to `dltHub_dlt` by default, if you prefer not to share the application ID,

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -50,6 +50,11 @@ The `application` field enables Snowflake Support Engineers (SE) to offer target
 It is set to `dltHub_dlt` by default, if you prefer not to share the application ID for privacy or other reasons,
 just set `application` to an empty string (`""`) will prevent this information from being sent to Snowflake
 or simply you can take advantage of this as well by setting your own value.
+:::note
+The `application` field enables Snowflake to identify details about connections made to
+Snowflake instances. Snowflake will use this identifier to better understand the usage patterns
+associated with specific partner integrations. It is set to `dltHub_dlt` by default, if you prefer not to share the application ID,
+just set `application` to an empty string (`""`).
 :::
 
 ### Setup the database user and permissions

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -6,8 +6,8 @@ keywords: [Snowflake, destination, data warehouse]
 
 # Snowflake
 
-## Install dlt with Snowflake
-**To install the dlt library with Snowflake dependencies, run:**
+## Install `dlt` with Snowflake
+**To install the `dlt` library with Snowflake dependencies, run:**
 ```sh
 pip install dlt[snowflake]
 ```
@@ -25,7 +25,7 @@ pip install -r requirements.txt
 ```
 This will install `dlt` with the `snowflake` extra, which contains the Snowflake Python dbapi client.
 
-**3. Create a new database, user, and give dlt access.**
+**3. Create a new database, user, and give `dlt` access.**
 
 Read the next chapter below.
 
@@ -39,18 +39,10 @@ username = "loader"
 host = "kgiotue-wn98412"
 warehouse = "COMPUTE_WH"
 role = "DLT_LOADER_ROLE"
-application = "dltHub_dlt"
 ```
 In the case of Snowflake, the **host** is your [Account Identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier). You can get it in **Admin**/**Accounts** by copying the account URL: https://kgiotue-wn98412.snowflakecomputing.com and extracting the host name (**kgiotue-wn98412**).
 
 The **warehouse** and **role** are optional if you assign defaults to your user. In the example below, we do not do that, so we set them explicitly.
-
-:::note
-The `application` field enables Snowflake to identify details about connections made to
-Snowflake instances. Snowflake will use this identifier to better understand the usage patterns
-associated with specific partner integrations. It is set to `dltHub_dlt` by default, if you prefer not to share the application ID,
-just set `application` to an empty string (`""`).
-:::
 
 ### Setup the database user and permissions
 The instructions below assume that you use the default account setup that you get after creating a Snowflake account. You should have a default warehouse named **COMPUTE_WH** and a Snowflake account. Below, we create a new database, user, and assign permissions. The permissions are very generous. A more experienced user can easily reduce `dlt` permissions to just one schema in the database.
@@ -64,7 +56,7 @@ CREATE ROLE DLT_LOADER_ROLE;
 GRANT ROLE DLT_LOADER_ROLE TO USER loader;
 -- give database access to new role
 GRANT USAGE ON DATABASE dlt_data TO DLT_LOADER_ROLE;
--- allow dlt to create new schemas
+-- allow `dlt` to create new schemas
 GRANT CREATE SCHEMA ON DATABASE dlt_data TO ROLE DLT_LOADER_ROLE
 -- allow access to a warehouse named COMPUTE_WH
 GRANT USAGE ON WAREHOUSE COMPUTE_WH TO DLT_LOADER_ROLE;
@@ -150,22 +142,22 @@ Names of tables and columns in [schemas](../../general-usage/schema.md) are kept
 
 ## Staging support
 
-Snowflake supports S3 and GCS as file staging destinations. dlt will upload files in the parquet format to the bucket provider and will ask Snowflake to copy their data directly into the db.
+Snowflake supports S3 and GCS as file staging destinations. `dlt` will upload files in the parquet format to the bucket provider and will ask Snowflake to copy their data directly into the db.
 
 Alternatively to parquet files, you can also specify jsonl as the staging file format. For this, set the `loader_file_format` argument of the `run` command of the pipeline to `jsonl`.
 
 ### Snowflake and Amazon S3
 
-Please refer to the [S3 documentation](./filesystem.md#aws-s3) to learn how to set up your bucket with the bucket_url and credentials. For S3, the dlt Redshift loader will use the AWS credentials provided for S3 to access the S3 bucket if not specified otherwise (see config options below). Alternatively, you can create a stage for your S3 Bucket by following the instructions provided in the [Snowflake S3 documentation](https://docs.snowflake.com/en/user-guide/data-load-s3-config-storage-integration).
+Please refer to the [S3 documentation](./filesystem.md#aws-s3) to learn how to set up your bucket with the bucket_url and credentials. For S3, the `dlt` Redshift loader will use the AWS credentials provided for S3 to access the S3 bucket if not specified otherwise (see config options below). Alternatively, you can create a stage for your S3 Bucket by following the instructions provided in the [Snowflake S3 documentation](https://docs.snowflake.com/en/user-guide/data-load-s3-config-storage-integration).
 The basic steps are as follows:
 
 * Create a storage integration linked to GCS and the right bucket
 * Grant access to this storage integration to the Snowflake role you are using to load the data into Snowflake.
 * Create a stage from this storage integration in the PUBLIC namespace, or the namespace of the schema of your data.
 * Also grant access to this stage for the role you are using to load data into Snowflake.
-* Provide the name of your stage (including the namespace) to dlt like so:
+* Provide the name of your stage (including the namespace) to `dlt` like so:
 
-To prevent dlt from forwarding the S3 bucket credentials on every command, and set your S3 stage, change these settings:
+To prevent `dlt` from forwarding the S3 bucket credentials on every command, and set your S3 stage, change these settings:
 
 ```toml
 [destination]
@@ -175,7 +167,7 @@ stage_name="PUBLIC.my_s3_stage"
 To run Snowflake with S3 as the staging destination:
 
 ```py
-# Create a dlt pipeline that will load
+# Create a `dlt` pipeline that will load
 # chess player data to the Snowflake destination
 # via staging on S3
 pipeline = dlt.pipeline(
@@ -194,7 +186,7 @@ Please refer to the [Google Storage filesystem documentation](./filesystem.md#go
 * Grant access to this storage integration to the Snowflake role you are using to load the data into Snowflake.
 * Create a stage from this storage integration in the PUBLIC namespace, or the namespace of the schema of your data.
 * Also grant access to this stage for the role you are using to load data into Snowflake.
-* Provide the name of your stage (including the namespace) to dlt like so:
+* Provide the name of your stage (including the namespace) to `dlt` like so:
 
 ```toml
 [destination]
@@ -204,7 +196,7 @@ stage_name="PUBLIC.my_gcs_stage"
 To run Snowflake with GCS as the staging destination:
 
 ```py
-# Create a dlt pipeline that will load
+# Create a `dlt` pipeline that will load
 # chess player data to the Snowflake destination
 # via staging on GCS
 pipeline = dlt.pipeline(
@@ -225,7 +217,7 @@ Please consult the Snowflake Documentation on [how to create a stage for your Az
 * Grant access to this storage integration to the Snowflake role you are using to load the data into Snowflake.
 * Create a stage from this storage integration in the PUBLIC namespace, or the namespace of the schema of your data.
 * Also grant access to this stage for the role you are using to load data into Snowflake.
-* Provide the name of your stage (including the namespace) to dlt like so:
+* Provide the name of your stage (including the namespace) to `dlt` like so:
 
 ```toml
 [destination]
@@ -235,7 +227,7 @@ stage_name="PUBLIC.my_azure_stage"
 To run Snowflake with Azure as the staging destination:
 
 ```py
-# Create a dlt pipeline that will load
+# Create a `dlt` pipeline that will load
 # chess player data to the Snowflake destination
 # via staging on Azure
 pipeline = dlt.pipeline(
@@ -261,6 +253,10 @@ This destination [integrates with dbt](../transformations/dbt/dbt.md) via [dbt-s
 
 ### Syncing of `dlt` state
 This destination fully supports [dlt state sync](../../general-usage/state#syncing-state-with-destination)
+
+### Snowflake connection identifier
+We enable Snowflake to identify that the connection is created by `dlt`. Snowflake will use this identifier to better understand the usage patterns
+associated with `dlt` integration. The connection identifier is `dltHub_dlt`.
 
 <!--@@@DLT_TUBA snowflake-->
 

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -48,7 +48,7 @@ The **warehouse** and **role** are optional if you assign defaults to your user.
 :::note
 The `application` field enables Snowflake Support Engineers (SE) to offer targeted customer support.
 It is set to `dltHub_dlt` by default, if you prefer not to share the application ID for privacy or other reasons,
-just set `application` to an empty string (`""`) will prevent this information from being sent to Snowflake, thereby disabling the feature
+just set `application` to an empty string (`""`) will prevent this information from being sent to Snowflake
 or simply you can take advantage of this as well by setting your own value.
 :::
 

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -39,11 +39,16 @@ username = "loader"
 host = "kgiotue-wn98412"
 warehouse = "COMPUTE_WH"
 role = "DLT_LOADER_ROLE"
+application = "dltHub_dlt"
 ```
 In the case of Snowflake, the **host** is your [Account Identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier). You can get it in **Admin**/**Accounts** by copying the account URL: https://kgiotue-wn98412.snowflakecomputing.com and extracting the host name (**kgiotue-wn98412**).
 
 The **warehouse** and **role** are optional if you assign defaults to your user. In the example below, we do not do that, so we set them explicitly.
 
+:::note
+We use `application = "dltHub_dlt"` to let Snowflake to know about dlt users if you would like to disable this behavior
+please set it to empty string `application = ""` this will disable it.
+:::
 
 ### Setup the database user and permissions
 The instructions below assume that you use the default account setup that you get after creating a Snowflake account. You should have a default warehouse named **COMPUTE_WH** and a Snowflake account. Below, we create a new database, user, and assign permissions. The permissions are very generous. A more experienced user can easily reduce `dlt` permissions to just one schema in the database.

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -46,8 +46,10 @@ In the case of Snowflake, the **host** is your [Account Identifier](https://docs
 The **warehouse** and **role** are optional if you assign defaults to your user. In the example below, we do not do that, so we set them explicitly.
 
 :::note
-We use `application = "dltHub_dlt"` to let Snowflake to know about dlt users if you would like to disable this behavior
-please set it to empty string `application = ""` this will disable it.
+The `application` field enables Snowflake Support Engineers (SE) to offer targeted customer support.
+It is set to `dltHub_dlt` by default, if you prefer not to share the application ID for privacy or other reasons,
+just set `application` to an empty string (`""`) will prevent this information from being sent to Snowflake, thereby disabling the feature
+or simply you can take advantage of this as well by setting your own value.
 :::
 
 ### Setup the database user and permissions

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -146,8 +146,8 @@ def test_snowflake_credentials_native_value(environment) -> None:
     assert c.private_key == "pk"
     assert "application=dlt" in str(c.to_url())
 
-    # check with application = skip it should not be in connection string
-    os.environ["CREDENTIALS__APPLICATION"] = "skip"
+    # check with application = "" it should not be in connection string
+    os.environ["CREDENTIALS__APPLICATION"] = ""
     c = resolve_configuration(
         SnowflakeCredentials(),
         explicit_value="snowflake://user1@host1/db1?warehouse=warehouse1&role=role1",

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -10,6 +10,7 @@ from dlt.common.configuration.exceptions import ConfigurationValueError
 from dlt.common.utils import digest128
 
 from dlt.destinations.impl.snowflake.configuration import (
+    SNOWFLAKE_APPLICATION_ID,
     SnowflakeClientConfiguration,
     SnowflakeCredentials,
 )
@@ -78,7 +79,7 @@ def test_to_connector_params() -> None:
         warehouse="warehouse1",
         role="role1",
         # default application identifier will be used
-        application="dltHub_dlt",
+        application=SNOWFLAKE_APPLICATION_ID,
     )
 
     # base64 encoded DER key
@@ -93,7 +94,7 @@ def test_to_connector_params() -> None:
     creds.warehouse = "warehouse1"
     creds.role = "role1"
     # set application identifier and check it
-    creds.application = "dltHub_dlt"
+    creds.application = "custom_app_id"
 
     params = creds.to_connector_params()
 
@@ -107,7 +108,7 @@ def test_to_connector_params() -> None:
         password=None,
         warehouse="warehouse1",
         role="role1",
-        application="dltHub_dlt",
+        application="custom_app_id",
     )
 
 

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -103,12 +103,14 @@ def test_snowflake_credentials_native_value(environment) -> None:
         )
     # set password via env
     os.environ["CREDENTIALS__PASSWORD"] = "pass"
+    os.environ["CREDENTIALS__APPLICATION"] = "dlt"
     c = resolve_configuration(
         SnowflakeCredentials(),
         explicit_value="snowflake://user1@host1/db1?warehouse=warehouse1&role=role1",
     )
     assert c.is_resolved()
     assert c.password == "pass"
+    assert "application=dlt" in str(c.to_url())
     # # but if password is specified - it is final
     c = resolve_configuration(
         SnowflakeCredentials(),
@@ -126,6 +128,7 @@ def test_snowflake_credentials_native_value(environment) -> None:
     )
     assert c.is_resolved()
     assert c.private_key == "pk"
+    assert "application=dlt" in str(c.to_url())
 
 
 def test_snowflake_configuration() -> None:

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.essential
 
 
 def test_connection_string_with_all_params() -> None:
-    url = "snowflake://user1:pass1@host1/db1?warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr"
+    url = "snowflake://user1:pass1@host1/db1?application=dltHub_dlt&warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr"
 
     creds = SnowflakeCredentials()
     creds.parse_native_representation(url)
@@ -36,9 +36,20 @@ def test_connection_string_with_all_params() -> None:
     assert creds.private_key_passphrase == "paphr"
 
     expected = make_url(url)
+    to_url_value = str(creds.to_url())
 
     # Test URL components regardless of query param order
     assert make_url(creds.to_native_representation()) == expected
+    assert to_url_value == str(expected)
+
+    creds.application = "custom"
+    url = "snowflake://user1:pass1@host1/db1?application=custom&warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr"
+    creds.parse_native_representation(url)
+    expected = make_url(url)
+    to_url_value = str(creds.to_url())
+    assert make_url(creds.to_native_representation()) == expected
+    assert to_url_value == str(expected)
+    assert "application=custom" in str(expected)
 
 
 def test_to_connector_params() -> None:
@@ -66,6 +77,8 @@ def test_to_connector_params() -> None:
         password=None,
         warehouse="warehouse1",
         role="role1",
+        # default application identifier will be used
+        application="dltHub_dlt",
     )
 
     # base64 encoded DER key
@@ -79,6 +92,8 @@ def test_to_connector_params() -> None:
     creds.host = "host1"
     creds.warehouse = "warehouse1"
     creds.role = "role1"
+    # set application identifier and check it
+    creds.application = "dltHub_dlt"
 
     params = creds.to_connector_params()
 
@@ -92,6 +107,7 @@ def test_to_connector_params() -> None:
         password=None,
         warehouse="warehouse1",
         role="role1",
+        application="dltHub_dlt",
     )
 
 
@@ -129,6 +145,15 @@ def test_snowflake_credentials_native_value(environment) -> None:
     assert c.is_resolved()
     assert c.private_key == "pk"
     assert "application=dlt" in str(c.to_url())
+
+    # check with application = skip it should not be in connection string
+    os.environ["CREDENTIALS__APPLICATION"] = "skip"
+    c = resolve_configuration(
+        SnowflakeCredentials(),
+        explicit_value="snowflake://user1@host1/db1?warehouse=warehouse1&role=role1",
+    )
+    assert c.is_resolved()
+    assert "application=" not in str(c.to_url())
 
 
 def test_snowflake_configuration() -> None:


### PR DESCRIPTION
To allow snowflake to track users using dlt we need to pass application parameter as query parameter.

~~If the value is set to `skip` we do not include it (some users might want to disable). @rudolfix wdyt?~~
Will use `""` as a way to skip the addition of `application` parameter.

**Config example**
```toml
[destination.snowflake.credentials]
application="some identifier"
```