### PR TITLE
ability to add partitions in Athena to resources

### DIFF
--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -91,6 +91,7 @@ class TColumnType(TypedDict, total=False):
     data_type: Optional[TDataType]
     precision: Optional[int]
     scale: Optional[int]
+    partition: Optional[bool]
 
 
 class TColumnSchemaBase(TColumnType, total=False):


### PR DESCRIPTION
dlt version
0.4.10

Describe the problem
[Athena code](https://github.com/dlt-hub/dlt/blob/devel/dlt/destinations/impl/athena/athena.py#L408) there is no way to add partitions for Athena tables



Expected behavior
Added the ability to partition Athena tables in a schema

Steps to reproduce
try to create a partitioned table in Athena

Operating system
Linux

Runtime environment
Airflow

Python version
3.11

dlt data source
No response

dlt destination
AWS Athena / Glue Catalog

Other deployment details
No response

Additional information
No response