### PR TITLE
Extend motherduck client configuration to pass custom user agent

### DIFF
--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -2,7 +2,7 @@ import os
 import dataclasses
 import threading
 from pathvalidate import is_valid_filepath
-from typing import Any, ClassVar, Final, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, Final, List, Optional, Tuple, Type, Union
 
 from dlt.common import logger
 from dlt.common.configuration import configspec
@@ -37,10 +37,16 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
         if not hasattr(self, "_conn_lock"):
             self._conn_lock = threading.Lock()
 
+        config = {}
+        if hasattr(self, "_conn_config"):
+            config = self._conn_config
+
         # obtain a lock because duck releases the GIL and we have refcount concurrency
         with self._conn_lock:
             if not hasattr(self, "_conn"):
-                self._conn = duckdb.connect(database=self._conn_str(), read_only=read_only)
+                self._conn = duckdb.connect(
+                    database=self._conn_str(), read_only=read_only, config=config
+                )
                 self._conn_owner = True
                 self._conn_borrows = 0
 
@@ -82,6 +88,14 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
                 self.database = native_value
             else:
                 raise
+
+    @property
+    def conn_config(self) -> Dict[str, Any]:
+        return self._conn_config or {}
+
+    @conn_config.setter
+    def conn_config(self, new_config: Dict[str, Any]) -> None:
+        self._conn_config = new_config
 
     def _conn_str(self) -> str:
         return self.database

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -2,16 +2,13 @@ import os
 import dataclasses
 import threading
 from pathvalidate import is_valid_filepath
-from typing import Any, ClassVar, Final, List, Optional, Tuple, TYPE_CHECKING, Type, Union
+from typing import Any, ClassVar, Final, List, Optional, Tuple, Type, Union
 
 from dlt.common import logger
 from dlt.common.configuration import configspec
 from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.configuration.specs.exceptions import InvalidConnectionString
-from dlt.common.destination.reference import (
-    DestinationClientDwhWithStagingConfiguration,
-    DestinationClientStagingConfiguration,
-)
+from dlt.common.destination.reference import DestinationClientDwhWithStagingConfiguration
 from dlt.common.typing import TSecretValue
 
 try:

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -37,11 +37,15 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
         if not hasattr(self, "_conn_lock"):
             self._conn_lock = threading.Lock()
 
+        config = {}
+        if hasattr(self, "_conn_config"):
+            config = self._conn_config
+
         # obtain a lock because duck releases the GIL and we have refcount concurrency
         with self._conn_lock:
             if not hasattr(self, "_conn"):
                 self._conn = duckdb.connect(
-                    database=self._conn_str(), read_only=read_only, config=self.conn_config
+                    database=self._conn_str(), read_only=read_only, config=config
                 )
                 self._conn_owner = True
                 self._conn_borrows = 0
@@ -84,14 +88,6 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
                 self.database = native_value
             else:
                 raise
-
-    @property
-    def conn_config(self) -> Dict[str, Any]:
-        return getattr(self, "_conn_config", {})
-
-    @conn_config.setter
-    def conn_config(self, new_config: Dict[str, Any]) -> None:
-        self._conn_config = new_config
 
     def _conn_str(self) -> str:
         return self.database

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -2,7 +2,7 @@ import os
 import dataclasses
 import threading
 from pathvalidate import is_valid_filepath
-from typing import Any, ClassVar, Final, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, Final, List, Optional, Tuple, Type, Union
 
 from dlt.common import logger
 from dlt.common.configuration import configspec
@@ -37,10 +37,7 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
         if not hasattr(self, "_conn_lock"):
             self._conn_lock = threading.Lock()
 
-        config = {}
-        if hasattr(self, "_conn_config"):
-            config = self._conn_config
-
+        config = self._get_conn_config()
         # obtain a lock because duck releases the GIL and we have refcount concurrency
         with self._conn_lock:
             if not hasattr(self, "_conn"):
@@ -88,6 +85,9 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
                 self.database = native_value
             else:
                 raise
+
+    def _get_conn_config(self) -> Dict[str, Any]:
+        return {}
 
     def _conn_str(self) -> str:
         return self.database

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -2,7 +2,7 @@ import os
 import dataclasses
 import threading
 from pathvalidate import is_valid_filepath
