### PR TITLE
fix: allow loggeradapter in addition to logger in logcollector

### DIFF
--- a/dlt/common/runtime/collector.py
+++ b/dlt/common/runtime/collector.py
@@ -227,8 +227,9 @@ class LogCollector(Collector):
         self._log(self.log_level, log_message)
 
     def _log(self, log_level: int, log_message: str) -> None:
-        if isinstance(self.logger, logging.Logger):
+        if isinstance(self.logger, (logging.Logger, logging.LoggerAdapter)):
             self.logger.log(log_level, log_message)
+            
         else:
             print(log_message, file=self.logger or sys.stdout)
 

--- a/dlt/common/runtime/collector.py
+++ b/dlt/common/runtime/collector.py
@@ -229,7 +229,6 @@ class LogCollector(Collector):
     def _log(self, log_level: int, log_message: str) -> None:
         if isinstance(self.logger, (logging.Logger, logging.LoggerAdapter)):
             self.logger.log(log_level, log_message)
-            
         else:
             print(log_message, file=self.logger or sys.stdout)
 


### PR DESCRIPTION
the _log method in LogCollector now checks for either logging.Logger or logging.LoggerAdapter unlike previously were it only allowed the former.

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
