### PR TITLE
fix: validation with pydantic should not coerce the items to models

### DIFF
--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -304,13 +304,13 @@ def validate_items(
     items: List[TDataItem],
     column_mode: TSchemaEvolutionMode,
     data_mode: TSchemaEvolutionMode,
-) -> List[_TPydanticModel]:
+) -> List[TDataItem]:
     """Validates list of `item` with `list_model` and returns parsed Pydantic models
 
     `list_model` should be created with `create_list_model` and have `items` field which this function returns.
     """
     try:
-        return list_model(items=items).items
+        return [i.model_dump() for i in list_model(items=items).items]
     except ValidationError as e:
         deleted: Set[int] = set()
         for err in e.errors():
@@ -385,13 +385,13 @@ def validate_items(
 def validate_item(
     table_name: str,
     model: Type[_TPydanticModel],
-    item: TDataItems,
+    item: TDataItem,
     column_mode: TSchemaEvolutionMode,
     data_mode: TSchemaEvolutionMode,
-) -> _TPydanticModel:
-    """Validates `item` against model `model` and returns an instance of it"""
+) -> TDataItem:
+    """Validates `item` against model `model` and returns the original item"""
     try:
-        return model.parse_obj(item)
+        return model.model_validate(item).model_dump()
     except ValidationError as e:
         for err in e.errors():
             # raise on freeze

--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -305,7 +305,7 @@ def validate_items(
     column_mode: TSchemaEvolutionMode,
     data_mode: TSchemaEvolutionMode,
 ) -> List[TDataItem]:
