### PR TITLE
improves trackers thread pool

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -104,7 +104,7 @@ jobs:
         if: runner.os != 'Windows'
         name: Run pipeline smoke tests with minimum deps Linux/MAC
       - run: |
-          poetry run pytest tests/pipeline/test_pipeline.py tests/pipeline/test_import_export_schema.py
+          poetry run pytest tests/pipeline/test_pipeline.py tests/pipeline/test_import_export_schema.py -m "not forked"
         if: runner.os == 'Windows'
         name: Run smoke tests with minimum deps Windows
         shell: cmd
@@ -117,7 +117,7 @@ jobs:
         if: runner.os != 'Windows'
         name: Run pipeline tests with pyarrow but no pandas installed
       - run: |
-          poetry run pytest tests/pipeline/test_pipeline_extra.py -k arrow
+          poetry run pytest tests/pipeline/test_pipeline_extra.py -k arrow  -m "not forked"
         if: runner.os == 'Windows'
         name: Run pipeline tests with pyarrow but no pandas installed Windows
         shell: cmd
@@ -130,7 +130,7 @@ jobs:
         if: runner.os != 'Windows'
         name: Run extract and pipeline tests Linux/MAC
       - run: |
-          poetry run pytest tests/extract tests/pipeline tests/libs tests/cli/common tests/destinations
+          poetry run pytest tests/extract tests/pipeline tests/libs tests/cli/common tests/destinations  -m "not forked"
         if: runner.os == 'Windows'
         name: Run extract tests Windows
         shell: cmd

--- a/dlt/common/managed_thread_pool.py
+++ b/dlt/common/managed_thread_pool.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import atexit
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -15,8 +14,6 @@ class ManagedThreadPool:
         self._thread_pool = ThreadPoolExecutor(
             self._max_workers, thread_name_prefix=self.thread_name_prefix
         )
-        # flush pool on exit
-        atexit.register(self.stop)
 
     @property
     def thread_pool(self) -> ThreadPoolExecutor:
@@ -28,4 +25,3 @@ class ManagedThreadPool:
         if self._thread_pool:
             self._thread_pool.shutdown(wait=wait)
             self._thread_pool = None
-            atexit.unregister(self.stop)

--- a/dlt/common/managed_thread_pool.py
+++ b/dlt/common/managed_thread_pool.py
@@ -5,13 +5,16 @@ from concurrent.futures import ThreadPoolExecutor
 
 
 class ManagedThreadPool:
-    def __init__(self, max_workers: int = 1) -> None:
+    def __init__(self, thread_name_prefix: str, max_workers: int = 1) -> None:
+        self.thread_name_prefix = thread_name_prefix
         self._max_workers = max_workers
         self._thread_pool: Optional[ThreadPoolExecutor] = None
 
     def _create_thread_pool(self) -> None:
         assert not self._thread_pool, "Thread pool already created"
-        self._thread_pool = ThreadPoolExecutor(self._max_workers)
+        self._thread_pool = ThreadPoolExecutor(
+            self._max_workers, thread_name_prefix=self.thread_name_prefix
+        )
         # flush pool on exit
         atexit.register(self.stop)
 
@@ -25,3 +28,4 @@ class ManagedThreadPool:
         if self._thread_pool:
             self._thread_pool.shutdown(wait=wait)
             self._thread_pool = None
+            atexit.unregister(self.stop)

--- a/dlt/common/runtime/anon_tracker.py
+++ b/dlt/common/runtime/anon_tracker.py
@@ -2,20 +2,18 @@
 
 # several code fragments come from https://github.com/RasaHQ/rasa/blob/main/rasa/telemetry.py
 import os
-
-import atexit
 import base64
 from typing import Literal, Optional
-from dlt.common.configuration.paths import get_dlt_data_dir
+from requests import Session
 
 from dlt.common import logger
 from dlt.common.managed_thread_pool import ManagedThreadPool
 from dlt.common.configuration.specs import RunConfiguration
+from dlt.common.configuration.paths import get_dlt_data_dir
 from dlt.common.runtime.exec_info import get_execution_context, TExecutionContext
 from dlt.common.typing import DictStrAny, StrAny
 from dlt.common.utils import uniq_id
 
-from dlt.sources.helpers import requests
 from dlt.version import __version__
 
 TEventCategory = Literal["pipeline", "command", "helper"]
@@ -25,6 +23,7 @@ _WRITE_KEY: str = None
 _REQUEST_TIMEOUT = (1.0, 1.0)  # short connect & send timeouts
 _ANON_TRACKER_ENDPOINT: str = None
 _TRACKER_CONTEXT: TExecutionContext = None
