### PR TITLE
fix(dockerfile): remove extra spaces around equals sign in LABEL inst…

### DIFF
--- a/deploy/dlt/Dockerfile
+++ b/deploy/dlt/Dockerfile
@@ -31,7 +31,7 @@ RUN apk update &&\
 # add build labels and envs
 ARG COMMIT_SHA=""
 ARG IMAGE_VERSION=""
-LABEL commit_sha = ${COMMIT_SHA}
+LABEL commit_sha=${COMMIT_SHA}
 LABEL version=${IMAGE_VERSION}
 ENV COMMIT_SHA=${COMMIT_SHA}
 ENV IMAGE_VERSION=${IMAGE_VERSION}

--- a/deploy/dlt/Dockerfile.airflow
+++ b/deploy/dlt/Dockerfile.airflow
@@ -14,7 +14,7 @@ WORKDIR /tmp/pydlt
 # add build labels and envs
 ARG COMMIT_SHA=""
 ARG IMAGE_VERSION=""
-LABEL commit_sha = ${COMMIT_SHA}
+LABEL commit_sha=${COMMIT_SHA}
 LABEL version=${IMAGE_VERSION}
 ENV COMMIT_SHA=${COMMIT_SHA}
 ENV IMAGE_VERSION=${IMAGE_VERSION}


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Removed extra spaces around the equals sign in LABEL instructions in `Dockerfile` and `Dockerfile.airflow` to ensure proper syntax and avoid potential build errors. This change ensures that labels are correctly assigned.


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #1572 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
