### PR TITLE
Enable `upsert` merge strategy for more SQL destinations

### DIFF
--- a/dlt/destinations/impl/athena/factory.py
+++ b/dlt/destinations/impl/athena/factory.py
@@ -46,7 +46,7 @@ class athena(Destination[AthenaClientConfiguration, "AthenaClient"]):
         caps.schema_supports_numeric_precision = False
         caps.timestamp_precision = 3
         caps.supports_truncate_command = False
-        caps.supported_merge_strategies = ["delete-insert", "scd2"]
+        caps.supported_merge_strategies = ["delete-insert", "upsert", "scd2"]
         return caps
 
     @property

--- a/dlt/destinations/impl/bigquery/factory.py
+++ b/dlt/destinations/impl/bigquery/factory.py
@@ -42,7 +42,7 @@ class bigquery(Destination[BigQueryClientConfiguration, "BigQueryClient"]):
         caps.supports_ddl_transactions = False
         caps.supports_clone_table = True
         caps.schema_supports_numeric_precision = False  # no precision information in BigQuery
-        caps.supported_merge_strategies = ["delete-insert", "scd2"]
+        caps.supported_merge_strategies = ["delete-insert", "upsert", "scd2"]
 
         return caps
 

--- a/dlt/destinations/impl/databricks/factory.py
+++ b/dlt/destinations/impl/databricks/factory.py
@@ -42,7 +42,7 @@ class databricks(Destination[DatabricksClientConfiguration, "DatabricksClient"])
         caps.alter_add_multi_column = True
         caps.supports_multiple_statements = False
         caps.supports_clone_table = True
-        caps.supported_merge_strategies = ["delete-insert", "scd2"]
+        caps.supported_merge_strategies = ["delete-insert", "upsert", "scd2"]
         return caps
 
     @property

--- a/dlt/destinations/impl/mssql/factory.py
+++ b/dlt/destinations/impl/mssql/factory.py
@@ -39,7 +39,7 @@ class mssql(Destination[MsSqlClientConfiguration, "MsSqlJobClient"]):
         caps.supports_ddl_transactions = True
         caps.max_rows_per_insert = 1000
         caps.timestamp_precision = 7
-        caps.supported_merge_strategies = ["delete-insert", "scd2"]
+        caps.supported_merge_strategies = ["delete-insert", "upsert", "scd2"]
 
         return caps
 

--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -395,7 +395,11 @@ column in the root table to stamp changes in nested data.
 ### `upsert` strategy
 
 :::caution
-The `upsert` merge strategy is currently only supported for these destinations:
+The `upsert` merge strategy is currently supported for these destinations:
+- `athena`
+- `bigquery`
+- `databricks`
+- `mssql`
 - `postgres`
 - `snowflake`
 - 🧪 `filesytem` with `delta` table format (see limitations [here](../dlt-ecosystem/destinations/filesystem.md#known-limitations))


### PR DESCRIPTION
### Description
Currently, only `postgres` and `snowflake` support the `upsert` merge strategy.

This PR enables `upsert` for:
- `athena`
- `bigquery`
- `databricks`
- `mssql`

### Related Issues

Closes #1621 

### Additional context

The other SQL destinations are not enabled because they either:
- don't support `MERGE INTO`
- support `MERGE INTO` with limitations/complications

We could enable some more destinations if we're okay with partial support: basic upsert works, but `hard_delete` hint does not:
- `redshift` ➜ works with current SQL logic
- `dremio` ➜ perhaps works with current SQL logic (haven't been able to test it locally)
- `duckdb` /  `motherduck` ➜ requires custom SQL logic 

Details:

- `clickhouse`
  - does not support `MERGE INTO` or similar functionality
- `duckdb` / `motherduck`
  - does not support `MERGE INTO`
  - It supports the [upsert](https://duckdb.org/docs/sql/statements/insert.html#do-update-clause-upsert) pattern with `INSERT INTO ... ON CONFLICT DO UPDATE`, but this can't handle the `hard_delete` hint.
- `dremio`
  - does not support `WHEN MATCHED THEN DELETE` ➜ `hard_delete` hint can't be handled 
- `synapse`
  - [requires](https://learn.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=azure-sqldw-latest&preserve-view=true#azure-synapse-analytics-considerations) the target table to have `HASH` distribution when using a `WHEN NOT MATCHED` clause
  - I tried making it work by configuring tables with `HASH` distribution when `upsert` is chosen, but this comes with its own set of challenges related to setting/choosing the distribution column(s).
- `redshift`
  - only supports having one `WHEN MATCHED` clause in the `MERGE` statement (makes supporting `hard_delete` hint difficult)
  - I tried working around this limitation but couldn't find an elegant solution.
  - (`redshift` also doesn't support using an alias for the target table in a `MERGE` statement. I managed to work around this with some conditional logic, so this isn't a blocking limitation.)