### PR TITLE
RESTClient: Added "values" to the data pattern of the rest_api helper

### DIFF
--- a/dlt/sources/helpers/rest_client/detector.py
+++ b/dlt/sources/helpers/rest_client/detector.py
@@ -25,6 +25,7 @@ RECORD_KEY_PATTERNS = frozenset(
         "payload",
         "content",
         "objects",
+        "values",
     ]
 )
 


### PR DESCRIPTION
### Description
Quick PR to add the value `values` to the path recognized automatically as data in an API response. This is actually used by the JIRA api, but it looks like a quite generic name

### Related Issues

None
 