### PR TITLE
fix: suppress alembic logs for tests

### DIFF
--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -332,7 +332,7 @@ def validate_items(
                     list_model,
                     {"columns": "freeze"},
                     items,
-                    err["msg"]
+                    err["msg"],
                 ) from e
             # raise on freeze
             if err["type"] == "extra_forbidden":
@@ -346,7 +346,7 @@ def validate_items(
                         list_model,
                         {"columns": "freeze"},
                         err_item,
-                        err["msg"]
+                        err["msg"],
                     ) from e
                 elif column_mode == "discard_row":
                     # pop at the right index
@@ -368,7 +368,7 @@ def validate_items(
                         list_model,
                         {"data_type": "freeze"},
                         err_item,
-                        err["msg"]
+                        err["msg"],
                     ) from e
                 elif data_mode == "discard_row":
                     items.pop(err_idx - len(deleted))
@@ -406,7 +406,7 @@ def validate_item(
                         model,
                         {"columns": "freeze"},
                         item,
-                        err["msg"]
+                        err["msg"],
                     ) from e
                 elif column_mode == "discard_row":
                     return None
@@ -424,7 +424,7 @@ def validate_item(
                         model,
                         {"data_type": "freeze"},
                         item,
-                        err["msg"]
+                        err["msg"],
                     ) from e
                 elif data_mode == "discard_row":
                     return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,8 @@ def pytest_configure(config):
 
         try:
             from airflow.utils import db
+            import contextlib
+            import io
 
             for log in [
                 "airflow.models.crypto",
@@ -133,7 +135,10 @@ def pytest_configure(config):
             ]:
                 logging.getLogger(log).setLevel("ERROR")
 
-            db.resetdb()
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+                io.StringIO()
+            ):
+                db.resetdb()
 
         except Exception:
             pass


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Suppresses alembic logs when running airflow db reset in tests.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #1559 
<!--
Provide any additional context about the PR here.
-->

