### PR TITLE
Azure service principal credentials

### DIFF
--- a/dlt/common/configuration/specs/__init__.py
+++ b/dlt/common/configuration/specs/__init__.py
@@ -20,7 +20,13 @@ from .gcp_credentials import (
 from .connection_string_credentials import ConnectionStringCredentials
 from .api_credentials import OAuth2Credentials
 from .aws_credentials import AwsCredentials, AwsCredentialsWithoutDefaults
-from .azure_credentials import AzureCredentials, AzureCredentialsWithoutDefaults
+from .azure_credentials import (
+    AzureCredentials,
+    AzureCredentialsWithoutDefaults,
+    AzureServicePrincipalCredentials,
+    AzureServicePrincipalCredentialsWithoutDefaults,
+    AnyAzureCredentials,
+)
 
 
 # backward compatibility for service account credentials
@@ -51,6 +57,9 @@ __all__ = [
     "AwsCredentialsWithoutDefaults",
     "AzureCredentials",
     "AzureCredentialsWithoutDefaults",
+    "AzureServicePrincipalCredentials",
+    "AzureServicePrincipalCredentialsWithoutDefaults",
+    "AnyAzureCredentials",
     "GcpClientCredentials",
     "GcpClientCredentialsWithDefault",
 ]

--- a/dlt/common/configuration/specs/azure_credentials.py
+++ b/dlt/common/configuration/specs/azure_credentials.py
@@ -7,10 +7,6 @@ from dlt.common.configuration.specs import (
     CredentialsWithDefault,
     configspec,
 )
-from dlt.common.configuration.specs.exceptions import InvalidBoto3Session
-from dlt import version
-
-import fsspec
 
 
 @configspec

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -10,8 +10,7 @@ from dlt.common.configuration.specs import (
     GcpServiceAccountCredentials,
     AwsCredentials,
     GcpOAuthCredentials,
-    AzureCredentials,
-    AzureCredentialsWithoutDefaults,
+    AnyAzureCredentials,
     BaseConfiguration,
 )
 from dlt.common.typing import DictStrAny
@@ -49,7 +48,7 @@ class LoadStorageConfiguration(BaseConfiguration):
 
 
 FileSystemCredentials = Union[
-    AwsCredentials, GcpServiceAccountCredentials, AzureCredentials, GcpOAuthCredentials
+    AwsCredentials, GcpServiceAccountCredentials, AnyAzureCredentials, GcpOAuthCredentials
 ]
 
 
@@ -70,9 +69,9 @@ class FilesystemConfiguration(BaseConfiguration):
         "gcs": Union[GcpServiceAccountCredentials, GcpOAuthCredentials],
         "gdrive": Union[GcpServiceAccountCredentials, GcpOAuthCredentials],
         "s3": AwsCredentials,
-        "az": Union[AzureCredentialsWithoutDefaults, AzureCredentials],
-        "abfs": Union[AzureCredentialsWithoutDefaults, AzureCredentials],
-        "adl": Union[AzureCredentialsWithoutDefaults, AzureCredentials],
+        "az": AnyAzureCredentials,
+        "abfs": AnyAzureCredentials,
+        "adl": AnyAzureCredentials,
     }
 
     bucket_url: str = None

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -184,7 +184,7 @@ bucket_url = "az://[your_container name]" # replace with your container name
 
 [destination.filesystem.credentials]
 azure_client_id = "client_id" # please set me up!
-azure_client_secret = "client_secret
+azure_client_secret = "client_secret"
 azure_tenant_id = "tenant_id" # please set me up!
 ```
 

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -150,7 +150,13 @@ Use **Cloud Storage** admin to create a new bucket. Then assign the **Storage Ob
 #### Azure Blob Storage
 Run `pip install dlt[az]` which will install the `adlfs` package to interface with Azure Blob Storage.
 
-Edit the credentials in `.dlt/secrets.toml`, you'll see AWS credentials by default replace them with your Azure credentials:
+Edit the credentials in `.dlt/secrets.toml`, you'll see AWS credentials by default replace them with your Azure credentials.
+
+Two forms of Azure credentials are supported:
+
+##### SAS token credentials
+
+Supply storage account name and either sas token or storage account key
 
 ```toml
 [destination.filesystem]
@@ -167,6 +173,20 @@ azure_storage_sas_token = "sas_token" # please set me up!
 If you have the correct Azure credentials set up on your machine (e.g. via azure cli),
 you can omit both `azure_storage_account_key` and `azure_storage_sas_token` and `dlt` will fall back to the available default.
 Note that `azure_storage_account_name` is still required as it can't be inferred from the environment.
+
+##### Service principal credentials
+
+Supply a client ID, client secret and a tenant ID for a service principal authorized to access your container
+
+```toml
+[destination.filesystem]
+bucket_url = "az://[your_container name]" # replace with your container name
+
+[destination.filesystem.credentials]
+azure_client_id = "client_id" # please set me up!
+azure_client_secret = "client_secret
+azure_tenant_id = "tenant_id" # please set me up!
+```
 
 #### Local file system
 If for any reason you want to have those files in a local folder, set up the `bucket_url` as follows (you are free to use `config.toml` for that as there are no secrets required)

