### PR TITLE
Catch MissingDependencyException in telemetry and check for sentry_sdk

### DIFF
--- a/dlt/common/runtime/sentry.py
+++ b/dlt/common/runtime/sentry.py
@@ -8,6 +8,7 @@ try:
     from sentry_sdk.transport import HttpTransport
     from sentry_sdk.integrations.logging import LoggingIntegration
 except ModuleNotFoundError:
+    sentry_sdk = None
     raise MissingDependencyException(
         "sentry telemetry",
         ["sentry-sdk"],
@@ -53,7 +54,8 @@ def init_sentry(config: RunConfiguration) -> None:
 
 def disable_sentry() -> None:
     # init without parameters disables sentry
-    sentry_sdk.init()
+    if sentry_sdk:
+        sentry_sdk.init()
 
 
 def before_send(event: DictStrAny, _unused_hint: Optional[StrAny] = None) -> Optional[DictStrAny]:

--- a/dlt/common/runtime/sentry.py
+++ b/dlt/common/runtime/sentry.py
@@ -8,7 +8,6 @@ try:
     from sentry_sdk.transport import HttpTransport
     from sentry_sdk.integrations.logging import LoggingIntegration
 except ModuleNotFoundError:
-    sentry_sdk = None
     raise MissingDependencyException(
         "sentry telemetry",
         ["sentry-sdk"],
@@ -54,8 +53,7 @@ def init_sentry(config: RunConfiguration) -> None:
 
 def disable_sentry() -> None:
     # init without parameters disables sentry
-    if sentry_sdk:
-        sentry_sdk.init()
+    sentry_sdk.init()
 
 
 def before_send(event: DictStrAny, _unused_hint: Optional[StrAny] = None) -> Optional[DictStrAny]:

--- a/dlt/common/runtime/telemetry.py
+++ b/dlt/common/runtime/telemetry.py
@@ -5,6 +5,7 @@ import inspect
 from typing import Any, Callable
 
 from dlt.common.configuration.specs import RunConfiguration
+from dlt.common.exceptions import MissingDependencyException
 from dlt.common.typing import TFun
 from dlt.common.configuration import resolve_configuration
 from dlt.common.runtime.anon_tracker import (
@@ -50,7 +51,7 @@ def stop_telemetry() -> None:
         from dlt.common.runtime.sentry import disable_sentry
 
         disable_sentry()
-    except ImportError:
+    except (MissingDependencyException, ImportError):
         pass
 
     disable_anon_tracker()


### PR DESCRIPTION
This PR fixes telemetry when we disable sentry, before we were not catching `MissingDependencyException` now we do ~~also we check `sentry_sdk`~~