### PR TITLE
selects all tables from info schema if number of tables > threshold

### DIFF
--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -411,11 +411,12 @@ class BigQueryClient(SqlJobClientWithStaging, SupportsStagingDestination):
         query = f"""
 SELECT {",".join(self._get_storage_table_query_columns())}
     FROM {catalog_name}.{schema_name}.INFORMATION_SCHEMA.COLUMNS
-WHERE """
-
-        # placeholder for each table
-        table_placeholders = ",".join(["%s"] * len(folded_table_names))
-        query += f"table_name IN ({table_placeholders}) ORDER BY table_name, ordinal_position;"
+"""
+        if folded_table_names:
+            # placeholder for each table
+            table_placeholders = ",".join(["%s"] * len(folded_table_names))
+            query += f"WHERE table_name IN ({table_placeholders}) "
+        query += "ORDER BY table_name, ordinal_position;"
 
         return query, folded_table_names
 

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -328,8 +328,10 @@ class SqlJobClientBase(JobClientBase, WithStateSync):
             f"One or more of tables in {table_names} after applying"
             f" {self.capabilities.casefold_identifier} produced a name collision."
         )
+        # if we have more tables to lookup than a threshold, we prefer to filter them in code
+        if len(name_lookup) > 2:
+            folded_table_names = []
 
-        # rows = self.sql_client.execute_sql(query, *db_params)
         query, db_params = self._get_info_schema_columns_query(
             catalog_name, schema_name, folded_table_names
         )
@@ -337,6 +339,9 @@ class SqlJobClientBase(JobClientBase, WithStateSync):
         prev_table: str = None
         storage_columns: TTableSchemaColumns = None
         for c in rows:
+            # if we are selecting all tables this is expected
+            if not folded_table_names and c[0] not in name_lookup:
+                continue
             # make sure that new table is known
             assert (
                 c[0] in name_lookup
@@ -437,7 +442,7 @@ class SqlJobClientBase(JobClientBase, WithStateSync):
         self, catalog_name: Optional[str], schema_name: str, folded_table_names: List[str]
     ) -> Tuple[str, List[Any]]:
         """Generates SQL to query INFORMATION_SCHEMA.COLUMNS for a set of tables in `folded_table_names`. Input identifiers must be already
-        in a form that can be passed to a query via db_params. `catalogue_name` is optional and when None, the part of query selecting it
+        in a form that can be passed to a query via db_params. `catalogue_name` and `folded_tableS_name` is optional and when None, the part of query selecting it
         is skipped.
 
         Returns: query and list of db_params tuple
@@ -452,13 +457,14 @@ WHERE """
             db_params.append(catalog_name)
             query += "table_catalog = %s AND "
         db_params.append(schema_name)
-        db_params = db_params + folded_table_names
-        # placeholder for each table
-        table_placeholders = ",".join(["%s"] * len(folded_table_names))
-        query += (
-            f"table_schema = %s AND table_name IN ({table_placeholders}) ORDER BY table_name,"
-            " ordinal_position;"
-        )
+        select_tables_clause = ""
+        # look for particular tables only when requested, otherwise return the full schema
+        if folded_table_names:
+            db_params = db_params + folded_table_names
+            # placeholder for each table
+            table_placeholders = ",".join(["%s"] * len(folded_table_names))
+            select_tables_clause = f"AND table_name IN ({table_placeholders})"
+        query += f"table_schema = %s {select_tables_clause} ORDER BY table_name, ordinal_position;"
 
         return query, db_params
 

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -197,7 +197,9 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         # use thread based pool as jobs processing is mostly I/O and we do not want to pickle jobs
         load_files = filter_new_jobs(
             self.load_storage.list_new_jobs(load_id),
-            self.destination.capabilities(self.destination.configuration(self.initial_client_config)),
+            self.destination.capabilities(
+                self.destination.configuration(self.initial_client_config)
+            ),
             self.config,
         )
         file_count = len(load_files)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,3 +114,5 @@ def pytest_configure(config):
 
     # disable httpx request logging (too verbose when testing qdrant)
     logging.getLogger("httpx").setLevel("WARNING")
+
+    logging.getLogger("airflow.models.variable").setLevel("CRITICAL")


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
We create a single large query to get all columns for all tables in `dlt` schema when migrating. This PR will fallback to selecting all columns in schema and filtering out in code when number of tables is very large (so the query size is not exceeded)