### PR TITLE
Fix: use correct check for column prop in column schema

### DIFF
--- a/dlt/common/normalizers/json/relational.py
+++ b/dlt/common/normalizers/json/relational.py
@@ -95,7 +95,7 @@ class DataItemNormalizer(DataItemNormalizerBase[RelationalNormalizerConfig]):
         table = schema.tables.get(table_name)
         if table:
             column = table["columns"].get(field_name)
-        if column is None:
+        if column is None or "data_type" not in column:
             data_type = schema.get_preferred_type(field_name)
         else:
             data_type = column["data_type"]

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -446,7 +446,7 @@ class Schema:
             for column_name in table:
                 if column_name in row:
                     hint_value = table[column_name][column_prop]
-                    if not utils.has_default_column_hint_value(column_prop, hint_value):
+                    if not utils.has_default_column_prop_value(column_prop, hint_value):
                         rv_row[column_name] = row[column_name]
         except KeyError:
             for k, v in row.items():
@@ -702,7 +702,7 @@ class Schema:
         for hint in COLUMN_HINTS:
             column_prop = utils.hint_to_column_prop(hint)
             hint_value = self._infer_hint(hint, v, k)
-            if not utils.has_default_column_hint_value(column_prop, hint_value):
+            if not utils.has_default_column_prop_value(column_prop, hint_value):
                 column_schema[column_prop] = hint_value
 
         if is_variant:

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -115,23 +115,26 @@ def remove_defaults(stored_schema: TStoredSchema) -> TStoredSchema:
     return stored_schema
 
 
-def has_default_column_hint_value(hint: str, value: Any) -> bool:
-    """Checks if `value` is a default for `hint`. Only known column hints (COLUMN_HINTS) are checked"""
+def has_default_column_prop_value(prop: str, value: Any) -> bool:
+    """Checks if `value` is a default for `prop`."""
     # remove all boolean hints that are False, except "nullable" which is removed when it is True
-    if hint in COLUMN_HINTS and value is False:
-        return True
-    if hint == "nullable" and value is True:
-        return True
-    return False
+    # TODO: merge column props and hints
+    if prop in COLUMN_HINTS:
+        return value in (False, None)
+    # TODO: type all the hints including default value so those exceptions may be removed
+    if prop == "nullable":
+        return value in (True, None)
+    if prop == "x-active-record-timestamp":
+        # None is a valid value so it is not a default
+        return False
+    return value is None
 
 
 def remove_column_defaults(column_schema: TColumnSchema) -> TColumnSchema:
     """Removes default values from `column_schema` in place, returns the input for chaining"""
     # remove hints with default values
     for h in list(column_schema.keys()):
-        if has_default_column_hint_value(h, column_schema[h]):  # type: ignore
-            del column_schema[h]  # type: ignore
-        elif column_schema[h] is None:  # type: ignore
+        if has_default_column_prop_value(h, column_schema[h]):  # type: ignore
             del column_schema[h]  # type: ignore
     return column_schema
 