-from typing import Any, ClassVar, Dict, Final, List, Optional, Tuple, Type, Union
+from typing import Any, ClassVar, Final, List, Optional, Tuple, Type, Union
 
 from dlt.common import logger
 from dlt.common.configuration import configspec

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -37,15 +37,11 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
         if not hasattr(self, "_conn_lock"):
             self._conn_lock = threading.Lock()
 
-        config = {}
-        if hasattr(self, "_conn_config"):
-            config = self._conn_config
-
         # obtain a lock because duck releases the GIL and we have refcount concurrency
         with self._conn_lock:
             if not hasattr(self, "_conn"):
                 self._conn = duckdb.connect(
-                    database=self._conn_str(), read_only=read_only, config=config
+                    database=self._conn_str(), read_only=read_only, config=self.conn_config
                 )
                 self._conn_owner = True
                 self._conn_borrows = 0
@@ -91,7 +87,7 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
 
     @property
     def conn_config(self) -> Dict[str, Any]:
-        return self._conn_config or {}
+        return getattr(self, "_conn_config", {})
 
     @conn_config.setter
     def conn_config(self, new_config: Dict[str, Any]) -> None:

--- a/dlt/destinations/impl/motherduck/configuration.py
+++ b/dlt/destinations/impl/motherduck/configuration.py
@@ -41,7 +41,7 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
         from duckdb import HTTPException, InvalidInputException
 
         if self.custom_user_agent and self.custom_user_agent != "":
-            self.conn_config = {"custom_user_agent": self.custom_user_agent}
+            self._conn_config = {"custom_user_agent": self.custom_user_agent}
 
         try:
             return super().borrow_conn(read_only)

--- a/dlt/destinations/impl/motherduck/configuration.py
+++ b/dlt/destinations/impl/motherduck/configuration.py
@@ -1,6 +1,5 @@
 import dataclasses
-import threading
-from typing import Any, ClassVar, Final, List
+from typing import Any, ClassVar, Final, List, Optional
 
 from dlt.version import __version__
 from dlt.common.configuration import configspec
@@ -23,7 +22,7 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
     username: str = "motherduck"
     password: TSecretValue = None
     database: str = "my_db"
-    custom_user_agent: str = MOTHERDUCK_USER_AGENT
+    custom_user_agent: Optional[str] = MOTHERDUCK_USER_AGENT
 
     read_only: bool = False  # open database read/write
 

--- a/dlt/destinations/impl/motherduck/configuration.py
+++ b/dlt/destinations/impl/motherduck/configuration.py
@@ -1,16 +1,18 @@
 import dataclasses
+import threading
 from typing import Any, ClassVar, Final, List
 
+from dlt.version import __version__
 from dlt.common.configuration import configspec
 from dlt.common.destination.reference import DestinationClientDwhWithStagingConfiguration
 from dlt.common.destination.exceptions import DestinationTerminalException
 from dlt.common.typing import TSecretValue
 from dlt.common.utils import digest128
-from dlt.common.configuration.exceptions import ConfigurationValueError
 
 from dlt.destinations.impl.duckdb.configuration import DuckDbBaseCredentials
 
 MOTHERDUCK_DRIVERNAME = "md"
+MOTHERDUCK_USER_AGENT = f"dltHub_dlt@{__version__}"
 
 
 @configspec(init=False)
@@ -19,6 +21,7 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
     username: str = "motherduck"
     password: TSecretValue = None
     database: str = "my_db"
+    custom_user_agent: str = MOTHERDUCK_USER_AGENT
 
     read_only: bool = False  # open database read/write
 
@@ -32,11 +35,38 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
         if self.query and "token" in self.query:
             self.password = TSecretValue(self.query.pop("token"))
 
+    def _connect(self, read_only: bool) -> Any:
+        # TODO: Can this be done in sql client instead?
+        import duckdb
+
+        if not hasattr(self, "_conn_lock"):
+            self._conn_lock = threading.Lock()
+
+        # obtain a lock because duck releases the GIL and we have refcount concurrency
+        with self._conn_lock:
+            config = {}
+            if self.custom_user_agent and self.custom_user_agent != "":
+                config = {"custom_user_agent": self.custom_user_agent}
+
+            if not hasattr(self, "_conn"):
+                self._conn = duckdb.connect(
+                    database=self._conn_str(),
+                    read_only=read_only,
+                    config=config,
+                )
+                self._conn_owner = True
+                self._conn_borrows = 0
+
+            # track open connections to properly close it
+            self._conn_borrows += 1
+            # print(f"getting conn refcnt {self._conn_borrows} at {id(self)}")
+            return self._conn.cursor()
+
     def borrow_conn(self, read_only: bool) -> Any:
         from duckdb import HTTPException, InvalidInputException
 
         try:
