### PR TITLE
allows fsspec until 2023.1.0

### DIFF
--- a/tests/common/storages/test_local_filesystem.py
+++ b/tests/common/storages/test_local_filesystem.py
@@ -223,7 +223,7 @@ def test_filesystem_decompress() -> None:
         with file_dict.open(mode="tr") as f:
             lines = f.readlines()
             assert len(lines) > 1
-            assert lines[0].startswith('"1200864931","2015-07-01 00:00:13"')  # type: ignore
+            assert lines[0].startswith('"1200864931","2015-07-01 00:00:13"')
         # read as uncompressed binary
         with file_dict.open(compression="enable") as f:
             assert f.read().startswith(b'"1200864931","2015-07-01 00:00:13"')

--- a/tests/common/storages/utils.py
+++ b/tests/common/storages/utils.py
@@ -113,7 +113,7 @@ def assert_sample_files(
 
                 # fieldnames below are not really correct but allow to load first 3 columns
                 # even if first row does not have header names
-                elements = list(DictReader(f, fieldnames=["A", "B", "C"]))  # type: ignore
+                elements = list(DictReader(f, fieldnames=["A", "B", "C"]))
                 assert len(elements) > 0
         if item["mime_type"] == "application/parquet":
             # verify it is a real parquet


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
We were using "local" to recognize local filesystem. it works from 2023.10.0. Now we use "file"