### PR TITLE
Fix/1465 fixes snowflake auth credentials

### DIFF
--- a/dlt/common/configuration/resolve.py
+++ b/dlt/common/configuration/resolve.py
@@ -126,6 +126,8 @@ def _maybe_parse_native_value(
         not isinstance(explicit_value, C_Mapping) or isinstance(explicit_value, BaseConfiguration)
     ):
         try:
+            # parse the native value anyway because there are configs with side effects
+            config.parse_native_representation(explicit_value)
             default_value = config.__class__()
             # parse native value and convert it into dict, extract the diff and use it as exact value
             # NOTE: as those are the same dataclasses, the set of keys must be the same
@@ -134,7 +136,6 @@ def _maybe_parse_native_value(
                 for k, v in config.__class__.from_init_value(explicit_value).items()
                 if default_value[k] != v
             }
-
         except ValueError as v_err:
             # provide generic exception
             raise InvalidNativeValue(type(config), type(explicit_value), embedded_sections, v_err)

--- a/dlt/common/configuration/resolve.py
+++ b/dlt/common/configuration/resolve.py
@@ -126,14 +126,20 @@ def _maybe_parse_native_value(
         not isinstance(explicit_value, C_Mapping) or isinstance(explicit_value, BaseConfiguration)
     ):
         try:
-            config.parse_native_representation(explicit_value)
+            default_value = config.__class__()
+            # parse native value and convert it into dict, extract the diff and use it as exact value
+            # NOTE: as those are the same dataclasses, the set of keys must be the same
+            explicit_value = {
+                k: v
+                for k, v in config.__class__.from_init_value(explicit_value).items()
+                if default_value[k] != v
+            }
+
         except ValueError as v_err:
             # provide generic exception
             raise InvalidNativeValue(type(config), type(explicit_value), embedded_sections, v_err)
         except NotImplementedError:
             pass
-        # explicit value was consumed
-        explicit_value = None
     return explicit_value
 
 
@@ -336,7 +342,11 @@ def _resolve_config_field(
             # print(f"{embedded_config} IS RESOLVED with VALUE {value}")
             # injected context will be resolved
             if value is not None:
-                _maybe_parse_native_value(embedded_config, value, embedded_sections + (key,))
+                from_native_explicit = _maybe_parse_native_value(
+                    embedded_config, value, embedded_sections + (key,)
+                )
+                if from_native_explicit is not value:
+                    embedded_config.update(from_native_explicit)
             value = embedded_config
         else:
             # only config with sections may look for initial values

--- a/dlt/common/configuration/specs/base_configuration.py
+++ b/dlt/common/configuration/specs/base_configuration.py
@@ -43,7 +43,6 @@ from dlt.common.data_types import py_type_to_sc_type
 from dlt.common.configuration.exceptions import (
     ConfigFieldMissingTypeHintException,
     ConfigFieldTypeHintNotSupported,
-    ConfigurationException,
 )
 
 
@@ -304,7 +303,7 @@ class BaseConfiguration(MutableMapping[str, Any]):
         self._apply_init_value(init_value)
         if not self.is_partial():
             # let it fail gracefully
-            with contextlib.suppress(ConfigurationException):
+            with contextlib.suppress(Exception):
                 self.resolve()
         return self
 

--- a/dlt/common/configuration/utils.py
+++ b/dlt/common/configuration/utils.py
@@ -100,7 +100,7 @@ def deserialize_value(key: str, value: Any, hint: Type[TAny]) -> TAny:
         raise ConfigValueCannotBeCoercedException(key, value, hint) from exc
 
 
-def serialize_value(value: Any) -> Any:
+def serialize_value(value: Any) -> str:
     if value is None:
         raise ValueError(value)
     # return literal for tuples
@@ -108,13 +108,13 @@ def serialize_value(value: Any) -> Any:
         return str(value)
     if isinstance(value, BaseConfiguration):
         try:
-            return value.to_native_representation()
+            return str(value.to_native_representation())
         except NotImplementedError:
             # no native representation: use dict
             value = dict(value)
     # coerce type to text which will use json for mapping and sequences
     value_dt = py_type_to_sc_type(type(value))
-    return coerce_value("text", value_dt, value)
+    return coerce_value("text", value_dt, value)  # type: ignore[no-any-return]
 
 
 def auto_cast(value: str) -> Any:

--- a/dlt/destinations/impl/clickhouse/configuration.py
+++ b/dlt/destinations/impl/clickhouse/configuration.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import ClassVar, List, Any, Final, Literal, cast, Optional
+from typing import ClassVar, Dict, List, Any, Final, Literal, cast, Optional
 
 from dlt.common.configuration import configspec
 from dlt.common.configuration.specs import ConnectionStringCredentials
@@ -59,23 +59,21 @@ class ClickHouseCredentials(ConnectionStringCredentials):
             self.query.get("send_receive_timeout", self.send_receive_timeout)
         )
         self.secure = cast(TSecureConnection, int(self.query.get("secure", self.secure)))
