### PR TITLE
make missing keys warning conditional on merge strategy

### DIFF
--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -353,13 +353,16 @@ class JobClientBase(ABC):
                         f'"{table["x-merge-strategy"]}" is not a valid merge strategy. '  # type: ignore[typeddict-item]
                         f"""Allowed values: {', '.join(['"' + s + '"' for s in MERGE_STRATEGIES])}."""
                     )
-                if not has_column_with_prop(table, "primary_key") and not has_column_with_prop(
-                    table, "merge_key"
+                if (
+                    table.get("x-merge-strategy") == "delete-insert"
+                    and not has_column_with_prop(table, "primary_key")
+                    and not has_column_with_prop(table, "merge_key")
                 ):
                     logger.warning(
-                        f"Table {table_name} has write_disposition set to merge, but no primary or"
-                        " merge keys defined. "
-                        + "dlt will fall back to append for this table."
+                        f"Table {table_name} has `write_disposition` set to `merge`"
+                        " and `merge_strategy` set to `delete-insert`, but no primary or"
+                        " merge keys defined."
+                        " dlt will fall back to `append` for this table."
                     )
             if has_column_with_prop(table, "hard_delete"):
                 if len(get_columns_names_with_prop(table, "hard_delete")) > 1:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
The missing keys warning message only applies to the `delete-insert` merge strategy, but was also shown when using the `scd2` strategy. Fixed by making the warning conditional on the strategy.

![image](https://github.com/dlt-hub/dlt/assets/47451109/b2dbbf36-9633-40b9-9946-ba4d10d87fe7)
link to chat: https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1714050325808869

