### PR TITLE
Add `upsert` merge strategy

### DIFF
--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -54,6 +54,7 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
     supports_multiple_statements: bool = True
     supports_clone_table: bool = False
     """Destination supports CREATE TABLE ... CLONE ... statements"""
+    supports_temp_table: bool = True
     max_table_nesting: Optional[int] = None  # destination can overwrite max table nesting
 
     # do not allow to create default value, destination caps must be always explicitly inserted into container
@@ -84,6 +85,7 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
         caps.supports_ddl_transactions = True
         caps.supports_transactions = True
         caps.supports_multiple_statements = True
+        caps.supports_temp_table = True
         return caps
 
 

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -553,9 +553,9 @@ class Schema:
             )
         ]
 
-    def data_table_names(self) -> List[str]:
+    def data_table_names(self, include_incomplete: bool = False) -> List[str]:
         """Returns list of table table names. Excludes dlt table names."""
-        return [t["name"] for t in self.data_tables()]
+        return [t["name"] for t in self.data_tables(include_incomplete=include_incomplete)]
 
     def dlt_tables(self) -> List[TTableSchema]:
         """Gets dlt tables"""

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -155,7 +155,7 @@ class NormalizerInfo(TypedDict, total=True):
 
 
 TWriteDisposition = Literal["skip", "append", "replace", "merge"]
-TLoaderMergeStrategy = Literal["delete-insert", "scd2"]
+TLoaderMergeStrategy = Literal["delete-insert", "scd2", "upsert"]
 
 
 WRITE_DISPOSITIONS: Set[TWriteDisposition] = set(get_args(TWriteDisposition))

--- a/dlt/destinations/impl/athena/__init__.py
+++ b/dlt/destinations/impl/athena/__init__.py
@@ -25,4 +25,5 @@ def capabilities() -> DestinationCapabilitiesContext:
     caps.schema_supports_numeric_precision = False
     caps.timestamp_precision = 3
     caps.supports_truncate_command = False
+    caps.supports_temp_table = False
     return caps

--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -415,7 +415,8 @@ class AthenaClient(SqlJobClientWithStaging, SupportsStagingDestination):
         return super()._create_replace_followup_jobs(table_chain)
 
     def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[NewLoadJob]:
-        # fall back to append jobs for merge
+        if table_chain[0]["x-merge-strategy"] == "upsert":  # type: ignore[typeddict-item]
+            return super()._create_merge_followup_jobs(table_chain)
         return self._create_append_followup_jobs(table_chain)
 
     def _is_iceberg_table(self, table: TTableSchema) -> bool:

--- a/dlt/destinations/sql_client.py
+++ b/dlt/destinations/sql_client.py
@@ -146,6 +146,12 @@ SELECT 1
             table_name = self.capabilities.escape_identifier(table_name)
         return f"{self.fully_qualified_dataset_name(escape=escape)}.{table_name}"
 
+    def get_qualified_table_names(self, table_name: str, escape: bool = True) -> Tuple[str, str]:
+        """Returns qualified names for table and corresponding staging table as tuple."""
+        with self.with_staging_dataset(staging=True):
+            staging_table_name = self.make_qualified_table_name(table_name, escape)
+        return self.make_qualified_table_name(table_name, escape), staging_table_name
+
     def escape_column_name(self, column_name: str, escape: bool = True) -> str:
         if escape:
             return self.capabilities.escape_identifier(column_name)

--- a/tests/load/pipeline/test_scd2.py
+++ b/tests/load/pipeline/test_scd2.py
@@ -22,6 +22,7 @@ from tests.load.pipeline.utils import (
     destinations_configs,
     DestinationTestConfiguration,
     load_tables_to_dicts,
+    assert_records_as_set,
 )
 from tests.utils import TPythonTableFormat
 
@@ -72,13 +73,6 @@ def get_table(
         ],
         key=lambda d: d[sort_column],
     )
-
-
-def assert_records_as_set(actual: List[Dict[str, Any]], expected: List[Dict[str, Any]]) -> None:
-    """Compares two lists of dicts regardless of order"""
-    actual_set = set(frozenset(dict_.items()) for dict_ in actual)
-    expected_set = set(frozenset(dict_.items()) for dict_ in expected)
-    assert actual_set == expected_set
 
 
 @pytest.mark.essential