-        if not self.is_partial():
-            self.resolve()
 
-    def to_url(self) -> URL:
-        url = super().to_url()
-        url = url.update_query_pairs(
-            [
-                ("connect_timeout", str(self.connect_timeout)),
-                ("send_receive_timeout", str(self.send_receive_timeout)),
-                ("secure", str(1) if self.secure else str(0)),
+    def get_query(self) -> Dict[str, Any]:
+        query = dict(super().get_query())
+        query.update(
+            {
+                "connect_timeout": str(self.connect_timeout),
+                "send_receive_timeout": str(self.send_receive_timeout),
+                "secure": 1 if self.secure else 0,
                 # Toggle experimental settings. These are necessary for certain datatypes and not optional.
-                ("allow_experimental_lightweight_delete", "1"),
-                # ("allow_experimental_object_type", "1"),
-                ("enable_http_compression", "1"),
-            ]
+                "allow_experimental_lightweight_delete": 1,
+                # "allow_experimental_object_type": 1,
+                "enable_http_compression": 1,
+            }
         )
-        return url
+        return query
 
 
 @configspec

--- a/dlt/destinations/impl/mssql/configuration.py
+++ b/dlt/destinations/impl/mssql/configuration.py
@@ -34,8 +34,6 @@ class MsSqlCredentials(ConnectionStringCredentials):
             self.query = {k.lower(): v for k, v in self.query.items()}  # Make case-insensitive.
         self.driver = self.query.get("driver", self.driver)
         self.connect_timeout = int(self.query.get("connect_timeout", self.connect_timeout))
-        if not self.is_partial():
-            self.resolve()
 
     def on_resolved(self) -> None:
         if self.driver not in self.SUPPORTED_DRIVERS:
@@ -45,10 +43,10 @@ class MsSqlCredentials(ConnectionStringCredentials):
             )
         self.database = self.database.lower()
 
-    def to_url(self) -> URL:
-        url = super().to_url()
-        url.update_query_pairs([("connect_timeout", str(self.connect_timeout))])
-        return url
+    def get_query(self) -> Dict[str, Any]:
+        query = dict(super().get_query())
+        query["connect_timeout"] = self.connect_timeout
+        return query
 
     def on_partial(self) -> None:
         self.driver = self._get_driver()

--- a/dlt/destinations/impl/postgres/configuration.py
+++ b/dlt/destinations/impl/postgres/configuration.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Final, ClassVar, Any, List, TYPE_CHECKING, Union
+from typing import Dict, Final, ClassVar, Any, List, TYPE_CHECKING, Union
 
 from dlt.common.libs.sql_alchemy import URL
 from dlt.common.configuration import configspec
@@ -23,13 +23,11 @@ class PostgresCredentials(ConnectionStringCredentials):
     def parse_native_representation(self, native_value: Any) -> None:
         super().parse_native_representation(native_value)
         self.connect_timeout = int(self.query.get("connect_timeout", self.connect_timeout))
-        if not self.is_partial():
-            self.resolve()
 
-    def to_url(self) -> URL:
-        url = super().to_url()
-        url.update_query_pairs([("connect_timeout", str(self.connect_timeout))])
-        return url
+    def get_query(self) -> Dict[str, Any]:
+        query = dict(super().get_query())
+        query["connect_timeout"] = self.connect_timeout
+        return query
 
 
 @configspec

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -13,8 +13,8 @@ from dlt.common.destination.reference import DestinationClientDwhWithStagingConf
 from dlt.common.utils import digest128
 
 