+requests: Session = None
 
 
 def init_anon_tracker(config: RunConfiguration) -> None:
@@ -36,6 +35,12 @@ def init_anon_tracker(config: RunConfiguration) -> None:
             config.dlthub_telemetry_segment_write_key
         ), "dlthub_telemetry_segment_write_key not present in RunConfiguration"
 
+    # lazily import requests to avoid binding config before initialization
+    global requests
+    from dlt.sources.helpers import requests as r_
+
+    requests = r_  # type: ignore[assignment]
+
     global _WRITE_KEY, _ANON_TRACKER_ENDPOINT, _THREAD_POOL
     # start the pool
     # create thread pool to send telemetry to anonymous tracker
@@ -44,8 +49,6 @@ def init_anon_tracker(config: RunConfiguration) -> None:
         # do not instantiate lazy: this happens in _future_send which may be triggered
         # from a thread and also in parallel when many pipelines are run at once
         _THREAD_POOL._create_thread_pool()
-        # flush pool on exit
-        atexit.register(_at_exit_cleanup)
     # store write key if present
     if config.dlthub_telemetry_segment_write_key:
         key_bytes = (config.dlthub_telemetry_segment_write_key + ":").encode("ascii")
@@ -57,8 +60,13 @@ def init_anon_tracker(config: RunConfiguration) -> None:
 
 
 def disable_anon_tracker() -> None:
-    _at_exit_cleanup()
-    atexit.unregister(_at_exit_cleanup)
+    global _WRITE_KEY, _TRACKER_CONTEXT, _ANON_TRACKER_ENDPOINT, _THREAD_POOL
+    if _THREAD_POOL is not None:
+        _THREAD_POOL.stop(True)
+    _ANON_TRACKER_ENDPOINT = None
+    _WRITE_KEY = None
+    _TRACKER_CONTEXT = None
+    _THREAD_POOL = None
 
 
 def track(event_category: TEventCategory, event_name: str, properties: DictStrAny) -> None:
@@ -86,16 +94,6 @@ def track(event_category: TEventCategory, event_name: str, properties: DictStrAn
 def before_send(event: DictStrAny) -> Optional[DictStrAny]:
     """Called before sending event. Does nothing, patch this function in the module for custom behavior"""
     return event
-
-
-def _at_exit_cleanup() -> None:
-    global _WRITE_KEY, _TRACKER_CONTEXT, _ANON_TRACKER_ENDPOINT, _THREAD_POOL
-    if _THREAD_POOL is not None:
-        _THREAD_POOL.stop(True)
-    _ANON_TRACKER_ENDPOINT = None
-    _WRITE_KEY = None
-    _TRACKER_CONTEXT = None
-    _THREAD_POOL = None
 
 
 def _tracker_request_header(write_key: str) -> StrAny:

--- a/dlt/common/runtime/anon_tracker.py
+++ b/dlt/common/runtime/anon_tracker.py
@@ -5,7 +5,6 @@ import os
 
 import atexit
 import base64
-import requests
 from typing import Literal, Optional
 from dlt.common.configuration.paths import get_dlt_data_dir
 
@@ -15,12 +14,13 @@ from dlt.common.configuration.specs import RunConfiguration
 from dlt.common.runtime.exec_info import get_execution_context, TExecutionContext
 from dlt.common.typing import DictStrAny, StrAny
 from dlt.common.utils import uniq_id
+
+from dlt.sources.helpers import requests
 from dlt.version import __version__
 
 TEventCategory = Literal["pipeline", "command", "helper"]
 
-_THREAD_POOL: ManagedThreadPool = ManagedThreadPool(1)
-_SESSION: requests.Session = None
+_THREAD_POOL: ManagedThreadPool = None
 _WRITE_KEY: str = None
 _REQUEST_TIMEOUT = (1.0, 1.0)  # short connect & send timeouts
 _ANON_TRACKER_ENDPOINT: str = None
@@ -36,10 +36,14 @@ def init_anon_tracker(config: RunConfiguration) -> None:
             config.dlthub_telemetry_segment_write_key
         ), "dlthub_telemetry_segment_write_key not present in RunConfiguration"
 
-    global _WRITE_KEY, _SESSION, _ANON_TRACKER_ENDPOINT
+    global _WRITE_KEY, _ANON_TRACKER_ENDPOINT, _THREAD_POOL
+    # start the pool
     # create thread pool to send telemetry to anonymous tracker
