### PR TITLE
Accept :memory: mode for credentials parameter in duckdb factory

### DIFF
--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -69,17 +69,9 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
             # check if database was passed as explicit connection
             import duckdb
 
-            # if in-memory mode has been requested
-            # then prepare duckdb connection so later
-            # it is configured appropriately
-            is_owner = False
-            if isinstance(native_value, str) and native_value == ":memory:":
-                native_value = duckdb.connect(native_value)
-                is_owner = True
-
             if isinstance(native_value, duckdb.DuckDBPyConnection):
                 self._conn = native_value
-                self._conn_owner = is_owner
+                self._conn_owner = False
                 self._conn_borrows = 0
                 self.database = ":external:"
                 self.__is_resolved__ = True

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -69,6 +69,12 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
             # check if database was passed as explicit connection
             import duckdb
 
+            # if in-memory mode has been requested
+            # then prepare duckdb connection so later
+            # it is configured appropriately
+            if native_value == ":memory:":
+                native_value = duckdb.connect(native_value)
+
             if isinstance(native_value, duckdb.DuckDBPyConnection):
                 self._conn = native_value
                 self._conn_owner = False

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -11,7 +11,7 @@ from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.configuration.specs.exceptions import InvalidConnectionString
 from dlt.common.destination.reference import DestinationClientDwhWithStagingConfiguration
 from dlt.common.typing import TSecretValue
-from dlt.destinations.impl.duckdb.exceptions import InvalidInMemoryDuckDbUsage
+from dlt.destinations.impl.duckdb.exceptions import InvalidInMemoryDuckdbCredentials
 
 try:
     from duckdb import DuckDBPyConnection
@@ -120,7 +120,7 @@ class DuckDbCredentials(DuckDbBaseCredentials):
 
     def on_resolved(self) -> None:
         if isinstance(self.database, str) and self.database == ":memory:":
-            raise InvalidInMemoryDuckDbUsage()
+            raise InvalidInMemoryDuckdbCredentials()
 
         # do not set any paths for external database
         if self.database == ":external:":

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -1,15 +1,17 @@
 import os
 import dataclasses
 import threading
-from pathvalidate import is_valid_filepath
+
 from typing import Any, ClassVar, Dict, Final, List, Optional, Tuple, Type, Union
 
+from pathvalidate import is_valid_filepath
 from dlt.common import logger
 from dlt.common.configuration import configspec
 from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.configuration.specs.exceptions import InvalidConnectionString
 from dlt.common.destination.reference import DestinationClientDwhWithStagingConfiguration
 from dlt.common.typing import TSecretValue
+from dlt.destinations.impl.duckdb.exceptions import InvalidInMemoryDuckDbUsage
 
 try:
     from duckdb import DuckDBPyConnection
@@ -117,6 +119,9 @@ class DuckDbCredentials(DuckDbBaseCredentials):
         return self.database == ":pipeline:"
 
     def on_resolved(self) -> None:
+        if isinstance(self.database, str) and self.database == ":memory:":
+            raise InvalidInMemoryDuckDbUsage()
+
         # do not set any paths for external database
         if self.database == ":external:":
             return

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -72,7 +72,7 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
             # if in-memory mode has been requested
             # then prepare duckdb connection so later
             # it is configured appropriately
-            if native_value == ":memory:":
+            if isinstance(native_value, str) and native_value == ":memory:":
                 native_value = duckdb.connect(native_value)
 
             if isinstance(native_value, duckdb.DuckDBPyConnection):

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -72,12 +72,14 @@ class DuckDbBaseCredentials(ConnectionStringCredentials):
             # if in-memory mode has been requested
             # then prepare duckdb connection so later
             # it is configured appropriately
+            is_owner = False
             if isinstance(native_value, str) and native_value == ":memory:":
                 native_value = duckdb.connect(native_value)
+                is_owner = True
 
             if isinstance(native_value, duckdb.DuckDBPyConnection):
                 self._conn = native_value
-                self._conn_owner = False
+                self._conn_owner = is_owner
                 self._conn_borrows = 0
                 self.database = ":external:"
                 self.__is_resolved__ = True