-def _read_private_key(private_key: str, password: Optional[str] = None) -> bytes:
-    """Load an encrypted or unencrypted private key from string."""
+def _decode_private_key(private_key: str, password: Optional[str] = None) -> bytes:
+    """Decode encrypted or unencrypted private key from string."""
     try:
         from cryptography.hazmat.backends import default_backend
         from cryptography.hazmat.primitives.asymmetric import rsa
@@ -61,66 +61,63 @@ class SnowflakeCredentials(ConnectionStringCredentials):
     warehouse: Optional[str] = None
     role: Optional[str] = None
     authenticator: Optional[str] = None
+    token: Optional[str] = None
     private_key: Optional[TSecretStrValue] = None
     private_key_passphrase: Optional[TSecretStrValue] = None
     application: Optional[str] = SNOWFLAKE_APPLICATION_ID
 
     __config_gen_annotations__: ClassVar[List[str]] = ["password", "warehouse", "role"]
+    __query_params__: ClassVar[List[str]] = [
+        "warehouse",
+        "role",
+        "authenticator",
+        "token",
+        "private_key",
+        "private_key_passphrase",
+    ]
 
     def parse_native_representation(self, native_value: Any) -> None:
         super().parse_native_representation(native_value)
-        self.warehouse = self.query.get("warehouse")
-        self.role = self.query.get("role")
-        self.private_key = self.query.get("private_key")  # type: ignore
-        self.private_key_passphrase = self.query.get("private_key_passphrase")  # type: ignore
-        if not self.is_partial() and (self.password or self.private_key):
-            self.resolve()
+        for param in self.__query_params__:
+            if param in self.query:
+                setattr(self, param, self.query.get(param))
+
+        # if not self.is_partial() and (self.password or self.private_key):
+        #     self.resolve()
 
     def on_resolved(self) -> None:
-        if not self.password and not self.private_key:
+        if not self.password and not self.private_key and not self.authenticator:
             raise ConfigurationValueError(
-                "Please specify password or private_key. SnowflakeCredentials supports password and"
-                " private key authentication and one of those must be specified."
+                "Please specify password or private_key or authenticator fields."
+                " SnowflakeCredentials supports password, private key and authenticator based (ie."
+                " oauth2) authentication and one of those must be specified."
             )
 
-    def to_url(self) -> URL:
-        query = dict(self.query or {})
-        if self.warehouse and "warehouse" not in query:
-            query["warehouse"] = self.warehouse
-        if self.role and "role" not in query:
-            query["role"] = self.role
-
-        if self.application != "" and "application" not in query:
-            query["application"] = self.application
-
-        return URL.create(
-            self.drivername,
-            self.username,
-            self.password,
-            self.host,
-            self.port,
-            self.database,
-            query,
-        )
+    def get_query(self) -> Dict[str, Any]:
+        query = dict(super().get_query() or {})
+        for param in self.__query_params__:
+            if self.get(param, None) is not None:
+                query[param] = self[param]
+        return query
 
     def to_connector_params(self) -> Dict[str, Any]:
-        private_key: Optional[bytes] = None
+        # gather all params in query
+        query = self.get_query()
         if self.private_key:
-            private_key = _read_private_key(self.private_key, self.private_key_passphrase)
+            query["private_key"] = _decode_private_key(
+                self.private_key, self.private_key_passphrase
+            )
 
