### PR TITLE
Add load_id to arrow tables in extract step instead of normalize

### DIFF
--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -342,15 +342,23 @@ class ArrowExtractor(Extractor):
             # normalize arrow table before merging
             arrow_table = self.schema.normalize_table_identifiers(arrow_table)
             # Add load_id column
+            dlt_load_id_col = self.naming.normalize_table_identifier("_dlt_load_id")
             if (
                 self._normalize_config.add_dlt_load_id
-                and "_dlt_load_id" not in arrow_table["columns"]
+                and dlt_load_id_col not in arrow_table["columns"]
             ):
-                arrow_table["columns"]["_dlt_load_id"] = {
-                    "name": "_dlt_load_id",
-                    "data_type": "text",
-                    "nullable": False,
-                }
+                self.schema.update_table(
+                    {
+                        "name": arrow_table["name"],
+                        "columns": {
+                            dlt_load_id_col: {
+                                "name": dlt_load_id_col,
+                                "data_type": "text",
+                                "nullable": False,
+                            }
+                        },
+                    }
+                )
             # issue warnings when overriding computed with arrow
             override_warn: bool = False
             for col_name, column in arrow_table["columns"].items():

--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -43,6 +43,7 @@ class IncrementalTransform:
     Subclasses must implement the `__call__` method which will be called
     for each data item in the extracted data.
     """
+
     def __init__(
         self,
         resource_name: str,
@@ -110,6 +111,7 @@ class IncrementalTransform:
 
 class JsonIncremental(IncrementalTransform):
     """Extracts incremental data from JSON data items."""
+
     def find_cursor_value(self, row: TDataItem) -> Any:
         """Finds value in row at cursor defined by self.cursor_path.
 

--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -34,6 +34,15 @@ except MissingDependencyException:
 
 
 class IncrementalTransform:
+    """A base class for handling extraction and stateful tracking
+    of incremental data from input data items.
+
+    By default, the descendant classes are instantiated within the
+    `dlt.extract.incremental.Incremental` class.
+
+    Subclasses must implement the `__call__` method which will be called
+    for each data item in the extracted data.
+    """
     def __init__(
         self,
         resource_name: str,
@@ -100,6 +109,7 @@ class IncrementalTransform:
 
 
 class JsonIncremental(IncrementalTransform):
+    """Extracts incremental data from JSON data items."""
     def find_cursor_value(self, row: TDataItem) -> Any:
         """Finds value in row at cursor defined by self.cursor_path.
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/arrow-pandas.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/arrow-pandas.md
@@ -84,7 +84,10 @@ add_dlt_load_id = true
 add_dlt_id = true
 ```
 
-Keep in mind that enabling these incurs some performance overhead because the `parquet` file needs to be read back from disk in chunks, processed and rewritten with new columns.
+Keep in mind that enabling these incurs some performance overhead:
+
+- `add_dlt_load_id` has minimal overhead since the column is added to arrow table in memory during `extract` stage, before parquet file is written to disk
+- `add_dlt_id` adds the column during `normalize` stage after file has been extracted to disk. The file needs to be read back from disk in chunks, processed and rewritten with new columns
 
 ## Incremental loading with Arrow tables
 

--- a/tests/common/schema/test_inference.py
+++ b/tests/common/schema/test_inference.py
@@ -565,3 +565,24 @@ def test_infer_on_incomplete_column(schema: Schema) -> None:
     assert i_column["x-special"] == "spec"  # type: ignore[typeddict-item]
     assert i_column["primary_key"] is True
     assert i_column["data_type"] == "text"
+
+
+def test_update_table_adds_at_end(schema: Schema) -> None:
+    row = {"evm": Wei(1)}
+    _, new_table = schema.coerce_row("eth", None, row)
+    schema.update_table(new_table)
+    schema.update_table(
+        {
+            "name": new_table["name"],
+            "columns": {
+                "_dlt_load_id": {
+                    "name": "_dlt_load_id",
+                    "data_type": "text",
+                    "nullable": False,
+                }
+            },
+        }
+    )
+    table = schema.tables["eth"]
+    # place new columns at the end
+    assert list(table["columns"].keys()) == ["evm", "_dlt_load_id"]

--- a/tests/pipeline/test_arrow_sources.py
+++ b/tests/pipeline/test_arrow_sources.py
@@ -522,7 +522,7 @@ def test_extract_adds_dlt_load_id(item_type: TPythonTableFormat) -> None:
     info = pipeline.extract(some_data())
 
     load_id = info.loads_ids[0]
-    jobs = info.load_packages[0].jobs['new_jobs']
+    jobs = info.load_packages[0].jobs["new_jobs"]
     extracted_file = [job for job in jobs if "some_data" in job.file_path][0].file_path
 
     with pa.parquet.ParquetFile(extracted_file) as pq:
@@ -549,7 +549,7 @@ def test_extract_json_normalize_parquet_adds_dlt_load_id():
     n_info = pipeline.normalize(loader_file_format="parquet")
 
     load_id = n_info.loads_ids[0]
-    jobs = n_info.load_packages[0].jobs['new_jobs']
+    jobs = n_info.load_packages[0].jobs["new_jobs"]
     normalized_file = [job for job in jobs if "some_data" in job.file_path][0].file_path
 
     with pa.parquet.ParquetFile(normalized_file) as pq:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

- Add `_dlt_load_id` to arrow tables in extract step before writing file to disk.
- Remove the load_id adding logic from normalize

Should be backwards compatible, aside from the edge case where you upgrade dlt in between extract and normalize

Will add/check tests

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

Step 1 of https://github.com/dlt-hub/dlt/issues/1317

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