@@ -486,7 +489,8 @@ def get_columns_names_with_prop(
     return [
         c["name"]
         for c in table["columns"].values()
-        if bool(column_prop in c and c.get(column_prop, False))
+        if column_prop in c
+        and not has_default_column_prop_value(column_prop, c[column_prop])  # type: ignore[literal-required]
         and (include_incomplete or is_complete_column(c))
     ]
 

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -486,7 +486,7 @@ def get_columns_names_with_prop(
     return [
         c["name"]
         for c in table["columns"].values()
-        if (bool(c.get(column_prop, False)) or c.get(column_prop, False) is None)
+        if bool(column_prop in c and c.get(column_prop, False))
         and (include_incomplete or is_complete_column(c))
     ]
 

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -127,7 +127,7 @@ def has_default_column_prop_value(prop: str, value: Any) -> bool:
     if prop == "x-active-record-timestamp":
         # None is a valid value so it is not a default
         return False
-    return value is None
+    return value in (None, False)
 
 
 def remove_column_defaults(column_schema: TColumnSchema) -> TColumnSchema:
@@ -484,8 +484,6 @@ def hint_to_column_prop(h: TColumnHint) -> TColumnProp:
 def get_columns_names_with_prop(
     table: TTableSchema, column_prop: Union[TColumnProp, str], include_incomplete: bool = False
 ) -> List[str]:
-    # column_prop: TColumnProp = hint_to_column_prop(hint_type)
-    # default = column_prop != "nullable"  # default is true, only for nullable false
     return [
         c["name"]
         for c in table["columns"].values()

--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -176,6 +176,7 @@ class Extractor:
             computed_table["x-normalizer"] = {"evolve-columns-once": True}  # type: ignore[typeddict-unknown-key]
         existing_table = self.schema._schema_tables.get(table_name, None)
         if existing_table:
+            # TODO: revise this. computed table should overwrite certain hints (ie. primary and merge keys) completely
             diff_table = utils.diff_table(existing_table, computed_table)
         else:
             diff_table = computed_table

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -392,7 +392,9 @@ class DltResourceHints:
             keys = [keys]
         for key in keys:
             if key in partial["columns"]:
-                merge_column(partial["columns"][key], {hint: True})  # type: ignore
+                # set nullable to False if not set
+                nullable = partial["columns"][key].get("nullable", False)
+                merge_column(partial["columns"][key], {hint: True, "nullable": nullable})  # type: ignore
             else:
                 partial["columns"][key] = new_column(key, nullable=False)
                 partial["columns"][key][hint] = True

--- a/tests/common/schema/test_merges.py
+++ b/tests/common/schema/test_merges.py
@@ -16,21 +16,22 @@ COL_1_HINTS: TColumnSchema = {  # type: ignore[typeddict-unknown-key]
     "foreign_key": True,
     "data_type": "text",
     "name": "test",
-    "x-special": True,
+    "x-special": "value",
     "x-special-int": 100,
     "nullable": False,
+    "x-special-bool-true": True,
     "x-special-bool": False,
     "prop": None,
 }
 
-COL_1_HINTS_DEFAULTS: TColumnSchema = {  # type: ignore[typeddict-unknown-key]
+COL_1_HINTS_NO_DEFAULTS: TColumnSchema = {  # type: ignore[typeddict-unknown-key]
     "foreign_key": True,
     "data_type": "text",
     "name": "test",
-    "x-special": True,
+    "x-special": "value",
     "x-special-int": 100,
     "nullable": False,
-    "x-special-bool": False,
+    "x-special-bool-true": True,
 }
 
 COL_2_HINTS: TColumnSchema = {"nullable": True, "name": "test_2", "primary_key": False}
@@ -46,7 +47,7 @@ COL_2_HINTS: TColumnSchema = {"nullable": True, "name": "test_2", "primary_key":
         ("nullable", True, True),
         ("nullable", False, False),
         ("nullable", None, True),
-        ("x-special", False, False),
+        ("x-special", False, True),
         ("x-special", True, False),
         ("x-special", None, True),
         ("unique", False, True),
@@ -90,7 +91,7 @@ def test_check_column_with_props(prop: str, value: Any, is_default: bool) -> Non
 def test_column_remove_defaults() -> None:
     clean = utils.remove_column_defaults(copy(COL_1_HINTS))
     # mind that nullable default is False and Nones will be removed
-    assert clean == COL_1_HINTS_DEFAULTS
+    assert clean == COL_1_HINTS_NO_DEFAULTS
     # check nullable True
     assert utils.remove_column_defaults(copy(COL_2_HINTS)) == {"name": "test_2"}
 
@@ -101,9 +102,11 @@ def test_column_add_defaults() -> None:
     assert full["unique"] is False
     # remove defaults from full
     clean = utils.remove_column_defaults(copy(full))
-    assert clean == COL_1_HINTS_DEFAULTS
+    assert clean == COL_1_HINTS_NO_DEFAULTS
     # prop is None and will be removed
     del full["prop"]  # type: ignore[typeddict-item]
+    # same for x-special-bool
+    del full["x-special-bool"]  # type: ignore[typeddict-item]
     assert utils.add_column_defaults(copy(clean)) == full
 
     # test incomplete
@@ -182,9 +185,10 @@ def test_merge_columns() -> None:
         "cluster": False,
         "foreign_key": True,
         "data_type": "text",
-        "x-special": True,
+        "x-special": "value",
         "x-special-int": 100,
         "x-special-bool": False,
+        "x-special-bool-true": True,
         "prop": None,
     }
 
@@ -196,9 +200,10 @@ def test_merge_columns() -> None:
         "cluster": False,
         "foreign_key": True,
         "data_type": "text",
-        "x-special": True,
+        "x-special": "value",
         "x-special-int": 100,
         "x-special-bool": False,
+        "x-special-bool-true": True,
         "prop": None,
         "primary_key": False,
     }

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -820,7 +820,10 @@ def test_dedup_sort_hint(destination_config: DestinationTestConfiguration) -> No
         name=table_name,
         write_disposition="merge",
         primary_key="id",  # sort hints only have effect when a primary key is provided
-        columns={"sequence": {"dedup_sort": "desc"}, "id": {"dedup_sort": None}},
+        columns={
+            "sequence": {"dedup_sort": "desc", "nullable": False},
+            "val": {"dedup_sort": None},
+        },
     )
     def data_resource(data):
         yield data
@@ -848,7 +851,7 @@ def test_dedup_sort_hint(destination_config: DestinationTestConfiguration) -> No
     assert sorted(observed, key=lambda d: d["id"]) == expected
 
     # now test "asc" sorting
-    data_resource.apply_hints(columns={"sequence": {"dedup_sort": "asc"}})
+    data_resource.apply_hints(columns={"sequence": {"dedup_sort": "asc", "nullable": False}})
 
     info = p.run(data_resource(data), loader_file_format=destination_config.file_format)
     assert_load_info(info)
@@ -867,7 +870,7 @@ def test_dedup_sort_hint(destination_config: DestinationTestConfiguration) -> No
     table_name = "test_dedup_sort_hint_complex"
     data_resource.apply_hints(
         table_name=table_name,
-        columns={"sequence": {"dedup_sort": "desc"}},
+        columns={"sequence": {"dedup_sort": "desc", "nullable": False}},
     )
 
     # three records with same primary key
@@ -891,7 +894,10 @@ def test_dedup_sort_hint(destination_config: DestinationTestConfiguration) -> No
     table_name = "test_dedup_sort_hint_with_hard_delete"
     data_resource.apply_hints(
         table_name=table_name,
-        columns={"sequence": {"dedup_sort": "desc"}, "deleted": {"hard_delete": True}},
+        columns={
+            "sequence": {"dedup_sort": "desc", "nullable": False},
+            "deleted": {"hard_delete": True},
+        },
     )
 
     # three records with same primary key

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -807,6 +807,7 @@ def test_hard_delete_hint_config(destination_config: DestinationTestConfiguratio
         info = p.run(r(), loader_file_format=destination_config.file_format)
 
 
+@pytest.mark.essential
 @pytest.mark.parametrize(
     "destination_config",
     destinations_configs(default_sql_configs=True, supports_merge=True),
@@ -819,7 +820,7 @@ def test_dedup_sort_hint(destination_config: DestinationTestConfiguration) -> No
         name=table_name,
         write_disposition="merge",
         primary_key="id",  # sort hints only have effect when a primary key is provided
-        columns={"sequence": {"dedup_sort": "desc"}},
+        columns={"sequence": {"dedup_sort": "desc"}, "id": {"dedup_sort": None}},
     )
     def data_resource(data):
         yield data


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

In dlt <= 0.4.9
I would construct schemas like so:
```python
def describe_to_columns(
    describe: Describe, normalizer: t.Callable[[str], str] = str
) -> t.List[TColumnSchema]:
    """Convert a Salesforce describe to a list of SCT columns."""
    compound = {f["compoundFieldName"] for f in describe["fields"] if f["compoundFieldName"]}
    compound -= {"Name"}
    _, rk = get_projection_and_rk(describe)
    return [
        {
            "name": normalizer(field["name"]),
            "unique": field["unique"],
            "hard_delete": field["name"].lower() == "isdeleted",  # type: ignore
            "primary_key": field["name"].lower() == "id",
            "dedup_sort": "desc" if field["name"] is rk else None,
            **SF_TO_DLT.get(field["type"], {"data_type": "text"}),
        }
        for field in describe["fields"]
        if field["name"] != "attributes" and field["name"] not in compound
    ]
```

And this would work fine. However in 0.4.10, there is an irrecoverable error that took down our pipelines leveraging this technique. This is due to the check for column props which would detect multiple `dedup_sort` hints in the following schema (and in all schemas) incorrectly. There is no dedup_sort hint unless there is a truthy value that is one of asc or desc

```python
{
    "name": "business_value_assessment_c",
    "columns": {
        "id": {
            "name": "id",
            "unique": False,
            "hard_delete": False,
            "primary_key": True,
            "dedup_sort": None,
            "data_type": "text",
            "nullable": False,
        },
        "is_deleted": {
            "name": "is_deleted",
            "unique": False,
            "hard_delete": True,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "bool",
        },
        "name": {
            "name": "name",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "created_date": {
            "name": "created_date",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "timestamp",
        },
        "created_by_id": {
            "name": "created_by_id",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "last_modified_date": {
            "name": "last_modified_date",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "timestamp",
        },
        "last_modified_by_id": {
            "name": "last_modified_by_id",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "system_modstamp": {
            "name": "system_modstamp",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "timestamp",
        },
        "last_activity_date": {
            "name": "last_activity_date",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "date",
        },
        "last_viewed_date": {
            "name": "last_viewed_date",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "timestamp",
        },
        "last_referenced_date": {
            "name": "last_referenced_date",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "timestamp",
        },
        "account_c": {
            "name": "account_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "completed_date_c": {
            "name": "completed_date_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "date",
        },
        "deliverable_c": {
            "name": "deliverable_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "description_c": {
            "name": "description_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "engaged_date_c": {
            "name": "engaged_date_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "date",
        },
        "opportunity_c": {
            "name": "opportunity_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "owner_c": {
            "name": "owner_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "status_c": {
            "name": "status_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "closed_reason_c": {
            "name": "closed_reason_c",
            "unique": False,
            "hard_delete": False,
            "primary_key": False,
            "dedup_sort": None,
            "data_type": "text",
        },
        "_dlt_load_id": {
            "name": "_dlt_load_id",
            "data_type": "text",
            "nullable": False,
        },
        "_dlt_id": {
            "name": "_dlt_id",
            "data_type": "text",
            "nullable": False,
            "unique": True,
        },
    },
    "write_disposition": "merge",
    "resource": "Business_Value_Assessment__c",
    "x-normalizer": {"seen-data": True},
    "x-merge-strategy": "delete-insert",
}
```

I have fixed this check and verified my pipelines are working again.
