### PR TITLE
Shorten the installation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Be it a Google Colab notebook, AWS Lambda function, an Airflow DAG, your local l
 
 dlt supports Python 3.8+.
 
-**pip:**
 ```sh
 pip install dlt
 ```

--- a/README.md
+++ b/README.md
@@ -35,15 +35,8 @@ dlt supports Python 3.8+.
 pip install dlt
 ```
 
-**pixi:**
-```sh
-pixi add dlt
-```
+More options: [Install via Conda or Pixi](https://dlthub.com/docs/reference/installation#install-dlt-via-pixi-and-conda)
 
-**conda:**
-```sh
-conda install -c conda-forge dlt
-```
 
 ## Quick Start
 

--- a/docs/website/docs/reference/installation.md
+++ b/docs/website/docs/reference/installation.md
@@ -110,7 +110,7 @@ You can install `dlt` in your virtual environment by running:
 pip install -U dlt
 ```
 
-## Install dlt via pixi and conda
+## Install dlt via Pixi and Conda
 
 Install dlt using `pixi`:
 


### PR DESCRIPTION
### Motivation

Let's focus on the primary installation method in README.md and centralize the alternative options in the docs.