### PR TITLE
Create _dlt_* tables even when schema contract is frozen

### DIFF
--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -297,11 +297,12 @@ class Schema:
         existing_table: TTableSchema = self._schema_tables.get(table_name, None)
 
         # table is new when not yet exist or
-        is_dlt_table = not table_name.startswith("_dlt")
-        is_new_table = (not existing_table or self.is_new_table(table_name)) and is_dlt_table
+        is_dlt_table = table_name.startswith("_dlt")
+        should_raise = raise_on_freeze and not is_dlt_table
+        is_new_table = not existing_table or self.is_new_table(table_name)
         # check case where we have a new table
         if is_new_table and schema_contract["tables"] != "evolve":
-            if (raise_on_freeze and schema_contract["tables"] == "freeze") and not is_dlt_table:
+            if should_raise and schema_contract["tables"] == "freeze":
                 raise DataValidationError(
                     self.name,
                     table_name,

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -297,10 +297,11 @@ class Schema:
         existing_table: TTableSchema = self._schema_tables.get(table_name, None)
 
         # table is new when not yet exist or
-        is_new_table = not existing_table or self.is_new_table(table_name)
+        is_dlt_table = not table_name.startswith("_dlt")
+        is_new_table = (not existing_table or self.is_new_table(table_name)) and is_dlt_table
         # check case where we have a new table
         if is_new_table and schema_contract["tables"] != "evolve":
-            if raise_on_freeze and schema_contract["tables"] == "freeze":
+            if (raise_on_freeze and schema_contract["tables"] == "freeze") and not is_dlt_table:
                 raise DataValidationError(
                     self.name,
                     table_name,

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -297,7 +297,7 @@ class Schema:
         existing_table: TTableSchema = self._schema_tables.get(table_name, None)
 
         # table is new when not yet exist or
-        is_dlt_table = table_name.startswith("_dlt")
+        is_dlt_table = table_name.startswith(self._dlt_tables_prefix)
         should_raise = raise_on_freeze and not is_dlt_table
         is_new_table = not existing_table or self.is_new_table(table_name)
         # check case where we have a new table

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -2314,3 +2314,4 @@ def test_pipeline_with_frozen_schema_contract() -> None:
         "_dlt_version",
         "_dlt_pipeline_state",
     }
+    assert table_counts["test_items"] == 2

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -2285,6 +2285,24 @@ def test_pipeline_with_frozen_schema_contract() -> None:
         {"id": 101, "name": "sub item 102"},
     ]
 
+    # with pipeline.sql_client() as c:
+    #     c.execute_sql("CREATE SCHEMA frozen_schema_contract_dataset")
+    #     c.execute_sql(
+    #         "CREATE TABLE frozen_schema_contract_dataset.test_items "
+    #         "(id INTEGER PRIMARY KEY, name VARCHAR)"
+    #     )
+
+    pipeline.run(
+        data,
+        table_name="test_items",
+    )
+
+    with pipeline.sql_client() as c:
+        c.execute_sql("DROP TABLE _dlt_loads")
+        c.execute_sql("DROP TABLE _dlt_version")
+        c.execute_sql("DROP TABLE _dlt_pipeline_state")
+        c.execute_sql("TRUNCATE TABLE test_items")
+
     pipeline.run(
         data,
         table_name="test_items",
@@ -2296,7 +2314,10 @@ def test_pipeline_with_frozen_schema_contract() -> None:
         pipeline, *[t["name"] for t in pipeline.default_schema._schema_tables.values()]
     )
 
-    assert len(table_counts) == 3
-    assert table_counts["_dlt_loads"] == 1
-    assert table_counts["_dlt_version"] == 1
-    assert table_counts["_dlt_pipeline_state"] == 1
+    assert len(table_counts) == 4
+    assert set(table_counts.keys()) == {
+        "test_items",
+        "_dlt_loads",
+        "_dlt_version",
+        "_dlt_pipeline_state",
+    }

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -2285,13 +2285,6 @@ def test_pipeline_with_frozen_schema_contract() -> None:
         {"id": 101, "name": "sub item 102"},
     ]
 