--- a/tests/load/filesystem/test_azure_credentials.py
+++ b/tests/load/filesystem/test_azure_credentials.py
@@ -1,9 +1,10 @@
-from typing import Dict
+from typing import Dict, Optional
 from urllib.parse import parse_qs
 from uuid import uuid4
 
 import pytest
 
+import dlt
 from dlt.common import pendulum
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.configuration import resolve_configuration, ConfigFieldMissingException
@@ -13,7 +14,8 @@ from dlt.common.configuration.specs import (
     AzureServicePrincipalCredentialsWithoutDefaults,
     AzureCredentialsWithoutDefaults,
 )
-from tests.load.utils import ALL_FILESYSTEM_DRIVERS
+from dlt.common.storages.configuration import FilesystemConfiguration
+from tests.load.utils import ALL_FILESYSTEM_DRIVERS, AZ_BUCKET
 from tests.common.configuration.utils import environment
 from tests.utils import preserve_environ, autouse_test_storage
 from dlt.common.storages.fsspec_filesystem import fsspec_from_config
@@ -23,6 +25,25 @@ pytestmark = pytest.mark.essential
 
 if "az" not in ALL_FILESYSTEM_DRIVERS:
     pytest.skip("az filesystem driver not configured", allow_module_level=True)
+
+
+@pytest.fixture
+def az_service_principal_config() -> Optional[FilesystemConfiguration]:
+    """FS config with alternate azure credentials format if available in environment"""
+    credentials = AzureServicePrincipalCredentialsWithoutDefaults(
+        azure_tenant_id=dlt.config.get("tests.az_sp_tenant_id", str),
+        azure_client_id=dlt.config.get("tests.az_sp_client_id", str),
+        azure_client_secret=dlt.config.get("tests.az_sp_client_secret", str),  # type: ignore[arg-type]
+        azure_storage_account_name=dlt.config.get("tests.az_sp_storage_account_name", str),
+    )
+    try:
+        credentials = resolve_configuration(credentials)
+    except ConfigFieldMissingException:
+        pytest.skip("Azure service principal credentials not available in environment")
+        return None
+    cfg = FilesystemConfiguration(bucket_url=AZ_BUCKET, credentials=credentials)
+
+    return resolve_configuration(cfg)
 
 
 def test_azure_credentials_from_account_key(environment: Dict[str, str]) -> None:
@@ -124,9 +145,6 @@ def test_azure_service_principal_credentials(environment: Dict[str, str]) -> Non
     }
 
 
-from dlt.common.storages.configuration import FilesystemConfiguration
-
-
 def test_azure_filesystem_configuration_service_principal(environment: Dict[str, str]) -> None:
     """Filesystem config resolves correct credentials type"""
     environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"] = "fake_account_name"
@@ -163,3 +181,18 @@ def test_azure_filesystem_configuration_sas_token(environment: Dict[str, str]) -
 
     assert fs.sas_token == "?" + environment["CREDENTIALS__AZURE_STORAGE_SAS_TOKEN"]
     assert fs.account_name == environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"]
+
+
+def test_azure_service_principal_fs_operations(
+    az_service_principal_config: Optional[FilesystemConfiguration],
+) -> None:
+    """Test connecting to azure filesystem with service principal credentials"""
+    config = az_service_principal_config
+    fs, bucket = fsspec_from_config(config)
+
+    fn = uuid4().hex
+    # Try some file ops to see if the credentials work
+    fs.touch(f"{bucket}/{fn}")
+    files = fs.ls(bucket)
+    assert f"{bucket}/{fn}" in files
+    fs.delete(f"{bucket}/{fn}")

--- a/tests/load/filesystem/test_filesystem_common.py
+++ b/tests/load/filesystem/test_filesystem_common.py
@@ -12,10 +12,7 @@ from dlt.common import logger
 from dlt.common import json, pendulum
 from dlt.common.configuration import resolve
 from dlt.common.configuration.inject import with_config
-from dlt.common.configuration.specs import (
-    AzureCredentials,
-    AzureCredentialsWithoutDefaults,
-)
+from dlt.common.configuration.specs import AnyAzureCredentials
 from dlt.common.storages import fsspec_from_config, FilesystemConfiguration
 from dlt.common.storages.fsspec_filesystem import MTIME_DISPATCH, glob_files
 from dlt.common.utils import custom_environ, uniq_id
@@ -43,10 +40,7 @@ def test_filesystem_configuration() -> None:
     config = FilesystemConfiguration(bucket_url="az://root")
     assert config.protocol == "az"
     # print(config.resolve_credentials_type())
-    assert (
-        config.resolve_credentials_type()
-        == Union[AzureCredentialsWithoutDefaults, AzureCredentials]
-    )
+    assert config.resolve_credentials_type() == AnyAzureCredentials
     assert dict(config) == {
         "read_only": False,
         "bucket_url": "az://root",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Adds support for authenticating Azure with service principal (client ID/secret/tenant ID):

```toml
[destination.filesystem]
bucket_url = "az://[your_container name]" # replace with your container name

[destination.filesystem.credentials]
azure_client_id = "client_id" # please set me up!
azure_client_secret = "client_secret
azure_tenant_id = "tenant_id" # please set me up!
```


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
 - Resolves https://github.com/dlt-hub/dlt/issues/1378

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