-    """Validates list of `item` with `list_model` and returns parsed Pydantic models
+    """Validates list of `item` with `list_model` and returns a parsed then dumped list of data items.
 
     `list_model` should be created with `create_list_model` and have `items` field which this function returns.
     """
@@ -389,7 +389,7 @@ def validate_item(
     column_mode: TSchemaEvolutionMode,
     data_mode: TSchemaEvolutionMode,
 ) -> TDataItem:
-    """Validates `item` against model `model` and returns the original item"""
+    """Validates `item` against model `model` and returns the parsed then dumped item"""
     try:
         return model.model_validate(item).model_dump()
     except ValidationError as e:

--- a/dlt/extract/validation.py
+++ b/dlt/extract/validation.py
@@ -30,9 +30,7 @@ class PydanticValidator(ValidateItem, Generic[_TPydanticModel]):
         self.model = apply_schema_contract_to_model(model, column_mode, data_mode)
         self.list_model = create_list_model(self.model, data_mode)
 
-    def __call__(
-        self, item: TDataItems, meta: Any = None
-    ) -> Union[_TPydanticModel, List[_TPydanticModel]]:
+    def __call__(self, item: TDataItems, meta: Any = None) -> Union[TDataItems, None]:
         """Validate a data item against the pydantic model"""
         if item is None:
             return None

--- a/tests/extract/test_validation.py
+++ b/tests/extract/test_validation.py
@@ -214,15 +214,15 @@ def test_validation_with_contracts(yield_list: bool) -> None:
     items = list(r)
     assert len(items) == 3
     # fully valid
-    assert items[0].a == 1
-    assert items[0].b == "z"
+    assert items[0]["a"] == 1
+    assert items[0]["b"] == "z"
     # data type not valid
-    assert items[1].a == "not_int"
-    assert items[1].b == "x"
+    assert items[1]["a"] == "not_int"
+    assert items[1]["b"] == "x"
     # extra attr and data invalid
-    assert items[2].a is None
-    assert items[2].b is None
-    assert items[2].c == "not_int"
+    assert items[2]["a"] is None
+    assert items[2]["b"] is None
+    assert items[2]["c"] == "not_int"
 
     # let it drop
     r = dlt.resource(some_data(), schema_contract="discard_row", columns=SimpleModel)
@@ -232,8 +232,8 @@ def test_validation_with_contracts(yield_list: bool) -> None:
     assert validator.model.__name__.endswith("ExtraForbid")
     items = list(r)
     assert len(items) == 1
-    assert items[0].a == 1
-    assert items[0].b == "z"
+    assert items[0]["a"] == 1
+    assert items[0]["b"] == "z"
 
     # filter just offending values
     with pytest.raises(NotImplementedError):

--- a/tests/libs/test_pydantic.py
+++ b/tests/libs/test_pydantic.py
@@ -442,8 +442,8 @@ def test_item_list_validation() -> None:
     # {"b": 2, "opt": "not int", "extra": 1.2} - note that this will generate 3 errors for the same item
     # and is crucial in our tests when discarding rows
     assert len(items) == 2
-    assert items[0].b is True
-    assert items[1].b is False
+    assert items[0]["b"] is True
+    assert items[1]["b"] is False
     # violate extra field
     items = validate_items(
         "items",
@@ -453,7 +453,7 @@ def test_item_list_validation() -> None:
         "discard_row",
     )
     assert len(items) == 1
-    assert items[0].b is True
+    assert items[0]["b"] is True
 
     # freeze on non validating items (both extra and declared)
     freeze_model = apply_schema_contract_to_model(ItemModel, "freeze", "freeze")
@@ -504,7 +504,7 @@ def test_item_list_validation() -> None:
     )
     assert len(items) == 2
     # "a" extra got remove
-    assert items[1].dict() == {"b": False, "opt": None}
+    assert items[1] == {"b": False, "opt": None}
     # violate data type
     with pytest.raises(NotImplementedError):
         apply_schema_contract_to_model(ItemModel, "discard_value", "discard_value")
@@ -521,8 +521,8 @@ def test_item_list_validation() -> None:
         "evolve",
     )
     assert len(items) == 4
-    assert items[0].b is True
-    assert items[1].b == 2
+    assert items[0]["b"] is True
+    assert items[1]["b"] == 2
     # extra fields allowed
     items = validate_items(
         "items",
@@ -532,8 +532,8 @@ def test_item_list_validation() -> None:
         "evolve",
     )
     assert len(items) == 4
-    assert items[3].b is False
-    assert items[3].a is False  # type: ignore[attr-defined]
+    assert items[3]["b"] is False
+    assert items[3]["b"] is False
 
     # accept new types but discard new columns
     mixed_model = apply_schema_contract_to_model(ItemModel, "discard_row", "evolve")
@@ -547,8 +547,8 @@ def test_item_list_validation() -> None:
         "evolve",
     )
     assert len(items) == 4
-    assert items[0].b is True
-    assert items[1].b == 2
+    assert items[0]["b"] is True
+    assert items[1]["b"] == 2
     # extra fields forbidden - full rows discarded
     items = validate_items(
         "items",
@@ -607,23 +607,23 @@ def test_item_validation() -> None:
         "items", discard_value_model, {"b": False, "a": False}, "discard_value", "freeze"
     )
     # "a" extra got removed
-    assert item.dict() == {"b": False}
+    assert item == {"b": False}
 
     # evolve data types and extras
     evolve_model = apply_schema_contract_to_model(ItemModel, "evolve", "evolve")
     # for data types a lenient model will be created that accepts any type
     item = validate_item("items", evolve_model, {"b": 2}, "evolve", "evolve")
-    assert item.b == 2
+    assert item["b"] == 2
     # extra fields allowed
     item = validate_item("items", evolve_model, {"b": False, "a": False}, "evolve", "evolve")
-    assert item.b is False
-    assert item.a is False  # type: ignore[attr-defined]
+    assert item["b"] is False
+    assert item["a"] is False
 
     # accept new types but discard new columns
     mixed_model = apply_schema_contract_to_model(ItemModel, "discard_row", "evolve")
     # for data types a lenient model will be created that accepts any type
     item = validate_item("items", mixed_model, {"b": 3}, "discard_row", "evolve")
-    assert item.b == 3
+    assert item["b"] == 3
     # extra fields forbidden - full rows discarded
     assert (
         validate_item("items", mixed_model, {"b": False, "a": False}, "discard_row", "evolve")


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
I've taken the liberty of changing the way dlt uses pydantic to validate against its model schema. I haven't done any end to end testing however to make sure that schemas are correctly applied when running it in a full pipeline against a database/warehouse.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #1606

<!--
Provide any additional context about the PR here.
-->
### Additional Context
My approach was simply to adhere to the validator base class
```python
class ValidateItem(ItemTransform[TDataItem]):
    """Base class for validators of data items.

    Subclass should implement the `__call__` method to either return the data item(s) or raise `extract.exceptions.ValidationError`.
    See `PydanticValidator` for possible implementation.
    """

    table_name: str

    def bind(self, pipe: SupportsPipe) -> ItemTransform[TDataItem]:
        self.table_name = pipe.name
        return self
```
where it states that the validation functions should either return the data items as is, or filtered in some cases for list validation where the `column_code="discard_row"`, but not change the data type so that any downstream processing may be broken (like `dlt.extract.incremental`). This is my first PR so please be lenient :sweat_smile: 

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
