### PR TITLE
RESTClient: pass environment settings to `requests.Session.send`

### DIFF
--- a/dlt/sources/helpers/rest_client/client.py
+++ b/dlt/sources/helpers/rest_client/client.py
@@ -124,7 +124,11 @@ class RESTClient:
 
         prepared_request = self.session.prepare_request(request)
 
-        return self.session.send(prepared_request)
+        send_kwargs = self.session.merge_environment_settings(
+            prepared_request.url, {}, None, None, None
+        )
+
+        return self.session.send(prepared_request, **send_kwargs)
 
     def request(self, path: str = "", method: HTTPMethod = "GET", **kwargs: Any) -> Response:
         prepared_request = self._create_request(

--- a/tests/sources/helpers/rest_client/test_client.py
+++ b/tests/sources/helpers/rest_client/test_client.py
@@ -241,3 +241,17 @@ class TestRESTClient:
             assert_pagination(pages_list)
 
             assert pages_list[0].response.request.headers["Authorization"] == "Bearer test-token"
+
+    def test_send_request_allows_ca_bundle(self, mocker, rest_client):
+        mocker.patch.dict(os.environ, {"REQUESTS_CA_BUNDLE": "/path/to/some/ca-bundle"})
+
+        _send = rest_client.session.send
+
+        def _fake_send(*args, **kwargs):
+            assert kwargs["verify"] == "/path/to/some/ca-bundle"
+            return _send(*args, **kwargs)
+
+        rest_client.session.send = _fake_send
+
+        result = rest_client.get("/posts/1")
+        assert result.status_code == 200


### PR DESCRIPTION
Fixes #1447