### PR TITLE
fix - enables query tagging

### DIFF
--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -66,7 +66,6 @@ class SnowflakeCredentials(ConnectionStringCredentials):
     private_key: Optional[TSecretStrValue] = None
     private_key_passphrase: Optional[TSecretStrValue] = None
     application: Optional[str] = SNOWFLAKE_APPLICATION_ID
-    query_tag: Optional[str] = None
 
     __config_gen_annotations__: ClassVar[List[str]] = ["password", "warehouse", "role"]
     __query_params__: ClassVar[List[str]] = [
@@ -136,6 +135,9 @@ class SnowflakeClientConfiguration(DestinationClientDwhWithStagingConfiguration)
 
     csv_format: Optional[CsvFormatConfiguration] = None
     """Optional csv format configuration"""
+
+    query_tag: Optional[str] = None
+    """A tag with placeholders to tag sessions executing jobs"""
 
     def fingerprint(self) -> str:
         """Returns a fingerprint of host part of a connection string"""

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -260,6 +260,7 @@ class SnowflakeClient(SqlJobClientWithStaging, SupportsStagingDestination):
             config.normalize_staging_dataset_name(schema),
             config.credentials,
             capabilities,
+            config.query_tag,
         )
         super().__init__(schema, config, sql_client)
         self.config: SnowflakeClientConfiguration = config

--- a/dlt/destinations/impl/snowflake/sql_client.py
+++ b/dlt/destinations/impl/snowflake/sql_client.py
@@ -38,10 +38,12 @@ class SnowflakeSqlClient(SqlClientBase[snowflake_lib.SnowflakeConnection], DBTra
         staging_dataset_name: str,
         credentials: SnowflakeCredentials,
         capabilities: DestinationCapabilitiesContext,
+        query_tag: Optional[str],
     ) -> None:
         super().__init__(credentials.database, dataset_name, staging_dataset_name, capabilities)
         self._conn: snowflake_lib.SnowflakeConnection = None
         self.credentials = credentials
+        self.query_tag = query_tag
 
     def open_connection(self) -> snowflake_lib.SnowflakeConnection:
         conn_params = self.credentials.to_connector_params()
@@ -123,14 +125,13 @@ class SnowflakeSqlClient(SqlClientBase[snowflake_lib.SnowflakeConnection], DBTra
 
     def set_query_tags(self, tags: TJobQueryTags) -> None:
         super().set_query_tags(tags)
-        self._tag_session()
+        if self.query_tag:
+            self._tag_session()
 
     def _tag_session(self) -> None:
         """Wraps query with Snowflake query tag"""
-        if not self.credentials.query_tag:
-            return
         if self._query_tags:
-            tag = self.credentials.query_tag.format(**self._query_tags)
+            tag = self.query_tag.format(**self._query_tags)
             tag_query = f"ALTER SESSION SET QUERY_TAG = '{tag}'"
         else:
             tag_query = "ALTER SESSION UNSET QUERY_TAG"

--- a/dlt/destinations/impl/snowflake/sql_client.py
+++ b/dlt/destinations/impl/snowflake/sql_client.py
@@ -38,7 +38,7 @@ class SnowflakeSqlClient(SqlClientBase[snowflake_lib.SnowflakeConnection], DBTra
         staging_dataset_name: str,
         credentials: SnowflakeCredentials,
         capabilities: DestinationCapabilitiesContext,
-        query_tag: Optional[str],
+        query_tag: Optional[str] = None,
     ) -> None:
         super().__init__(credentials.database, dataset_name, staging_dataset_name, capabilities)
         self._conn: snowflake_lib.SnowflakeConnection = None

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -263,7 +263,7 @@ class SqlJobClientBase(JobClientBase, WithStateSync):
 
     def start_file_load(self, table: TTableSchema, file_path: str, load_id: str) -> LoadJob:
         """Starts SqlLoadJob for files ending with .sql or returns None to let derived classes to handle their specific jobs"""
-
+        self._set_query_tags_for_job(load_id, table)
         if SqlLoadJob.is_sql_job(file_path):
             # execute sql load job
             return SqlLoadJob(file_path, self.sql_client)

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -320,7 +320,7 @@ You'll need those setting when [importing external files](../../general-usage/re
 
 You can define query tag by defining a query tag placeholder in snowflake credentials:
 ```toml
-[destination.snowflake.credentials]
+[destination.snowflake]
 query_tag='{{"source":"{source}", "resource":"{resource}", "table": "{table}", "load_id":"{load_id}", "pipeline_name":"{pipeline_name}"}}'
 ```
 which contains Python named formatters corresponding to tag names ie. `{source}` will assume the name of the dlt source.

--- a/tests/load/pipeline/test_snowflake_pipeline.py
+++ b/tests/load/pipeline/test_snowflake_pipeline.py
@@ -1,11 +1,13 @@
 import os
 import pytest
+from pytest_mock import MockerFixture
 
 import dlt
 
 from dlt.common.utils import uniq_id
 from dlt.destinations.exceptions import DatabaseUndefinedRelation
 
+from dlt.destinations.impl.snowflake.sql_client import SnowflakeSqlClient
 from tests.load.snowflake.test_snowflake_client import QUERY_TAG
 from tests.pipeline.utils import assert_load_info
 from tests.load.utils import destinations_configs, DestinationTestConfiguration
@@ -20,11 +22,12 @@ pytestmark = pytest.mark.essential
     ids=lambda x: x.name,
 )
 def test_snowflake_case_sensitive_identifiers(
-    destination_config: DestinationTestConfiguration,
+    destination_config: DestinationTestConfiguration, mocker: MockerFixture
 ) -> None:
     # enable query tagging
