### PR TITLE
RESTClient: implement AuthConfigBase.__bool__ + update docs

### DIFF
--- a/dlt/sources/helpers/rest_client/auth.py
+++ b/dlt/sources/helpers/rest_client/auth.py
@@ -38,7 +38,11 @@ class AuthConfigBase(AuthBase, CredentialsConfiguration):
     configurable via env variables or toml files
     """
 
-    pass
+    def __bool__(self) -> bool:
+        # This is needed to avoid AuthConfigBase-derived classes
+        # which do not implement CredentialsConfiguration interface
+        # to be evaluated as False in requests.sessions.Session.prepare_request()
+        return True
 
 
 @configspec

--- a/dlt/sources/helpers/rest_client/client.py
+++ b/dlt/sources/helpers/rest_client/client.py
@@ -6,12 +6,14 @@ from typing import (
     Any,
     TypeVar,
     Iterable,
+    Union,
     cast,
 )
 import copy
 from urllib.parse import urlparse
 from requests import Session as BaseSession  # noqa: I251
 from requests import Response, Request
+from requests.auth import AuthBase
 
 from dlt.common import jsonpath, logger
 
@@ -41,7 +43,7 @@ class PageData(List[_T]):
         request: Request,
         response: Response,
         paginator: BasePaginator,
-        auth: AuthConfigBase,
+        auth: AuthBase,
     ):
         super().__init__(__iterable)
         self.request = request
@@ -57,7 +59,7 @@ class RESTClient:
     Args:
         base_url (str): The base URL of the API to make requests to.
         headers (Optional[Dict[str, str]]): Default headers to include in all requests.
-        auth (Optional[AuthConfigBase]): Authentication configuration for all requests.
+        auth (Optional[AuthBase]): Authentication configuration for all requests.
         paginator (Optional[BasePaginator]): Default paginator for handling paginated responses.
         data_selector (Optional[jsonpath.TJsonPath]): JSONPath selector for extracting data from responses.
         session (BaseSession): HTTP session for making requests.
@@ -69,7 +71,7 @@ class RESTClient:
         self,
         base_url: str,
         headers: Optional[Dict[str, str]] = None,
-        auth: Optional[AuthConfigBase] = None,
+        auth: Optional[AuthBase] = None,
         paginator: Optional[BasePaginator] = None,
         data_selector: Optional[jsonpath.TJsonPath] = None,
         session: BaseSession = None,
@@ -105,7 +107,7 @@ class RESTClient:
         method: HTTPMethod,
         params: Dict[str, Any],
         json: Optional[Dict[str, Any]] = None,
-        auth: Optional[AuthConfigBase] = None,
+        auth: Optional[AuthBase] = None,
         hooks: Optional[Hooks] = None,
     ) -> Request:
         parsed_url = urlparse(path)
@@ -154,7 +156,7 @@ class RESTClient:
         method: HTTPMethodBasic = "GET",
         params: Optional[Dict[str, Any]] = None,
         json: Optional[Dict[str, Any]] = None,
-        auth: Optional[AuthConfigBase] = None,
+        auth: Optional[AuthBase] = None,
         paginator: Optional[BasePaginator] = None,
         data_selector: Optional[jsonpath.TJsonPath] = None,
         hooks: Optional[Hooks] = None,
@@ -166,7 +168,7 @@ class RESTClient:
             method (HTTPMethodBasic): HTTP method for the request, defaults to 'get'.
             params (Optional[Dict[str, Any]]): URL parameters for the request.
             json (Optional[Dict[str, Any]]): JSON payload for the request.
-            auth (Optional[AuthConfigBase]): Authentication configuration for the request.
+            auth (Optional[AuthBase): Authentication configuration for the request.
             paginator (Optional[BasePaginator]): Paginator instance for handling
                 pagination logic.
             data_selector (Optional[jsonpath.TJsonPath]): JSONPath selector for

--- a/docs/examples/custom_destination_bigquery/custom_destination_bigquery.py
+++ b/docs/examples/custom_destination_bigquery/custom_destination_bigquery.py
@@ -60,7 +60,9 @@ def resource(url: str):
 # dlt biquery custom destination
 # we can use the dlt provided credentials class
 # to retrieve the gcp credentials from the secrets
-@dlt.destination(name="bigquery", loader_file_format="parquet", batch_size=0)
+@dlt.destination(
+    name="bigquery", loader_file_format="parquet", batch_size=0, naming_convention="snake_case"
+)
 def bigquery_insert(
     items, table, credentials: GcpServiceAccountCredentials = dlt.secrets.value
 ) -> None:

--- a/docs/website/docs/general-usage/http/rest-client.md
+++ b/docs/website/docs/general-usage/http/rest-client.md
@@ -407,7 +407,7 @@ The available authentication methods are defined in the `dlt.sources.helpers.res
 - [APIKeyAuth](#api-key-authentication)
 - [HttpBasicAuth](#http-basic-authentication)
 
-For specific use cases, you can [implement custom authentication](#implementing-custom-authentication) by subclassing the `AuthConfigBase` class.
+For specific use cases, you can [implement custom authentication](#implementing-custom-authentication) by subclassing the `AuthBase` class from the Requests library.
 
 ### Bearer token authentication
 
@@ -479,12 +479,12 @@ response = client.get("/protected/resource")
 
 ### Implementing custom authentication
 
-You can implement custom authentication by subclassing the `AuthConfigBase` class and implementing the `__call__` method:
+You can implement custom authentication by subclassing the `AuthBase` class and implementing the `__call__` method:
 
 ```py
-from dlt.sources.helpers.rest_client.auth import AuthConfigBase
+from requests.auth import AuthBase
 
-class CustomAuth(AuthConfigBase):
+class CustomAuth(AuthBase):
     def __init__(self, token):
         self.token = token
 

--- a/tests/sources/helpers/rest_client/test_client.py
+++ b/tests/sources/helpers/rest_client/test_client.py
@@ -201,7 +201,6 @@ class TestRESTClient:
                 request.headers["Authorization"] = f"Bearer {self.token}"
                 return request
 
-
         auth_list = [
             CustomAuthConfigBase("test-token"),
             CustomAuthAuthBase("test-token"),

--- a/tests/sources/helpers/rest_client/test_client.py
+++ b/tests/sources/helpers/rest_client/test_client.py
@@ -1,9 +1,10 @@
 import os
 import pytest
 from typing import Any, cast
+from requests import PreparedRequest, Request
 from requests.auth import AuthBase
 from dlt.common.typing import TSecretStrValue
-from dlt.sources.helpers.requests import Response, Request
+from dlt.sources.helpers.requests import Response
 from dlt.sources.helpers.rest_client import RESTClient
 from dlt.sources.helpers.rest_client.client import Hooks
 from dlt.sources.helpers.rest_client.paginators import JSONResponsePaginator
@@ -189,7 +190,7 @@ class TestRESTClient:
             def __init__(self, token: str):
                 self.token = token
 
-            def __call__(self, request: Request) -> Request:
+            def __call__(self, request: PreparedRequest) -> PreparedRequest:
                 request.headers["Authorization"] = f"Bearer {self.token}"
                 return request
 
@@ -197,7 +198,7 @@ class TestRESTClient:
             def __init__(self, token: str):
                 self.token = token
 
-            def __call__(self, request: Request) -> Request:
+            def __call__(self, request: PreparedRequest) -> PreparedRequest:
                 request.headers["Authorization"] = f"Bearer {self.token}"
                 return request
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR is resubmitted because I merged the last one with typing problems that made linting to fail. Let's try to fix our qdrant problem so we see CI green again...

linting fixes included
- using correct types in Auths defined in tests
- changing the types for auth in `RESTClient` to `AuthBase` which is a common base for `AuthConfigBase` and the one used by requests (`AuthBase` itself)

all tests including those in rest api source are passing after this

----
This PR implements __bool__ on AuthConfigBase so instances of this class evaluate to True in requests.sessions.Session.prepare_request() when auth argument is evaluated otherwise instances of AuthConfigBase have no effect when passed as arguments to RESTClient's methods.

The PR also updates the documentation to suggest explicit inheritance from requests.auth.AuthBase for custom authentication.
