### PR TITLE
Docs: update integrations and verified sources pages

### DIFF
--- a/docs/website/docs/dlt-ecosystem/index.md
+++ b/docs/website/docs/dlt-ecosystem/index.md
@@ -11,8 +11,8 @@ Speed up the process of creating data pipelines by using dlt's multiple pre-buil
 - Each [dlt verified source](verified-sources) allows you to create [pipelines](../general-usage/pipeline) that extract data from a particular source: a database, a cloud service, or an API.
 - [Destinations](destinations) are where you want to load your data. dlt supports a variety of destinations, including databases, data warehouses, and data lakes.
 
+<DocCardList />
+
 :::tip
 Most source-destination pairs work seamlessly together. Where a merge [write disposition](../general-usage/incremental-loading#choosing-a-write-disposition) is unsupported, data still loads and appends but may require additional adjustment.
 :::
-
-<DocCardList />

--- a/docs/website/docs/dlt-ecosystem/index.md
+++ b/docs/website/docs/dlt-ecosystem/index.md
@@ -1,0 +1,18 @@
+---
+title: Integrations
+description: List of integrations
+keywords: ['integrations, sources, destinations']
+---
+import DocCardList from '@theme/DocCardList';
+import Link from '../_book-onboarding-call.md';
+
+Speed up the process of creating data pipelines by using dlt's multiple pre-built sources and destinations:
+
+- Each [dlt verified source](verified-sources) allows you to create [pipelines](../general-usage/pipeline) that extract data from a particular source: a database, a cloud service, or an API.
+- [Destinations](destinations) are where you want to load your data. dlt supports a variety of destinations, including databases, data warehouses, and data lakes.
+
+:::tip
+Most source-destination pairs work seamlessly together. Where a merge [write disposition](../general-usage/incremental-loading#choosing-a-write-disposition) is unsupported, data still loads and appends but may require additional adjustment.
+:::
+
+<DocCardList />

--- a/docs/website/docs/dlt-ecosystem/index.md
+++ b/docs/website/docs/dlt-ecosystem/index.md
@@ -14,5 +14,5 @@ Speed up the process of creating data pipelines by using dlt's multiple pre-buil
 <DocCardList />
 
 :::tip
-Most source-destination pairs work seamlessly together. Where a merge [write disposition](../general-usage/incremental-loading#choosing-a-write-disposition) is unsupported, data still loads and appends but may require additional adjustment.
+Most source-destination pairs work seamlessly together. If the merge [write disposition](../general-usage/incremental-loading#choosing-a-write-disposition) is not supported by a destination (for example, [file sytem destination](destinations/filesystem)), dlt will automatically fall back to the [append](../general-usage/incremental-loading#append) write disposition.
 :::

--- a/docs/website/docs/dlt-ecosystem/verified-sources/index.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/index.md
@@ -14,7 +14,7 @@ Planning to use dlt in production and need a source that isn't listed? We're hap
 * [Join our Slack community](https://dlthub.com/community) and ask in the tech help channel.
 
 :::tip
-If you're looking for a source that isn't listed and it provides a REST API, be sure to check out our [REST API generic source](verified-sources/rest_api)
+If you're looking for a source that isn't listed and it provides a REST API, be sure to check out our [REST API generic source](rest_api)
  source.
 :::
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/index.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/index.md
@@ -9,7 +9,7 @@ import Link from '../../_book-onboarding-call.md';
 Choose from our collection of verified sources, which dlt team developed and maintains. Each source is rigorously tested with real data and provided as Python code for easy customization.
 
 Planning to use dlt in production and need a source that isn't listed? We're happy to build it for you: <Link />.
-* Source missing? [Request a new verified source](https://github.com/dlt-hub/verified-sources/issues/new?template=source-request.md)
+* Source missing? [Request a new verified source.](https://github.com/dlt-hub/verified-sources/issues/new?template=source-request.md)
 * Missing endpoint or a feature? [Request or contribute](https://github.com/dlt-hub/verified-sources/issues/new?template=extend-a-source.md)
 * [Join our Slack community](https://dlthub.com/community) and ask in the tech help channel.
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/index.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/index.md
@@ -6,7 +6,7 @@ keywords: ['verified source']
 import DocCardList from '@theme/DocCardList';
 import Link from '../../_book-onboarding-call.md';
 
-Choose from our collection of verified sources, which dlt team developed and maintains. Each source is rigorously tested with real data and provided as Python code for easy customization.
+Choose from our collection of verified sources, developed and maintained by the dlt team and community. Each source is rigorously tested against a real API and provided as Python code for easy customization.
 
 Planning to use dlt in production and need a source that isn't listed? We're happy to build it for you: <Link />.
 * Source missing? [Request a new verified source.](https://github.com/dlt-hub/verified-sources/issues/new?template=source-request.md)

--- a/docs/website/docs/dlt-ecosystem/verified-sources/index.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/index.md
@@ -11,7 +11,7 @@ Choose from our collection of verified sources, which dlt team developed and mai
 Planning to use dlt in production and need a source that isn't listed? We're happy to build it for you: <Link />.
 * Source missing? [Request a new verified source.](https://github.com/dlt-hub/verified-sources/issues/new?template=source-request.md)
 * Missing endpoint or a feature? [Request or contribute](https://github.com/dlt-hub/verified-sources/issues/new?template=extend-a-source.md)
-* [Join our Slack community](https://dlthub.com/community) and ask in the tech help channel.
+* [Join our Slack community](https://dlthub.com/community) and ask in the technical-help channel.
 
 :::tip
 If you're looking for a source that isn't listed and it provides a REST API, be sure to check out our [REST API generic source](rest_api)

--- a/docs/website/docs/dlt-ecosystem/verified-sources/index.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/index.md
@@ -6,14 +6,18 @@ keywords: ['verified source']
 import DocCardList from '@theme/DocCardList';
 import Link from '../../_book-onboarding-call.md';
 
-Pick one of our verified sources that we wrote or maintain ourselves. All of them are constantly tested on real data and distributed as simple Python code so they can be easily customized or hacked.
+Choose from our collection of verified sources, which dlt team developed and maintains. Each source is rigorously tested with real data and provided as Python code for easy customization.
 
-* Need more info? [Join our Slack community](https://dlthub.com/community) and ask in the tech help channel or <Link/>.
-
-Do you plan to run dlt in production and source is missing? We are happy to build it.
+Planning to use dlt in production and need a source that isn't listed? We're happy to build it for you: <Link />.
 * Source missing? [Request a new verified source](https://github.com/dlt-hub/verified-sources/issues/new?template=source-request.md)
 * Missing endpoint or a feature? [Request or contribute](https://github.com/dlt-hub/verified-sources/issues/new?template=extend-a-source.md)
+* [Join our Slack community](https://dlthub.com/community) and ask in the tech help channel.
 
-Otherwise pick a source below:
+:::tip
+If you're looking for a source that isn't listed and it provides a REST API, be sure to check out our [REST API generic source](verified-sources/rest_api)
+ source.
+:::
+
+Browse our pre-built sources:
 
 <DocCardList />

--- a/docs/website/docs/dlt-ecosystem/verified-sources/index.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/index.md
@@ -9,15 +9,26 @@ import Link from '../../_book-onboarding-call.md';
 Choose from our collection of verified sources, developed and maintained by the dlt team and community. Each source is rigorously tested against a real API and provided as Python code for easy customization.
 
 Planning to use dlt in production and need a source that isn't listed? We're happy to build it for you: <Link />.
-* Source missing? [Request a new verified source.](https://github.com/dlt-hub/verified-sources/issues/new?template=source-request.md)
-* Missing endpoint or a feature? [Request or contribute](https://github.com/dlt-hub/verified-sources/issues/new?template=extend-a-source.md)
-* [Join our Slack community](https://dlthub.com/community) and ask in the technical-help channel.
+
+### Popular sources
+
+- [SQL databases](sql_database). Supports PostgreSQL, MySQL, MS SQL Server, BigQuery, Redshift, and more.
+- [REST API generic source](rest_api). Loads data from REST APIs using declarative configuration.
+- [OpenAPI source generator](openapi-generator). Generates a source from an OpenAPI 3.x spec using the REST API source.
+- [Cloud and local storage](filesystem). Retrieves data from AWS S3, Google Cloud Storage, Azure Blob Storage, local files, and more.
+
+### Full list of verified sources
+
+<DocCardList />
 
 :::tip
 If you're looking for a source that isn't listed and it provides a REST API, be sure to check out our [REST API generic source](rest_api)
  source.
 :::
 
-Browse our pre-built sources:
 
-<DocCardList />
+### Get help
+
+* Source missing? [Request a new verified source.](https://github.com/dlt-hub/verified-sources/issues/new?template=source-request.md)
+* Missing endpoint or a feature? [Request or contribute](https://github.com/dlt-hub/verified-sources/issues/new?template=extend-a-source.md)
+* [Join our Slack community](https://dlthub.com/community) and ask in the technical-help channel.

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -46,11 +46,8 @@ const sidebars = {
       type: 'category',
       label: 'Integrations',
       link: {
-        type: 'generated-index',
-        title: 'Integrations',
-        description: 'dlt fits everywhere where the data flows. check out our curated data sources, destinations and unexpected places where dlt runs',
-        slug: 'dlt-ecosystem',
-        keywords: ['getting started'],
+        type: 'doc',
+        id: 'dlt-ecosystem/index',
       },
       items: [
         {


### PR DESCRIPTION
This PR:
- Expands the integrations page with brief details on dlt sources and destinations
- Links the REST API source from the sources page