### PR TITLE
WIP: Add missing parts for rest client docs

### DIFF
--- a/docs/website/docs/general-usage/http/rest-client.md
+++ b/docs/website/docs/general-usage/http/rest-client.md
@@ -80,7 +80,7 @@ For example, if the API response looks like this:
 }
 ```
 
-The `data_selector` should be set to `"posts"` to extract the list of posts from the response.
+The `data_selector` should be set to `"posts"` or `"$.posts"` to extract the list of posts from the response.
 
 For a nested structure like this:
 
@@ -96,7 +96,7 @@ For a nested structure like this:
 }
 ```
 
-The `data_selector` needs to be set to `"results.posts"`. Read more about [JSONPath syntax](https://github.com/h2non/jsonpath-ng?tab=readme-ov-file#jsonpath-syntax) to learn how to write selectors.
+The `data_selector` needs to be set to `"results.posts"` or `"$.results.posts"`. Read more about [JSONPath syntax](https://github.com/h2non/jsonpath-ng?tab=readme-ov-file#jsonpath-syntax) to learn how to write selectors.
 
 ### PageData
 
@@ -430,6 +430,26 @@ client = RESTClient(
 
 for page in client.paginate("/protected/resource"):
     print(page)
+```
+
+## Common resource defaults
+
+In `RESTAPIConfig` you can provide via `resource_defaults` which will then be applied to all requests
+
+```py
+my_params = {
+    "from_year": 2018,
+    "end_year": 2024,
+}
+
+source_config: RESTAPIConfig = {
+    "client": {...},
+    "resource_defaults": {
+        "endpoint": {
+            "params": my_params,
+        }
+    }
+}
 ```
 
 ### API key authentication

--- a/docs/website/docs/general-usage/http/rest-client.md
+++ b/docs/website/docs/general-usage/http/rest-client.md
@@ -1,7 +1,7 @@
 ---
 title: RESTClient
 description: Learn how to use the RESTClient class to interact with RESTful APIs
-keywords: [api, http, rest, request, extract, restclient, client, pagination, json, response, data_selector, session, auth, paginator, jsonresponsepaginator, headerlinkpaginator, offsetpaginator, jsonresponsecursorpaginator, queryparampaginator, bearer, token, authentication]
+keywords: [api, http, rest, request, extract, restclient, client, pagination, json, response, data_selector, session, auth, paginator, jsonresponsepaginator, headerlinkpaginator, offsetpaginator, jsonresponsecursorpaginator, queryparampaginator, bearer, token, authentication, reverse etl, json path, openapi, swagger]
 ---
 
 The `RESTClient` class offers an interface for interacting with RESTful APIs, including features like:


### PR DESCRIPTION
This PR improves and add more details on certain features of our rest client like
* common parameters via `resource_defaults`,
* addition `data_selector` path examples,
* basic guide on converting older specs to OAS 3