### PR TITLE
RESTClient: implement AuthConfigBase.__bool__ + update docs

### DIFF
--- a/dlt/sources/helpers/rest_client/auth.py
+++ b/dlt/sources/helpers/rest_client/auth.py
@@ -38,7 +38,11 @@ class AuthConfigBase(AuthBase, CredentialsConfiguration):
     configurable via env variables or toml files
     """
 
-    pass
+    def __bool__(self) -> bool:
+        # This is needed to avoid AuthConfigBase-derived classes
+        # which do not implement CredentialsConfiguration interface
+        # to be evaluated as False in requests.sessions.Session.prepare_request()
+        return True
 
 
 @configspec

--- a/docs/website/docs/general-usage/http/rest-client.md
+++ b/docs/website/docs/general-usage/http/rest-client.md
@@ -407,7 +407,7 @@ The available authentication methods are defined in the `dlt.sources.helpers.res
 - [APIKeyAuth](#api-key-authentication)
 - [HttpBasicAuth](#http-basic-authentication)
 
-For specific use cases, you can [implement custom authentication](#implementing-custom-authentication) by subclassing the `AuthConfigBase` class.
+For specific use cases, you can [implement custom authentication](#implementing-custom-authentication) by subclassing the `AuthBase` class from the Requests library.
 
 ### Bearer token authentication
 
@@ -479,12 +479,12 @@ response = client.get("/protected/resource")
 
 ### Implementing custom authentication
 
-You can implement custom authentication by subclassing the `AuthConfigBase` class and implementing the `__call__` method:
+You can implement custom authentication by subclassing the `AuthBase` class and implementing the `__call__` method:
 
 ```py
-from dlt.sources.helpers.rest_client.auth import AuthConfigBase
+from requests.auth import AuthBase
 
-class CustomAuth(AuthConfigBase):
+class CustomAuth(AuthBase):
     def __init__(self, token):
         self.token = token
 

--- a/tests/sources/helpers/rest_client/test_client.py
+++ b/tests/sources/helpers/rest_client/test_client.py
@@ -201,7 +201,6 @@ class TestRESTClient:
                 request.headers["Authorization"] = f"Bearer {self.token}"
                 return request
 
-
         auth_list = [
             CustomAuthConfigBase("test-token"),
             CustomAuthAuthBase("test-token"),


### PR DESCRIPTION
This PR implements __bool__ on AuthConfigBase so instances of this class evaluate to True in requests.sessions.Session.prepare_request() when auth argument is evaluated otherwise instances of AuthConfigBase have no effect when passed as arguments to RESTClient's methods.

The PR also updates the documentation to suggest explicit inheritance from `requests.auth.AuthBase` for custom authentication.