--- a/tests/load/pipeline/test_upsert.py
+++ b/tests/load/pipeline/test_upsert.py
@@ -1,0 +1,178 @@
+import pytest
+
+import dlt
+
+from tests.pipeline.utils import assert_load_info, load_tables_to_dicts
+from tests.load.pipeline.utils import (
+    destinations_configs,
+    DestinationTestConfiguration,
+    load_table_counts,
+    assert_records_as_set,
+)
+
+
+@pytest.mark.parametrize(
+    "destination_config", destinations_configs(default_sql_configs=True), ids=lambda x: x.name
+)
+def test_upsert_core(destination_config: DestinationTestConfiguration) -> None:
+    def get_table(pipeline: dlt.Pipeline, table_name: str):
+        dicts = load_tables_to_dicts(pipeline, table_name)[table_name]
+        return [{k: v for k, v in d.items() if not k.startswith("_dlt")} for d in dicts]
+
+    p = destination_config.setup_pipeline("upsert", full_refresh=True)
+
+    @dlt.resource(
+        table_name="upsert",
+        write_disposition={"disposition": "merge", "strategy": "upsert"},
+        primary_key="id",
+    )
+    def r(data):
+        yield data
+
+    l1 = [  # initial load
+        {
+            "id": 1,
+            "foo": "foo",
+            "child1": [1, 2],
+            "child2": [{"grandchild1": 1, "grandchild2": [1, 2]}],
+            "nested": {"foo": 1},
+        },
+        {
+            "id": 2,
+            "foo": "bar",
+            "child1": [3],
+            "child2": [{"grandchild1": 2, "grandchild2": [3]}],
+            "nested": {"foo": 2},
+        },
+    ]
+    info = p.run(r(l1))
+    assert_load_info(info)
+    assert_records_as_set(
+        get_table(p, "upsert"),
+        [{"id": 1, "foo": "foo", "nested__foo": 1}, {"id": 2, "foo": "bar", "nested__foo": 2}],
+    )
+    assert_records_as_set(
+        get_table(p, "upsert__child1"), [{"value": 1}, {"value": 2}, {"value": 3}]
+    )
+    assert_records_as_set(get_table(p, "upsert__child2"), [{"grandchild1": 1}, {"grandchild1": 2}])
+    assert_records_as_set(
+        get_table(p, "upsert__child2__grandchild2"), [{"value": 1}, {"value": 2}, {"value": 3}]
+    )
+    assert load_table_counts(
+        p, "upsert", "upsert__child1", "upsert__child2", "upsert__child2__grandchild2"
+    ) == {"upsert": 2, "upsert__child1": 3, "upsert__child2": 2, "upsert__child2__grandchild2": 3}
+
+    l2 = [  # insert new primary key value
+        {
+            "id": 1,
+            "foo": "foo",
+            "child1": [1, 2],
+            "child2": [{"grandchild1": 1, "grandchild2": [1, 2]}],
+            "nested": {"foo": 1},
+        },
+        {
+            "id": 3,
+            "foo": "baz",
+            "child1": [4],
+            "child2": [{"grandchild1": 3, "grandchild2": [4]}],
+            "nested": {"foo": 3},
+        },
+    ]
+    info = p.run(r(l2))
+    assert_load_info(info)
+    assert_records_as_set(
+        get_table(p, "upsert"),
+        [
+            {"id": 1, "foo": "foo", "nested__foo": 1},
+            {"id": 2, "foo": "bar", "nested__foo": 2},
+            {"id": 3, "foo": "baz", "nested__foo": 3},
+        ],
+    )
+    assert_records_as_set(
+        get_table(p, "upsert__child1"), [{"value": 1}, {"value": 2}, {"value": 3}, {"value": 4}]
+    )
+    assert_records_as_set(
+        get_table(p, "upsert__child2"), [{"grandchild1": 1}, {"grandchild1": 2}, {"grandchild1": 3}]
+    )
+    assert_records_as_set(
+        get_table(p, "upsert__child2__grandchild2"),
+        [{"value": 1}, {"value": 2}, {"value": 3}, {"value": 4}],
+    )
+    assert load_table_counts(
+        p, "upsert", "upsert__child1", "upsert__child2", "upsert__child2__grandchild2"
+    ) == {"upsert": 3, "upsert__child1": 4, "upsert__child2": 3, "upsert__child2__grandchild2": 4}
+
+    l3 = [  # update existing record — change not in child table
+        {
+            "id": 3,
+            "foo": "baz_updated",  # column `foo` changed
+            "child1": [4],
+            "child2": [{"grandchild1": 3, "grandchild2": [4]}],
+            "nested": {"foo": 3},
+        }
+    ]
+    info = p.run(r(l3))
+    assert_load_info(info)
+    assert_records_as_set(
+        get_table(p, "upsert"),
+        [
+            {"id": 1, "foo": "foo", "nested__foo": 1},
+            {"id": 2, "foo": "bar", "nested__foo": 2},
+            {"id": 3, "foo": "baz_updated", "nested__foo": 3},  # column `foo` changed
+        ],
+    )
+    assert load_table_counts(
+        p, "upsert", "upsert__child1", "upsert__child2", "upsert__child2__grandchild2"
+    ) == {"upsert": 3, "upsert__child1": 4, "upsert__child2": 3, "upsert__child2__grandchild2": 4}
+
+    l4 = [  # update existing record — change in child table
+        {
+            "id": 3,
+            "foo": "baz_updated",
+            "child1": [4, 5],  # 5 added to list
+            "child2": [{"grandchild1": 3, "grandchild2": [4]}],
+            "nested": {"foo": 3},
+        }
+    ]
+    info = p.run(r(l4))
+    assert_load_info(info)
+    assert_records_as_set(
+        get_table(p, "upsert__child1"),
+        [{"value": 1}, {"value": 2}, {"value": 3}, {"value": 4}, {"value": 5}],  # new record for 5
+    )
+    assert load_table_counts(
+        p, "upsert", "upsert__child1", "upsert__child2", "upsert__child2__grandchild2"
+    ) == {"upsert": 3, "upsert__child1": 5, "upsert__child2": 3, "upsert__child2__grandchild2": 4}
+
+    l5 = [  # update existing record — change in child table
+        {
+            "id": 3,
+            "foo": "baz_updated",
+            "child1": [4],  # 5 removed from list
+            "child2": [{"grandchild1": 3, "grandchild2": [4]}],
+            "nested": {"foo": 3},
+        }
+    ]
+    info = p.run(r(l5))
+    assert_load_info(info)
+    assert_records_as_set(
+        get_table(p, "upsert"),
+        [
+            {"id": 1, "foo": "foo", "nested__foo": 1},
+            {"id": 2, "foo": "bar", "nested__foo": 2},
+            {"id": 3, "foo": "baz_updated", "nested__foo": 3},
+        ],
+    )
+    assert_records_as_set(
+        get_table(p, "upsert__child1"), [{"value": 1}, {"value": 2}, {"value": 3}, {"value": 4}]
+    )
+    assert_records_as_set(
+        get_table(p, "upsert__child2"), [{"grandchild1": 1}, {"grandchild1": 2}, {"grandchild1": 3}]
+    )
+    assert_records_as_set(
+        get_table(p, "upsert__child2__grandchild2"),
+        [{"value": 1}, {"value": 2}, {"value": 3}, {"value": 4}],  # 5 is no longer here
+    )
+    assert load_table_counts(
+        p, "upsert", "upsert__child1", "upsert__child2", "upsert__child2__grandchild2"
+    ) == {"upsert": 3, "upsert__child1": 4, "upsert__child2": 3, "upsert__child2__grandchild2": 4}

--- a/tests/load/pipeline/utils.py
+++ b/tests/load/pipeline/utils.py
@@ -158,3 +158,10 @@ def assert_query_data(
         # the second is load id
         if info:
             assert row[1] in info.loads_ids
+
+
+def assert_records_as_set(actual, expected) -> None:
+    """Compares two lists of dicts regardless of order"""
+    actual_set = set(frozenset(dict_.items()) for dict_ in actual)
+    expected_set = set(frozenset(dict_.items()) for dict_ in expected)
+    assert actual_set == expected_set


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This started as building `merge` support for Athena Iceberg, but the SQL logic runs on some other engines out-of-the-box too (e.g. `postgres`, `mssql`, `snowflake`, `databricks`, `bigquery`). It primarily uses the `MERGE INTO` statement to implement upsert (update + insert) logic. Since both `delete-insert` and `scd2` don't apply, I introduced a new merge strategy called `upsert`.

Characteristics:
- needs a `primary_key`
- uses hash of `primary_key` as deterministic row identifier (`_dlt_id`) in root table
- implements "true" upsert for root table (only updates and inserts), but still needs deletes for child tables (to delete records for elements which have been removed from an updated list)

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Closes #633 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