-            return super().borrow_conn(read_only)
+            return self._connect(read_only)
         except (InvalidInputException, HTTPException) as ext_ex:
             if "Failed to download extension" in str(ext_ex) and "motherduck" in str(ext_ex):
                 from importlib.metadata import version as pkg_version

--- a/dlt/destinations/impl/motherduck/configuration.py
+++ b/dlt/destinations/impl/motherduck/configuration.py
@@ -1,6 +1,6 @@
 import dataclasses
 import sys
-from typing import Any, ClassVar, Final, List, Optional
+from typing import Any, ClassVar, Dict, Final, List, Optional
 
 from dlt.version import __version__
 from dlt.common.configuration import configspec
@@ -40,14 +40,6 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
     def borrow_conn(self, read_only: bool) -> Any:
         from duckdb import HTTPException, InvalidInputException
 
-        # If it was explicitly set to None/null then we
-        # need to use the default value
-        if self.custom_user_agent is None:
-            self.custom_user_agent = MOTHERDUCK_USER_AGENT
-
-        if self.custom_user_agent and self.custom_user_agent != "":
-            self._conn_config = {"custom_user_agent": self.custom_user_agent}
-
         try:
             return super().borrow_conn(read_only)
         except (InvalidInputException, HTTPException) as ext_ex:
@@ -67,6 +59,18 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
         self._token_to_password()
         if not self.is_partial():
             self.resolve()
+
+    def _get_conn_config(self) -> Dict[str, Any]:
+        # If it was explicitly set to None/null then we
+        # need to use the default value
+        if self.custom_user_agent is None:
+            self.custom_user_agent = MOTHERDUCK_USER_AGENT
+
+        config = {}
+        if self.custom_user_agent and self.custom_user_agent != "":
+            config["custom_user_agent"] = self.custom_user_agent
+
+        return config
 
 
 @configspec

--- a/dlt/destinations/impl/motherduck/configuration.py
+++ b/dlt/destinations/impl/motherduck/configuration.py
@@ -40,6 +40,11 @@ class MotherDuckCredentials(DuckDbBaseCredentials):
     def borrow_conn(self, read_only: bool) -> Any:
         from duckdb import HTTPException, InvalidInputException
 
+        # If it was explicitly set to None/null then we
+        # need to use the default value
+        if self.custom_user_agent is None:
+            self.custom_user_agent = MOTHERDUCK_USER_AGENT
+
         if self.custom_user_agent and self.custom_user_agent != "":
             self._conn_config = {"custom_user_agent": self.custom_user_agent}
 

--- a/dlt/destinations/impl/motherduck/configuration.py
+++ b/dlt/destinations/impl/motherduck/configuration.py
@@ -1,4 +1,5 @@
 import dataclasses
+import sys
 from typing import Any, ClassVar, Final, List, Optional
 
 from dlt.version import __version__
@@ -11,7 +12,7 @@ from dlt.common.utils import digest128
 from dlt.destinations.impl.duckdb.configuration import DuckDbBaseCredentials
 
 MOTHERDUCK_DRIVERNAME = "md"
-MOTHERDUCK_USER_AGENT = f"dltHub_dlt@{__version__}"
+MOTHERDUCK_USER_AGENT = f"dlt/{__version__}({sys.platform})"
 
 
 @configspec(init=False)

--- a/docs/website/docs/dlt-ecosystem/destinations/motherduck.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/motherduck.md
@@ -98,5 +98,7 @@ Our observation is that if you write a lot of data into the database, then close
 ### Invalid Input Error: Initialization function "motherduck_init" from file
 Use `duckdb 0.8.1` or above.
 
