### PR TITLE
Replace weather api example with github in create a pipeline walkthrough

### DIFF
--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -23,6 +23,8 @@ To achieve this, you need to write code that accomplishes the following:
 3. Fetches and handles paginated issue data.
 4. Stores the data for analysis.
 
+This sounds complicated and it is indeed complicated, but we offer you our [rest client](https://dlthub.com/devel/general-usage/http/rest-client) which let's you put more focus on your data.
+
 
 ## 1. Initialize project
 

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -6,7 +6,7 @@ keywords: [how to, create a pipeline, rest client]
 
 # Create a pipeline
 
-This guide walks you through creating a pipeline that utilizes our [REST API Client](../general-usage/http/rest-client)
+This guide walks you through creating a pipeline that uses our [REST API Client](../general-usage/http/rest-client)
 to connect to [DuckDB](../dlt-ecosystem/destinations/duckdb).
 Although this example uses DuckDB, you can adapt the steps to any source and destination by
 using the [command](../reference/command-line-interface#dlt-init) `dlt init <source> <destination>` and tweaking the pipeline accordingly.

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -24,9 +24,7 @@ To achieve this, you need to write code that accomplishes the following:
 3. Fetches and handles paginated issue data.
 4. Stores the data for analysis.
 
-This sounds complicated, and it is indeed complicated,
-but we offer you our [REST API Client,](../general-usage/http/rest-client)
-which lets you put more focus on your data.
+This may sound complicated, but dlt provides a [REST API Client](../general-usage/http/rest-client) that allows you to focus more on your data rather than on managing API interactions.
 
 
 ## 1. Initialize project

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -64,7 +64,7 @@ Below `api_secret_key` [will get its value](../general-usage/credentials/configu
 
 ```py
 @dlt.source
-def githubapi_source(api_secret_key=dlt.secrets.value):
+def githubapi_source(api_secret_key: str = dlt.secrets.value):
     return githubapi_resource(api_secret_key=api_secret_key)
 ```
 
@@ -90,7 +90,7 @@ from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
 @dlt.resource(write_disposition="append")
-def githubapi_resource(api_secret_key=dlt.secrets.value):
+def githubapi_resource(api_secret_key: str = dlt.secrets.value):
     url = "https://api.github.com/repos/dlt-hub/dlt/issues"
 
     for page in paginate(

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -82,7 +82,7 @@ Your API key should be printed out to stdout along with some test data.
 
 
 :::tip
-We will use `dlt` as an example project https://github.com/dlt-hub/dlt, feel free to replace it with your own repository.
+We will use `dlt` repository as an example GitHub project https://github.com/dlt-hub/dlt, feel free to replace it with your own repository.
 :::
 
 Modify `github_api_resource` in `github_api.py` to request issues data from your GitHub project's API:

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -65,7 +65,7 @@ Below `api_secret_key` [will get its value](../general-usage/credentials/configu
 ```py
 @dlt.source
 def githubapi_source(api_secret_key=dlt.secrets.value):
-    return githubapi_my_repo_issues(api_secret_key=api_secret_key)
+    return githubapi_resource(api_secret_key=api_secret_key)
 ```
 
 Run the `githubapi.py` pipeline script to test that authentication headers look fine:
@@ -82,7 +82,7 @@ Your API key should be printed out to stdout along with some test data.
 >[!NOTE]
 > We will use dlt as an example project https://github.com/dlt-hub/dlt, feel free to replace it with your own repository.
 
-Modify `githubapi_my_repo_issues` in `githubapi.py` to request issues data from your GitHub project's API:
+Modify `githubapi_resource` in `githubapi.py` to request issues data from your GitHub project's API:
 
 ```py
 from dlt.sources.helpers.rest_client import paginate
@@ -90,7 +90,7 @@ from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
 @dlt.resource(write_disposition="append")
-def githubapi_my_repo_issues(api_secret_key=dlt.secrets.value):
+def githubapi_resource(api_secret_key=dlt.secrets.value):
     url = "https://api.github.com/repos/dlt-hub/dlt/issues"
 
     for page in paginate(
@@ -135,7 +135,7 @@ if __name__=='__main__':
     )
 
     # print credentials by running the resource
-    data = list(githubapi_my_repo_issues())
+    data = list(githubapi_resource())
 
     # print the data yielded from resource
     print(data)

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -46,7 +46,7 @@ Install the dependencies necessary for DuckDB:
 pip install -r requirements.txt
 ```
 
-## 2. Obtain and Add API credentials from GitHub
+## 2. Obtain and add API credentials from GitHub
 
 You will need to [sign in](https://github.com/login) to your github account and create your access token via [Personal access tokens page](https://github.com/settings/tokens).
 

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -154,7 +154,7 @@ This will open a Streamlit app that gives you an overview of the data loaded.
 
 With a functioning pipeline, consider exploring:
 
-- Learn more about our [rest client](https://dlthub.com/devel/general-usage/http/rest-client).
+- Our [rest client](https://dlthub.com/devel/general-usage/http/rest-client).
 - [Deploy this pipeline with GitHub Actions](deploy-a-pipeline/deploy-with-github-actions), so that
   the data is automatically loaded on a schedule.
 - Transform the [loaded data](../dlt-ecosystem/transformations) with dbt or in

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -143,7 +143,7 @@ python github_api.py
 
 This should print out json data containig the issues in the GitHub project.
 
-Then, confirm the data is loaded with printing `load_info` object.
+It also prints `load_info` object.
 
 Let's explore the loaded data with the [command](../reference/command-line-interface#show-tables-and-data-in-the-destination) `dlt pipeline <pipeline_name> show`.
 

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -141,7 +141,7 @@ Run the `github_api.py` pipeline script to test that the API call works:
 python github_api.py
 ```
 
-This should print out json data containig the issues in the GitHub project.
+This should print out JSON data containing the issues in the GitHub project.
 
 It also prints `load_info` object.
 

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -63,7 +63,7 @@ Below `api_secret_key` [will get its value](../general-usage/credentials/configu
 ```py
 @dlt.source
 def githubapi_source(api_secret_key=dlt.secrets.value):
-    return repo_issues_resource(api_secret_key=api_secret_key)
+    return githubapi_my_repo_issues(api_secret_key=api_secret_key)
 ```
 
 Run the `githubapi.py` pipeline script to test that authentication headers look fine:
@@ -80,7 +80,7 @@ Your API key should be printed out to stdout along with some test data.
 >[!NOTE]
 > We will use dlt as an example project https://github.com/dlt-hub/dlt, feel free to replace it with your own repository.
 
-Modify `repo_issues_resource` in `githubapi.py` to request issues data from your GitHub project's API:
+Modify `githubapi_my_repo_issues` in `githubapi.py` to request issues data from your GitHub project's API:
 
 ```py
 from dlt.sources.helpers.rest_client import paginate
@@ -88,7 +88,7 @@ from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 
 @dlt.resource(write_disposition="append")
-def repo_issues_resource(api_secret_key=dlt.secrets.value):
+def githubapi_my_repo_issues(api_secret_key=dlt.secrets.value):
     url = "https://api.github.com/repos/dlt-hub/dlt/issues"
 
     for page in paginate(
@@ -133,7 +133,7 @@ if __name__=='__main__':
     )
 
     # print credentials by running the resource
-    data = list(repo_issues_resource())
+    data = list(githubapi_my_repo_issues())
 
     # print the data yielded from resource
     print(data)

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -8,7 +8,7 @@ keywords: [how to, create a pipeline, rest client]
 
 This guide walks you through creating a pipeline that uses our [REST API Client](../general-usage/http/rest-client)
 to connect to [DuckDB](../dlt-ecosystem/destinations/duckdb).
-Although this example uses DuckDB, you can adapt the steps to any source and destination by
+Although this example uses DuckDB, you can adapt the steps to any [source](https://dlthub.com/docs/dlt-ecosystem/verified-sources/) and [destination]( https://dlthub.com/docs/dlt-ecosystem/destinations/) by
 using the [command](../reference/command-line-interface#dlt-init) `dlt init <source> <destination>` and tweaking the pipeline accordingly.
 
 Please make sure you have [installed `dlt`](../reference/installation) before following the

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -13,7 +13,7 @@ using the command `dlt init <source> <destination>` and tweaking the pipeline ac
 Please make sure you have [installed `dlt`](../reference/installation.md) before following the
 steps below.
 
-## Task Overview
+## Task overview
 
 Imagine you want to analyze issues from a GitHub project locally.
 To achieve this, you need to write code that accomplishes the following:

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -22,7 +22,7 @@ Imagine you want to analyze issues from a GitHub project locally.
 To achieve this, you need to write code that accomplishes the following:
 
 1. Constructs a correct request.
-2. Authenticates your requests.
+2. Authenticates your request.
 3. Fetches and handles paginated issue data.
 4. Stores the data for analysis.
 

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -9,7 +9,7 @@ keywords: [how to, create a pipeline, rest client]
 This guide walks you through creating a pipeline that uses our [REST API Client](../general-usage/http/rest-client)
 to connect to [DuckDB](../dlt-ecosystem/destinations/duckdb).
 :::tip 
-This example uses DuckDB, but you can adapt the steps to any [source](https://dlthub.com/docs/dlt-ecosystem/verified-sources/) and [destination](https://dlthub.com/docs/dlt-ecosystem/destinations/) by
+We're using DuckDB as a destination here, but you can adapt the steps to any [source](https://dlthub.com/docs/dlt-ecosystem/verified-sources/) and [destination](https://dlthub.com/docs/dlt-ecosystem/destinations/) by
 using the [command](../reference/command-line-interface#dlt-init) `dlt init <source> <destination>` and tweaking the pipeline accordingly.
 :::
 

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -8,8 +8,10 @@ keywords: [how to, create a pipeline, rest client]
 
 This guide walks you through creating a pipeline that uses our [REST API Client](../general-usage/http/rest-client)
 to connect to [DuckDB](../dlt-ecosystem/destinations/duckdb).
-Although this example uses DuckDB, you can adapt the steps to any [source](https://dlthub.com/docs/dlt-ecosystem/verified-sources/) and [destination](https://dlthub.com/docs/dlt-ecosystem/destinations/) by
+:::tip 
+This example uses DuckDB, but you can adapt the steps to any [source](https://dlthub.com/docs/dlt-ecosystem/verified-sources/) and [destination](https://dlthub.com/docs/dlt-ecosystem/destinations/) by
 using the [command](../reference/command-line-interface#dlt-init) `dlt init <source> <destination>` and tweaking the pipeline accordingly.
+:::
 
 Please make sure you have [installed `dlt`](../reference/installation) before following the
 steps below.

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -1,29 +1,28 @@
 ---
 title: Create a pipeline
 description: How to create a pipeline
-keywords: [how to, create a pipeline]
+keywords: [how to, create a pipeline, rest client]
 ---
 
 # Create a pipeline
 
-Follow the steps below to create a [pipeline](../general-usage/glossary.md#pipeline) using the
-our rest API client to DuckDB from scratch. The same steps can be repeated for any source and
-destination of your choice—use `dlt init <source> <destination>` and then build the pipeline for
-that API instead.
+This guide walks you through creating a pipeline that utilizes our REST API client to connect to DuckDB.
+Although this example uses DuckDB, you can adapt the steps to any source and destination by
+using the command `dlt init <source> <destination>` and tweaking the pipeline accordingly.
 
 Please make sure you have [installed `dlt`](../reference/installation.md) before following the
 steps below.
 
+## Task Overview
 
-## Task
-Let's suppose you have a github project and would like to download all issues to analyze them in
-your local machine, thus you need to write some code which does the following things:
+Imagine you want to analyze issues from a GitHub project locally.
+To achieve this, you need to write code that accomplishes the following:
 
-1. Authenticates requests,
-2. Fetches and paginates over the issues,
-3. Saves the data somewhere.
+1. Build correct requests.
+1. Authenticates your requests.
+2. Fetches and handles paginated issue data.
+3. Stores the data for analysis.
 
-With this in mind let's continue.
 
 ## 1. Initialize project
 
@@ -56,6 +55,8 @@ Copy your new access token over to `.dlt/secrets.toml`:
 api_secret_key = '<api key value>'
 ```
 
+This token will be used by `githubapi_source()` to authenticate requests.
+
 The **secret name** corresponds to the **argument name** in the source function.
 Below `api_secret_key` [will get its value](../general-usage/credentials/configuration.md#general-usage-and-an-example) from `secrets.toml` when `githubapi_source()` is called.
 
@@ -75,11 +76,11 @@ Your API key should be printed out to stdout along with some test data.
 
 ## 3. Request project issues from then GitHub API
 
-Replace the definition of the `githubapi_resource` function definition in the `githubapi.py`
-pipeline script with a call to the GitHub API:
 
 >[!NOTE]
 > We will use dlt as an example project https://github.com/dlt-hub/dlt, feel free to replace it with your own repository.
+
+Modify `repo_issues_resource` in `githubapi.py` to request issues data from your GitHub project's API:
 
 ```py
 from dlt.sources.helpers.rest_client import paginate
@@ -106,7 +107,16 @@ Run the `githubapi.py` pipeline script to test that the API call works:
 python3 githubapi.py
 ```
 
-This should print out the weather in New York City right now.
+This should print out json data containig the issues in the GitHub project.
+
+Then, confirm the data is loaded
+
+>[!NOTE]
+> Make sure you have `streamlit` installed `pip install streamlit`
+
+```sh
+dlt pipeline githubapi show
+```
 
 ## 4. Load the data
 
@@ -135,7 +145,7 @@ if __name__=='__main__':
     print(load_info)
 ```
 
-Run the `githubapi.py` pipeline script to load data into DuckDB:
+Load your GitHub issues into DuckDB:
 
 ```sh
 python3 githubapi.py
@@ -151,7 +161,7 @@ This will open a Streamlit app that gives you an overview of the data loaded.
 
 ## 5. Next steps
 
-Now that you have a working pipeline, you have options for what to learn next:
+With a functioning pipeline, consider exploring:
 
 - Learn more about our [rest client](https://dlthub.com/devel/general-usage/http/rest-client).
 - [Deploy this pipeline with GitHub Actions](deploy-a-pipeline/deploy-with-github-actions), so that

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -103,35 +103,18 @@ def githubapi_resource(api_secret_key=dlt.secrets.value):
         yield page
 ```
 
-Run the `githubapi.py` pipeline script to test that the API call works:
-
-```sh
-python3 githubapi.py
-```
-
-This should print out json data containig the issues in the GitHub project.
-
-Then, confirm the data is loaded
-
->[!NOTE]
-> Make sure you have `streamlit` installed `pip install streamlit`
-
-```sh
-dlt pipeline githubapi show
-```
-
 ## 4. Load the data
 
-Remove the `exit()` call from the `main` function in `githubapi.py`, so that running the
+Uncomment the commented out code in `main` function in `githubapi.py`, so that running the
 `python3 githubapi.py` command will now also run the pipeline:
 
 ```py
 if __name__=='__main__':
     # configure the pipeline with your destination details
     pipeline = dlt.pipeline(
-        pipeline_name='githubapi_repo_issues',
+        pipeline_name='githubapi',
         destination='duckdb',
-        dataset_name='repo_issues_data'
+        dataset_name='githubapi_data'
     )
 
     # print credentials by running the resource
@@ -147,13 +130,19 @@ if __name__=='__main__':
     print(load_info)
 ```
 
-Load your GitHub issues into DuckDB:
+
+Run the `githubapi.py` pipeline script to test that the API call works:
 
 ```sh
 python3 githubapi.py
 ```
 
-Then this command to see that the data loaded:
+This should print out json data containig the issues in the GitHub project.
+
+Then, confirm the data is loaded
+
+>[!NOTE]
+> Make sure you have `streamlit` installed `pip install streamlit`
 
 ```sh
 dlt pipeline githubapi show

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -115,12 +115,11 @@ Remove the `exit()` call from the `main` function in `githubapi.py`, so that run
 
 ```py
 if __name__=='__main__':
-
     # configure the pipeline with your destination details
     pipeline = dlt.pipeline(
-        pipeline_name='githubapi_issues',
+        pipeline_name='githubapi_repo_issues',
         destination='duckdb',
-        dataset_name='githubapi_issues_data'
+        dataset_name='repo_issues_data'
     )
 
     # print credentials by running the resource

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -18,7 +18,7 @@ steps below.
 Imagine you want to analyze issues from a GitHub project locally.
 To achieve this, you need to write code that accomplishes the following:
 
-1. Build correct requests.
+1. Constructs a correct request.
 2. Authenticates your requests.
 3. Fetches and handles paginated issue data.
 4. Stores the data for analysis.

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -8,7 +8,7 @@ keywords: [how to, create a pipeline, rest client]
 
 This guide walks you through creating a pipeline that uses our [REST API Client](../general-usage/http/rest-client)
 to connect to [DuckDB](../dlt-ecosystem/destinations/duckdb).
-Although this example uses DuckDB, you can adapt the steps to any [source](https://dlthub.com/docs/dlt-ecosystem/verified-sources/) and [destination]( https://dlthub.com/docs/dlt-ecosystem/destinations/) by
+Although this example uses DuckDB, you can adapt the steps to any [source](https://dlthub.com/docs/dlt-ecosystem/verified-sources/) and [destination](https://dlthub.com/docs/dlt-ecosystem/destinations/) by
 using the [command](../reference/command-line-interface#dlt-init) `dlt init <source> <destination>` and tweaking the pipeline accordingly.
 
 Please make sure you have [installed `dlt`](../reference/installation) before following the

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -147,7 +147,7 @@ Then, confirm the data is loaded with printing `load_info` object.
 
 Let's explore the loaded data with the [command](../reference/command-line-interface#show-tables-and-data-in-the-destination) `dlt pipeline <pipeline_name> show`.
 
-:::warning
+:::info
 Make sure you have `streamlit` installed `pip install streamlit`
 :::
 

--- a/docs/website/docs/walkthroughs/create-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/create-a-pipeline.md
@@ -19,9 +19,9 @@ Imagine you want to analyze issues from a GitHub project locally.
 To achieve this, you need to write code that accomplishes the following:
 
 1. Build correct requests.
-1. Authenticates your requests.
-2. Fetches and handles paginated issue data.
-3. Stores the data for analysis.
+2. Authenticates your requests.
+3. Fetches and handles paginated issue data.
+4. Stores the data for analysis.
 
 
 ## 1. Initialize project


### PR DESCRIPTION
This PR updates a walkthrough (Create a pipeline): [Create a pipeline](https://dlthub.com/docs/walkthroughs/create-a-pipeline)

Closes: https://github.com/dlt-hub/dlt/issues/1350