### PR TITLE
fix(incremental): don't filter Arrow tables with empty filters

### DIFF
--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -213,7 +213,7 @@ class ArrowIncremental(IncrementalTransform):
 
     def compute_unique_values_with_index(
         self, item: "TAnyArrowItem", unique_columns: List[str]
-    ) -> List[Tuple[int, str]]:
+    ) -> List[Tuple[Any, str]]:
         if not unique_columns:
             return []
         indices = item[self._dlt_index].to_pylist()
@@ -318,10 +318,9 @@ class ArrowIncremental(IncrementalTransform):
                     for i, uq_val in unique_values_index
                     if uq_val in self.start_unique_hashes
                 ]
-                # find rows with unique ids that were stored from previous run
-                remove_idx = pa.array(i for i, _ in unique_values_index)
-                # Filter the table
-                if remove_idx:
+                if len(unique_values_index) > 0:
+                    # find rows with unique ids that were stored from previous run
+                    remove_idx = pa.array(i for i, _ in unique_values_index)
                     tbl = tbl.filter(
                         pa.compute.invert(pa.compute.is_in(tbl[self._dlt_index], remove_idx))
                     )

--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -321,9 +321,10 @@ class ArrowIncremental(IncrementalTransform):
                 # find rows with unique ids that were stored from previous run
                 remove_idx = pa.array(i for i, _ in unique_values_index)
                 # Filter the table
-                tbl = tbl.filter(
-                    pa.compute.invert(pa.compute.is_in(tbl[self._dlt_index], remove_idx))
-                )
+                if remove_idx:
+                    tbl = tbl.filter(
+                        pa.compute.invert(pa.compute.is_in(tbl[self._dlt_index], remove_idx))
+                    )
 
         if (
             self.last_value is None

--- a/docs/website/docs/dlt-ecosystem/verified-sources/mongodb.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/mongodb.md
@@ -317,16 +317,28 @@ verified source.
 1. To load a selected collection and rename it in the destination:
 
    ```py
-    # Create the MongoDB source and select the "collection_1" collection
-    source = mongodb().with_resources("collection_1")
+   # Create the MongoDB source and select the "collection_1" collection
+   source = mongodb().with_resources("collection_1")
 
-    # Apply the hint to rename the table in the destination
-    source.resources["collection_1"].apply_hints(table_name="loaded_data_1")
+   # Apply the hint to rename the table in the destination
+   source.resources["collection_1"].apply_hints(table_name="loaded_data_1")
 
-    # Run the pipeline
-    info = pipeline.run(source, write_disposition="replace")
-    print(info)
+   # Run the pipeline
+   info = pipeline.run(source, write_disposition="replace")
+   print(info)
    ```
 
+1. To load a selected collection, using Apache Arrow for data conversion:
+   ```py
+   # Load collection "movies", using Apache Arrow for converion
+   movies = mongodb_collection(
+      collection="movies",
+      data_item_format="arrow",
+   )
+
+   # Run the pipeline
+   info = pipeline.run(source)
+   print(info)
+   ```
 
 <!--@@@DLT_TUBA mongodb-->

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -8,7 +8,6 @@ from unittest import mock
 from datetime import datetime  # noqa: I251
 from itertools import chain, count
 
-import bson
 import duckdb
 import pytest
 

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -793,11 +793,13 @@ def test_empty_filter(item_type: TestDataItemFormat) -> None:
         for i in range(-10, 10)
     ]
     source_items = data_to_item_format(item_type, data)
+    start = now.add(days=-10)
+    end = now.add(days=10)
 
     @dlt.resource
     def some_data(
         last_timestamp=dlt.sources.incremental(
-            "ts", initial_value=now.add(days=-10), end_value=now.add(days=10), primary_key="_id"  # type: ignore
+            "ts", initial_value=start, end_value=end, primary_key="_id"
         ),
     ):
         yield from source_items

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -797,7 +797,7 @@ def test_empty_filter(item_type: TestDataItemFormat) -> None:
     @dlt.resource
     def some_data(
         last_timestamp=dlt.sources.incremental(
-            "ts", initial_value=now.add(days=-10), end_value=now.add(days=10), primary_key="_id"
+            "ts", initial_value=now.add(days=-10), end_value=now.add(days=10), primary_key="_id"  # type: ignore
         ),
     ):
         yield from source_items


### PR DESCRIPTION
Towards https://github.com/dlt-hub/verified-sources/pull/486