### PR TITLE
`delta` table format test setup improvements

### DIFF
--- a/tests/load/pipeline/test_filesystem_pipeline.py
+++ b/tests/load/pipeline/test_filesystem_pipeline.py
@@ -24,18 +24,13 @@ from dlt.destinations.path_utils import create_path
 from tests.load.utils import (
     destinations_configs,
     DestinationTestConfiguration,
+    MEMORY_BUCKET,
 )
 
 from tests.pipeline.utils import load_table_counts, assert_load_info, load_tables_to_dicts
 
 
 skip_if_not_active("filesystem")
-
-
-@pytest.fixture
-def local_filesystem_pipeline() -> dlt.Pipeline:
-    os.environ["DESTINATION__FILESYSTEM__BUCKET_URL"] = "_storage"
-    return dlt.pipeline(pipeline_name="fs_pipe", destination="filesystem", dev_mode=True)
 
 
 def test_pipeline_merge_write_disposition(default_buckets_env: str) -> None:
@@ -224,23 +219,25 @@ def test_pipeline_parquet_filesystem_destination() -> None:
 
 
 @pytest.mark.essential
-def test_delta_table_core(default_buckets_env: str) -> None:
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        all_buckets_filesystem_configs=True,
+        table_format="delta",
+        bucket_exclude=(MEMORY_BUCKET),
+    ),
+    ids=lambda x: x.name,
+)
+def test_delta_table_core(
+    destination_config: DestinationTestConfiguration,
+) -> None:
     """Tests core functionality for `delta` table format.
 
-    Tests all data types, all filesystems, all write dispositions.
+    Tests all data types, all filesystems.
+    Tests `append` and `replace` write dispositions (`merge` is tested elsewhere).
     """
 
     from tests.pipeline.utils import _get_delta_table
-
-    if default_buckets_env.startswith("memory://"):
-        pytest.skip(
-            "`deltalake` library does not support `memory` protocol (write works, read doesn't)"
-        )
-    if default_buckets_env.startswith("s3://"):
-        # https://delta-io.github.io/delta-rs/usage/writing/writing-to-s3-with-locking-provider/
-        os.environ["DESTINATION__FILESYSTEM__DELTALAKE_STORAGE_OPTIONS"] = (
-            '{"AWS_S3_ALLOW_UNSAFE_RENAME": "true"}'
-        )
 
     # create resource that yields rows with all data types
     column_schemas, row = table_update_and_row()
@@ -250,7 +247,7 @@ def test_delta_table_core(default_buckets_env: str) -> None:
         nonlocal row
         yield [row] * 10
 
-    pipeline = dlt.pipeline(pipeline_name="fs_pipe", destination="filesystem", dev_mode=True)
+    pipeline = destination_config.setup_pipeline("fs_pipe", dev_mode=True)
 
     # run pipeline, this should create Delta table
     info = pipeline.run(data_types())
@@ -285,8 +282,16 @@ def test_delta_table_core(default_buckets_env: str) -> None:
     assert len(rows) == 10
 
 
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        local_filesystem_configs=True,
+        table_format="delta",
+    ),
+    ids=lambda x: x.name,
+)
 def test_delta_table_multiple_files(
-    local_filesystem_pipeline: dlt.Pipeline,
+    destination_config: DestinationTestConfiguration,
 ) -> None:
     """Tests loading multiple files into a Delta table.
 
@@ -301,7 +306,9 @@ def test_delta_table_multiple_files(
     def delta_table():
         yield [{"foo": True}] * 10
 
-    info = local_filesystem_pipeline.run(delta_table())
+    pipeline = destination_config.setup_pipeline("fs_pipe", dev_mode=True)
+
+    info = pipeline.run(delta_table())
     assert_load_info(info)
 
     # multiple Parquet files should have been created
@@ -315,16 +322,22 @@ def test_delta_table_multiple_files(
     assert len(delta_table_parquet_jobs) == 5  # 10 records, max 2 per file
 
     # all 10 records should have been loaded into a Delta table in a single commit
-    client = cast(FilesystemClient, local_filesystem_pipeline.destination_client())
+    client = cast(FilesystemClient, pipeline.destination_client())
     assert _get_delta_table(client, "delta_table").version() == 0
-    rows = load_tables_to_dicts(local_filesystem_pipeline, "delta_table", exclude_system_cols=True)[
-        "delta_table"
-    ]
+    rows = load_tables_to_dicts(pipeline, "delta_table", exclude_system_cols=True)["delta_table"]
     assert len(rows) == 10
 
 
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        local_filesystem_configs=True,
+        table_format="delta",
+    ),
+    ids=lambda x: x.name,
+)
 def test_delta_table_child_tables(
-    local_filesystem_pipeline: dlt.Pipeline,
+    destination_config: DestinationTestConfiguration,
 ) -> None:
     """Tests child table handling for `delta` table format."""
 
@@ -343,10 +356,12 @@ def test_delta_table_child_tables(
             },
         ]
 
-    info = local_filesystem_pipeline.run(complex_table())
+    pipeline = destination_config.setup_pipeline("fs_pipe", dev_mode=True)
+
+    info = pipeline.run(complex_table())
     assert_load_info(info)
     rows_dict = load_tables_to_dicts(
-        local_filesystem_pipeline,
+        pipeline,
         "complex_table",
         "complex_table__child",
         "complex_table__child__grandchild",
@@ -362,10 +377,10 @@ def test_delta_table_child_tables(
     assert rows_dict["complex_table__child__grandchild"][0].keys() == {"value"}
 
     # test write disposition handling with child tables
-    info = local_filesystem_pipeline.run(complex_table())
+    info = pipeline.run(complex_table())
     assert_load_info(info)
     rows_dict = load_tables_to_dicts(
-        local_filesystem_pipeline,
+        pipeline,
         "complex_table",
         "complex_table__child",
         "complex_table__child__grandchild",
@@ -375,10 +390,10 @@ def test_delta_table_child_tables(
     assert len(rows_dict["complex_table__child"]) == 3 * 2
     assert len(rows_dict["complex_table__child__grandchild"]) == 5 * 2
 
-    info = local_filesystem_pipeline.run(complex_table(), write_disposition="replace")
+    info = pipeline.run(complex_table(), write_disposition="replace")
     assert_load_info(info)
     rows_dict = load_tables_to_dicts(
-        local_filesystem_pipeline,
+        pipeline,
         "complex_table",
         "complex_table__child",
         "complex_table__child__grandchild",
@@ -389,8 +404,16 @@ def test_delta_table_child_tables(
     assert len(rows_dict["complex_table__child__grandchild"]) == 5
 
 
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        local_filesystem_configs=True,
+        table_format="delta",
+    ),
+    ids=lambda x: x.name,
+)
 def test_delta_table_mixed_source(
-    local_filesystem_pipeline: dlt.Pipeline,
+    destination_config: DestinationTestConfiguration,
 ) -> None:
     """Tests file format handling in mixed source.
 
