### PR TITLE
Fix/1606 fixes validator incremental step order

### DIFF
--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -144,7 +144,7 @@ def custom_pua_encode(obj: Any) -> str:
     elif dataclasses.is_dataclass(obj):
         return dataclasses.asdict(obj)  # type: ignore
     elif PydanticBaseModel and isinstance(obj, PydanticBaseModel):
-        return obj.dict()  # type: ignore[return-value]
+        return obj.dict(by_alias=True)  # type: ignore[return-value]
     elif isinstance(obj, Enum):
         # Enum value is just int or str
         return obj.value  # type: ignore[no-any-return]

--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -4,6 +4,7 @@ from copy import copy
 from typing import (
     Dict,
     Generic,
+    Optional,
     Set,
     TypedDict,
     List,
@@ -298,14 +299,16 @@ def create_list_model(
     )
 
 
-def validate_items(
+def validate_and_filter_items(
     table_name: str,
     list_model: Type[ListModel[_TPydanticModel]],
     items: List[TDataItem],
     column_mode: TSchemaEvolutionMode,
     data_mode: TSchemaEvolutionMode,
 ) -> List[_TPydanticModel]:
-    """Validates list of `item` with `list_model` and returns parsed Pydantic models
+    """Validates list of `item` with `list_model` and returns parsed Pydantic models. If `column_mode` and `data_mode` are set
+    this function will remove non validating items (`discard_row`) or raise on the first non-validating items (`freeze`). Note
+    that the model itself may be configured to remove non validating or extra items as well.
 
     `list_model` should be created with `create_list_model` and have `items` field which this function returns.
     """
@@ -379,17 +382,19 @@ def validate_items(
                     )
 
         # validate again with error items removed
-        return validate_items(table_name, list_model, items, column_mode, data_mode)
+        return validate_and_filter_items(table_name, list_model, items, column_mode, data_mode)
 
 
-def validate_item(
+def validate_and_filter_item(
     table_name: str,
     model: Type[_TPydanticModel],
     item: TDataItems,
     column_mode: TSchemaEvolutionMode,
     data_mode: TSchemaEvolutionMode,
-) -> _TPydanticModel:
-    """Validates `item` against model `model` and returns an instance of it"""
+) -> Optional[_TPydanticModel]:
+    """Validates `item` against model `model` and returns an instance of it. If `column_mode` and `data_mode` are set
+    this function will return None (`discard_row`) or raise on non-validating items (`freeze`). Note
+    that the model itself may be configured to remove non validating or extra items as well."""
     try:
         return model.parse_obj(item)
     except ValidationError as e:

--- a/dlt/common/logger.py
+++ b/dlt/common/logger.py
@@ -34,11 +34,11 @@ def metrics(name: str, extra: Mapping[str, Any], stacklevel: int = 1) -> None:
 
 
 @contextlib.contextmanager
-def suppress_and_warn() -> Iterator[None]:
+def suppress_and_warn(msg: str) -> Iterator[None]:
     try:
         yield
     except Exception:
-        LOGGER.warning("Suppressed exception", exc_info=True)
+        LOGGER.warning(msg, exc_info=True)
 
 
 def is_logging() -> bool:

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -107,6 +107,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
 
     # incremental acting as empty
     EMPTY: ClassVar["Incremental[Any]"] = None
+    placement_affinity: ClassVar[float] = 1  # stick to end
 
     def __init__(
         self,
@@ -496,6 +497,8 @@ Incremental.EMPTY.__is_resolved__ = True
 
 
 class IncrementalResourceWrapper(ItemTransform[TDataItem]):
+    placement_affinity: ClassVar[float] = 1  # stick to end
+
     _incremental: Optional[Incremental[Any]] = None
     """Keeps the injectable incremental"""
     _from_hints: bool = False

--- a/dlt/extract/items.py
+++ b/dlt/extract/items.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Generic,
     Iterator,
     Iterable,
@@ -135,6 +136,9 @@ class ItemTransform(ABC, Generic[TAny]):
     _f_meta: ItemTransformFunctionWithMeta[TAny] = None
     _f: ItemTransformFunctionNoMeta[TAny] = None
 
+    placement_affinity: ClassVar[float] = 0
+    """Tell how strongly an item sticks to start (-1) or end (+1) of pipe."""
+
     def __init__(self, transform_f: ItemTransformFunc[TAny]) -> None:
         # inspect the signature
         sig = inspect.signature(transform_f)
@@ -222,6 +226,8 @@ class ValidateItem(ItemTransform[TDataItem]):
     Subclass should implement the `__call__` method to either return the data item(s) or raise `extract.exceptions.ValidationError`.
     See `PydanticValidator` for possible implementation.
     """
+
+    placement_affinity: ClassVar[float] = 0.9  # stick to end but less than incremental
 
     table_name: str
 

--- a/dlt/pipeline/trace.py
+++ b/dlt/pipeline/trace.py
@@ -3,7 +3,6 @@ from copy import copy
 import os
 import pickle
 import datetime  # noqa: 251
-import dataclasses
 from typing import Any, List, NamedTuple, Optional, Protocol, Sequence
 import humanize
 
@@ -26,6 +25,7 @@ from dlt.common.pipeline import (
     SupportsPipeline,
 )
 from dlt.common.source import get_current_pipe_name
+from dlt.common.storages.file_storage import FileStorage
 from dlt.common.typing import DictStrAny, StrAny, SupportsHumanize
 from dlt.common.utils import uniq_id, get_exception_trace_chain
 
@@ -103,7 +103,8 @@ class PipelineStepTrace(SupportsHumanize, _PipelineStepTrace):
             d["step_info"] = {}
             # take only the base keys
             for prop in self.step_info._astuple()._asdict():
-                d["step_info"][prop] = step_info_dict.pop(prop)
+                if prop in step_info_dict:
+                    d["step_info"][prop] = step_info_dict.pop(prop)
         # replace the attributes in exception traces with json dumps
         if self.exception_traces:
             # do not modify original traces
@@ -232,7 +233,7 @@ def start_trace(step: TPipelineStep, pipeline: SupportsPipeline) -> PipelineTrac
         resolved_config_values=[],
     )
     for module in TRACKING_MODULES:
-        with suppress_and_warn():
+        with suppress_and_warn(f"on_start_trace on module {module} failed"):
             module.on_start_trace(trace, step, pipeline)
     return trace
 
@@ -242,7 +243,7 @@ def start_trace_step(
 ) -> PipelineStepTrace:
     trace_step = PipelineStepTrace(uniq_id(), step, pendulum.now())
     for module in TRACKING_MODULES:
-        with suppress_and_warn():
+        with suppress_and_warn(f"start_trace_step on module {module} failed"):
             module.on_start_trace_step(trace, step, pipeline)
     return trace_step
 
@@ -292,7 +293,7 @@ def end_trace_step(
     trace.resolved_config_values[:] = list(resolved_values)
     trace.steps.append(step)
     for module in TRACKING_MODULES:
-        with suppress_and_warn():
+        with suppress_and_warn(f"end_trace_step on module {module} failed"):
             module.on_end_trace_step(trace, step, pipeline, step_info, send_state)
     return trace
 
@@ -304,7 +305,7 @@ def end_trace(
     if trace_path:
         save_trace(trace_path, trace)
     for module in TRACKING_MODULES:
-        with suppress_and_warn():
+        with suppress_and_warn(f"end_trace on module {module} failed"):
             module.on_end_trace(trace, pipeline, send_state)
     return trace
 
@@ -324,8 +325,13 @@ def merge_traces(last_trace: PipelineTrace, new_trace: PipelineTrace) -> Pipelin
 
 
 def save_trace(trace_path: str, trace: PipelineTrace) -> None:
-    with open(os.path.join(trace_path, TRACE_FILE_NAME), mode="bw") as f:
-        f.write(pickle.dumps(trace))
+    # remove previous file, we do not want to keep old trace even if we fail later
+    trace_dump_path = os.path.join(trace_path, TRACE_FILE_NAME)
+    if os.path.isfile(trace_dump_path):
+        os.unlink(trace_dump_path)
+    with suppress_and_warn("Failed to create trace dump via pickle"):
+        trace_dump = pickle.dumps(trace)
+        FileStorage.save_atomic(trace_path, TRACE_FILE_NAME, trace_dump, file_type="b")
 
 
 def load_trace(trace_path: str) -> PipelineTrace:

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database.md
@@ -301,6 +301,15 @@ With dataset above and local postgres instance, connectorx is 2x faster than pya
 #### Postgres / MSSQL
 No issues found. Postgres is the only backend where we observed 2x speedup with connector x. On other db systems it performs same as `pyarrrow` backend or slower.
 
+### Noted on data types
+
+#### JSON
+JSON data type is represented as Python object for the **sqlalchemy** backend and as JSON string for the **pyarrow** backend. Currently it does not work correctly
+with **pandas** and **connector-x** which cast Python objects to str generating invalid JSON strings that cannot be loaded into destination.
+
+#### UUID
+UUIDs are represented as string by default. You can switch that behavior by using table adapter callback and modifying properties of the UUID type for a particular column.
+
 
 ## Incremental Loading
 Efficient data management often requires loading only new or updated data from your SQL databases, rather than reprocessing the entire dataset. This is where incremental loading comes into play.

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database.md
@@ -301,7 +301,7 @@ With dataset above and local postgres instance, connectorx is 2x faster than pya
 #### Postgres / MSSQL
 No issues found. Postgres is the only backend where we observed 2x speedup with connector x. On other db systems it performs same as `pyarrrow` backend or slower.
 
-### Noted on data types
+### Notes on data types
 
 #### JSON
 JSON data type is represented as Python object for the **sqlalchemy** backend and as JSON string for the **pyarrow** backend. Currently it does not work correctly

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -25,6 +25,7 @@ from dlt.common.json import json
 
 from dlt.extract import DltSource
 from dlt.extract.exceptions import InvalidStepFunctionArguments
+from dlt.extract.items import ValidateItem
 from dlt.extract.resource import DltResource
 from dlt.sources.helpers.transform import take_first
 from dlt.extract.incremental import IncrementalResourceWrapper, Incremental
@@ -2007,3 +2008,57 @@ def test_allow_external_schedulers(item_type: TestDataItemFormat) -> None:
     r.incremental.allow_external_schedulers = True
     result = data_item_to_list(item_type, list(r))
     assert len(result) == 3
+
+
+@pytest.mark.parametrize("yield_pydantic", (True, False))
+def test_pydantic_columns_validator(yield_pydantic: bool) -> None:
+    from pydantic import BaseModel, Field, ConfigDict
+
+    # forbid extra fields so "id" in json is not a valid field BUT
+    # add alias for id_ that will serde "id" correctly
+    class TestRow(BaseModel):
+        model_config = ConfigDict(frozen=True, extra="forbid")
+
+        id_: int = Field(alias="id")
+        example_string: str
+        ts: datetime
+
+    @dlt.resource(name="table_name", columns=TestRow, primary_key="id", write_disposition="replace")
+    def generate_rows():
+        for i in range(10):
+            item = {"id": i, "example_string": "abc", "ts": datetime.now()}
+            yield TestRow.model_validate(item) if yield_pydantic else item
+
+    @dlt.resource(name="table_name", columns=TestRow, primary_key="id", write_disposition="replace")
+    def generate_rows_incremental(
+        ts: dlt.sources.incremental[datetime] = dlt.sources.incremental(cursor_path="ts"),
+    ):
+        for i in range(10):
+            item = {"id": i, "example_string": "abc", "ts": datetime.now()}
+            yield TestRow.model_validate(item) if yield_pydantic else item
+            if ts.end_out_of_range:
+                return
+
+    @dlt.source
+    def test_source_incremental():
+        return generate_rows_incremental
+
+    @dlt.source
+    def test_source():
+        return generate_rows
+
+    pip_1_name = "test_pydantic_columns_validator_" + uniq_id()
+    pipeline = dlt.pipeline(pipeline_name=pip_1_name, destination="duckdb")
+
+    info = pipeline.run(test_source())
+    info.raise_on_failed_jobs()
+
+    info = pipeline.run(test_source_incremental())
+    info.raise_on_failed_jobs()
+
+    # verify that right steps are at right place
+    steps = test_source().table_name._pipe._steps
+    assert isinstance(steps[-1], ValidateItem)
+    incremental_steps = test_source_incremental().table_name._pipe._steps
+    assert isinstance(incremental_steps[-2], ValidateItem)
+    assert isinstance(incremental_steps[-1], IncrementalResourceWrapper)

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -863,6 +863,9 @@ def test_replace_resets_state(item_type: TestDataItemFormat) -> None:
         state["mark"] = f"mark:{item['delta']}"
         yield item
 
+    print(parent_r._pipe._steps)
+    print(child._pipe._steps)
+
     # also transformer will not receive new data
     info = p.run(child)
     assert len(info.loads_ids) == 0

--- a/tests/extract/test_validation.py
+++ b/tests/extract/test_validation.py
@@ -214,15 +214,15 @@ def test_validation_with_contracts(yield_list: bool) -> None:
     items = list(r)
     assert len(items) == 3
     # fully valid
-    assert items[0].a == 1
-    assert items[0].b == "z"
+    assert items[0]["a"] == 1
+    assert items[0]["b"] == "z"
     # data type not valid
-    assert items[1].a == "not_int"
-    assert items[1].b == "x"
+    assert items[1]["a"] == "not_int"
+    assert items[1]["b"] == "x"
     # extra attr and data invalid
-    assert items[2].a is None
-    assert items[2].b is None
-    assert items[2].c == "not_int"
+    assert items[2]["a"] is None
+    assert items[2]["b"] is None
+    assert items[2]["c"] == "not_int"
 
     # let it drop
     r = dlt.resource(some_data(), schema_contract="discard_row", columns=SimpleModel)
@@ -232,8 +232,8 @@ def test_validation_with_contracts(yield_list: bool) -> None:
     assert validator.model.__name__.endswith("ExtraForbid")
     items = list(r)
     assert len(items) == 1
-    assert items[0].a == 1
-    assert items[0].b == "z"
+    assert items[0]["a"] == 1
+    assert items[0]["b"] == "z"
 
     # filter just offending values
     with pytest.raises(NotImplementedError):
@@ -252,4 +252,4 @@ def test_validation_with_contracts(yield_list: bool) -> None:
     items = list(r)
     assert len(items) == 3
     # c is gone from the last model
-    assert not hasattr(items[2], "c")
+    assert "c" not in items[2]

--- a/tests/extract/utils.py
+++ b/tests/extract/utils.py
@@ -46,6 +46,8 @@ def expect_extracted_file(
 
 
 class AssertItems(ItemTransform[TDataItem]):
+    placement_affinity = 2.0  # even more sticky than incremental so gathers data after it
+
     def __init__(self, expected_items: Any, item_type: TestDataItemFormat = "object") -> None:
         self.expected_items = expected_items
         self.item_type = item_type

--- a/tests/pipeline/test_pipeline_trace.py
+++ b/tests/pipeline/test_pipeline_trace.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import io
 import os
 import asyncio
@@ -267,7 +268,12 @@ def test_save_load_trace() -> None:
     loaded_trace = load_trace(pipeline.working_dir)
     print(loaded_trace.asstr(2))
     assert len(trace.steps) == 4
-    assert loaded_trace.asdict() == trace.asdict()
+    loaded_trace_dict = deepcopy(loaded_trace.asdict())
+    trace_dict = deepcopy(trace.asdict())
+    assert loaded_trace_dict == trace_dict
+    # do it again to check if we are not popping
+    assert loaded_trace_dict == loaded_trace.asdict()
+    assert trace_dict == trace.asdict()
 
     # exception also saves trace
     @dlt.resource
@@ -292,6 +298,29 @@ def test_save_load_trace() -> None:
     assert step.step_exception == run_step.step_exception
     assert_trace_printable(trace)
     assert pipeline.last_trace.last_normalize_info is None
+
+
+def test_save_load_empty_trace() -> None:
+    os.environ["COMPLETED_PROB"] = "1.0"
+    os.environ["RESTORE_FROM_DESTINATION"] = "false"
+    pipeline = dlt.pipeline()
+    pipeline.run([], table_name="data", destination="dummy")
+    trace = pipeline.last_trace
+    assert_trace_printable(trace)
+    assert len(trace.steps) == 4
+
+    pipeline.activate()
+
+    # load trace and check if all elements are present
+    loaded_trace = load_trace(pipeline.working_dir)
+    print(loaded_trace.asstr(2))
+    assert len(trace.steps) == 4
+    loaded_trace_dict = deepcopy(loaded_trace.asdict())
+    trace_dict = deepcopy(trace.asdict())
+    assert loaded_trace_dict == trace_dict
+    # do it again to check if we are not popping
+    assert loaded_trace_dict == loaded_trace.asdict()
+    assert trace_dict == trace.asdict()
 
 
 def test_disable_trace(environment: DictStrStr) -> None:
@@ -499,7 +528,9 @@ def assert_trace_printable(trace: PipelineTrace) -> None:
     str(trace)
     trace.asstr(0)
     trace.asstr(1)
-    trace.asdict()
+    trace_dict = deepcopy(trace.asdict())
+    # check if we do not pop
+    assert trace_dict == trace.asdict()
     with io.BytesIO() as b:
         json.typed_dump(trace, b, pretty=True)
         b.getvalue()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
fixes #1606 

* adds left or right affinity to transforms to keep incremental and validator to the end of the pipe
* validator does not emit Pydantic models, it emits Python objects (ie. dicts)
* we dump Pydantic always with aliases
* fixes `as_dict` for trace (where `started_at` key was missing)
