### PR TITLE
exp/logging-messages-style

### DIFF
--- a/dlt/common/configuration/specs/run_configuration.py
+++ b/dlt/common/configuration/specs/run_configuration.py
@@ -17,7 +17,7 @@ class RunConfiguration(BaseConfiguration):
     dlthub_telemetry: bool = True  # enable or disable dlthub telemetry
     dlthub_telemetry_endpoint: Optional[str] = "https://telemetry.scalevector.ai"
     dlthub_telemetry_segment_write_key: Optional[str] = None
-    log_format: str = "{asctime}|[{levelname:<21}]|{process}|{thread}|{name}|{filename}|{funcName}:{lineno}|{message}"
+    log_format: str = "{asctime}|[{levelname}]|{process}|{thread}|{name}|{filename}|{funcName}:{lineno}|{message}"
     log_level: str = "WARNING"
     request_timeout: float = 60
     """Timeout for http requests"""

--- a/tests/common/configuration/test_configuration.py
+++ b/tests/common/configuration/test_configuration.py
@@ -549,7 +549,7 @@ def test_configuration_is_mutable_mapping(environment: Any, env_provider: Config
         "dlthub_telemetry": True,
         "dlthub_telemetry_endpoint": "https://telemetry-tracker.services4758.workers.dev",
         "dlthub_telemetry_segment_write_key": None,
-        "log_format": "{asctime}|[{levelname:<21}]|{process}|{thread}|{name}|{filename}|{funcName}:{lineno}|{message}",
+        "log_format": "{asctime}|[{levelname}]|{process}|{thread}|{name}|{filename}|{funcName}:{lineno}|{message}",
         "log_level": "WARNING",
         "request_timeout": 60,
         "request_max_attempts": 5,

--- a/tests/common/runtime/test_logging.py
+++ b/tests/common/runtime/test_logging.py
@@ -129,6 +129,27 @@ def test_double_log_init(environment: DictStrStr) -> None:
     logger.error("test warning", extra={"metrics": "props"})
 
 
+def test_formatted_output(capfd) -> None:
+    init_test_logging(PureBasicConfiguration())
+    import re
+
+    log_pattern = (
+        r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3})\|\[(WARNING|ERROR)\]\|"
+        r"(\d+)\|(\d+)\|(\w+)\|(\w+\.py)\|(\w+:\d+)\|test\n"
+    )
+    # Using capdf, we can test at least warning and error outputs.
+    # testing warning message
+    logger.warning("test")
+    message = capfd.readouterr().err
+    match = re.match(log_pattern, message)
+    assert match is not None
+    # testing error message
+    logger.error("test")
+    message = capfd.readouterr().err
+    match = re.match(log_pattern, message)
+    assert match is not None
+
+
 def test_cleanup(environment: DictStrStr) -> None:
     # this must happen after all forked tests (problems with tests teardowns in other tests)
     pass


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Hi all!

I noticed that the logging output levels are currently left-aligned with a width of 21 characters. Is there any specific reason for this?

Here's an example of the current formatting:
![image](https://github.com/dlt-hub/dlt/assets/10950697/878cdf2f-77a8-4459-8130-17e2d5e13abe)

While it's not a major issue, I believe removing the white spaces could improve the visualization. 

In this PR, I've adjusted the formatting accordingly and included a new test to validate the output format, specifically for error and warning messages:
![image](https://github.com/dlt-hub/dlt/assets/10950697/16d61d30-0557-4a0e-b4da-eb65297f1daf)

Another option could be centering the text and reducing the total width slightly...

Perhaps in the future, we could explore using colors to differentiate between different log levels.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

Nope

<!--
Provide any additional context about the PR here.
-->
Thanks!
<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
