### PR TITLE
RESTClient: add paginator initialization

### DIFF
--- a/dlt/sources/helpers/rest_client/client.py
+++ b/dlt/sources/helpers/rest_client/client.py
@@ -204,6 +204,9 @@ class RESTClient:
             path=path, method=method, params=params, json=json, auth=auth, hooks=hooks
         )
 
+        if paginator:
+            paginator.init_request(request)
+
         while True:
             try:
                 response = self._send_request(request)

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -25,7 +25,7 @@ class BasePaginator(ABC):
         """
         return self._has_next_page
 
-    def init_request(self, request: Request) -> None:
+    def init_request(self, request: Request) -> None:  # noqa: B027, optional override
         """Initializes the request object with parameters for the first
         pagination request.
 

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -25,6 +25,18 @@ class BasePaginator(ABC):
         """
         return self._has_next_page
 
+    def init_request(self, request: Request) -> None:
+        """Initializes the request object with parameters for the first
+        pagination request.
+
+        This method can be overridden by subclasses to include specific
+        initialization logic.
+
+        Args:
+            request (Request): The request object to be initialized.
+        """
+        pass
+
     @abstractmethod
     def update_state(self, response: Response) -> None:
         """Updates the paginator's state based on the response from the API.
@@ -130,6 +142,14 @@ class OffsetPaginator(BasePaginator):
 
         self.offset = initial_offset
         self.limit = initial_limit
+
+    def init_request(self, request: Request) -> None:
+        """Initializes the request with the offset and limit query parameters."""
+        if request.params is None:
+            request.params = {}
+
+        request.params[self.offset_param] = self.offset
+        request.params[self.limit_param] = self.limit
 
     def update_state(self, response: Response) -> None:
         """Extracts the total count from the response and updates the offset."""

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -202,3 +202,26 @@ class TestOffsetPaginator:
         response = Mock(Response, json=lambda: {})
         with pytest.raises(ValueError):
             paginator.update_state(response)
+
+    def test_init_request(self):
+        paginator = OffsetPaginator(initial_offset=123, initial_limit=42)
+        request = Mock(Request)
+        request.params = {}
+
+        paginator.init_request(request)
+
+        assert request.params['offset'] == 123
+        assert request.params['limit'] == 42
+
+        response = Mock(Response, json=lambda: {"total": 200})
+
+        paginator.update_state(response)
+
+        # Test for the next request
+        next_request = Mock(spec=Request)
+        next_request.params = {}
+
+        paginator.update_request(next_request)
+
+        assert next_request.params['offset'] == 165
+        assert next_request.params['limit'] == 42

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -210,8 +210,8 @@ class TestOffsetPaginator:
 
         paginator.init_request(request)
 
-        assert request.params['offset'] == 123
-        assert request.params['limit'] == 42
+        assert request.params["offset"] == 123
+        assert request.params["limit"] == 42
 
         response = Mock(Response, json=lambda: {"total": 200})
 
@@ -223,5 +223,5 @@ class TestOffsetPaginator:
 
         paginator.update_request(next_request)
 
-        assert next_request.params['offset'] == 165
-        assert next_request.params['limit'] == 42
+        assert next_request.params["offset"] == 165
+        assert next_request.params["limit"] == 42


### PR DESCRIPTION
This PR adds a new method `BasePaginator.init_request()` which is called in `RESTClient.paginate()` before sending it for the first time.

Implements #1295