### PR TITLE
removes deprecated credentials argument from Pipeline

### DIFF
--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -618,7 +618,7 @@ class Destination(ABC, Generic[TDestinationConfig, TDestinationClient]):
     @staticmethod
     def from_reference(
         ref: TDestinationReferenceArg,
-        credentials: Optional[CredentialsConfiguration] = None,
+        credentials: Optional[Any] = None,
         destination_name: Optional[str] = None,
         environment: Optional[str] = None,
         **kwargs: Any,

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -23,14 +23,13 @@ from dlt.common import logger
 from dlt.common.json import json
 from dlt.common.pendulum import pendulum
 from dlt.common.configuration import inject_section, known_sections
-from dlt.common.configuration.specs import RunConfiguration, CredentialsConfiguration
+from dlt.common.configuration.specs import RunConfiguration
 from dlt.common.configuration.container import Container
 from dlt.common.configuration.exceptions import (
     ConfigFieldMissingException,
     ContextDefaultCannotBeCreated,
 )
 from dlt.common.configuration.specs.config_section_context import ConfigSectionContext
-from dlt.common.configuration.resolve import initialize_credentials
 from dlt.common.destination.exceptions import (
     DestinationIncompatibleLoaderFileFormatException,
     DestinationNoStagingMode,
@@ -145,7 +144,6 @@ from dlt.pipeline.state_sync import (
     state_resource,
     default_pipeline_state,
 )
-from dlt.pipeline.warnings import credentials_argument_deprecated
 from dlt.common.storages.load_package import TLoadPackageState
 from dlt.pipeline.helpers import refresh_source
 
@@ -307,7 +305,6 @@ class Pipeline(SupportsPipeline):
     """The destination reference which is the Destination Class. `destination.destination_name` returns the name string"""
     dataset_name: str = None
     """Name of the dataset to which pipeline will be loaded to"""
-    credentials: Any = None
     is_active: bool = False
     """Tells if instance is currently active and available via dlt.pipeline()"""
     collector: _Collector
@@ -323,7 +320,6 @@ class Pipeline(SupportsPipeline):
         destination: TDestination,
         staging: TDestination,
         dataset_name: str,
-        credentials: Any,
         import_schema_path: str,
         export_schema_path: str,
         dev_mode: bool,
@@ -357,7 +353,6 @@ class Pipeline(SupportsPipeline):
         self._init_working_dir(pipeline_name, pipelines_dir)
 
         with self.managed_state() as state:
-            self.credentials = credentials
             self._configure(import_schema_path, export_schema_path, must_attach_to_local_pipeline)
             # changing the destination could be dangerous if pipeline has pending load packages
             self._set_destinations(destination=destination, staging=staging, initializing=True)
@@ -382,7 +377,6 @@ class Pipeline(SupportsPipeline):
             self.destination,
             self.staging,
             self.dataset_name,
-            self.credentials,
             self._schema_storage.config.import_schema_path,
             self._schema_storage.config.export_schema_path,
             self.dev_mode,
@@ -533,14 +527,12 @@ class Pipeline(SupportsPipeline):
         workers: int = 20,
         raise_on_failed_jobs: bool = False,
     ) -> LoadInfo:
-        """Loads the packages prepared by `normalize` method into the `dataset_name` at `destination`, using provided `credentials`"""
+        """Loads the packages prepared by `normalize` method into the `dataset_name` at `destination`, optionally using provided `credentials`"""
         # set destination and default dataset if provided (this is the reason we have state sync here)
-        self._set_destinations(destination=destination, staging=None)
+        self._set_destinations(
+            destination=destination, destination_credentials=credentials, staging=None
+        )
         self._set_dataset_name(dataset_name)
-
-        credentials_argument_deprecated("pipeline.load", credentials, destination)
-
-        self.credentials = credentials or self.credentials
 
         # check if any schema is present, if not then no data was extracted
         if not self.default_schema_name:
@@ -623,7 +615,6 @@ class Pipeline(SupportsPipeline):
             dataset_name (str, optional):A name of the dataset to which the data will be loaded. A dataset is a logical group of tables ie. `schema` in relational databases or folder grouping many files.
             If not provided, the value passed to `dlt.pipeline` will be used. If not provided at all then defaults to the `pipeline_name`
 
-
             credentials (Any, optional): Credentials for the `destination` ie. database connection string or a dictionary with google cloud credentials.
             In most cases should be set to None, which lets `dlt` to use `secrets.toml` or environment variables to infer right credentials values.
 
@@ -661,10 +652,10 @@ class Pipeline(SupportsPipeline):
 
         signals.raise_if_signalled()
         self.activate()
-        self._set_destinations(destination=destination, staging=staging)
+        self._set_destinations(
+            destination=destination, destination_credentials=credentials, staging=staging
+        )
         self._set_dataset_name(dataset_name)
-
-        credentials_argument_deprecated("pipeline.run", credentials, self.destination)
 
         # sync state with destination
         if (
@@ -926,7 +917,7 @@ class Pipeline(SupportsPipeline):
             normalize_storage.extracted_packages.delete_package(load_id)
 
     @with_schemas_sync
-    def sync_schema(self, schema_name: str = None, credentials: Any = None) -> TSchemaTables:
+    def sync_schema(self, schema_name: str = None) -> TSchemaTables:
         """Synchronizes the schema `schema_name` with the destination. If no name is provided, the default schema will be synchronized."""
         if not schema_name and not self.default_schema_name:
             raise PipelineConfigMissing(
@@ -962,7 +953,7 @@ class Pipeline(SupportsPipeline):
             state = self._get_state()
         return state["_local"][key]  # type: ignore
 
-    def sql_client(self, schema_name: str = None, credentials: Any = None) -> SqlClientBase[Any]:
+    def sql_client(self, schema_name: str = None) -> SqlClientBase[Any]:
         """Returns a sql client configured to query/change the destination and dataset that were used to load the data.
         Use the client with `with` statement to manage opening and closing connection to the destination:
         >>> with pipeline.sql_client() as client:
@@ -972,7 +963,7 @@ class Pipeline(SupportsPipeline):
         >>>         print(cursor.fetchall())
 
         The client is authenticated and defaults all queries to dataset_name used by the pipeline. You can provide alternative
-        `schema_name` which will be used to normalize dataset name and alternative `credentials`.
+        `schema_name` which will be used to normalize dataset name.
         """
         # if not self.default_schema_name and not schema_name:
         #     raise PipelineConfigMissing(
@@ -982,9 +973,9 @@ class Pipeline(SupportsPipeline):
         #         "Sql Client is not available in a pipeline without a default schema. Extract some data first or restore the pipeline from the destination using 'restore_from_destination' flag. There's also `_inject_schema` method for advanced users."
         #     )
         schema = self._get_schema_or_create(schema_name)
-        return self._sql_job_client(schema, credentials).sql_client
+        return self._sql_job_client(schema).sql_client
 
-    def _fs_client(self, schema_name: str = None, credentials: Any = None) -> FSClientBase:
+    def _fs_client(self, schema_name: str = None) -> FSClientBase:
         """Returns a filesystem client configured to point to the right folder / bucket for each table.
         For example you may read all parquet files as bytes for one table with the following code:
         >>> files = pipeline._fs_client.list_table_files("customers")
@@ -996,18 +987,18 @@ class Pipeline(SupportsPipeline):
         NOTE: This currently is considered a private endpoint and will become stable after we have decided on the
         interface of FSClientBase.
         """
-        client = self.destination_client(schema_name, credentials)
+        client = self.destination_client(schema_name)
         if isinstance(client, FSClientBase):
             return client
         raise FSClientNotAvailable(self.pipeline_name, self.destination.destination_name)
 
-    def destination_client(self, schema_name: str = None, credentials: Any = None) -> JobClientBase:
+    def destination_client(self, schema_name: str = None) -> JobClientBase:
         """Get the destination job client for the configured destination
         Use the client with `with` statement to manage opening and closing connection to the destination:
         >>> with pipeline.destination_client() as client:
         >>>     client.drop_storage()  # removes storage which typically wipes all data in it
 
-        The client is authenticated. You can provide alternative `schema_name` which will be used to normalize dataset name and alternative `credentials`.
+        The client is authenticated. You can provide alternative `schema_name` which will be used to normalize dataset name.
         If no schema name is provided and no default schema is present in the pipeline, and ad hoc schema will be created and discarded after use.
         """
         schema = self._get_schema_or_create(schema_name)
@@ -1021,8 +1012,8 @@ class Pipeline(SupportsPipeline):
         with self._maybe_destination_capabilities():
             return Schema(self.pipeline_name)
 
-    def _sql_job_client(self, schema: Schema, credentials: Any = None) -> SqlJobClientBase:
-        client_config = self._get_destination_client_initial_config(credentials=credentials)
+    def _sql_job_client(self, schema: Schema) -> SqlJobClientBase:
+        client_config = self._get_destination_client_initial_config()
         client = self._get_destination_clients(schema, client_config)[0]
         if isinstance(client, SqlJobClientBase):
             return client
@@ -1154,7 +1145,7 @@ class Pipeline(SupportsPipeline):
         return load_id
 
     def _get_destination_client_initial_config(
-        self, destination: TDestination = None, credentials: Any = None, as_staging: bool = False
+        self, destination: TDestination = None, as_staging: bool = False
     ) -> DestinationClientConfiguration:
         destination = destination or self.destination
         if not destination:
@@ -1165,19 +1156,9 @@ class Pipeline(SupportsPipeline):
                 "Please provide `destination` argument to `pipeline`, `run` or `load` method"
                 " directly or via .dlt config.toml file or environment variable.",
             )
-        # create initial destination client config
         client_spec = destination.spec
-        # initialize explicit credentials
-        if not as_staging:
-            # explicit credentials passed to dlt.pipeline should not be applied to staging
-            credentials = credentials or self.credentials
-        if credentials is not None and not isinstance(credentials, CredentialsConfiguration):
-            # use passed credentials as initial value. initial value may resolve credentials
-            credentials = initialize_credentials(
-                client_spec.get_resolvable_fields()["credentials"], credentials
-            )
 
-        # this client support many schemas and datasets
+        # this client supports many schemas and datasets
         if issubclass(client_spec, DestinationClientDwhConfiguration):
             if not self.dataset_name and self.dev_mode:
                 logger.warning(
@@ -1190,18 +1171,13 @@ class Pipeline(SupportsPipeline):
             )
 
             if issubclass(client_spec, DestinationClientStagingConfiguration):
-                spec: DestinationClientDwhConfiguration = client_spec(
-                    credentials=credentials,
-                    as_staging=as_staging,
-                )
+                spec: DestinationClientDwhConfiguration = client_spec(as_staging=as_staging)
             else:
-                spec = client_spec(
-                    credentials=credentials,
-                )
+                spec = client_spec()
             spec._bind_dataset_name(self.dataset_name, default_schema_name)
             return spec
 
-        return client_spec(credentials=credentials)
+        return client_spec()
 
     def _get_destination_clients(
         self,
@@ -1308,6 +1284,7 @@ class Pipeline(SupportsPipeline):
         staging: Optional[TDestinationReferenceArg] = None,
         staging_name: Optional[str] = None,
         initializing: bool = False,
+        destination_credentials: Any = None,
     ) -> None:
         destination_changed = destination is not None and destination != self.destination
         # set destination if provided but do not swap if factory is the same
@@ -1349,6 +1326,9 @@ class Pipeline(SupportsPipeline):
             # set new context
             if not initializing:
                 self._set_context(is_active=True)
+        # apply explicit credentials
+        if self.destination and destination_credentials:
+            self.destination.config_params["credentials"] = destination_credentials
 
     @contextmanager
     def _maybe_destination_capabilities(

--- a/dlt/pipeline/warnings.py
+++ b/dlt/pipeline/warnings.py
@@ -5,23 +5,6 @@ from dlt.common.warnings import Dlt04DeprecationWarning
 from dlt.common.destination import Destination, TDestinationReferenceArg
 
 
-def credentials_argument_deprecated(
-    caller_name: str, credentials: t.Optional[t.Any], destination: TDestinationReferenceArg = None
-) -> None:
-    if credentials is None:
-        return
-
-    dest_name = Destination.to_name(destination) if destination else "postgres"
-
-    warnings.warn(
-        f"The `credentials argument` to {caller_name} is deprecated and will be removed in a future"
-        " version. Pass the same credentials to the `destination` instance instead, e.g."
-        f" {caller_name}(destination=dlt.destinations.{dest_name}(credentials=...))",
-        Dlt04DeprecationWarning,
-        stacklevel=2,
-    )
-
-
 def full_refresh_argument_deprecated(caller_name: str, full_refresh: t.Optional[bool]) -> None:
     """full_refresh argument is replaced with dev_mode"""
     if full_refresh is None:

--- a/docs/examples/archive/credentials/explicit.py
+++ b/docs/examples/archive/credentials/explicit.py
@@ -1,6 +1,7 @@
 import os
 from typing import Iterator
 import dlt
+from dlt.destinations import postgres
 
 
 @dlt.resource
@@ -32,14 +33,14 @@ print(list(data))
 
 # you are free to pass credentials from custom location to destination
 pipeline = dlt.pipeline(
-    destination="postgres", credentials=dlt.secrets["custom.destination.credentials"]
+    destination=postgres(credentials=dlt.secrets["custom.destination.credentials"])
 )
 # see nice credentials object
 print(pipeline.credentials)
 
 # you can also pass credentials partially, only the password comes from the secrets or environment
 pipeline = dlt.pipeline(
-    destination="postgres", credentials="postgres://loader@localhost:5432/dlt_data"
+    destination=postgres(credentials="postgres://loader@localhost:5432/dlt_data")
 )
 
 # now lets compare it with default location for config and credentials

--- a/docs/examples/archive/quickstart.py
+++ b/docs/examples/archive/quickstart.py
@@ -46,7 +46,6 @@ pipeline = dlt.pipeline(
     pipeline_name,
     destination=destination_name,
     dataset_name=dataset_name,
-    credentials=credentials,
     export_schema_path=export_schema_path,
     dev_mode=True,
 )
@@ -69,7 +68,9 @@ rows = [
     },
 ]
 
-load_info = pipeline.run(rows, table_name=table_name, write_disposition="replace")
+load_info = pipeline.run(
+    rows, table_name=table_name, write_disposition="replace", credentials=credentials
+)
 
 # 4. Optional error handling - print, raise or handle.
 print()

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -164,8 +164,7 @@ destination.duckdb.credentials=":pipeline:"
 ```py
 p = pipeline_one = dlt.pipeline(
   pipeline_name="my_pipeline",
-  destination="duckdb",
-  credentials=":pipeline:",
+  destination=dlt.destinations.duckdb(":pipeline:"),
 )
 ```
 

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -198,7 +198,8 @@ def test_unique_keys_are_deduplicated(item_type: TestDataItemFormat) -> None:
             yield from source_items2
 
     p = dlt.pipeline(
-        pipeline_name=uniq_id(), destination="duckdb", credentials=duckdb.connect(":memory:")
+        pipeline_name=uniq_id(),
+        destination=dlt.destinations.duckdb(credentials=duckdb.connect(":memory:")),
     )
     p.run(some_data()).raise_on_failed_jobs()
     p.run(some_data()).raise_on_failed_jobs()
@@ -238,7 +239,8 @@ def test_unique_rows_by_hash_are_deduplicated(item_type: TestDataItemFormat) -> 
             yield from source_items2
 
     p = dlt.pipeline(
-        pipeline_name=uniq_id(), destination="duckdb", credentials=duckdb.connect(":memory:")
+        pipeline_name=uniq_id(),
+        destination=dlt.destinations.duckdb(credentials=duckdb.connect(":memory:")),
     )
     p.run(some_data()).raise_on_failed_jobs()
     p.run(some_data()).raise_on_failed_jobs()
@@ -444,7 +446,8 @@ def test_composite_primary_key(item_type: TestDataItemFormat) -> None:
         yield from source_items
 
     p = dlt.pipeline(
-        pipeline_name=uniq_id(), destination="duckdb", credentials=duckdb.connect(":memory:")
+        pipeline_name=uniq_id(),
+        destination=dlt.destinations.duckdb(credentials=duckdb.connect(":memory:")),
     )
     p.run(some_data()).raise_on_failed_jobs()
 

--- a/tests/helpers/airflow_tests/test_airflow_wrapper.py
+++ b/tests/helpers/airflow_tests/test_airflow_wrapper.py
@@ -150,8 +150,7 @@ def test_regular_run() -> None:
     pipeline_standalone = dlt.pipeline(
         pipeline_name="pipeline_standalone",
         dataset_name="mock_data_" + uniq_id(),
-        destination="duckdb",
-        credentials=":pipeline:",
+        destination=dlt.destinations.duckdb(credentials=":pipeline:"),
     )
     pipeline_standalone.run(mock_data_source())
     pipeline_standalone_counts = load_table_counts(
@@ -170,8 +169,7 @@ def test_regular_run() -> None:
         pipeline_dag_regular = dlt.pipeline(
             pipeline_name="pipeline_dag_regular",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=":pipeline:",
+            destination=dlt.destinations.duckdb(credentials=":pipeline:"),
         )
         tasks_list = tasks.add_run(
             pipeline_dag_regular,
@@ -214,8 +212,7 @@ def test_regular_run() -> None:
         pipeline_dag_decomposed = dlt.pipeline(
             pipeline_name="pipeline_dag_decomposed",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=quackdb_path,
+            destination=dlt.destinations.duckdb(credentials=quackdb_path),
         )
         tasks_list = tasks.add_run(
             pipeline_dag_decomposed,
@@ -247,8 +244,7 @@ def test_run() -> None:
     pipeline_standalone = dlt.pipeline(
         pipeline_name="pipeline_standalone",
         dataset_name="mock_data_" + uniq_id(),
-        destination="duckdb",
-        credentials=":pipeline:",
+        destination=dlt.destinations.duckdb(credentials=":pipeline:"),
     )
     pipeline_standalone.run(mock_data_source())
     pipeline_standalone_counts = load_table_counts(
@@ -268,8 +264,7 @@ def test_run() -> None:
         pipeline_dag_regular = dlt.pipeline(
             pipeline_name="pipeline_dag_regular",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=quackdb_path,
+            destination=dlt.destinations.duckdb(credentials=quackdb_path),
         )
         task = tasks.run(pipeline_dag_regular, mock_data_source())
 
@@ -292,8 +287,7 @@ def test_parallel_run():
     pipeline_standalone = dlt.pipeline(
         pipeline_name="pipeline_parallel",
         dataset_name="mock_data_" + uniq_id(),
-        destination="duckdb",
-        credentials=":pipeline:",
+        destination=dlt.destinations.duckdb(credentials=":pipeline:"),
     )
     pipeline_standalone.run(mock_data_source())
     pipeline_standalone_counts = load_table_counts(
@@ -315,8 +309,7 @@ def test_parallel_run():
         pipeline_dag_parallel = dlt.pipeline(
             pipeline_name="pipeline_dag_parallel",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=quackdb_path,
+            destination=dlt.destinations.duckdb(credentials=quackdb_path),
         )
         tasks_list = tasks.add_run(
             pipeline_dag_parallel,
@@ -349,8 +342,7 @@ def test_parallel_incremental():
     pipeline_standalone = dlt.pipeline(
         pipeline_name="pipeline_parallel",
         dataset_name="mock_data_" + uniq_id(),
-        destination="duckdb",
-        credentials=":pipeline:",
+        destination=dlt.destinations.duckdb(credentials=":pipeline:"),
     )
     pipeline_standalone.run(mock_data_incremental_source())
 
@@ -369,8 +361,7 @@ def test_parallel_incremental():
         pipeline_dag_parallel = dlt.pipeline(
             pipeline_name="pipeline_dag_parallel",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=quackdb_path,
+            destination=dlt.destinations.duckdb(credentials=quackdb_path),
         )
         tasks.add_run(
             pipeline_dag_parallel,
@@ -401,8 +392,7 @@ def test_parallel_isolated_run():
     pipeline_standalone = dlt.pipeline(
         pipeline_name="pipeline_parallel",
         dataset_name="mock_data_" + uniq_id(),
-        destination="duckdb",
-        credentials=":pipeline:",
+        destination=dlt.destinations.duckdb(credentials=":pipeline:"),
     )
     pipeline_standalone.run(mock_data_source())
     pipeline_standalone_counts = load_table_counts(
@@ -424,8 +414,7 @@ def test_parallel_isolated_run():
         pipeline_dag_parallel = dlt.pipeline(
             pipeline_name="pipeline_dag_parallel",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=quackdb_path,
+            destination=dlt.destinations.duckdb(credentials=quackdb_path),
         )
         tasks_list = tasks.add_run(
             pipeline_dag_parallel,
@@ -466,8 +455,7 @@ def test_parallel_run_single_resource():
     pipeline_standalone = dlt.pipeline(
         pipeline_name="pipeline_parallel",
         dataset_name="mock_data_" + uniq_id(),
-        destination="duckdb",
-        credentials=":pipeline:",
+        destination=dlt.destinations.duckdb(credentials=":pipeline:"),
     )
     pipeline_standalone.run(mock_data_single_resource())
     pipeline_standalone_counts = load_table_counts(
@@ -489,8 +477,7 @@ def test_parallel_run_single_resource():
         pipeline_dag_parallel = dlt.pipeline(
             pipeline_name="pipeline_dag_parallel",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=quackdb_path,
+            destination=dlt.destinations.duckdb(credentials=quackdb_path),
         )
         tasks_list = tasks.add_run(
             pipeline_dag_parallel,
@@ -555,8 +542,7 @@ def test_run_with_retry() -> None:
         pipeline_fail_3 = dlt.pipeline(
             pipeline_name="pipeline_fail_3",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=":pipeline:",
+            destination=dlt.destinations.duckdb(credentials=":pipeline:"),
         )
         tasks.add_run(
             pipeline_fail_3, _fail_3, trigger_rule="all_done", retries=0, provide_context=True
@@ -582,8 +568,7 @@ def test_run_with_retry() -> None:
         pipeline_fail_3 = dlt.pipeline(
             pipeline_name="pipeline_fail_3",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=":pipeline:",
+            destination=dlt.destinations.duckdb(credentials=":pipeline:"),
         )
         tasks.add_run(
             pipeline_fail_3, _fail_3, trigger_rule="all_done", retries=0, provide_context=True
@@ -611,8 +596,7 @@ def test_run_with_retry() -> None:
         pipeline_fail_3 = dlt.pipeline(
             pipeline_name="pipeline_fail_3",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=":pipeline:",
+            destination=dlt.destinations.duckdb(credentials=":pipeline:"),
         )
         tasks.add_run(
             pipeline_fail_3, _fail_3, trigger_rule="all_done", retries=0, provide_context=True
@@ -886,8 +870,9 @@ def test_task_already_added():
         pipe = dlt.pipeline(
             pipeline_name="test_pipeline",
             dataset_name="mock_data",
-            destination="duckdb",
-            credentials=os.path.join("_storage", "test_pipeline.duckdb"),
+            destination=dlt.destinations.duckdb(
+                credentials=os.path.join("_storage", "test_pipeline.duckdb")
+            ),
         )
         task = tasks.add_run(
             pipe,
@@ -954,8 +939,7 @@ def test_run_callable() -> None:
         call_dag = dlt.pipeline(
             pipeline_name="callable_dag",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=quackdb_path,
+            destination=dlt.destinations.duckdb(credentials=quackdb_path),
         )
         tasks.run(call_dag, callable_source)
 
@@ -991,8 +975,7 @@ def test_on_before_run() -> None:
         call_dag = dlt.pipeline(
             pipeline_name="callable_dag",
             dataset_name="mock_data_" + uniq_id(),
-            destination="duckdb",
-            credentials=quackdb_path,
+            destination=dlt.destinations.duckdb(credentials=quackdb_path),
         )
         tasks.run(call_dag, mock_data_source, on_before_run=on_before_run)
 

--- a/tests/helpers/airflow_tests/test_join_airflow_scheduler.py
+++ b/tests/helpers/airflow_tests/test_join_airflow_scheduler.py
@@ -292,8 +292,7 @@ def test_scheduler_pipeline_state() -> None:
     pipeline = dlt.pipeline(
         pipeline_name="pipeline_dag_regular",
         dataset_name="mock_data_" + uniq_id(),
-        destination="duckdb",
-        credentials=":pipeline:",
+        destination=dlt.destinations.duckdb(credentials=":pipeline:"),
     )
     now = pendulum.now()
 

--- a/tests/load/duckdb/test_duckdb_client.py
+++ b/tests/load/duckdb/test_duckdb_client.py
@@ -67,7 +67,9 @@ def test_duckdb_in_memory_mode_via_factory():
 
         # Check if passing :memory: to factory fails
         with pytest.raises(PipelineStepFailed) as exc:
-            p = dlt.pipeline(pipeline_name="booboo", destination="duckdb", credentials=":memory:")
+            p = dlt.pipeline(
+                pipeline_name="booboo", destination=dlt.destinations.duckdb(credentials=":memory:")
+            )
             p.run([1, 2, 3])
 
         assert isinstance(exc.value.exception, InvalidInMemoryDuckdbCredentials)
@@ -85,7 +87,7 @@ def test_duckdb_in_memory_mode_via_factory():
         with pytest.raises(PipelineStepFailed) as exc:
             p = dlt.pipeline(
                 pipeline_name="booboo",
-                destination=Destination.from_reference("duckdb", credentials=":memory:"),  # type: ignore[arg-type]
+                destination=Destination.from_reference("duckdb", credentials=":memory:"),
             )
             p.run([1, 2, 3], table_name="numbers")
 
@@ -203,7 +205,9 @@ def test_duckdb_database_path() -> None:
 
 def test_keeps_initial_db_path() -> None:
     db_path = "_storage/path_test_quack.duckdb"
-    p = dlt.pipeline(pipeline_name="quack_pipeline", credentials=db_path, destination="duckdb")
+    p = dlt.pipeline(
+        pipeline_name="quack_pipeline", destination=dlt.destinations.duckdb(credentials=db_path)
+    )
     print(p.pipelines_dir)
     with p.sql_client() as conn:
         # still cwd
@@ -251,7 +255,7 @@ def test_duck_database_path_delete() -> None:
     db_folder = "_storage/db_path"
     os.makedirs(db_folder)
     db_path = f"{db_folder}/path_test_quack.duckdb"
-    p = dlt.pipeline(pipeline_name="deep_quack_pipeline", credentials=db_path, destination="duckdb")
+    p = dlt.pipeline(pipeline_name="deep_quack_pipeline", destination=duckdb(credentials=db_path))
     p.run([1, 2, 3], table_name="table", dataset_name="dataset")
     # attach the pipeline
     p = dlt.attach(pipeline_name="deep_quack_pipeline")
@@ -272,7 +276,7 @@ def test_case_sensitive_database_name() -> None:
     cs_quack = os.path.join(TEST_STORAGE_ROOT, "QuAcK")
     os.makedirs(cs_quack, exist_ok=True)
     db_path = os.path.join(cs_quack, "path_TEST_quack.duckdb")
-    p = dlt.pipeline(pipeline_name="NOT_QUAck", credentials=db_path, destination="duckdb")
+    p = dlt.pipeline(pipeline_name="NOT_QUAck", destination=duckdb(credentials=db_path))
     with p.sql_client() as conn:
         conn.execute_sql("DESCRIBE;")
 

--- a/tests/load/filesystem/test_aws_credentials.py
+++ b/tests/load/filesystem/test_aws_credentials.py
@@ -142,6 +142,24 @@ def test_aws_credentials_with_endpoint_url(environment: Dict[str, str]) -> None:
     }
 
 
+def test_explicit_filesystem_credentials() -> None:
+    import dlt
+    from dlt.destinations import filesystem
+
+    # try filesystem which uses union of credentials that requires bucket_url to resolve
+    p = dlt.pipeline(
+        pipeline_name="postgres_pipeline",
+        destination=filesystem(
+            bucket_url="s3://test",
+            destination_name="uniq_s3_bucket",
+            credentials={"aws_access_key_id": "key_id", "aws_secret_access_key": "key"},
+        ),
+    )
+    config = p.destination_client().config
+    assert isinstance(config.credentials, AwsCredentials)
+    assert config.credentials.is_resolved()
+
+
 def set_aws_credentials_env(environment: Dict[str, str]) -> None:
     environment["AWS_ACCESS_KEY_ID"] = "fake_access_key"
     environment["AWS_SECRET_ACCESS_KEY"] = "fake_secret_key"

--- a/tests/load/filesystem/test_gcs_credentials.py
+++ b/tests/load/filesystem/test_gcs_credentials.py
@@ -1,0 +1,32 @@
+import pytest
+
+import dlt
+from dlt.destinations import filesystem
+from dlt.sources.credentials import GcpOAuthCredentials
+from tests.load.utils import ALL_FILESYSTEM_DRIVERS
+
+# mark all tests as essential, do not remove
+pytestmark = pytest.mark.essential
+
+if "gs" not in ALL_FILESYSTEM_DRIVERS:
+    pytest.skip("gcs filesystem driver not configured", allow_module_level=True)
+
+
+def test_explicit_filesystem_credentials() -> None:
+    # resolve gcp oauth
+    p = dlt.pipeline(
+        pipeline_name="postgres_pipeline",
+        destination=filesystem(
+            "gcs://test",
+            destination_name="uniq_gcs_bucket",
+            credentials={
+                "project_id": "pxid",
+                "refresh_token": "123token",
+                "client_id": "cid",
+                "client_secret": "s",
+            },
+        ),
+    )
+    config = p.destination_client().config
+    assert config.credentials.is_resolved()
+    assert isinstance(config.credentials, GcpOAuthCredentials)

--- a/tests/load/pipeline/test_pipelines.py
+++ b/tests/load/pipeline/test_pipelines.py
@@ -583,48 +583,6 @@ def test_pipeline_explicit_destination_credentials(
     )
 
 
-@pytest.mark.parametrize(
-    "destination_config",
-    destinations_configs(local_filesystem_configs=True, subset=["filesystem"]),
-    ids=lambda x: x.name,
-)
-def test_destination_explicit_filesystem_credentials(
-    destination_config: DestinationTestConfiguration,
-) -> None:
-    from dlt.destinations import filesystem
-    from dlt.sources.credentials import AwsCredentials, GcpOAuthCredentials
-
-    # try filesystem which uses union of credentials that requires bucket_url to resolve
-    p = dlt.pipeline(
-        pipeline_name="postgres_pipeline",
-        destination=filesystem(
-            bucket_url="s3://test",
-            destination_name="uniq_s3_bucket",
-            credentials={"aws_access_key_id": "key_id", "aws_secret_access_key": "key"},
-        ),
-    )
-    config = p.destination_client().config
-    assert isinstance(config.credentials, AwsCredentials)
-    assert config.credentials.is_resolved()
-    # resolve gcp oauth
-    p = dlt.pipeline(
-        pipeline_name="postgres_pipeline",
-        destination=filesystem(
-            "gcs://test",
-            destination_name="uniq_gcs_bucket",
-            credentials={
-                "project_id": "pxid",
-                "refresh_token": "123token",
-                "client_id": "cid",
-                "client_secret": "s",
-            },
-        ),
-    )
-    config = p.destination_client().config
-    assert config.credentials.is_resolved()
-    assert isinstance(config.credentials, GcpOAuthCredentials)
-
-
 # do not remove - it allows us to filter tests by destination
 @pytest.mark.parametrize(
     "destination_config",

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -15,7 +15,7 @@ import pytest
 import dlt
 from dlt.common import json, pendulum
 from dlt.common.configuration.container import Container
-from dlt.common.configuration.exceptions import ConfigFieldMissingException
+from dlt.common.configuration.exceptions import ConfigFieldMissingException, InvalidNativeValue
 from dlt.common.configuration.specs.aws_credentials import AwsCredentials
 from dlt.common.configuration.specs.exceptions import NativeValueError
 from dlt.common.configuration.specs.gcp_credentials import GcpOAuthCredentials
@@ -270,45 +270,21 @@ def test_destination_explicit_credentials(environment: Any) -> None:
     # test redshift
     p = dlt.pipeline(
         pipeline_name="postgres_pipeline",
-        destination="redshift",
-        credentials="redshift://loader:loader@localhost:5432/dlt_data",
+        destination=redshift(credentials="redshift://loader:password@localhost:5432/dlt_data"),
     )
-    config = p._get_destination_client_initial_config()
+    config = p.destination_client().config
     assert config.credentials.is_resolved()
+    assert (
+        config.credentials.to_native_representation()
+        == "redshift://loader:password@localhost:5432/dlt_data?connect_timeout=15"
+    )
     # with staging
     p = dlt.pipeline(
         pipeline_name="postgres_pipeline",
-        staging="filesystem",
-        destination="redshift",
-        credentials="redshift://loader:loader@localhost:5432/dlt_data",
+        staging=filesystem("_storage"),
+        destination=redshift(credentials="redshift://loader:password@localhost:5432/dlt_data"),
     )
-    config = p._get_destination_client_initial_config(p.destination)
-    assert config.credentials.is_resolved()
-    config = p._get_destination_client_initial_config(p.staging, as_staging=True)
-    assert config.credentials is None
-    p._wipe_working_folder()
-    # try filesystem which uses union of credentials that requires bucket_url to resolve
-    p = dlt.pipeline(
-        pipeline_name="postgres_pipeline",
-        destination="filesystem",
-        credentials={"aws_access_key_id": "key_id", "aws_secret_access_key": "key"},
-    )
-    config = p._get_destination_client_initial_config(p.destination)
-    assert isinstance(config.credentials, AwsCredentials)
-    assert config.credentials.is_resolved()
-    # resolve gcp oauth
-    p = dlt.pipeline(
-        pipeline_name="postgres_pipeline",
-        destination="filesystem",
-        credentials={
-            "project_id": "pxid",
-            "refresh_token": "123token",
-            "client_id": "cid",
-            "client_secret": "s",
-        },
-    )
-    config = p._get_destination_client_initial_config(p.destination)
-    assert isinstance(config.credentials, GcpOAuthCredentials)
+    config = p.destination_client().config
     assert config.credentials.is_resolved()
 
 
@@ -362,14 +338,15 @@ def test_destination_credentials_in_factory(environment: Any) -> None:
     assert dest_config.credentials.database == "some_db"
 
 
-@pytest.mark.skip(reason="does not work on CI. probably takes right credentials from somewhere....")
 def test_destination_explicit_invalid_credentials_filesystem(environment: Any) -> None:
     # if string cannot be parsed
     p = dlt.pipeline(
-        pipeline_name="postgres_pipeline", destination="filesystem", credentials="PR8BLEM"
+        pipeline_name="postgres_pipeline",
+        destination=filesystem(bucket_url="s3://test", destination_name="uniq_s3_bucket"),
     )
-    with pytest.raises(NativeValueError):
-        p._get_destination_client_initial_config(p.destination)
+    with pytest.raises(PipelineStepFailed) as pip_ex:
+        p.run([1, 2, 3], table_name="data", credentials="PR8BLEM")
+    assert isinstance(pip_ex.value.__cause__, InvalidNativeValue)
 
 
 def test_extract_source_twice() -> None:

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -267,25 +267,16 @@ def test_deterministic_salt(environment) -> None:
 
 
 def test_destination_explicit_credentials(environment: Any) -> None:
+    from dlt.destinations import motherduck
+
     # test redshift
     p = dlt.pipeline(
         pipeline_name="postgres_pipeline",
-        destination=redshift(credentials="redshift://loader:password@localhost:5432/dlt_data"),
+        destination=motherduck(credentials="md://user:password@/dlt_data"),
     )
     config = p.destination_client().config
     assert config.credentials.is_resolved()
-    assert (
-        config.credentials.to_native_representation()
-        == "redshift://loader:password@localhost:5432/dlt_data?connect_timeout=15"
-    )
-    # with staging
-    p = dlt.pipeline(
-        pipeline_name="postgres_pipeline",
-        staging=filesystem("_storage"),
-        destination=redshift(credentials="redshift://loader:password@localhost:5432/dlt_data"),
-    )
-    config = p.destination_client().config
-    assert config.credentials.is_resolved()
+    assert config.credentials.to_native_representation() == "md://user:password@/dlt_data"
 
 
 def test_destination_staging_config(environment: Any) -> None:

--- a/tests/pipeline/test_schema_contracts.py
+++ b/tests/pipeline/test_schema_contracts.py
@@ -177,8 +177,7 @@ def get_pipeline():
 
     return dlt.pipeline(
         pipeline_name="contracts_" + uniq_id(),
-        destination="duckdb",
-        credentials=duckdb.connect(":memory:"),
+        destination=dlt.destinations.duckdb(credentials=duckdb.connect(":memory:")),
         dev_mode=True,
     )
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. `credentials` argument removed from Pipeline and helpers
2. docs and tests are updated