@@ -409,9 +432,9 @@ def test_delta_table_mixed_source(
     def s():
         return [delta_table(), non_delta_table()]
 
-    info = local_filesystem_pipeline.run(
-        s(), loader_file_format="jsonl"
-    )  # set file format at pipeline level
+    pipeline = destination_config.setup_pipeline("fs_pipe", dev_mode=True)
+
+    info = pipeline.run(s(), loader_file_format="jsonl")  # set file format at pipeline level
     assert_load_info(info)
     completed_jobs = info.load_packages[0].jobs["completed_jobs"]
 
@@ -429,8 +452,16 @@ def test_delta_table_mixed_source(
     assert non_delta_table_job.file_path.endswith(".jsonl")
 
 
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        local_filesystem_configs=True,
+        table_format="delta",
+    ),
+    ids=lambda x: x.name,
+)
 def test_delta_table_dynamic_dispatch(
-    local_filesystem_pipeline: dlt.Pipeline,
+    destination_config: DestinationTestConfiguration,
 ) -> None:
     @dlt.resource(primary_key="id", table_name=lambda i: i["type"], table_format="delta")
     def github_events():
@@ -439,7 +470,9 @@ def test_delta_table_dynamic_dispatch(
         ) as f:
             yield json.load(f)
 
-    info = local_filesystem_pipeline.run(github_events())
+    pipeline = destination_config.setup_pipeline("fs_pipe", dev_mode=True)
+
+    info = pipeline.run(github_events())
     assert_load_info(info)
     completed_jobs = info.load_packages[0].jobs["completed_jobs"]
     # 20 event types, two jobs per table (.parquet and .reference), 1 job for _dlt_pipeline_state

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -529,7 +529,7 @@ def destinations_configs(
         destination_configs = [
             conf
             for conf in destination_configs
-            if conf.bucket_url is None or conf.bucket_url in bucket_subset
+            if conf.destination != "filesystem" or conf.bucket_url in bucket_subset
         ]
     if exclude:
         destination_configs = [

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -133,6 +133,7 @@ class DestinationTestConfiguration:
     disable_compression: bool = False
     dev_mode: bool = False
     credentials: Optional[Union[CredentialsConfiguration, Dict[str, Any]]] = None
+    env_vars: Optional[Dict[str, str]] = None
 
     @property
     def name(self) -> str:
@@ -176,6 +177,10 @@ class DestinationTestConfiguration:
             for key, value in dict(self.credentials).items():
                 os.environ[f"DESTINATION__CREDENTIALS__{key.upper()}"] = str(value)
 
+        if self.env_vars is not None:
+            for k, v in self.env_vars.items():
+                os.environ[k] = v
+
     def setup_pipeline(
         self, pipeline_name: str, dataset_name: str = None, dev_mode: bool = False, **kwargs
     ) -> dlt.Pipeline:
@@ -209,6 +214,7 @@ def destinations_configs(
     subset: Sequence[str] = (),
     bucket_subset: Sequence[str] = (),
     exclude: Sequence[str] = (),
+    bucket_exclude: Sequence[str] = (),
     file_format: Union[TLoaderFileFormat, Sequence[TLoaderFileFormat]] = None,
     table_format: Union[TTableFormat, Sequence[TTableFormat]] = None,
     supports_merge: Optional[bool] = None,
@@ -514,6 +520,15 @@ def destinations_configs(
                     extra_info=bucket,
                     table_format="delta",
                     supports_merge=True,
+                    env_vars=(
+                        {
+                            "DESTINATION__FILESYSTEM__DELTALAKE_STORAGE_OPTIONS": (
+                                '{"AWS_S3_ALLOW_UNSAFE_RENAME": "true"}'
+                            )
+                        }
+                        if bucket == AWS_BUCKET
+                        else None
+                    ),
                 )
             ]
 
@@ -534,6 +549,12 @@ def destinations_configs(
     if exclude:
         destination_configs = [
             conf for conf in destination_configs if conf.destination not in exclude
+        ]
+    if bucket_exclude:
+        destination_configs = [
+            conf
+            for conf in destination_configs
+            if conf.destination != "filesystem" or conf.bucket_url not in bucket_exclude
         ]
     if file_format:
         if not isinstance(file_format, Sequence):


### PR DESCRIPTION
Two things in this PR:
- make `bucket_subset` specific to `filesystem` destination (because it was unintentionally filtering `athena` from `test_merge_on_keys_in_schema`)
- use `destination_configs` function for `delta` table format tests