### PR TITLE
Streamlit caching and session state store fixes

### DIFF
--- a/dlt/helpers/streamlit_app/blocks/show_data.py
+++ b/dlt/helpers/streamlit_app/blocks/show_data.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import dlt
 import streamlit as st
 

--- a/dlt/helpers/streamlit_app/blocks/table_hints.py
+++ b/dlt/helpers/streamlit_app/blocks/table_hints.py
@@ -10,9 +10,9 @@ from dlt.helpers.streamlit_app.blocks.show_data import show_data_button
 
 
 def list_table_hints(pipeline: dlt.Pipeline, tables: List[TTableSchema]) -> None:
-    current_schema = st.session_state["schema"] or pipeline.default_schema
-    if st.session_state["schema"]:
-        current_schema = st.session_state["schema"]
+    current_schema = pipeline.default_schema
+    if st.session_state["schema_name"]:
+        current_schema = pipeline.schemas[st.session_state["schema_name"]]
 
     for table in tables:
         table_hints: List[str] = []

--- a/dlt/helpers/streamlit_app/blocks/table_hints.py
+++ b/dlt/helpers/streamlit_app/blocks/table_hints.py
@@ -11,8 +11,8 @@ from dlt.helpers.streamlit_app.blocks.show_data import show_data_button
 
 def list_table_hints(pipeline: dlt.Pipeline, tables: List[TTableSchema]) -> None:
     current_schema = pipeline.default_schema
-    if st.session_state["schema_name"]:
-        current_schema = pipeline.schemas[st.session_state["schema_name"]]
+    if schema_name := st.session_state.get("schema_name"):
+        current_schema = pipeline.schemas[schema_name]
 
     for table in tables:
         table_hints: List[str] = []

--- a/dlt/helpers/streamlit_app/pages/dashboard.py
+++ b/dlt/helpers/streamlit_app/pages/dashboard.py
@@ -29,7 +29,8 @@ def write_data_explorer_page(
 
     st.subheader("Schemas and tables", divider="rainbow")
     schema_picker(pipeline)
-    if schema := st.session_state["schema"]:
+    if schema_name := st.session_state.get("schema_name"):
+        schema = pipeline.schemas.get(schema_name)
         tables = sorted(
             schema.data_tables(),
             key=lambda table: table["name"],

--- a/dlt/helpers/streamlit_app/utils.py
+++ b/dlt/helpers/streamlit_app/utils.py
@@ -61,7 +61,7 @@ def query_data(
     schema_name: str = None,
     chunk_size: Optional[int] = None,
 ) -> pd.DataFrame:
-    query_maker = query_using_cache(pipeline, ttl=600)
+    query_maker = query_using_cache(pipeline, ttl=60)
     return query_maker(query, schema_name, chunk_size=chunk_size)
 
 

--- a/dlt/helpers/streamlit_app/widgets/schema.py
+++ b/dlt/helpers/streamlit_app/widgets/schema.py
@@ -16,6 +16,6 @@ def schema_picker(pipeline: dlt.Pipeline) -> None:
         )
         schema = pipeline.schemas.get(selected_schema_name)
 
-    st.session_state["schema"] = schema
     if schema:
+        st.session_state["schema_name"] = schema.name
         st.subheader(f"Schema: {schema.name}")


### PR DESCRIPTION
This PR does the following things

1. Lowers the TTL for query result cache to 1 minute (old was 5 minutes),
2. Avoids storing schema in streamlit's session state store.

Issue: https://github.com/dlt-hub/dlt/issues/1264