### PR TITLE
Update default log output to not have padding on log level

### DIFF
--- a/dlt/common/configuration/specs/run_configuration.py
+++ b/dlt/common/configuration/specs/run_configuration.py
@@ -17,7 +17,7 @@ class RunConfiguration(BaseConfiguration):
     dlthub_telemetry: bool = True  # enable or disable dlthub telemetry
     dlthub_telemetry_endpoint: Optional[str] = "https://telemetry.scalevector.ai"
     dlthub_telemetry_segment_write_key: Optional[str] = None
-    log_format: str = "{asctime}|[{levelname:<21}]|{process}|{thread}|{name}|{filename}|{funcName}:{lineno}|{message}"
+    log_format: str = "{asctime}|[{levelname}]|{process}|{thread}|{name}|{filename}|{funcName}:{lineno}|{message}"
     log_level: str = "WARNING"
     request_timeout: float = 60
     """Timeout for http requests"""

--- a/tests/common/configuration/test_configuration.py
+++ b/tests/common/configuration/test_configuration.py
@@ -621,7 +621,7 @@ def test_configuration_is_mutable_mapping(environment: Any, env_provider: Config
         "dlthub_telemetry": True,
         "dlthub_telemetry_endpoint": "https://telemetry-tracker.services4758.workers.dev",
         "dlthub_telemetry_segment_write_key": None,
-        "log_format": "{asctime}|[{levelname:<21}]|{process}|{thread}|{name}|{filename}|{funcName}:{lineno}|{message}",
+        "log_format": "{asctime}|[{levelname}]|{process}|{thread}|{name}|{filename}|{funcName}:{lineno}|{message}",
         "log_level": "WARNING",
         "request_timeout": 60,
         "request_max_attempts": 5,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Make logger output a bit shorter by not having padding on the log level. This PR is the reduced version of this: https://github.com/dlt-hub/dlt/pull/1444