-    os.environ["DESTINATION__SNOWFLAKE__CREDENTIALS__QUERY_TAG"] = QUERY_TAG
     snow_ = dlt.destinations.snowflake(naming_convention="sql_cs_v1")
+    # we make sure that session was not tagged (lack of query tag in config)
+    tag_query_spy = mocker.spy(SnowflakeSqlClient, "_tag_session")
 
     dataset_name = "CaseSensitive_Dataset_" + uniq_id()
     pipeline = destination_config.setup_pipeline(
@@ -40,6 +43,7 @@ def test_snowflake_case_sensitive_identifiers(
     # load some case sensitive data
     info = pipeline.run([{"Id": 1, "Capital": 0.0}], table_name="Expenses")
     assert_load_info(info)
+    tag_query_spy.assert_not_called()
     with pipeline.sql_client() as client:
         assert client.has_dataset()
         # use the same case sensitive dataset
@@ -57,3 +61,19 @@ def test_snowflake_case_sensitive_identifiers(
         print(rows)
         with pytest.raises(DatabaseUndefinedRelation):
             client.execute_sql('SELECT "Id", "Capital" FROM Expenses')
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["snowflake"]),
+    ids=lambda x: x.name,
+)
+def test_snowflake_query_tagging(
+    destination_config: DestinationTestConfiguration, mocker: MockerFixture
+):
+    os.environ["DESTINATION__SNOWFLAKE__QUERY_TAG"] = QUERY_TAG
+    tag_query_spy = mocker.spy(SnowflakeSqlClient, "_tag_session")
+    pipeline = destination_config.setup_pipeline("test_snowflake_case_sensitive_identifiers")
+    info = pipeline.run([1, 2, 3], table_name="digits")
+    assert_load_info(info)
+    assert tag_query_spy.call_count == 2

--- a/tests/load/pipeline/test_snowflake_pipeline.py
+++ b/tests/load/pipeline/test_snowflake_pipeline.py
@@ -7,7 +7,6 @@ import dlt
 from dlt.common.utils import uniq_id
 from dlt.destinations.exceptions import DatabaseUndefinedRelation
 
-from dlt.destinations.impl.snowflake.sql_client import SnowflakeSqlClient
 from tests.load.snowflake.test_snowflake_client import QUERY_TAG
 from tests.pipeline.utils import assert_load_info
 from tests.load.utils import destinations_configs, DestinationTestConfiguration
@@ -24,7 +23,8 @@ pytestmark = pytest.mark.essential
 def test_snowflake_case_sensitive_identifiers(
     destination_config: DestinationTestConfiguration, mocker: MockerFixture
 ) -> None:
-    # enable query tagging
+    from dlt.destinations.impl.snowflake.sql_client import SnowflakeSqlClient
+
     snow_ = dlt.destinations.snowflake(naming_convention="sql_cs_v1")
     # we make sure that session was not tagged (lack of query tag in config)
     tag_query_spy = mocker.spy(SnowflakeSqlClient, "_tag_session")
@@ -71,6 +71,8 @@ def test_snowflake_case_sensitive_identifiers(
 def test_snowflake_query_tagging(
     destination_config: DestinationTestConfiguration, mocker: MockerFixture
 ):
+    from dlt.destinations.impl.snowflake.sql_client import SnowflakeSqlClient
+
     os.environ["DESTINATION__SNOWFLAKE__QUERY_TAG"] = QUERY_TAG
     tag_query_spy = mocker.spy(SnowflakeSqlClient, "_tag_session")
     pipeline = destination_config.setup_pipeline("test_snowflake_case_sensitive_identifiers")

--- a/tests/load/snowflake/test_snowflake_client.py
+++ b/tests/load/snowflake/test_snowflake_client.py
@@ -29,12 +29,12 @@ QUERY_TAGS_DICT: TJobQueryTags = {
 
 @pytest.fixture(scope="function")
 def client() -> Iterator[SqlJobClientBase]:
-    os.environ["CREDENTIALS__QUERY_TAG"] = QUERY_TAG
+    os.environ["QUERY_TAG"] = QUERY_TAG
     yield from yield_client_with_storage("snowflake")
 
 
 def test_query_tag(client: SnowflakeClient, mocker: MockerFixture):
-    assert client.config.credentials.query_tag == QUERY_TAG
+    assert client.config.query_tag == QUERY_TAG
     # make sure we generate proper query
     execute_sql_spy = mocker.spy(client.sql_client, "execute_sql")
     # reset the query if tags are not set
@@ -53,7 +53,7 @@ def test_query_tag(client: SnowflakeClient, mocker: MockerFixture):
         )
     )
     # remove query tag from config
-    client.sql_client.credentials.query_tag = None
+    client.sql_client.query_tag = None
     execute_sql_spy.reset_mock()
     client.sql_client.set_query_tags(QUERY_TAGS_DICT)
     execute_sql_spy.assert_not_called

--- a/tests/load/snowflake/test_snowflake_client.py
+++ b/tests/load/snowflake/test_snowflake_client.py
@@ -3,7 +3,6 @@ from typing import Iterator
 from pytest_mock import MockerFixture
 import pytest
 
-from dlt.destinations.impl.snowflake.configuration import SnowflakeCredentials
 from dlt.destinations.impl.snowflake.snowflake import SnowflakeClient
 from dlt.destinations.job_client_impl import SqlJobClientBase
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. adds missing call to start query tagging
2. moves `query_tag` to configuration to keep credentials clean of additional settings