-    if not _SESSION:
-        _SESSION = requests.Session()
+    if _THREAD_POOL is None:
+        _THREAD_POOL = ManagedThreadPool("anon_tracker", 1)
+        # do not instantiate lazy: this happens in _future_send which may be triggered
+        # from a thread and also in parallel when many pipelines are run at once
+        _THREAD_POOL._create_thread_pool()
         # flush pool on exit
         atexit.register(_at_exit_cleanup)
     # store write key if present
@@ -85,14 +89,13 @@ def before_send(event: DictStrAny) -> Optional[DictStrAny]:
 
 
 def _at_exit_cleanup() -> None:
-    global _SESSION, _WRITE_KEY, _TRACKER_CONTEXT, _ANON_TRACKER_ENDPOINT
-    if _SESSION:
+    global _WRITE_KEY, _TRACKER_CONTEXT, _ANON_TRACKER_ENDPOINT, _THREAD_POOL
+    if _THREAD_POOL is not None:
         _THREAD_POOL.stop(True)
-        _SESSION.close()
-        _SESSION = None
     _ANON_TRACKER_ENDPOINT = None
     _WRITE_KEY = None
     _TRACKER_CONTEXT = None
+    _THREAD_POOL = None
 
 
 def _tracker_request_header(write_key: str) -> StrAny:
@@ -188,7 +191,7 @@ def _send_event(event_name: str, properties: StrAny, context: StrAny) -> None:
     def _future_send() -> None:
         # import time
         # start_ts = time.time_ns()
-        resp = _SESSION.post(
+        resp = requests.post(
             _ANON_TRACKER_ENDPOINT, headers=headers, json=payload, timeout=_REQUEST_TIMEOUT
         )
         # end_ts = time.time_ns()

--- a/dlt/common/runtime/telemetry.py
+++ b/dlt/common/runtime/telemetry.py
@@ -12,6 +12,7 @@ from dlt.common.runtime.anon_tracker import (
     disable_anon_tracker,
     track,
 )
+from dlt.pipeline.platform import disable_platform_tracker, init_platform_tracker
 
 _TELEMETRY_STARTED = False
 
@@ -32,6 +33,9 @@ def start_telemetry(config: RunConfiguration) -> None:
     if config.dlthub_telemetry:
         init_anon_tracker(config)
 
+    if config.dlthub_dsn:
+        init_platform_tracker()
+
     _TELEMETRY_STARTED = True
 
 
@@ -48,6 +52,7 @@ def stop_telemetry() -> None:
         pass
 
     disable_anon_tracker()
+    disable_platform_tracker()
 
     _TELEMETRY_STARTED = False
 

--- a/dlt/common/runtime/telemetry.py
+++ b/dlt/common/runtime/telemetry.py
@@ -1,3 +1,4 @@
+import atexit
 import time
 import contextlib
 import inspect
@@ -39,6 +40,7 @@ def start_telemetry(config: RunConfiguration) -> None:
     _TELEMETRY_STARTED = True
 
 
+@atexit.register
 def stop_telemetry() -> None:
     global _TELEMETRY_STARTED
     if not _TELEMETRY_STARTED:

--- a/tests/pipeline/test_platform_connection.py
+++ b/tests/pipeline/test_platform_connection.py
@@ -1,16 +1,20 @@
-import dlt
 import os
-import time
+import pytest
 import requests_mock
+
+import dlt
+
+from tests.utils import start_test_telemetry, stop_telemetry
 
 TRACE_URL_SUFFIX = "/trace"
 STATE_URL_SUFFIX = "/state"
 
 
+@pytest.mark.forked
 def test_platform_connection() -> None:
     mock_platform_url = "http://platform.com/endpoint"
-
     os.environ["RUNTIME__DLTHUB_DSN"] = mock_platform_url
+    start_test_telemetry()
 
     trace_url = mock_platform_url + TRACE_URL_SUFFIX
     state_url = mock_platform_url + STATE_URL_SUFFIX
@@ -42,11 +46,13 @@ def test_platform_connection() -> None:
         m.put(mock_platform_url, json={}, status_code=200)
         p.run([my_source(), my_source_2()])
 
-        # sleep a bit and find trace in mock requests
-        time.sleep(2)
+        # this will flush all telemetry queues
+        stop_telemetry()
 
         trace_result = None
         state_result = None
+
+        # mock tracks all calls
         for call in m.request_history:
             if call.url == trace_url:
                 assert not trace_result, "Multiple calls to trace endpoint"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Tracker pools were lazily instantiated. In case of many pipelines running at the same time this could cause problems.
1. all tracker pools are instantiated when telemetry starts
2. tracker pools have mandatory prefixes
3. they unregister at_exit when stopped