-    # with pipeline.sql_client() as c:
-    #     c.execute_sql("CREATE SCHEMA frozen_schema_contract_dataset")
-    #     c.execute_sql(
-    #         "CREATE TABLE frozen_schema_contract_dataset.test_items "
-    #         "(id INTEGER PRIMARY KEY, name VARCHAR)"
-    #     )
-
     pipeline.run(
         data,
         table_name="test_items",

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -1254,12 +1254,7 @@ def test_pipeline_source_state_activation() -> None:
 def test_extract_add_tables() -> None:
     # we extract and make sure that tables are added to schema
     s = airtable_emojis()
-    assert list(s.resources.keys()) == [
-        "💰Budget",
-        "📆 Schedule",
-        "🦚Peacock",
-        "🦚WidePeacock",
-    ]
+    assert list(s.resources.keys()) == ["💰Budget", "📆 Schedule", "🦚Peacock", "🦚WidePeacock"]
     assert s.resources["🦚Peacock"].compute_table_schema()["resource"] == "🦚Peacock"
     # only name will be normalized
     assert s.resources["🦚Peacock"].compute_table_schema()["name"] == "🦚Peacock"
@@ -1673,11 +1668,7 @@ def test_pipeline_list_packages() -> None:
     assert len(load_ids) == 1
     # two new packages: for emojis schema and emojis_2
     pipeline.extract(
-        [
-            airtable_emojis(),
-            airtable_emojis(),
-            airtable_emojis().clone(with_name="emojis_2"),
-        ]
+        [airtable_emojis(), airtable_emojis(), airtable_emojis().clone(with_name="emojis_2")]
     )
     load_ids = pipeline.list_extracted_load_packages()
     assert len(load_ids) == 3

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -2280,21 +2280,18 @@ def test_pipeline_with_frozen_schema_contract() -> None:
         destination="duckdb",
     )
 
+    # Create a database schema with table
+    with pipeline.sql_client() as c:
+        dataset = c.fully_qualified_dataset_name()
+        table = f"{c.fully_qualified_dataset_name()}.test_items"
+        conn = c.open_connection()
+        conn.sql(f"CREATE SCHEMA {dataset}")
+        conn.sql(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, name VARCHAR)")
+
     data = [
         {"id": 101, "name": "sub item 101"},
         {"id": 101, "name": "sub item 102"},
     ]
-
-    pipeline.run(
-        data,
-        table_name="test_items",
-    )
-
-    with pipeline.sql_client() as c:
-        c.execute_sql("DROP TABLE _dlt_loads")
-        c.execute_sql("DROP TABLE _dlt_version")
-        c.execute_sql("DROP TABLE _dlt_pipeline_state")
-        c.execute_sql("TRUNCATE TABLE test_items")
 
     pipeline.run(
         data,

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -2286,7 +2286,7 @@ def test_pipeline_with_frozen_schema_contract() -> None:
         table = f"{c.fully_qualified_dataset_name()}.test_items"
         conn = c.open_connection()
         conn.sql(f"CREATE SCHEMA {dataset}")
-        conn.sql(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, name VARCHAR)")
+        conn.sql(f"CREATE TABLE {table} (id INTEGER PRIMARY KEY, name VARCHAR NOT NULL, _dlt_load_id VARCHAR NOT NULL, _dlt_id VARCHAR NOT NULL)")
 
     data = [
         {"id": 101, "name": "sub item 101"},
@@ -2311,4 +2311,3 @@ def test_pipeline_with_frozen_schema_contract() -> None:
         "_dlt_version",
         "_dlt_pipeline_state",
     }
-    assert table_counts["test_items"] == 2


### PR DESCRIPTION
This PR let's dlt to create `_dlt_*` tables even when `schema_contract=freeze`

Resolves: https://github.com/dlt-hub/dlt/issues/1237