### PR TITLE
RESTClient: fix docstrings in paginators

### DIFF
--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -205,7 +205,8 @@ class PageNumberPaginator(RangePaginator):
         client = RESTClient(
             base_url="https://api.example.com",
             paginator=PageNumberPaginator(
-                maximum_page=5
+                maximum_page=5,
+                total_path=None
             )
         )
         ...
@@ -285,7 +286,8 @@ class OffsetPaginator(RangePaginator):
             base_url="https://api.example.com",
             paginator=OffsetPaginator(
                 limit=100,
-                maximum_offset=1000
+                maximum_offset=1000,
+                total_path=None
             )
         )
         ...


### PR DESCRIPTION
This PR updates docstrings of PageNumberPaginator and OffsetPaginator to show how to use them when `total` count of items is not available. For this case the users needs to explicitly turn off `total_path` parameter.