### PR TITLE
Add note that pg_replication doesn't support scd2

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/pg_replication.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/pg_replication.md
@@ -17,6 +17,10 @@ Resources that can be loaded using this verified source are:
 | -------------------- | ----------------------------------------------- |
 | replication_resource | Load published messages from a replication slot |
 
+:::info
+The postgres replication source currently **does not** suppport the [scd2 merge strategy](https://dlthub.com/docs/general-usage/incremental-loading#scd2-strategy). 
+:::
+
 ## Setup Guide
 
 ### Setup user

--- a/docs/website/docs/dlt-ecosystem/verified-sources/pg_replication.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/pg_replication.md
@@ -18,7 +18,7 @@ Resources that can be loaded using this verified source are:
 | replication_resource | Load published messages from a replication slot |
 
 :::info
-The postgres replication source currently **does not** suppport the [scd2 merge strategy](https://dlthub.com/docs/general-usage/incremental-loading#scd2-strategy). 
+The postgres replication source currently **does not** suppport the [scd2 merge strategy](../../general-usage/incremental-loading#scd2-strategy). 
 :::
 
 ## Setup Guide


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Based on this [discussion](https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1721220411348669) on slack we realised we should add a warning on the pg_replication docs page that it doesn't support the scd2 strategy.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
