### PR TITLE
Surface original err msg from pydantic as extended_info on DataValidationError

### DIFF
--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -332,6 +332,7 @@ def validate_items(
                     list_model,
                     {"columns": "freeze"},
                     items,
+                    err["msg"]
                 ) from e
             # raise on freeze
             if err["type"] == "extra_forbidden":
@@ -345,6 +346,7 @@ def validate_items(
                         list_model,
                         {"columns": "freeze"},
                         err_item,
+                        err["msg"]
                     ) from e
                 elif column_mode == "discard_row":
                     # pop at the right index
@@ -366,6 +368,7 @@ def validate_items(
                         list_model,
                         {"data_type": "freeze"},
                         err_item,
+                        err["msg"]
                     ) from e
                 elif data_mode == "discard_row":
                     items.pop(err_idx - len(deleted))
@@ -403,6 +406,7 @@ def validate_item(
                         model,
                         {"columns": "freeze"},
                         item,
+                        err["msg"]
                     ) from e
                 elif column_mode == "discard_row":
                     return None
@@ -420,6 +424,7 @@ def validate_item(
                         model,
                         {"data_type": "freeze"},
                         item,
+                        err["msg"]
                     ) from e
                 elif data_mode == "discard_row":
                     return None


### PR DESCRIPTION
### Description
After I found myself spending the better half of a day trying to understand why my schema contract was failing with `In Table: decision_outcome Column: ('detail', 'meta', 'node_level_timings') . Contract on data_type with mode freeze is violated. `, I figured I might as well just file a PR to add the original pydantic error message (i.e. `Field required`) to dlt's `DataValidationError`. 

I think this is an important piece of information because right now, one cannot tell from the `DataValidationError` whether it failed for nullability or for actual dtype mismatch. Here are two examples

```
# Before:
In Table: decision_outcome Column: ('detail', 'complex_list', 1, 'str') . Contract on data_type with mode freeze is violated.

# After
In Table: decision_outcome Column: ('detail', 'complex_list', 1, 'str') . Contract on data_type with mode freeze is violated. Input should be a valid string

# Before
In Table: decision_outcome Column: ('detail', 'meta', 'node_level_timings') . Contract on data_type with mode freeze is violated. 

# After
In Table: decision_outcome Column: ('detail', 'meta', 'node_level_timings') . Contract on data_type with mode freeze is violated. Field required
```

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
