### PR TITLE
Fix the order of checks for in-memory duckdb option

### DIFF
--- a/dlt/common/configuration/providers/airflow.py
+++ b/dlt/common/configuration/providers/airflow.py
@@ -15,7 +15,7 @@ class AirflowSecretsTomlProvider(VaultTomlProvider):
     def _look_vault(self, full_key: str, hint: type) -> str:
         """Get Airflow Variable with given `full_key`, return None if not found"""
         from airflow.models import Variable
-
+        return
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
             return Variable.get(full_key, default_var=None)  # type: ignore
 

--- a/dlt/common/configuration/providers/airflow.py
+++ b/dlt/common/configuration/providers/airflow.py
@@ -15,7 +15,7 @@ class AirflowSecretsTomlProvider(VaultTomlProvider):
     def _look_vault(self, full_key: str, hint: type) -> str:
         """Get Airflow Variable with given `full_key`, return None if not found"""
         from airflow.models import Variable
-        return
+
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
             return Variable.get(full_key, default_var=None)  # type: ignore
 

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -136,7 +136,7 @@ class DuckDbCredentials(DuckDbBaseCredentials):
                 self.database = maybe_database
 
         # We need to check it here because the default `native_value` for duckdb is :memory:
-        # because if we do this check at the very beginning we will fail the default usecase
+        # thus if we do this check at the very beginning we will fail the default usecase
         # when users just specify destination="duckdb" thus it is undesired behavior.
         if isinstance(self.database, str) and self.database == ":memory:":
             raise InvalidInMemoryDuckdbCredentials()

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -119,9 +119,6 @@ class DuckDbCredentials(DuckDbBaseCredentials):
         return self.database == ":pipeline:"
 
     def on_resolved(self) -> None:
-        if isinstance(self.database, str) and self.database == ":memory:":
-            raise InvalidInMemoryDuckdbCredentials()
-
         # do not set any paths for external database
         if self.database == ":external:":
             return
@@ -137,6 +134,9 @@ class DuckDbCredentials(DuckDbBaseCredentials):
                 # create database locally
                 is_default_path = maybe_is_default_path
                 self.database = maybe_database
+
+        if isinstance(self.database, str) and self.database == ":memory:":
+            raise InvalidInMemoryDuckdbCredentials()
 
         # always make database an abs path
         self.database = os.path.abspath(self.database)

--- a/dlt/destinations/impl/duckdb/configuration.py
+++ b/dlt/destinations/impl/duckdb/configuration.py
@@ -135,6 +135,9 @@ class DuckDbCredentials(DuckDbBaseCredentials):
                 is_default_path = maybe_is_default_path
                 self.database = maybe_database
 
+        # We need to check it here because the default `native_value` for duckdb is :memory:
+        # because if we do this check at the very beginning we will fail the default usecase
+        # when users just specify destination="duckdb" thus it is undesired behavior.
         if isinstance(self.database, str) and self.database == ":memory:":
             raise InvalidInMemoryDuckdbCredentials()
 

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -64,7 +64,11 @@ def test_duckdb_in_memory_mode_via_factory(preserve_environ):
 
         # Check if passing external duckdb connection works fine
         db = duckdb.connect(":memory:")
-        dlt.pipeline(pipeline_name="booboo", destination=dlt.destinations.duckdb(db))
+        p = dlt.pipeline(pipeline_name="booboo", destination=dlt.destinations.duckdb(db))
+        p.run()
+
+        p = dlt.pipeline(pipeline_name="normal-pipeline-with-duckdb", destination="duckdb")
+        p.run()
 
         # Check if passing :memory: to factory fails
         with pytest.raises(PipelineStepFailed) as exc:


### PR DESCRIPTION
This PR fixes a regression to https://github.com/dlt-hub/dlt/pull/1297 where we have been checking prematurely for if `database == :memory:` and in real life the default native value for duckdb is `:memory:` which might lead to failures for use cases with default pipeline with ducks like

```py
p = dlt.pipeline(
    pipeline_name="normal-pipeline-with-duckdb",
    destination="duckdb"
)
```