+### Motherduck connection identifier
+We enable Motherduck to identify that the connection is created by `dlt`. Motherduck will use this identifier to better understand the usage patterns
+associated with `dlt` integration. The connection identifier is `dltHub_dlt@DLT_VERSION`.
 <!--@@@DLT_TUBA motherduck-->
-

--- a/docs/website/docs/dlt-ecosystem/destinations/motherduck.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/motherduck.md
@@ -100,5 +100,5 @@ Use `duckdb 0.8.1` or above.
 
 ### Motherduck connection identifier
 We enable Motherduck to identify that the connection is created by `dlt`. Motherduck will use this identifier to better understand the usage patterns
-associated with `dlt` integration. The connection identifier is `dltHub_dlt@DLT_VERSION`.
+associated with `dlt` integration. The connection identifier is `dltHub_dlt/DLT_VERSION(OS_NAME)`.
 <!--@@@DLT_TUBA motherduck-->

--- a/tests/load/duckdb/test_motherduck_client.py
+++ b/tests/load/duckdb/test_motherduck_client.py
@@ -77,3 +77,5 @@ def test_motherduck_connect_with_user_agent_string(
     assert "config" in connect_spy.call_args.kwargs
     if custom_user_agent:
         assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == custom_user_agent
+    else:
+        assert "custom_user_agent" not in connect_spy.call_args.kwargs["config"]

--- a/tests/load/duckdb/test_motherduck_client.py
+++ b/tests/load/duckdb/test_motherduck_client.py
@@ -1,10 +1,15 @@
 import os
+
+import duckdb
 import pytest
+
+from pytest_mock import MockerFixture
 
 from dlt.common.configuration.exceptions import ConfigFieldMissingException
 from dlt.common.configuration.resolve import resolve_configuration
 
 from dlt.destinations.impl.motherduck.configuration import (
+    MOTHERDUCK_USER_AGENT,
     MotherDuckCredentials,
     MotherDuckClientConfiguration,
 )
@@ -47,10 +52,11 @@ def test_motherduck_configuration() -> None:
     assert config.password == "tok"
 
 
-def test_motherduck_connect() -> None:
+def test_motherduck_connect(mocker: MockerFixture) -> None:
     # set HOME env otherwise some internal components in ducdkb (HTTPS) do not initialize
     os.environ["HOME"] = "/tmp"
 
+    connect_spy = mocker.spy(duckdb, "connect")
     config = resolve_configuration(
         MotherDuckClientConfiguration()._bind_dataset_name(dataset_name="test"),
         sections=("destination", "motherduck"),
@@ -59,3 +65,36 @@ def test_motherduck_connect() -> None:
     con = config.credentials.borrow_conn(read_only=False)
     con.sql("SHOW DATABASES")
     config.credentials.return_conn(con)
+
+    # check for the default user agent value
+    connect_spy.assert_called()
+    assert "config" in connect_spy.call_args.kwargs
+    assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == MOTHERDUCK_USER_AGENT
+
+
+def test_motherduck_connect_disable_user_agent_passing(mocker: MockerFixture) -> None:
+    # set HOME env otherwise some internal components in ducdkb (HTTPS) do not initialize
+    os.environ["HOME"] = "/tmp"
+
+    connect_spy = mocker.spy(duckdb, "connect")
+    config = resolve_configuration(
+        MotherDuckClientConfiguration()._bind_dataset_name(dataset_name="test"),
+        sections=("destination", "motherduck"),
+    )
+    config.credentials.custom_user_agent = ""
+    # connect
+    con = config.credentials.borrow_conn(read_only=False)
+    con.sql("SHOW DATABASES")
+    config.credentials.return_conn(con)
+
+    # check for the default user agent value
+    connect_spy.assert_called()
+    assert "config" in connect_spy.call_args.kwargs
+    assert "custom_user_agent" not in connect_spy.call_args.kwargs["config"]
+
+    # now try to assign a custom value and check
+    config.credentials.custom_user_agent = "patates"
+    con = config.credentials.borrow_conn(read_only=False)
+    config.credentials.return_conn(con)
+    connect_spy.assert_called()
+    assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == "patates"

--- a/tests/load/duckdb/test_motherduck_client.py
+++ b/tests/load/duckdb/test_motherduck_client.py
@@ -75,10 +75,12 @@ def test_motherduck_connect_with_user_agent_string(
     # check for the default user agent value
     connect_spy.assert_called()
     assert "config" in connect_spy.call_args.kwargs
-    # if it is not specified the we expect the default `MOTHERDUCK_USER_AGENT``
+    # If empty string "" was set then we should not include it
     if custom_user_agent == "":
         assert "custom_user_agent" not in connect_spy.call_args.kwargs["config"]
+    # if it is not specified the we expect the default `MOTHERDUCK_USER_AGENT``
     elif custom_user_agent is None:
         assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == MOTHERDUCK_USER_AGENT
+    # otherwise all other values should be present
     else:
         assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == custom_user_agent

--- a/tests/load/duckdb/test_motherduck_client.py
+++ b/tests/load/duckdb/test_motherduck_client.py
@@ -78,7 +78,7 @@ def test_motherduck_connect_with_user_agent_string(
     # If empty string "" was set then we should not include it
     if custom_user_agent == "":
         assert "custom_user_agent" not in connect_spy.call_args.kwargs["config"]
-    # if it is not specified the we expect the default `MOTHERDUCK_USER_AGENT``
+    # if it is not specified, we expect the default `MOTHERDUCK_USER_AGENT``
     elif custom_user_agent is None:
         assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == MOTHERDUCK_USER_AGENT
     # otherwise all other values should be present

--- a/tests/load/duckdb/test_motherduck_client.py
+++ b/tests/load/duckdb/test_motherduck_client.py
@@ -52,7 +52,7 @@ def test_motherduck_configuration() -> None:
     assert config.password == "tok"
 
 
-@pytest.mark.parametrize("custom_user_agent", [MOTHERDUCK_USER_AGENT, "patates", None])
+@pytest.mark.parametrize("custom_user_agent", [MOTHERDUCK_USER_AGENT, "patates", None, ""])
 def test_motherduck_connect_with_user_agent_string(
     custom_user_agent: Optional[str], mocker: MockerFixture
 ) -> None:
@@ -64,8 +64,8 @@ def test_motherduck_connect_with_user_agent_string(
         MotherDuckClientConfiguration()._bind_dataset_name(dataset_name="test"),
         sections=("destination", "motherduck"),
     )
-    if custom_user_agent:
-        config.credentials.custom_user_agent = custom_user_agent
+
+    config.credentials.custom_user_agent = custom_user_agent
 
     # connect
     con = config.credentials.borrow_conn(read_only=False)
@@ -75,7 +75,10 @@ def test_motherduck_connect_with_user_agent_string(
     # check for the default user agent value
     connect_spy.assert_called()
     assert "config" in connect_spy.call_args.kwargs
-    if custom_user_agent:
-        assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == custom_user_agent
-    else:
+    # if it is not specified the we expect the default `MOTHERDUCK_USER_AGENT``
+    if custom_user_agent == "":
         assert "custom_user_agent" not in connect_spy.call_args.kwargs["config"]
+    elif custom_user_agent is None:
+        assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == MOTHERDUCK_USER_AGENT
+    else:
+        assert connect_spy.call_args.kwargs["config"]["custom_user_agent"] == custom_user_agent


### PR DESCRIPTION
This PR implements passing of `custom_user_agent` property via [connection configuration](https://motherduck.com/docs/integrations/how-to-integrate#language--framework-examples) for motherduck and resolves https://github.com/dlt-hub/dlt/issues/1257 

MotherDuck's guidelines on naming the integration https://motherduck.com/docs/integrations/how-to-integrate#user-agent-guidelines

**User-agent guidelines**

* The format is integration/version(custom-metadata1;custom-metadata2) where the version and metadata sections are optional.
* Avoid using spaces in integration and version sections.
* Multiple custom metadata sections should be separated by semicolons.

**Some examples:**

- my-integration
- my-integration/2.9.0
- my-integration/2.9.0(linux_amd64)
- my-integration/2.9.0(linux_amd64;us-east-1)

**Suggestion**

I suggest to use `dlt/VERSION(OS_NAME)`

**Example from motherduck's docs**
```py
con = duckdb.connect("md:my_database", config={
    "motherduck_token": token,
    "custom_user_agent": "INTEGRATION_NAME"
})
```

**Configuration example**

```toml
[destination.motherduck.credentials]
custom_user_agent="some motherduck identifier"
```