### PR TITLE
explains how to pass explicit credentials + few mssql cases

### DIFF
--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -83,20 +83,35 @@ to disable tz adjustments.
 
 By default, a DuckDB database will be created in the current working directory with a name `<pipeline_name>.duckdb` (`chess.duckdb` in the example above). After loading, it is available in `read/write` mode via `with pipeline.sql_client() as con:`, which is a wrapper over `DuckDBPyConnection`. See [duckdb docs](https://duckdb.org/docs/api/python/overview#persistent-storage) for details.
 
-The `duckdb` credentials do not require any secret values. You are free to pass the configuration explicitly via the `credentials` parameter to `dlt.pipeline` or `pipeline.run` methods. For example:
+The `duckdb` credentials do not require any secret values. [You are free to pass the credentials and configuration explicitly](../../general-usage/destination.md#pass-explicit-credentials). For example:
 ```py
-# will load data to files/data.db database file
-p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='chess_data', full_refresh=False, credentials="files/data.db")
+# will load data to files/data.db (relative path) database file
+p = dlt.pipeline(
+  pipeline_name='chess',
+  destination=dlt.destinations.duckdb("files/data.db"),
+  dataset_name='chess_data',
+  full_refresh=False
+)
 
-# will load data to /var/local/database.duckdb
-p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='chess_data', full_refresh=False, credentials="/var/local/database.duckdb")
+# will load data to /var/local/database.duckdb (absolute path)
+p = dlt.pipeline(
+  pipeline_name='chess',
+  destination=dlt.destinations.duckdb("/var/local/database.duckdb"),
+  dataset_name='chess_data',
+  full_refresh=False
+)
 ```
 
 The destination accepts a `duckdb` connection instance via `credentials`, so you can also open a database connection yourself and pass it to `dlt` to use. `:memory:` databases are supported.
 ```py
 import duckdb
 db = duckdb.connect()
-p = dlt.pipeline(pipeline_name='chess', destination='duckdb', dataset_name='chess_data', full_refresh=False, credentials=db)
+p = dlt.pipeline(
+  pipeline_name='chess',
+  destination=dlt.destinations.duckdb(db),
+  dataset_name='chess_data',
+  full_refresh=False,
+)
 ```
 
 This destination accepts database connection strings in the format used by [duckdb-engine](https://github.com/Mause/duckdb_engine#configuration).

--- a/docs/website/docs/dlt-ecosystem/destinations/mssql.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/mssql.md
@@ -53,24 +53,51 @@ password = "<password>"
 host = "loader.database.windows.net"
 port = 1433
 connect_timeout = 15
+[destination.mssql.credentials.query]
+# trust self signed SSL certificates
+TrustServerCertificate="yes"
+# require SSL connection
+Encrypt="yes"
+# send large string as VARCHAR, not legacy TEXT
+LongAsMax="yes"
 ```
 
 You can also pass a SQLAlchemy-like database connection:
 ```toml
 # keep it at the top of your toml file! before any section starts
-destination.mssql.credentials="mssql://loader:<password>@loader.database.windows.net/dlt_data?connect_timeout=15"
+destination.mssql.credentials="mssql://loader:<password>@loader.database.windows.net/dlt_data?TrustServerCertificate=yes&Encrypt=yes&LongAsMax=yes"
 ```
 
-To connect to an `mssql` server using Windows authentication, include `trusted_connection=yes` in the connection string. This method is useful when SQL logins aren't available, and you use Windows credentials.
+You can place any ODBC-specific settings into the query string or **destination.mssql.credentials.query** TOML table as in the example above.
+
+**To connect to an `mssql` server using Windows authentication**, include `trusted_connection=yes` in the connection string. This method is useful when SQL logins aren't available, and you use Windows credentials.
 
 ```toml
 destination.mssql.credentials="mssql://username:password@loader.database.windows.net/dlt_data?trusted_connection=yes"
 ```
 > The username and password must be filled out with the appropriate login credentials or left untouched. Leaving these empty is not recommended.
 
-To pass credentials directly, you can use the `credentials` argument passed to `dlt.pipeline` or `pipeline.run` methods.
+**To connect to a local sql server instance running without SSL** pass `encrypt=no` parameter:
+```toml
+destination.mssql.credentials="mssql://loader:loader@localhost/dlt_data?encrypt=no"
+```
+
+**To allow self signed SSL certificate** when you are getting `certificate verify failed:unable to get local issuer certificate`:
+```toml
+destination.mssql.credentials="mssql://loader:loader@localhost/dlt_data?TrustServerCertificate=yes"
+```
+
+***To use long strings (>8k) and avoid collation errors**:
+```toml
+destination.mssql.credentials="mssql://loader:loader@localhost/dlt_data?LongAsMax=yes"
+```
+
+**To pass credentials directly**, use the [explicit instance of the destination](../../general-usage/destination.md#pass-explicit-credentials)
 ```py
-pipeline = dlt.pipeline(pipeline_name='chess', destination='postgres', dataset_name='chess_data', credentials="mssql://loader:<password>@loader.database.windows.net/dlt_data?connect_timeout=15")
+pipeline = dlt.pipeline(
+  pipeline_name='chess',
+  destination=dlt.destinations.mssql("mssql://loader:<password>@loader.database.windows.net/dlt_data?connect_timeout=15"),
+  dataset_name='chess_data')
 ```
 
 ## Write disposition

--- a/docs/website/docs/dlt-ecosystem/destinations/postgres.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/postgres.md
@@ -65,9 +65,13 @@ You can also pass a database connection string similar to the one used by the `p
 destination.postgres.credentials="postgresql://loader:<password>@localhost/dlt_data?connect_timeout=15"
 ```
 
-To pass credentials directly, you can use the `credentials` argument passed to the `dlt.pipeline` or `pipeline.run` methods.
+To pass credentials directly, use the [explicit instance of the destination](../../general-usage/destination.md#pass-explicit-credentials)
 ```py
-pipeline = dlt.pipeline(pipeline_name='chess', destination='postgres', dataset_name='chess_data', credentials="postgresql://loader:<password>@localhost/dlt_data")
+pipeline = dlt.pipeline(
+  pipeline_name='chess',
+  destination=dlt.destinations.postgres("postgresql://loader:<password>@localhost/dlt_data"),
+  dataset_name='chess_data'
+)
 ```
 
 ## Write disposition

--- a/docs/website/docs/dlt-ecosystem/destinations/synapse.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/synapse.md
@@ -120,7 +120,7 @@ Once you have the connection URL, you can directly use it in your pipeline confi
 pipeline = dlt.pipeline(
     pipeline_name='chess',
     destination=dlt.destinations.synapse(
-        credentials=connection_url.render_as_string(hide_password=True)
+        credentials=connection_url.render_as_string(hide_password=False)
     ),
     dataset_name='chess_data'
 )


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Updates docs for `mssql` destination.
Removes reference to deprecated **credentials** argument in `duckdb` and `postgres`
