### PR TITLE
Do not show a notice if there is no resource state for schema

### DIFF
--- a/dlt/helpers/streamlit_app/blocks/resource_state.py
+++ b/dlt/helpers/streamlit_app/blocks/resource_state.py
@@ -24,9 +24,7 @@ def resource_state_info(
     sources_state = pipeline.state.get("sources") or {}
     schema = sources_state.get(schema_name, {})
     resource = schema.get("resources", {}).get(resource_name)
-    with st.expander("Resource state", expanded=(resource is None)):
-        if not resource:
-            st.info(f"{resource_name} is missing resource state")
-        else:
+    if resource:
+        with st.expander("Resource state", expanded=False):
             spec = yaml.safe_dump(resource)
             st.code(spec, language="yaml")

--- a/dlt/helpers/streamlit_app/blocks/resource_state.py
+++ b/dlt/helpers/streamlit_app/blocks/resource_state.py
@@ -24,7 +24,9 @@ def resource_state_info(
     sources_state = pipeline.state.get("sources") or {}
     schema = sources_state.get(schema_name, {})
     resource = schema.get("resources", {}).get(resource_name)
-    if resource:
-        with st.expander("Resource state", expanded=False):
-            spec = yaml.safe_dump(resource)
-            st.code(spec, language="yaml")
+    if not resource:
+        return
+
+    with st.expander("Resource state", expanded=False):
+        spec = yaml.safe_dump(resource)
+        st.code(spec, language="yaml")


### PR DESCRIPTION
This PR adjusts the UI in streamlit app to not show notice message if there is no resource state for the given schema.
Related to: https://github.com/dlt-hub/dlt/issues/1264