### PR TITLE
Support partitioning hints for athena iceberg

### DIFF
--- a/dlt/destinations/adapters.py
+++ b/dlt/destinations/adapters.py
@@ -5,6 +5,7 @@ from dlt.destinations.impl.qdrant import qdrant_adapter
 from dlt.destinations.impl.bigquery import bigquery_adapter
 from dlt.destinations.impl.synapse import synapse_adapter
 from dlt.destinations.impl.clickhouse import clickhouse_adapter
+from dlt.destinations.impl.athena import athena_adapter
 
 __all__ = [
     "weaviate_adapter",
@@ -12,4 +13,5 @@ __all__ = [
     "bigquery_adapter",
     "synapse_adapter",
     "clickhouse_adapter",
+    "athena_adapter",
 ]

--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -403,7 +403,9 @@ class AthenaClient(SqlJobClientWithStaging, SupportsStagingDestination):
         return self.type_mapper.from_db_type(hive_t, precision, scale)
 
     def _get_column_def_sql(self, c: TColumnSchema, table_format: TTableFormat = None) -> str:
-        return f"{self.sql_client.escape_ddl_identifier(c['name'])} {self.type_mapper.to_db_type(c, table_format)}"
+        return (
+            f"{self.sql_client.escape_ddl_identifier(c['name'])} {self.type_mapper.to_db_type(c, table_format)}"
+        )
 
     def _iceberg_partition_clause(self, partition_hints: Optional[Dict[str, str]]) -> str:
         if not partition_hints:
@@ -444,27 +446,21 @@ class AthenaClient(SqlJobClientWithStaging, SupportsStagingDestination):
                 partition_clause = self._iceberg_partition_clause(
                     cast(Optional[Dict[str, str]], table.get(PARTITION_HINT))
                 )
-                sql.append(
-                    f"""CREATE TABLE {qualified_table_name}
+                sql.append(f"""CREATE TABLE {qualified_table_name}
                         ({columns})
                         {partition_clause}
                         LOCATION '{location.rstrip('/')}'
-                        TBLPROPERTIES ('table_type'='ICEBERG', 'format'='parquet');"""
-                )
+                        TBLPROPERTIES ('table_type'='ICEBERG', 'format'='parquet');""")
             elif table_format == "jsonl":
-                sql.append(
-                    f"""CREATE EXTERNAL TABLE {qualified_table_name}
+                sql.append(f"""CREATE EXTERNAL TABLE {qualified_table_name}
                         ({columns})
                         ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
-                        LOCATION '{location}';"""
-                )
+                        LOCATION '{location}';""")
             else:
-                sql.append(
-                    f"""CREATE EXTERNAL TABLE {qualified_table_name}
+                sql.append(f"""CREATE EXTERNAL TABLE {qualified_table_name}
                         ({columns})
                         STORED AS PARQUET
-                        LOCATION '{location}';"""
-                )
+                        LOCATION '{location}';""")
         return sql
 
     def start_file_load(self, table: TTableSchema, file_path: str, load_id: str) -> LoadJob:

--- a/dlt/destinations/impl/athena/athena_adapter.py
+++ b/dlt/destinations/impl/athena/athena_adapter.py
@@ -1,0 +1,90 @@
+from typing import Any, Optional, Dict, Protocol, Sequence, Union, Final
+
+from dateutil import parser
+
+from dlt.common.pendulum import timezone
+from dlt.common.schema.typing import TColumnNames, TTableSchemaColumns, TColumnSchema
+from dlt.destinations.utils import ensure_resource
+from dlt.extract import DltResource
+from dlt.extract.items import TTableHintTemplate
+
+
+PARTITION_HINT: Final[str] = "x-athena-partition"
+
+
+class athena_partition:
+    """Helper class to generate iceberg partition transform strings.
+
+    E.g. `athena_partition.bucket(16, "id")` will return `bucket(16, "id")`.
+    """
+
+    @staticmethod
+    def year(column_name: str) -> str:
+        """Partition by year part of a date or timestamp column."""
+        return f"year({column_name})"
+
+    @staticmethod
+    def month(column_name: str) -> str:
+        """Partition by month part of a date or timestamp column."""
+        return f"month({column_name})"
+
+    @staticmethod
+    def day(column_name: str) -> str:
+        """Partition by day part of a date or timestamp column."""
+        return f"day({column_name})"
+
+    @staticmethod
+    def hour(column_name: str) -> str:
+        """Partition by hour part of a date or timestamp column."""
+        return f"hour({column_name})"
+
+    @staticmethod
+    def bucket(n: int, column_name: str) -> str:
+        """Partition by hashed value to n buckets."""
+        return f"bucket({n}, {column_name})"
+
+    @staticmethod
+    def truncate(length: int, column_name: str) -> str:
+        """Partition by value truncated to length."""
+        return f"truncate({length}, {column_name})"
+
+
+def athena_adapter(
+    data: Any,
+    partition: Union[str, Sequence[str]] = None,
+) -> DltResource:
+    """
+    Prepares data for loading into Athena
+
+    Args:
+        data: The data to be transformed.
+            This can be raw data or an instance of DltResource.
+            If raw data is provided, the function will wrap it into a `DltResource` object.
+        partition: Column name(s) partition transform string(s) to partition table by
+
+    Returns:
+        A `DltResource` object that is ready to be loaded into BigQuery.
+
+    Raises:
+        ValueError: If any hint is invalid or none are specified.
+
+    Examples:
+        >>> data = [{"name": "Marcel", "department": "Engineering", "date_hired": "2024-01-30"}]
+        >>> athena_adapter(data, partition=["department", athena_partition.year("date_hired"), athena_partition.bucket(8, "name")])
+        [DltResource with hints applied]
+    """
+    resource = ensure_resource(data)
+    additional_table_hints: Dict[str, TTableHintTemplate[Any]] = {}
+
+    if partition:
+        if isinstance(partition, str):
+            partition = [partition]
+
+        # Note: PARTITIONED BY clause identifiers are not allowed to be quoted. They are added as-is.
+        additional_table_hints[PARTITION_HINT] = list(partition)
+
+    if additional_table_hints:
+        resource.apply_hints(additional_table_hints=additional_table_hints)
+    else:
+        raise ValueError("A value for `partition` must be specified.")
+    return resource

--- a/dlt/destinations/impl/athena/athena_adapter.py
+++ b/dlt/destinations/impl/athena/athena_adapter.py
@@ -12,46 +12,60 @@ from dlt.extract.items import TTableHintTemplate
 PARTITION_HINT: Final[str] = "x-athena-partition"
 
 
-class athena_partition:
-    """Helper class to generate iceberg partition transform strings.
+class PartitionTransformation:
+    template: str
+    """Template string of the transformation including column name placeholder. E.g. `bucket(16, {column_name})`"""
+    column_name: str
+    """Column name to apply the transformation to"""
 
-    E.g. `athena_partition.bucket(16, "id")` will return `bucket(16, "id")`.
+    def __init__(self, template: str, column_name: str) -> None:
+        self.template = template
+        self.column_name = column_name
+
+
+class athena_partition:
+    """Helper class to generate iceberg partition transformations
+
+    E.g. `athena_partition.bucket(16, "id")` will return a transformation with template `bucket(16, {column_name})`
+    This can be correctly rendered by the athena loader with escaped column name.
     """
 
     @staticmethod
-    def year(column_name: str) -> str:
+    def year(column_name: str) -> PartitionTransformation:
         """Partition by year part of a date or timestamp column."""
-        return f"year({column_name})"
+        return PartitionTransformation("year({column_name})", column_name)
 
     @staticmethod
-    def month(column_name: str) -> str:
+    def month(column_name: str) -> PartitionTransformation:
         """Partition by month part of a date or timestamp column."""
-        return f"month({column_name})"
+        return PartitionTransformation("month({column_name})", column_name)
 
     @staticmethod
-    def day(column_name: str) -> str:
+    def day(column_name: str) -> PartitionTransformation:
         """Partition by day part of a date or timestamp column."""
-        return f"day({column_name})"
+        return PartitionTransformation("day({column_name})", column_name)
 
     @staticmethod
-    def hour(column_name: str) -> str:
+    def hour(column_name: str) -> PartitionTransformation:
         """Partition by hour part of a date or timestamp column."""
-        return f"hour({column_name})"
+        return PartitionTransformation("hour({column_name})", column_name)
 
     @staticmethod
-    def bucket(n: int, column_name: str) -> str:
+    def bucket(n: int, column_name: str) -> PartitionTransformation:
         """Partition by hashed value to n buckets."""
-        return f"bucket({n}, {column_name})"
+        return PartitionTransformation(f"bucket({n}, {{column_name}})", column_name)
 
     @staticmethod
-    def truncate(length: int, column_name: str) -> str:
+    def truncate(length: int, column_name: str) -> PartitionTransformation:
         """Partition by value truncated to length."""
-        return f"truncate({length}, {column_name})"
+        return PartitionTransformation(f"truncate({length}, {{column_name}})", column_name)
 
 
 def athena_adapter(
     data: Any,
-    partition: Union[str, Sequence[str]] = None,
+    partition: Union[
+        str, PartitionTransformation, Sequence[Union[str, PartitionTransformation]]
+    ] = None,
 ) -> DltResource:
     """
     Prepares data for loading into Athena
@@ -60,7 +74,9 @@ def athena_adapter(
         data: The data to be transformed.
             This can be raw data or an instance of DltResource.
             If raw data is provided, the function will wrap it into a `DltResource` object.
-        partition: Column name(s) partition transform string(s) to partition table by
+        partition: Column name(s) or instances of `PartitionTransformation` to partition the table by.
+            To use a transformation it's best to use the methods of the helper class `athena_partition`
+            to generate correctly escaped SQL in the loader.
 
     Returns:
         A `DltResource` object that is ready to be loaded into BigQuery.
@@ -77,11 +93,22 @@ def athena_adapter(
     additional_table_hints: Dict[str, TTableHintTemplate[Any]] = {}
 
     if partition:
-        if isinstance(partition, str):
+        if isinstance(partition, str) or not isinstance(partition, Sequence):
             partition = [partition]
 
-        # Note: PARTITIONED BY clause identifiers are not allowed to be quoted. They are added as-is.
-        additional_table_hints[PARTITION_HINT] = list(partition)
+        # Partition hint is `{column_name: template}`, e.g. `{"department": "{column_name}", "date_hired": "year({column_name})"}`
+        # Use one dict for all hints instead of storing on column so order is preserved
+        partition_hint: Dict[str, str] = {}
+
+        for item in partition:
+            if isinstance(item, PartitionTransformation):
+                # Client will generate the final SQL string with escaped column name injected
+                partition_hint[item.column_name] = item.template
+            else:
+                # Item is the column name
+                partition_hint[item] = "{column_name}"
+
+        additional_table_hints[PARTITION_HINT] = partition_hint
 
     if additional_table_hints:
         resource.apply_hints(additional_table_hints=additional_table_hints)

--- a/docs/website/docs/dlt-ecosystem/destinations/athena.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/athena.md
@@ -166,7 +166,18 @@ You can choose the following file formats:
 
 You can use the `athena_adapter` to add partitioning to Athena tables. This is currently only supported for Iceberg tables.
 
-Here is how you use it:
+Iceberg tables support a few transformation functions for partitioning. Info on all supported functions in the [AWS documentation](https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg-creating-tables.html#querying-iceberg-creating-tables-query-editor).
+
+Use the `athena_partition` helper to generate the partitioning hints for these functions:
+
+* `athena_partition.year(column_name: str)`: Partition by year of date/datetime column.
+* `athena_partition.month(column_name: str)`: Partition by month of date/datetime column.
+* `athena_partition.day(column_name: str)`: Partition by day of date/datetime column.
+* `athena_partition.hour(column_name: str)`: Partition by hour of date/datetime column.
+* `athena_partition.bucket(n: int, column_name: str)`: Partition by hashed value to `n` buckets
+* `athena_partition.truncate(length: int, column_name: str)`: Partition by truncated value to `length` (or width for numbers)
+
+Here is an example of how to use the adapter to partition a table:
 
 ```py
 from datetime import date
@@ -206,9 +217,6 @@ athena_adapter(
 pipeline = dlt.pipeline("athena_example")
 pipeline.run(partitioned_data)
 ```
-
-See the AWS Athena documentation for more information on [available partitioning options](https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg-creating-tables.html#querying-iceberg-creating-tables-query-editor).
-
 
 <!--@@@DLT_TUBA athena-->
 

--- a/tests/load/athena_iceberg/__init__.py
+++ b/tests/load/athena_iceberg/__init__.py
@@ -1,0 +1,4 @@
+from tests.utils import skip_if_not_active
+
+
+skip_if_not_active("athena")

--- a/tests/load/athena_iceberg/test_athena_adapter.py
+++ b/tests/load/athena_iceberg/test_athena_adapter.py
@@ -57,9 +57,7 @@ def test_iceberg_partition_hints():
         )[0]
 
     # Partition clause is generated with original order
-    expected_clause = (
-        "PARTITIONED BY (category, month(created_at), bucket(10, product_id), truncate(2, name))"
-    )
+    expected_clause = "PARTITIONED BY (`category`, month(`created_at`), bucket(10, `product_id`), truncate(2, `name`))"
     assert expected_clause in sql_partitioned
 
     # No partition clause otherwise

--- a/tests/load/athena_iceberg/test_athena_adapter.py
+++ b/tests/load/athena_iceberg/test_athena_adapter.py
@@ -1,0 +1,66 @@
+import pytest
+
+import dlt
+from dlt.destinations import filesystem
+from dlt.destinations.impl.athena.athena_adapter import athena_adapter, athena_partition
+from tests.load.utils import destinations_configs, DestinationTestConfiguration
+
+
+def test_iceberg_partition_hints():
+    """Create a table with athena partition hints and check that the SQL is generated correctly."""
+
+    @dlt.resource(table_format="iceberg")
+    def partitioned_table():
+        yield {
+            "product_id": 1,
+            "name": "product 1",
+            "created_at": "2021-01-01T00:00:00Z",
+            "category": "category 1",
+            "price": 100.0,
+            "quantity": 10,
+        }
+
+    @dlt.resource(table_format="iceberg")
+    def not_partitioned_table():
+        yield {"a": 1, "b": 2}
+
+    athena_adapter(
+        partitioned_table,
+        partition=[
+            "category",
+            athena_partition.month("created_at"),
+            athena_partition.bucket(10, "product_id"),
+            athena_partition.truncate(2, "name"),
+        ],
+    )
+
+    pipeline = dlt.pipeline(
+        "athena_test",
+        destination="athena",
+        staging=filesystem("s3://not-a-real-bucket"),
+        full_refresh=True,
+    )
+
+    pipeline.extract([partitioned_table, not_partitioned_table])
+    pipeline.normalize()
+
+    with pipeline._sql_job_client(pipeline.default_schema) as client:
+        sql_partitioned = client._get_table_update_sql(
+            "partitioned_table",
+            list(pipeline.default_schema.tables["partitioned_table"]["columns"].values()),
+            False,
+        )[0]
+        sql_not_partitioned = client._get_table_update_sql(
+            "not_partitioned_table",
+            list(pipeline.default_schema.tables["not_partitioned_table"]["columns"].values()),
+            False,
+        )[0]
+
+    # Partition clause is generated with original order
+    expected_clause = (
+        "PARTITIONED BY (category, month(created_at), bucket(10, product_id), truncate(2, name))"
+    )
+    assert expected_clause in sql_partitioned
+
+    # No partition clause otherwise
+    assert "PARTITIONED BY" not in sql_not_partitioned

--- a/tests/load/athena_iceberg/test_athena_adapter.py
+++ b/tests/load/athena_iceberg/test_athena_adapter.py
@@ -3,7 +3,9 @@ import pytest
 import dlt
 from dlt.destinations import filesystem
 from dlt.destinations.impl.athena.athena_adapter import athena_adapter, athena_partition
-from tests.load.utils import destinations_configs, DestinationTestConfiguration
+
+# mark all tests as essential, do not remove
+pytestmark = pytest.mark.essential
 
 
 def test_iceberg_partition_hints():
@@ -57,7 +59,10 @@ def test_iceberg_partition_hints():
         )[0]
 
     # Partition clause is generated with original order
-    expected_clause = "PARTITIONED BY (`category`, month(`created_at`), bucket(10, `product_id`), truncate(2, `name`))"
+    expected_clause = (
+        "PARTITIONED BY (`category`, month(`created_at`), bucket(10, `product_id`), truncate(2,"
+        " `name`))"
+    )
     assert expected_clause in sql_partitioned
 
     # No partition clause otherwise

--- a/tests/load/athena_iceberg/test_athena_iceberg.py
+++ b/tests/load/athena_iceberg/test_athena_iceberg.py
@@ -11,13 +11,10 @@ from tests.pipeline.utils import assert_load_info, load_table_counts
 
 from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
 
-from tests.utils import skip_if_not_active
 from dlt.destinations.exceptions import DatabaseTerminalException
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
-
-skip_if_not_active("athena")
 
 
 def test_iceberg() -> None:

--- a/tests/load/pipeline/test_athena.py
+++ b/tests/load/pipeline/test_athena.py
@@ -9,6 +9,8 @@ from tests.cases import table_update_and_row, assert_all_data_types_row
 from tests.pipeline.utils import assert_load_info, load_table_counts
 from tests.pipeline.utils import load_table_counts
 from dlt.destinations.exceptions import CantExtractTablePrefix
+from dlt.destinations.impl.athena.athena_adapter import athena_partition, athena_adapter
+from dlt.destinations.fs_client import FSClientBase
 
 from tests.load.pipeline.utils import destinations_configs, DestinationTestConfiguration
 from tests.load.utils import (
@@ -231,3 +233,68 @@ def test_athena_file_layouts(destination_config: DestinationTestConfiguration, l
         pipeline, *[t["name"] for t in pipeline.default_schema.data_tables()]
     )
     assert table_counts == {"items1": 3, "items2": 7}
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["athena"], force_iceberg=True),
+    ids=lambda x: x.name,
+)
+def test_athena_partitioned_iceberg_table(destination_config: DestinationTestConfiguration):
+    """Load an iceberg table with partition hints and verifiy partitions are created correctly."""
+    pipeline = destination_config.setup_pipeline("athena_" + uniq_id(), full_refresh=True)
+
+    data_items = [
+        (1, "A", datetime.date.fromisoformat("2021-01-01")),
+        (2, "A", datetime.date.fromisoformat("2021-01-02")),
+        (3, "A", datetime.date.fromisoformat("2021-01-03")),
+        (4, "A", datetime.date.fromisoformat("2021-02-01")),
+        (5, "A", datetime.date.fromisoformat("2021-02-02")),
+        (6, "B", datetime.date.fromisoformat("2021-01-01")),
+        (7, "B", datetime.date.fromisoformat("2021-01-02")),
+        (8, "B", datetime.date.fromisoformat("2021-01-03")),
+        (9, "B", datetime.date.fromisoformat("2021-02-01")),
+        (10, "B", datetime.date.fromisoformat("2021-03-02")),
+    ]
+
+    @dlt.resource(table_format="iceberg")
+    def partitioned_table():
+        yield [{"id": i, "category": c, "created_at": d} for i, c, d in data_items]
+
+    athena_adapter(
+        partitioned_table,
+        partition=[
+            "category",
+            athena_partition.month("created_at"),
+        ],
+    )
+
+    info = pipeline.run(partitioned_table)
+    assert_load_info(info)
+
+    # Get partitions from metadata
+    with pipeline.sql_client() as sql_client:
+        tbl_name = sql_client.make_qualified_table_name("partitioned_table$partitions")
+        rows = sql_client.execute_sql(f"SELECT partition FROM {tbl_name}")
+        partition_keys = {r[0] for r in rows}
+
+        data_rows = sql_client.execute_sql(
+            f"SELECT id, category, created_at FROM {sql_client.make_qualified_table_name('partitioned_table')}"
+        )
+        # data_rows = [(i, c, d.toisoformat()) for i, c, d in data_rows]
+
+    # All data is in table
+    assert len(data_rows) == len(data_items)
+    assert set(data_rows) == set(data_items)
+
+    # Compare with expected partitions
+    # Months are number of months since epoch
+    expected_partitions = {
+        "{category=A, created_at_month=612}",
+        "{category=A, created_at_month=613}",
+        "{category=B, created_at_month=612}",
+        "{category=B, created_at_month=613}",
+        "{category=B, created_at_month=614}",
+    }
+
+    assert partition_keys == expected_partitions

--- a/tests/load/pipeline/test_athena.py
+++ b/tests/load/pipeline/test_athena.py
@@ -279,7 +279,8 @@ def test_athena_partitioned_iceberg_table(destination_config: DestinationTestCon
         partition_keys = {r[0] for r in rows}
 
         data_rows = sql_client.execute_sql(
-            f"SELECT id, category, created_at FROM {sql_client.make_qualified_table_name('partitioned_table')}"
+            "SELECT id, category, created_at FROM"
+            f" {sql_client.make_qualified_table_name('partitioned_table')}"
         )
         # data_rows = [(i, c, d.toisoformat()) for i, c, d in data_rows]
 

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -180,6 +180,7 @@ def destinations_configs(
     file_format: Union[TLoaderFileFormat, Sequence[TLoaderFileFormat]] = None,
     supports_merge: Optional[bool] = None,
     supports_dbt: Optional[bool] = None,
+    force_iceberg: Optional[bool] = None,
 ) -> List[DestinationTestConfiguration]:
     # sanity check
     for item in subset:
@@ -494,6 +495,11 @@ def destinations_configs(
     destination_configs = [
         conf for conf in destination_configs if conf.name not in EXCLUDED_DESTINATION_CONFIGURATIONS
     ]
+
+    if force_iceberg is not None:
+        destination_configs = [
+            conf for conf in destination_configs if conf.force_iceberg is force_iceberg
+        ]
 
     return destination_configs
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Adds `athena_adapter` to add partitioning hints in athena. Generates `PARTITIONED BY` clause on iceberg tables.

The adapter generates a table hint: `x-athena-partition`.
This is a dict in form of `{<column_name>: <template_string>}`  
E.g. `{"department": "{column_name}", "date_hired": "year({column_name})"}`  

Using format strings so we can generate transform (`bucket(...)`, `year(...)`, etc) strings and inject the escaped column name later in the loader.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

Implements partially #555 -> Iceberg support