-        conn_params = dict(
-            self.query or {},
+        # we do not want passphrase to be passed
+        query.pop("private_key_passphrase", None)
+
+        conn_params: Dict[str, Any] = dict(
+            query,
             user=self.username,
             password=self.password,
             account=self.host,
             database=self.database,
-            warehouse=self.warehouse,
-            role=self.role,
-            private_key=private_key,
         )
-
-        if self.authenticator:
-            conn_params["authenticator"] = self.authenticator
 
         if self.application != "" and "application" not in conn_params:
             conn_params["application"] = self.application

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -269,6 +269,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
             self._primary_key = merged._primary_key
             self.allow_external_schedulers = merged.allow_external_schedulers
             self.row_order = merged.row_order
+            self.__is_resolved__ = self.__is_resolved__
         else:  # TODO: Maybe check if callable(getattr(native_value, '__lt__', None))
             # Passing bare value `incremental=44` gets parsed as initial_value
             self.initial_value = native_value
@@ -489,7 +490,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         return rows
 
 
-Incremental.EMPTY = Incremental[Any]("")
+Incremental.EMPTY = Incremental[Any]()
+Incremental.EMPTY.__is_resolved__ = True
 
 
 class IncrementalResourceWrapper(ItemTransform[TDataItem]):

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -272,8 +272,6 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         else:  # TODO: Maybe check if callable(getattr(native_value, '__lt__', None))
             # Passing bare value `incremental=44` gets parsed as initial_value
             self.initial_value = native_value
-        if not self.is_partial():
-            self.resolve()
 
     def get_state(self) -> IncrementalColumnState:
         """Returns an Incremental state for a particular cursor column"""

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -71,9 +71,10 @@ You can also decrease the suspend time for your warehouse to 1 minute (**Admin**
 
 ### Authentication types
 Snowflake destination accepts three authentication types:
+Snowflake destination accepts three authentication types:
 - password authentication
 - [key pair authentication](https://docs.snowflake.com/en/user-guide/key-pair-auth)
-- external authentication
+- oauth authentication
 
 The **password authentication** is not any different from other databases like Postgres or Redshift. `dlt` follows the same syntax as the [SQLAlchemy dialect](https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#required-parameters).
 
@@ -100,16 +101,32 @@ If you pass a passphrase in the connection string, please URL encode it.
 destination.snowflake.credentials="snowflake://loader:<password>@kgiotue-wn98412/dlt_data?private_key=<base64 encoded pem>&private_key_passphrase=<url encoded passphrase>"
 ```
 
-In **external authentication**, you can use an OAuth provider like Okta or an external browser to authenticate. You pass your authenticator and refresh token as below:
+In **oauth authentication**, you can use an OAuth provider like Snowflake, Okta or an external browser to authenticate. In case of Snowflake oauth, you pass your `authenticator` and refresh `token` as below:
 ```toml
 [destination.snowflake.credentials]
 database = "dlt_data"
 username = "loader"
-authenticator="..."
+authenticator="oauth"
 token="..."
 ```
 or in the connection string as query parameters.
-Refer to Snowflake [OAuth](https://docs.snowflake.com/en/user-guide/oauth-intro) for more details.
+
+In case of external authentication, you need to find documentation for your OAuth provider. Refer to Snowflake [OAuth](https://docs.snowflake.com/en/user-guide/oauth-intro) for more details.
+
+### Additional connection options
+We pass all query parameters to `connect` function of Snowflake Python Connector. For example:
+```toml
+[destination.snowflake.credentials]
+database = "dlt_data"
+authenticator="oauth"
+[destination.snowflake.credentials.query]
+timezone="UTC"
+# keep session alive beyond 4 hours
+client_session_keep_alive=true
+```
+Will set the timezone and session keep alive. Mind that if you use `toml` your configuration is typed. The alternative:
+`"snowflake://loader/dlt_data?authenticator=oauth&timezone=UTC&client_session_keep_alive=true"`
+will pass `client_session_keep_alive` as string to the connect method (which we didn't verify if it works).
 
 ## Write disposition
 All write dispositions are supported.

--- a/tests/common/configuration/test_configuration.py
+++ b/tests/common/configuration/test_configuration.py
@@ -63,6 +63,7 @@ from dlt.common.configuration.utils import (
 )
 from dlt.common.pipeline import TRefreshMode
 
+from dlt.destinations.impl.postgres.configuration import PostgresCredentials
 from tests.utils import preserve_environ
 from tests.common.configuration.utils import (
     MockProvider,
@@ -448,6 +449,43 @@ def test_invalid_native_config_value() -> None:
     assert py_ex.value.spec is InstrumentedConfiguration
     assert py_ex.value.native_value_type is int
     assert py_ex.value.embedded_sections == ()
+
+
+def test_maybe_use_explicit_value() -> None:
+    # pass through dict and configs
+    c = ConnectionStringCredentials()
+    dict_explicit = {"explicit": "is_dict"}
+    config_explicit = BaseConfiguration()
+    assert resolve._maybe_parse_native_value(c, dict_explicit, ()) is dict_explicit
+    assert resolve._maybe_parse_native_value(c, config_explicit, ()) is config_explicit
+
+    # postgres credentials have a default parameter (connect_timeout), which must be removed for explicit value
+    pg_c = PostgresCredentials()
+    explicit_value = resolve._maybe_parse_native_value(
+        pg_c, "postgres://loader@localhost:5432/dlt_data?a=b&c=d", ()
+    )
+    # NOTE: connect_timeout and password are not present
+    assert explicit_value == {
+        "drivername": "postgres",
+        "database": "dlt_data",
+        "username": "loader",
+        "host": "localhost",
+        "query": {"a": "b", "c": "d"},
+    }
+    pg_c = PostgresCredentials()
+    explicit_value = resolve._maybe_parse_native_value(
+        pg_c, "postgres://loader@localhost:5432/dlt_data?connect_timeout=33", ()
+    )
+    assert explicit_value["connect_timeout"] == 33
+
+
+def test_optional_params_resolved_if_complete_native_value(environment: Any) -> None:
+    # this native value fully resolves configuration
+    environment["CREDENTIALS"] = "postgres://loader:pwd@localhost:5432/dlt_data?a=b&c=d"
+    # still this config value will be injected
+    environment["CREDENTIALS__CONNECT_TIMEOUT"] = "300"
+    c = resolve.resolve_configuration(PostgresCredentials())
+    assert c.connect_timeout == 300
 
 
 def test_on_resolved(environment: Any) -> None:

--- a/tests/common/configuration/test_toml_provider.py
+++ b/tests/common/configuration/test_toml_provider.py
@@ -219,8 +219,8 @@ def test_secrets_toml_credentials_from_native_repr(
         " KEY-----\nMIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCNEN0bL39HmD+S\n...\n-----END"
         " PRIVATE KEY-----\n"
     )
-    # but project id got overridden from credentials.project_id
-    assert c.project_id.endswith("-credentials")
+    # project id taken from the same value, will not be overridden from any other configs
+    assert c.project_id.endswith("mock-project-id-source.credentials")
     # also try sql alchemy url (native repr)
     c2 = resolve.resolve_configuration(ConnectionStringCredentials(), sections=("databricks",))
     assert c2.drivername == "databricks+connector"

--- a/tests/load/duckdb/test_motherduck_client.py
+++ b/tests/load/duckdb/test_motherduck_client.py
@@ -28,7 +28,7 @@ def test_motherduck_configuration() -> None:
     assert cred.password == "TOKEN"
     assert cred.database == "dlt_data"
     assert cred.is_partial() is False
-    assert cred.is_resolved() is True
+    assert cred.is_resolved() is False
 
     cred = MotherDuckCredentials()
     cred.parse_native_representation("md:///?token=TOKEN")

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -123,7 +123,6 @@ def test_only_authenticator() -> None:
 
 def test_no_query(environment) -> None:
     c = SnowflakeCredentials("snowflake://user1:pass1@host1/db1")
-    c = resolve_configuration(c)
     assert str(c.to_url()) == "snowflake://user1:pass1@host1/db1"
     print(c.to_url())
 

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -1,10 +1,14 @@
 import os
 import pytest
 from pathlib import Path
-from dlt.common.libs.sql_alchemy import make_url
+from urllib3.util import parse_url
+
+from dlt.common.configuration.utils import add_config_to_env
+from tests.utils import TEST_DICT_CONFIG_PROVIDER
 
 pytest.importorskip("snowflake")
 
+from dlt.common.libs.sql_alchemy import make_url
 from dlt.common.configuration.resolve import resolve_configuration
 from dlt.common.configuration.exceptions import ConfigurationValueError
 from dlt.common.utils import digest128
@@ -20,12 +24,20 @@ from tests.common.configuration.utils import environment
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
 
+# PEM key
+PKEY_PEM_STR = Path("./tests/common/cases/secrets/encrypted-private-key").read_text("utf8")
+# base64 encoded DER key
+PKEY_DER_STR = Path("./tests/common/cases/secrets/encrypted-private-key-base64").read_text("utf8")
+
+PKEY_PASSPHRASE = "12345"
+
 
 def test_connection_string_with_all_params() -> None:
-    url = "snowflake://user1:pass1@host1/db1?application=dltHub_dlt&warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr"
+    url = "snowflake://user1:pass1@host1/db1?warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr&authenticator=oauth&token=TOK"
 
     creds = SnowflakeCredentials()
     creds.parse_native_representation(url)
+    assert not creds.is_resolved()
 
     assert creds.database == "db1"
     assert creds.username == "user1"
@@ -35,6 +47,8 @@ def test_connection_string_with_all_params() -> None:
     assert creds.role == "role1"
     assert creds.private_key == "cGs="
     assert creds.private_key_passphrase == "paphr"
+    assert creds.authenticator == "oauth"
+    assert creds.token == "TOK"
 
     expected = make_url(url)
     to_url_value = str(creds.to_url())
@@ -43,23 +57,104 @@ def test_connection_string_with_all_params() -> None:
     assert make_url(creds.to_native_representation()) == expected
     assert to_url_value == str(expected)
 
+
+def test_custom_application():
+    creds = SnowflakeCredentials()
     creds.application = "custom"
-    url = "snowflake://user1:pass1@host1/db1?application=custom&warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr"
+    url = "snowflake://user1:pass1@host1/db1?authenticator=oauth&warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr&token=TOK"
     creds.parse_native_representation(url)
+    assert not creds.is_resolved()
     expected = make_url(url)
     to_url_value = str(creds.to_url())
     assert make_url(creds.to_native_representation()) == expected
     assert to_url_value == str(expected)
-    assert "application=custom" in str(expected)
+    assert "application=custom" not in str(expected)
 
 
-def test_to_connector_params() -> None:
-    # PEM key
-    pkey_str = Path("./tests/common/cases/secrets/encrypted-private-key").read_text("utf8")
+def test_set_all_from_env(environment) -> None:
+    url = "snowflake://user1:pass1@host1/db1?authenticator=oauth&warehouse=warehouse1&role=role1&private_key=cGs%3D&private_key_passphrase=paphr&token=TOK"
+    c = SnowflakeCredentials(url)
+    add_config_to_env(c)
+    # resolve from environments
+    creds = resolve_configuration(SnowflakeCredentials())
+    assert creds.is_resolved()
+    assert creds.database == "db1"
+    assert creds.username == "user1"
+    assert creds.password == "pass1"
+    assert creds.host == "host1"
+    assert creds.warehouse == "warehouse1"
+    assert creds.role == "role1"
+    assert creds.private_key == "cGs="
+    assert creds.private_key_passphrase == "paphr"
+    assert creds.authenticator == "oauth"
+    assert creds.token == "TOK"
 
+
+def test_only_authenticator() -> None:
+    url = "snowflake://user1@host1/db1"
+    # password, pk or authenticator must be specified
+    with pytest.raises(ConfigurationValueError):
+        resolve_configuration(SnowflakeCredentials(url))
+    c = resolve_configuration(SnowflakeCredentials("snowflake://user1@host1/db1?authenticator=uri"))
+    assert c.authenticator == "uri"
+    assert c.token is None
+    # token not present
+    assert c.to_connector_params() == {
+        "authenticator": "uri",
+        "user": "user1",
+        "password": None,
+        "account": "host1",
+        "database": "db1",
+        "application": "dltHub_dlt",
+    }
+    c = resolve_configuration(
+        SnowflakeCredentials("snowflake://user1@host1/db1?authenticator=oauth&token=TOK")
+    )
+    assert c.to_connector_params() == {
+        "authenticator": "oauth",
+        "token": "TOK",
+        "user": "user1",
+        "password": None,
+        "account": "host1",
+        "database": "db1",
+        "application": "dltHub_dlt",
+    }
+
+
+def test_no_query(environment) -> None:
+    c = SnowflakeCredentials("snowflake://user1:pass1@host1/db1")
+    c = resolve_configuration(c)
+    assert str(c.to_url()) == "snowflake://user1:pass1@host1/db1"
+    print(c.to_url())
+
+
+def test_query_additional_params() -> None:
+    c = SnowflakeCredentials("snowflake://user1:pass1@host1/db1?keep_alive=true")
+    assert c.to_connector_params()["keep_alive"] == "true"
+
+    # try a typed param
+    with TEST_DICT_CONFIG_PROVIDER().values({"credentials": {"query": {"keep_alive": True}}}):
+        c = SnowflakeCredentials("snowflake://user1:pass1@host1/db1")
+        print(c.__is_resolved__)
+        assert c.is_resolved() is False
+        c = resolve_configuration(c)
+        assert c.to_connector_params()["keep_alive"] is True
+        # serialize to str
+        assert c.to_url().query["keep_alive"] == "True"
+
+
+def test_overwrite_query_value_from_explicit() -> None:
+    # value specified in the query is preserved over the value set in config
+    c = SnowflakeCredentials("snowflake://user1@host1/db1?authenticator=uri")
+    c.authenticator = "oauth"
+    assert c.to_url().query["authenticator"] == "oauth"
+    assert c.to_connector_params()["authenticator"] == "oauth"
+
+
+def test_to_connector_params_private_key() -> None:
     creds = SnowflakeCredentials()
-    creds.private_key = pkey_str  # type: ignore[assignment]
-    creds.private_key_passphrase = "12345"  # type: ignore[assignment]
+    creds.private_key = PKEY_PEM_STR  # type: ignore[assignment]
+    creds.private_key_passphrase = PKEY_PASSPHRASE  # type: ignore[assignment]
     creds.username = "user1"
     creds.database = "db1"
     creds.host = "host1"
@@ -82,12 +177,9 @@ def test_to_connector_params() -> None:
         application=SNOWFLAKE_APPLICATION_ID,
     )
 
-    # base64 encoded DER key
-    pkey_str = Path("./tests/common/cases/secrets/encrypted-private-key-base64").read_text("utf8")
-
     creds = SnowflakeCredentials()
-    creds.private_key = pkey_str  # type: ignore[assignment]
-    creds.private_key_passphrase = "12345"  # type: ignore[assignment]
+    creds.private_key = PKEY_DER_STR  # type: ignore[assignment]
+    creds.private_key_passphrase = PKEY_PASSPHRASE  # type: ignore[assignment]
     creds.username = "user1"
     creds.database = "db1"
     creds.host = "host1"
@@ -127,7 +219,8 @@ def test_snowflake_credentials_native_value(environment) -> None:
     )
     assert c.is_resolved()
     assert c.password == "pass"
-    assert "application=dlt" in str(c.to_url())
+    assert c.application == "dlt"
+    assert "application=dlt" not in str(c.to_url())
     # # but if password is specified - it is final
     c = resolve_configuration(
         SnowflakeCredentials(),
@@ -138,14 +231,16 @@ def test_snowflake_credentials_native_value(environment) -> None:
 
     # set PK via env
     del os.environ["CREDENTIALS__PASSWORD"]
-    os.environ["CREDENTIALS__PRIVATE_KEY"] = "pk"
+    os.environ["CREDENTIALS__PRIVATE_KEY"] = PKEY_DER_STR
+    os.environ["CREDENTIALS__PRIVATE_KEY_PASSPHRASE"] = PKEY_PASSPHRASE
     c = resolve_configuration(
         SnowflakeCredentials(),
         explicit_value="snowflake://user1@host1/db1?warehouse=warehouse1&role=role1",
     )
     assert c.is_resolved()
-    assert c.private_key == "pk"
-    assert "application=dlt" in str(c.to_url())
+    assert c.private_key == PKEY_DER_STR
+    assert c.private_key_passphrase == PKEY_PASSPHRASE
+    assert c.password is None
 
     # check with application = "" it should not be in connection string
     os.environ["CREDENTIALS__APPLICATION"] = ""
@@ -154,7 +249,18 @@ def test_snowflake_credentials_native_value(environment) -> None:
         explicit_value="snowflake://user1@host1/db1?warehouse=warehouse1&role=role1",
     )
     assert c.is_resolved()
+    assert c.application == ""
     assert "application=" not in str(c.to_url())
+    conn_params = c.to_connector_params()
+    assert isinstance(conn_params.pop("private_key"), bytes)
+    assert conn_params == {
+        "warehouse": "warehouse1",
+        "role": "role1",
+        "user": "user1",
+        "password": None,
+        "account": "host1",
+        "database": "db1",
+    }
 
 
 def test_snowflake_configuration() -> None:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Besides fixing #1465 it defines and tests a few config resolve behaviors:
- if you create an instance of a SPEC (ie. `SnowflakeCredentials`) it will not be marked as resolved even if all required fields are provided
- `parse_native_representation` never marks config as resolved
previously some were resolving and some were not.

see commit log for more changes

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #1465
