### PR TITLE
Automatically create destination folder for local filesystem

### DIFF
--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -73,7 +73,15 @@ class LoadFilesystemJob(LoadJob):
             load_package_timestamp=dlt.current.load_package()["state"]["created_at"],  # type: ignore
             extra_placeholders=config.extra_placeholders,
         )
+        # We would like to avoid failing for local filesystem where
+        # deeply nested directory will not exist before writing a file.
+        # It `auto_mkdir` is disabled by default in fsspec so we made some
+        # trade offs between different options and decided on this.
+
         item = self.make_remote_path()
+        if self.config.protocol.startswith("file"):
+            fs_client.makedirs(posixpath.dirname(item), exist_ok=True)
+
         fs_client.put_file(local_path, item)
 
     def make_remote_path(self) -> str:

--- a/tests/load/pipeline/test_filesystem_pipeline.py
+++ b/tests/load/pipeline/test_filesystem_pipeline.py
@@ -309,7 +309,6 @@ def test_filesystem_destination_extended_layout_placeholders(layout: str) -> Non
         destination=filesystem(
             layout=layout,
             extra_placeholders=extra_placeholders,
-            kwargs={"auto_mkdir": True},
             current_datetime=counter(now),
         ),
     )


### PR DESCRIPTION
This PR adjusts `LoadFilesystemJob` for local filesystem to automatically create the destination folder.