### PR TITLE
skips non resolvable fields from appearing in sample secrets.toml

### DIFF
--- a/dlt/cli/config_toml_writer.py
+++ b/dlt/cli/config_toml_writer.py
@@ -4,6 +4,7 @@ from tomlkit.items import Table as TOMLTable
 from tomlkit.container import Container as TOMLContainer
 from collections.abc import Sequence as C_Sequence
 
+from dlt.common.configuration.specs.base_configuration import is_hint_not_resolved
 from dlt.common.pendulum import pendulum
 from dlt.common.configuration.specs import (
     BaseConfiguration,
@@ -11,7 +12,7 @@ from dlt.common.configuration.specs import (
     extract_inner_hint,
 )
 from dlt.common.data_types import py_type_to_sc_type
-from dlt.common.typing import AnyType, is_final_type, is_optional_type
+from dlt.common.typing import AnyType, is_optional_type
 
 
 class WritableConfigValue(NamedTuple):
@@ -62,9 +63,9 @@ def write_value(
     # skip if table contains the name already
     if name in toml_table and not overwrite_existing:
         return
-    # do not dump final and optional fields if they are not of special interest
+    # do not dump nor resolvable and optional fields if they are not of special interest
     if (
-        is_final_type(hint) or is_optional_type(hint) or default_value is not None
+        is_hint_not_resolved(hint) or is_optional_type(hint) or default_value is not None
     ) and not is_default_of_interest:
         return
     # get the inner hint to generate cool examples

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -572,7 +572,13 @@ def assert_common_files(
         # destination is there
         assert secrets.get_value(destination_name, type, None, "destination") is not None
     # certain values are never there
-    for not_there in ["destination_name", "default_schema_name", "as_staging", "staging_config"]:
+    for not_there in [
+        "destination_name",
+        "default_schema_name",
+        "as_staging",
+        "staging_config",
+        "dataset_name",
+    ]:
         assert secrets.get_value(not_there, type, None, "destination", destination_name)[0] is None
 
     return visitor, secrets


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
We introduced an annotation for `configspec` that skips resolution of a given field and destination configurations were updated. toml write didn't take this into account and started to generate `dataset_name` (which got excluded this way).

this PR fixes this problem