--- a/dlt/destinations/impl/duckdb/exceptions.py
+++ b/dlt/destinations/impl/duckdb/exceptions.py
@@ -1,7 +1,7 @@
 from dlt.common.destination.exceptions import DestinationTerminalException
 
 
-class InvalidInMemoryDuckDbUsage(DestinationTerminalException):
+class InvalidInMemoryDuckdbCredentials(DestinationTerminalException):
     def __init__(self) -> None:
         super().__init__(
             "To use in-memory instance of duckdb, "

--- a/dlt/destinations/impl/duckdb/exceptions.py
+++ b/dlt/destinations/impl/duckdb/exceptions.py
@@ -5,7 +5,7 @@ class InvalidInMemoryDuckDbUsage(DestinationTerminalException):
     def __init__(self) -> None:
         super().__init__(
             'You have specicied credentials=":memory:" this is incorrect.\n'
-            'Please create in memory instance of duckdb `conn = duckdb.connect(":memory:")`\n'
+            'Please create in memory instance of duckdb conn = duckdb.connect(":memory:")\n'
             "then pass it as via parameter via destination factory"
             'dlt.pipeline(pipeline_name="...", destination=dlt.destinations.duckdb(conn)'
         )

--- a/dlt/destinations/impl/duckdb/exceptions.py
+++ b/dlt/destinations/impl/duckdb/exceptions.py
@@ -1,0 +1,10 @@
+from dlt.common.destination.exceptions import DestinationTerminalException
+
+
+class InvalidInMemoryDuckDbUsage(DestinationTerminalException):
+    def __init__(self) -> None:
+        super().__init__(
+            'You have specicied credentials=":memory:" this is incorrect.\n'
+            "Please pass in memory instance of duckdb connection\n"
+            'credentials=dlt.destinations.duckdb(":memory:")`'
+        )

--- a/dlt/destinations/impl/duckdb/exceptions.py
+++ b/dlt/destinations/impl/duckdb/exceptions.py
@@ -4,8 +4,8 @@ from dlt.common.destination.exceptions import DestinationTerminalException
 class InvalidInMemoryDuckDbUsage(DestinationTerminalException):
     def __init__(self) -> None:
         super().__init__(
-            'You have specicied credentials=":memory:" this is incorrect.\n'
-            'Please create in-memory instance of duckdb conn = duckdb.connect(":memory:")\n'
-            "then pass it as via parameter via destination factory"
+            "To use in-memory instance of duckdb, "
+            "please instantiate it first and then pass to destination factory\n"
+            '\nconn = duckdb.connect(":memory:")\n'
             'dlt.pipeline(pipeline_name="...", destination=dlt.destinations.duckdb(conn)'
         )

--- a/dlt/destinations/impl/duckdb/exceptions.py
+++ b/dlt/destinations/impl/duckdb/exceptions.py
@@ -5,6 +5,7 @@ class InvalidInMemoryDuckDbUsage(DestinationTerminalException):
     def __init__(self) -> None:
         super().__init__(
             'You have specicied credentials=":memory:" this is incorrect.\n'
-            "Please pass in memory instance of duckdb connection\n"
-            'credentials=dlt.destinations.duckdb(":memory:")`'
+            'Please create in memory instance of duckdb `conn = duckdb.connect(":memory:")`\n'
+            "then pass it as via parameter via destination factory"
+            'dlt.pipeline(pipeline_name="...", destination=dlt.destinations.duckdb(conn)'
         )

--- a/dlt/destinations/impl/duckdb/exceptions.py
+++ b/dlt/destinations/impl/duckdb/exceptions.py
@@ -5,7 +5,7 @@ class InvalidInMemoryDuckDbUsage(DestinationTerminalException):
     def __init__(self) -> None:
         super().__init__(
             'You have specicied credentials=":memory:" this is incorrect.\n'
-            'Please create in memory instance of duckdb conn = duckdb.connect(":memory:")\n'
+            'Please create in-memory instance of duckdb conn = duckdb.connect(":memory:")\n'
             "then pass it as via parameter via destination factory"
             'dlt.pipeline(pipeline_name="...", destination=dlt.destinations.duckdb(conn)'
         )

--- a/dlt/destinations/impl/duckdb/factory.py
+++ b/dlt/destinations/impl/duckdb/factory.py
@@ -3,7 +3,6 @@ import typing as t
 from dlt.common.destination import Destination, DestinationCapabilitiesContext
 from dlt.destinations.impl.duckdb.configuration import DuckDbCredentials, DuckDbClientConfiguration
 from dlt.destinations.impl.duckdb import capabilities
-from dlt.destinations.impl.duckdb.exceptions import InvalidInMemoryDuckDbUsage
 
 if t.TYPE_CHECKING:
     from duckdb import DuckDBPyConnection
@@ -38,14 +37,11 @@ class duckdb(Destination[DuckDbClientConfiguration, "DuckDbClient"]):
 
         Args:
             credentials: Credentials to connect to the duckdb database. Can be an instance of `DuckDbCredentials` or
-                a path to a database file. Use `:memory:` to create an in-memory database or :pipeline: to create a duckdb
+                a path to a database file. Use :pipeline: to create a duckdb
                 in the working folder of the pipeline
             create_indexes: Should unique indexes be created, defaults to False
             **kwargs: Additional arguments passed to the destination config
         """
-        if isinstance(credentials, str) and credentials == ":memory:":
-            raise InvalidInMemoryDuckDbUsage()
-
         super().__init__(
             credentials=credentials,
             create_indexes=create_indexes,

--- a/dlt/destinations/impl/duckdb/factory.py
+++ b/dlt/destinations/impl/duckdb/factory.py
@@ -3,6 +3,7 @@ import typing as t
 from dlt.common.destination import Destination, DestinationCapabilitiesContext
 from dlt.destinations.impl.duckdb.configuration import DuckDbCredentials, DuckDbClientConfiguration
 from dlt.destinations.impl.duckdb import capabilities
+from dlt.destinations.impl.duckdb.exceptions import InvalidInMemoryDuckDbUsage
 
 if t.TYPE_CHECKING:
     from duckdb import DuckDBPyConnection
@@ -42,6 +43,9 @@ class duckdb(Destination[DuckDbClientConfiguration, "DuckDbClient"]):
             create_indexes: Should unique indexes be created, defaults to False
             **kwargs: Additional arguments passed to the destination config
         """
+        if isinstance(credentials, str) and credentials == ":memory:":
+            raise InvalidInMemoryDuckDbUsage()
+
         super().__init__(
             credentials=credentials,
             create_indexes=create_indexes,

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -138,7 +138,7 @@ print(db.sql("DESCRIBE;"))
 ```
 
 :::note
-Be careful! The in-memory instance of the database will be destroyed, once your Python script is finished.
+Be careful! The in-memory instance of the database will be destroyed, once your Python script exits.
 :::
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -153,6 +153,22 @@ The **duckdb://** URL above creates a **relative** path to `_storage/test_quack.
 Dlt supports a unique connection string that triggers specific behavior for duckdb destination:
 * **:pipeline:** creates the database in the working directory of the pipeline, naming it `quack.duckdb`.
 
+Please see the code snippets below to showing how to use it
+
+1. Via `config.toml`
+```toml
+destination.duckdb.credentials=":pipeline:"
+```
+
+2. In Python code
+```py
+p = pipeline_one = dlt.pipeline(
+  pipeline_name="my_pipeline",
+  destination="duckdb",
+  credentials=":pipeline:",
+)
+```
+
 ### Additional configuration
 Unique indexes may be created during loading if the following config value is set:
 ```toml

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -136,7 +136,7 @@ print(db.sql("DESCRIBE;"))
 # └──────────┴───────────────┴─────────────────────┴──────────────────────┴───────────────────────┴───────────┘
 ```
 
-Once pipeline exits the in-memory instance of database will be destroyed.
+Once you python script exits the in-memory instance of database will be destroyed.
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -120,9 +120,7 @@ from dlt.common.destination.reference import Destination
 
 p = pipeline_one = dlt.pipeline(
   pipeline_name="in_memory_pipeline",
-  destination=Destination.from_reference(
-      "duckdb", credentials=duckdb.connect(":memory:")
-  ),
+  destination=dlt.destinations.duckdb(duckdb.connect(":memory:")),
   dataset_name="chess_data",
 )
 ```

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -117,7 +117,7 @@ p = dlt.pipeline(
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 
-Dlt supports unique connection strings that trigger specific behaviors:
+Dlt supports unique connection strings that trigger specific behaviors for duckdb destination:
 
 * **:pipeline:** creates the database in the working directory of the pipeline with the name `quack.duckdb`.
 * **:memory:** creates an in-memory database. This may be useful for testing.

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -116,13 +116,29 @@ p = dlt.pipeline(
 )
 
 # Or if you would like to use in-memory duckdb instance
-from dlt.common.destination.reference import Destination
-
+db = duckdb.connect(":memory:")
 p = pipeline_one = dlt.pipeline(
   pipeline_name="in_memory_pipeline",
-  destination=dlt.destinations.duckdb(duckdb.connect(":memory:")),
+  destination=dlt.destinations.duckdb(db),
   dataset_name="chess_data",
 )
+```
+
+Once pipeline exits in-memory database will be lost and upon the next run you will have an empty database again
+check out by running the following query
+
+```py
+db = duckdb.connect(":memory:")
+df = db.sql("SELECT * FROM pg_tables").df()
+print(df)
+```
+
+Empty duckdb database
+
+```
+Empty DataFrame
+Columns: [schemaname, tablename, tableowner, tablespace, hasindexes, hasrules, hastriggers]
+Index: []
 ```
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
@@ -130,7 +146,6 @@ This destination accepts database connection strings in the format used by [duck
 Dlt supports unique connection strings that trigger specific behaviors for duckdb destination:
 
 * **:pipeline:** creates the database in the working directory of the pipeline with the name `quack.duckdb`.
-* **:memory:** creates an in-memory database (this may be useful for testing).
 
 
 You can configure a DuckDB destination with [secret / config values](../../general-usage/credentials) (e.g., using a `secrets.toml` file)

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -128,7 +128,7 @@ This destination accepts database connection strings in the format used by [duck
 Dlt supports unique connection strings that trigger specific behaviors for duckdb destination:
 
 * **:pipeline:** creates the database in the working directory of the pipeline with the name `quack.duckdb`.
-* **:memory:** creates an in-memory database. This may be useful for testing.
+* **:memory:** creates an in-memory database (this may be useful for testing).
 
 
 You can configure a DuckDB destination with [secret / config values](../../general-usage/credentials) (e.g., using a `secrets.toml` file)

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -106,6 +106,7 @@ The destination accepts a `duckdb` connection instance via `credentials`, so you
 
 ```py
 import duckdb
+
 db = duckdb.connect()
 p = dlt.pipeline(
   pipeline_name="chess",
@@ -115,10 +116,11 @@ p = dlt.pipeline(
 )
 
 # Or if you would like to use in-memory duckdb instance
-db = duckdb.connect(":memory:")
+from dlt.common.destination.reference import Destination
+
 p = pipeline_one = dlt.pipeline(
   pipeline_name="in_memory_pipeline",
-  destination=dlt.destinations.duckdb(db),
+  destination=Destination.from_reference("duckdb", credentials=duckdb.connect(":memory:")),
   dataset_name="chess_data",
 )
 ```

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -143,11 +143,6 @@ Be careful! The in-memory instance of the database will be destroyed, once your 
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 
-Dlt supports a unique connection string that triggers specific behavior for duckdb destination:
-
-* **:pipeline:** creates the database in the working directory of the pipeline, naming it `quack.duckdb`.
-
-
 You can configure a DuckDB destination with [secret / config values](../../general-usage/credentials) (e.g., using a `secrets.toml` file)
 ```toml
 destination.duckdb.credentials="duckdb:///_storage/test_quack.duckdb"
@@ -155,6 +150,8 @@ destination.duckdb.credentials="duckdb:///_storage/test_quack.duckdb"
 
 The **duckdb://** URL above creates a **relative** path to `_storage/test_quack.duckdb`. To define an **absolute** path, you need to specify four slashes, i.e., `duckdb:////_storage/test_quack.duckdb`.
 
+Dlt supports a unique connection string that triggers specific behavior for duckdb destination:
+* **:pipeline:** creates the database in the working directory of the pipeline, naming it `quack.duckdb`.
 
 ### Additional configuration
 Unique indexes may be created during loading if the following config value is set:

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -137,7 +137,9 @@ print(db.sql("DESCRIBE;"))
 # └──────────┴───────────────┴─────────────────────┴──────────────────────┴───────────────────────┴───────────┘
 ```
 
-Once your python script exits the in-memory instance of database will be destroyed.
+:::note
+Be careful! The in-memory instance of the database will be destroyed, once your Python script is finished.
+:::
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -136,7 +136,7 @@ print(db.sql("DESCRIBE;"))
 # └──────────┴───────────────┴─────────────────────┴──────────────────────┴───────────────────────┴───────────┘
 ```
 
-Once you python script exits the in-memory instance of database will be destroyed.
+Once your python script exits the in-memory instance of database will be destroyed.
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -125,6 +125,7 @@ p = pipeline_one = dlt.pipeline(
 
 print(db.sql("DESCRIBE;"))
 
+# Example output
 # ┌──────────┬───────────────┬─────────────────────┬──────────────────────┬───────────────────────┬───────────┐
 # │ database │    schema     │        name         │     column_names     │     column_types      │ temporary │
 # │ varchar  │    varchar    │       varchar       │      varchar[]       │       varchar[]       │  boolean  │
@@ -140,9 +141,9 @@ Once your python script exits the in-memory instance of database will be destroy
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 
-Dlt supports a unique connection string that trigger specific behavior for duckdb destination:
+Dlt supports a unique connection string that triggers specific behavior for duckdb destination:
 
-* **:pipeline:** creates the database in the working directory of the pipeline with the name `quack.duckdb`.
+* **:pipeline:** creates the database in the working directory of the pipeline, naming it `quack.duckdb`.
 
 
 You can configure a DuckDB destination with [secret / config values](../../general-usage/credentials) (e.g., using a `secrets.toml` file)

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -108,10 +108,18 @@ The destination accepts a `duckdb` connection instance via `credentials`, so you
 import duckdb
 db = duckdb.connect()
 p = dlt.pipeline(
-  pipeline_name='chess',
+  pipeline_name="chess",
   destination=dlt.destinations.duckdb(db),
-  dataset_name='chess_data',
+  dataset_name="chess_data",
   full_refresh=False,
+)
+
+# Or if you would like to use in-memory duckdb instance
+db = duckdb.connect(":memory:")
+p = pipeline_one = dlt.pipeline(
+  pipeline_name="in_memory_pipeline",
+  destination=dlt.destinations.duckdb(db),
+  dataset_name="chess_data",
 )
 ```
 
@@ -122,25 +130,6 @@ Dlt supports unique connection strings that trigger specific behaviors for duckd
 * **:pipeline:** creates the database in the working directory of the pipeline with the name `quack.duckdb`.
 * **:memory:** creates an in-memory database. This may be useful for testing.
 
-Below you can see usage examples these special cases
-
-```py
-# in-memory duckdb instance :memory:
-pipeline_one = dlt.pipeline(
-  pipeline_name="in_memory_pipeline",
-  destination=dlt.destinations.duckdb(":memory:"),
-  dataset_name='chess_data',
-)
-
-# create duckdb database file in pipelne's directory :pipeline:
-# will create a database named pipeline_xyz.duckdb
-pipeline_one = dlt.pipeline(
-  pipeline_name="pipeline_xyz",
-  destination="duckdb",
-  credentials=":pipeline:",
-  dataset_name='chess_data',
-)
-```
 
 You can configure a DuckDB destination with [secret / config values](../../general-usage/credentials) (e.g., using a `secrets.toml` file)
 ```toml

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -122,24 +122,21 @@ p = pipeline_one = dlt.pipeline(
   destination=dlt.destinations.duckdb(db),
   dataset_name="chess_data",
 )
+
+print(db.sql("DESCRIBE;"))
+
+# ┌──────────┬───────────────┬─────────────────────┬──────────────────────┬───────────────────────┬───────────┐
+# │ database │    schema     │        name         │     column_names     │     column_types      │ temporary │
+# │ varchar  │    varchar    │       varchar       │      varchar[]       │       varchar[]       │  boolean  │
+# ├──────────┼───────────────┼─────────────────────┼──────────────────────┼───────────────────────┼───────────┤
+# │ memory   │ chess_data    │ _dlt_loads          │ [load_id, schema_n…  │ [VARCHAR, VARCHAR, …  │ false     │
+# │ memory   │ chess_data    │ _dlt_pipeline_state │ [version, engine_v…  │ [BIGINT, BIGINT, VA…  │ false     │
+# │ memory   │ chess_data    │ _dlt_version        │ [version, engine_v…  │ [BIGINT, BIGINT, TI…  │ false     │
+# │ memory   │ chess_data    │ my_table            │ [a, _dlt_load_id, …  │ [BIGINT, VARCHAR, V…  │ false     │
+# └──────────┴───────────────┴─────────────────────┴──────────────────────┴───────────────────────┴───────────┘
 ```
 
-Once pipeline exits in-memory database will be lost and upon the next run you will have an empty database again
-check out by running the following query
-
-```py
-db = duckdb.connect(":memory:")
-df = db.sql("SELECT * FROM pg_tables").df()
-print(df)
-```
-
-Empty duckdb database
-
-```
-Empty DataFrame
-Columns: [schemaname, tablename, tableowner, tablespace, hasindexes, hasrules, hastriggers]
-Index: []
-```
+Once pipeline exits the in-memory instance of database will be destroyed.
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -120,7 +120,9 @@ from dlt.common.destination.reference import Destination
 
 p = pipeline_one = dlt.pipeline(
   pipeline_name="in_memory_pipeline",
-  destination=Destination.from_reference("duckdb", credentials=duckdb.connect(":memory:")),
+  destination=Destination.from_reference(
+      "duckdb", credentials=duckdb.connect(":memory:")
+  ),
   dataset_name="chess_data",
 )
 ```

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -153,7 +153,7 @@ The **duckdb://** URL above creates a **relative** path to `_storage/test_quack.
 Dlt supports a unique connection string that triggers specific behavior for duckdb destination:
 * **:pipeline:** creates the database in the working directory of the pipeline, naming it `quack.duckdb`.
 
-Please see the code snippets below to showing how to use it
+Please see the code snippets below showing how to use it
 
 1. Via `config.toml`
 ```toml

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -102,7 +102,8 @@ p = dlt.pipeline(
 )
 ```
 
-The destination accepts a `duckdb` connection instance via `credentials`, so you can also open a database connection yourself and pass it to `dlt` to use. `:memory:` databases are supported.
+The destination accepts a `duckdb` connection instance via `credentials`, so you can also open a database connection yourself and pass it to `dlt` to use.
+
 ```py
 import duckdb
 db = duckdb.connect()
@@ -116,15 +117,37 @@ p = dlt.pipeline(
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 
+Dlt supports unique connection strings that trigger specific behaviors:
+
+* **:pipeline:** creates the database in the working directory of the pipeline with the name `quack.duckdb`.
+* **:memory:** creates an in-memory database. This may be useful for testing.
+
+Below you can see usage examples these special cases
+
+```py
+# in-memory duckdb instance :memory:
+pipeline_one = dlt.pipeline(
+  pipeline_name="in_memory_pipeline",
+  destination=dlt.destinations.duckdb(":memory:"),
+  dataset_name='chess_data',
+)
+
+# create duckdb database file in pipelne's directory :pipeline:
+# will create a database named pipeline_xyz.duckdb
+pipeline_one = dlt.pipeline(
+  pipeline_name="pipeline_xyz",
+  destination="duckdb",
+  credentials=":pipeline:",
+  dataset_name='chess_data',
+)
+```
+
 You can configure a DuckDB destination with [secret / config values](../../general-usage/credentials) (e.g., using a `secrets.toml` file)
 ```toml
 destination.duckdb.credentials="duckdb:///_storage/test_quack.duckdb"
 ```
-The **duckdb://** URL above creates a **relative** path to `_storage/test_quack.duckdb`. To define an **absolute** path, you need to specify four slashes, i.e., `duckdb:////_storage/test_quack.duckdb`.
 
-A few special connection strings are supported:
-* **:pipeline:** creates the database in the working directory of the pipeline with the name `quack.duckdb`.
-* **:memory:** creates an in-memory database. This may be useful for testing.
+The **duckdb://** URL above creates a **relative** path to `_storage/test_quack.duckdb`. To define an **absolute** path, you need to specify four slashes, i.e., `duckdb:////_storage/test_quack.duckdb`.
 
 
 ### Additional configuration

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -143,7 +143,7 @@ Index: []
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).
 
-Dlt supports unique connection strings that trigger specific behaviors for duckdb destination:
+Dlt supports a unique connection string that trigger specific behavior for duckdb destination:
 
 * **:pipeline:** creates the database in the working directory of the pipeline with the name `quack.duckdb`.
 

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -86,7 +86,7 @@ def test_duckdb_in_memory_mode_via_factory():
         with pytest.raises(PipelineStepFailed) as exc:
             p = dlt.pipeline(
                 pipeline_name="booboo",
-                destination=Destination.from_reference("duckdb", credentials=":memory:"),
+                destination=Destination.from_reference("duckdb", credentials=":memory:"),  # type: ignore[arg-type]
             )
             p.run([1, 2, 3], table_name="numbers")
 

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -258,18 +258,6 @@ def test_external_duckdb_database() -> None:
     assert not os.path.exists(":memory:")
 
 
-def test_in_memory_duckdb_database() -> None:
-    # pass explicit in memory database
-    c = resolve_configuration(
-        DuckDbClientConfiguration(credentials=":memory:")._bind_dataset_name(dataset_name="test_dataset")
-    )
-    conn = c.credentials.borrow_conn(read_only=False)
-    assert c.credentials._conn_borrows == 1
-    assert c.credentials._conn_owner
-    conn.close()
-    assert not os.path.exists(":memory:")
-
-
 def test_default_duckdb_dataset_name() -> None:
     # Check if dataset_name does not collide with pipeline_name
     data = ["a", "b", "c"]

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -6,6 +6,7 @@ import dlt
 from dlt.common.configuration.resolve import resolve_configuration
 from dlt.common.configuration.utils import get_resolved_traces
 
+from dlt.common.destination.reference import Destination
 from dlt.destinations.impl.duckdb.configuration import (
     DuckDbClientConfiguration,
     DEFAULT_DUCK_DB_NAME,
@@ -79,6 +80,15 @@ def test_duckdb_in_memory_mode_via_factory():
                 destination="duckdb",
             )
             p.run([1, 2, 3])
+
+        assert isinstance(exc.value.exception, InvalidInMemoryDuckdbCredentials)
+
+        with pytest.raises(PipelineStepFailed) as exc:
+            p = dlt.pipeline(
+                pipeline_name="booboo",
+                destination=Destination.from_reference("duckdb", credentials=":memory:"),
+            )
+            p.run([1, 2, 3], table_name="numbers")
 
         assert isinstance(exc.value.exception, InvalidInMemoryDuckdbCredentials)
     finally:

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -259,16 +259,13 @@ def test_external_duckdb_database() -> None:
 
 
 def test_in_memory_duckdb_database() -> None:
-    import duckdb
-
     # pass explicit in memory database
-    conn = duckdb.connect(":memory:")
     c = resolve_configuration(
-        DuckDbClientConfiguration(credentials=conn)._bind_dataset_name(dataset_name="test_dataset")
+        DuckDbClientConfiguration(credentials=":memory:")._bind_dataset_name(dataset_name="test_dataset")
     )
-    c.credentials.borrow_conn(read_only=False)
+    conn = c.credentials.borrow_conn(read_only=False)
     assert c.credentials._conn_borrows == 1
-    assert c.credentials._conn_owner is False
+    assert c.credentials._conn_owner
     conn.close()
     assert not os.path.exists(":memory:")
 

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -12,7 +12,7 @@ from dlt.destinations.impl.duckdb.configuration import (
 )
 from dlt.destinations import duckdb
 
-from dlt.destinations.impl.duckdb.exceptions import InvalidInMemoryDuckDbUsage
+from dlt.destinations.impl.duckdb.exceptions import InvalidInMemoryDuckdbCredentials
 from dlt.pipeline.exceptions import PipelineStepFailed
 from tests.load.pipeline.utils import drop_pipeline
 from tests.pipeline.utils import assert_table
@@ -70,7 +70,7 @@ def test_duckdb_in_memory_mode_via_factory():
             p = dlt.pipeline(pipeline_name="booboo", destination="duckdb", credentials=":memory:")
             p.run([1, 2, 3])
 
-        assert isinstance(exc.value.exception, InvalidInMemoryDuckDbUsage)
+        assert isinstance(exc.value.exception, InvalidInMemoryDuckdbCredentials)
 
         os.environ["DESTINATION__DUCKDB__CREDENTIALS"] = ":memory:"
         with pytest.raises(PipelineStepFailed):
@@ -80,7 +80,7 @@ def test_duckdb_in_memory_mode_via_factory():
             )
             p.run([1, 2, 3])
 
-        assert isinstance(exc.value.exception, InvalidInMemoryDuckDbUsage)
+        assert isinstance(exc.value.exception, InvalidInMemoryDuckdbCredentials)
     finally:
         delete_quack_db()
 

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -7,9 +7,7 @@ from dlt.common.configuration.resolve import resolve_configuration
 from dlt.common.configuration.utils import get_resolved_traces
 
 from dlt.destinations.impl.duckdb.configuration import (
-    DUCK_DB_NAME,
     DuckDbClientConfiguration,
-    DuckDbCredentials,
     DEFAULT_DUCK_DB_NAME,
 )
 from dlt.destinations import duckdb
@@ -257,6 +255,7 @@ def test_external_duckdb_database() -> None:
     assert c.credentials._conn_owner is False
     assert hasattr(c.credentials, "_conn")
     conn.close()
+    assert not os.path.exists(":memory:")
 
 
 def test_default_duckdb_dataset_name() -> None:

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -57,7 +57,7 @@ def test_duckdb_open_conn_default() -> None:
         delete_quack_db()
 
 
-def test_duckdb_in_memory_mode_via_factory():
+def test_duckdb_in_memory_mode_via_factory(preserve_environ):
     delete_quack_db()
     try:
         import duckdb

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -258,6 +258,19 @@ def test_external_duckdb_database() -> None:
     assert not os.path.exists(":memory:")
 
 
+def test_in_memory_duckdb_database() -> None:
+    import duckdb
+
+    # pass explicit in memory database
+    conn = duckdb.connect(":memory:")
+    c = resolve_configuration(DuckDbClientConfiguration(credentials=conn))
+    c.credentials.borrow_conn(read_only=False)
+    assert c.credentials._conn_borrows == 1
+    assert c.credentials._conn_owner is False
+    conn.close()
+    assert not os.path.exists(":memory:")
+
+
 def test_default_duckdb_dataset_name() -> None:
     # Check if dataset_name does not collide with pipeline_name
     data = ["a", "b", "c"]

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -263,7 +263,9 @@ def test_in_memory_duckdb_database() -> None:
 
     # pass explicit in memory database
     conn = duckdb.connect(":memory:")
-    c = resolve_configuration(DuckDbClientConfiguration(credentials=conn))
+    c = resolve_configuration(
+        DuckDbClientConfiguration(credentials=conn)._bind_dataset_name(dataset_name="test_dataset")
+    )
     c.credentials.borrow_conn(read_only=False)
     assert c.credentials._conn_borrows == 1
     assert c.credentials._conn_owner is False


### PR DESCRIPTION
This PR addresses https://github.com/dlt-hub/dlt/issues/1216 and allows `duckdb(:memory:)` request

## TODO
* [x] Tests