### PR TITLE
updates duckdb/motherduck load job, adds full ci for motherduck and updates docs

### DIFF
--- a/.github/workflows/test_destination_motherduck.yml
+++ b/.github/workflows/test_destination_motherduck.yml
@@ -1,0 +1,80 @@
+
+name: dest | motherduck
+
+on:
+  pull_request:
+    branches:
+      - master
+      - devel
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 2 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  DLT_SECRETS_TOML: ${{ secrets.DLT_SECRETS_TOML }}
+
+  RUNTIME__SENTRY_DSN: https://6f6f7b6f8e0f458a89be4187603b55fe@o1061158.ingest.sentry.io/4504819859914752
+  RUNTIME__LOG_LEVEL: ERROR
+  RUNTIME__DLTHUB_TELEMETRY_ENDPOINT: ${{ secrets.RUNTIME__DLTHUB_TELEMETRY_ENDPOINT }}
+
+  ACTIVE_DESTINATIONS: "[\"motherduck\"]"
+  ALL_FILESYSTEM_DRIVERS: "[\"memory\"]"
+
+jobs:
+  get_docs_changes:
+    name: docs changes
+    uses: ./.github/workflows/get_docs_changes.yml
+    if: ${{ !github.event.pull_request.head.repo.fork || contains(github.event.pull_request.labels.*.name, 'ci from fork')}}
+
+  run_loader:
+    name: dest | motherduck tests
+    needs: get_docs_changes
+    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    defaults:
+      run:
+        shell: bash
+    runs-on: "ubuntu-latest"
+
+    steps:
+
+      - name: Check out
+        uses: actions/checkout@master
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10.x"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.3.2
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}-motherduck
+
+      - name: Install dependencies
+        run: poetry install --no-interaction -E motherduck -E s3 -E gs -E az -E parquet --with sentry-sdk --with pipeline
+
+      - name: create secrets.toml
+        run: pwd && echo "$DLT_SECRETS_TOML" > tests/.dlt/secrets.toml
+
+      - run: |
+          poetry run pytest tests/load -m "essential"
+        name: Run essential tests Linux
+        if: ${{ ! (contains(github.event.pull_request.labels.*.name, 'ci full') || github.event_name == 'schedule')}}
+
+      - run: |
+          poetry run pytest tests/load
+        name: Run all tests Linux
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'ci full') || github.event_name == 'schedule'}}

--- a/.github/workflows/test_destinations.yml
+++ b/.github/workflows/test_destinations.yml
@@ -28,7 +28,7 @@ env:
   RUNTIME__DLTHUB_TELEMETRY_ENDPOINT: ${{ secrets.RUNTIME__DLTHUB_TELEMETRY_ENDPOINT }}
   # Test redshift and filesystem with all buckets
   # postgres runs again here so we can test on mac/windows
-  ACTIVE_DESTINATIONS: "[\"redshift\", \"postgres\", \"duckdb\", \"filesystem\", \"dummy\", \"motherduck\"]"
+  ACTIVE_DESTINATIONS: "[\"redshift\", \"postgres\", \"duckdb\", \"filesystem\", \"dummy\"]"
 
 jobs:
   get_docs_changes:

--- a/dlt/destinations/impl/motherduck/factory.py
+++ b/dlt/destinations/impl/motherduck/factory.py
@@ -33,10 +33,11 @@ class motherduck(Destination[MotherDuckClientConfiguration, "MotherDuckClient"])
         caps.is_max_query_length_in_bytes = True
         caps.max_text_data_type_length = 1024 * 1024 * 1024
         caps.is_max_text_data_type_length_in_bytes = True
-        caps.supports_ddl_transactions = False
+        caps.supports_ddl_transactions = True
         caps.alter_add_multi_column = False
         caps.supports_truncate_command = False
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
+        caps.max_parallel_load_jobs = 8
 
         return caps
 

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -63,7 +63,7 @@ You can configure the following file formats to load data to duckdb:
 :::note
 `duckdb` cannot COPY many parquet files to a single table from multiple threads. In this situation, `dlt` serializes the loads. Still, that may be faster than INSERT.
 :::
-* [jsonl](../file-formats/jsonl.md) **is supported but does not work if JSON fields are optional. The missing keys fail the COPY instead of being interpreted as NULL.**
+* [jsonl](../file-formats/jsonl.md)
 
 :::tip
 `duckdb` has [timestamp types](https://duckdb.org/docs/sql/data_types/timestamp.html) with resolutions from milliseconds to nanoseconds. However

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -178,7 +178,7 @@ def table_update_and_row(
     Optionally exclude some data types from the schema and row.
     """
     column_schemas = deepcopy(TABLE_UPDATE_COLUMNS_SCHEMA)
-    data_row = deepcopy(TABLE_ROW_ALL_DATA_TYPES)
+    data_row = deepcopy(TABLE_ROW_ALL_DATA_TYPES_DATETIMES)
     exclude_col_names = list(exclude_columns or [])
     if exclude_types:
         exclude_col_names.extend(
@@ -203,7 +203,7 @@ def assert_all_data_types_row(
     # content must equal
     # print(db_row)
     schema = schema or TABLE_UPDATE_COLUMNS_SCHEMA
-    expected_row = expected_row or TABLE_ROW_ALL_DATA_TYPES
+    expected_row = expected_row or TABLE_ROW_ALL_DATA_TYPES_DATETIMES
 
     # Include only columns requested in schema
     if isinstance(db_row, dict):
@@ -274,8 +274,8 @@ def assert_all_data_types_row(
             # then it must be json
             db_mapping["col9"] = json.loads(db_mapping["col9"])
 
-    if "col10" in db_mapping:
-        db_mapping["col10"] = db_mapping["col10"].isoformat()
+    # if "col10" in db_mapping:
+    #     db_mapping["col10"] = db_mapping["col10"].isoformat()
     if "col11" in db_mapping:
         db_mapping["col11"] = ensure_pendulum_time(db_mapping["col11"]).isoformat()
 

--- a/tests/common/test_json.py
+++ b/tests/common/test_json.py
@@ -217,6 +217,15 @@ def test_json_pendulum(json_impl: SupportsJson) -> None:
     assert s_r == pendulum.parse(dt_str_z)
 
 
+# @pytest.mark.parametrize("json_impl", _JSON_IMPL)
+# def test_json_timedelta(json_impl: SupportsJson) -> None:
+#     from datetime import timedelta
+#     start_date = pendulum.parse("2005-04-02T20:37:37.358236Z")
+#     delta = pendulum.interval(start_date, pendulum.now())
+#     assert isinstance(delta, timedelta)
+#     print(str(delta.as_timedelta()))
+
+
 @pytest.mark.parametrize("json_impl", _JSON_IMPL)
 def test_json_named_tuple(json_impl: SupportsJson) -> None:
     assert (

--- a/tests/load/pipeline/test_duckdb.py
+++ b/tests/load/pipeline/test_duckdb.py
@@ -3,17 +3,18 @@ import pytest
 import os
 from datetime import datetime  # noqa: I251
 
+import dlt
+from dlt.common import json
 from dlt.common.libs.pydantic import DltConfig
 from dlt.common.schema.exceptions import SchemaIdentifierNormalizationCollision
 from dlt.common.time import ensure_pendulum_datetime, pendulum
 
 from dlt.destinations import duckdb
-from dlt.destinations.exceptions import DatabaseTerminalException
 from dlt.pipeline.exceptions import PipelineStepFailed
 
 from tests.cases import TABLE_UPDATE_ALL_INT_PRECISIONS, TABLE_UPDATE_ALL_TIMESTAMP_PRECISIONS
 from tests.load.utils import destinations_configs, DestinationTestConfiguration
-from tests.pipeline.utils import airtable_emojis, load_table_counts
+from tests.pipeline.utils import airtable_emojis, assert_data_table_counts, load_table_counts
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
@@ -26,7 +27,6 @@ pytestmark = pytest.mark.essential
 )
 def test_duck_case_names(destination_config: DestinationTestConfiguration) -> None:
     # we want to have nice tables
-    # dlt.config["schema.naming"] = "duck_case"
     os.environ["SCHEMA__NAMING"] = "duck_case"
     pipeline = destination_config.setup_pipeline("test_duck_case_names")
     # create tables and columns with emojis and other special characters
@@ -205,3 +205,60 @@ def test_new_nested_prop_parquet(destination_config: DestinationTestConfiguratio
     )
     info.raise_on_failed_jobs()
     print(pipeline.default_schema.to_pretty_yaml())
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["duckdb"]),
+    ids=lambda x: x.name,
+)
+def test_jsonl_reader(destination_config: DestinationTestConfiguration) -> None:
+    pipeline = destination_config.setup_pipeline("test_jsonl_reader")
+
+    data = [{"a": 1, "b": 2}, {"a": 1}]
+    info = pipeline.run(data, table_name="data", loader_file_format="jsonl")
+    info.raise_on_failed_jobs()
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["duckdb"]),
+    ids=lambda x: x.name,
+)
+def test_provoke_parallel_parquet_same_table(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    @dlt.resource(name="events", file_format="parquet")
+    def _get_shuffled_events(repeat: int = 1):
+        for _ in range(repeat):
+            with open(
+                "tests/normalize/cases/github.events.load_page_1_duck.json", "r", encoding="utf-8"
+            ) as f:
+                issues = json.load(f)
+                yield issues
+
+    os.environ["DATA_WRITER__BUFFER_MAX_ITEMS"] = "200"
+    os.environ["DATA_WRITER__FILE_MAX_ITEMS"] = "200"
+
+    pipeline = destination_config.setup_pipeline("test_provoke_parallel_parquet_same_table")
+
+    info = pipeline.run(_get_shuffled_events(50))
+    info.raise_on_failed_jobs()
+    assert_data_table_counts(
+        pipeline,
+        expected_counts={
+            "events": 5000,
+            "events__payload__pull_request__base__repo__topics": 14500,
+            "events__payload__commits": 3850,
+            "events__payload__pull_request__requested_reviewers": 1200,
+            "events__payload__pull_request__labels": 1300,
+            "events__payload__issue__labels": 150,
+            "events__payload__issue__assignees": 50,
+        },
+    )
+    metrics = pipeline.last_trace.last_normalize_info.metrics[
+        pipeline.last_trace.last_normalize_info.loads_ids[0]
+    ][0]
+    event_files = [m for m in metrics["job_metrics"].keys() if m.startswith("events.")]
+    assert len(event_files) == 5000 // 200
+    assert all(m.endswith("parquet") for m in event_files)

--- a/tests/load/pipeline/test_pipelines.py
+++ b/tests/load/pipeline/test_pipelines.py
@@ -29,6 +29,7 @@ from dlt.pipeline.exceptions import (
     PipelineStepFailed,
 )
 
+from tests.cases import TABLE_ROW_ALL_DATA_TYPES_DATETIMES
 from tests.utils import TEST_STORAGE_ROOT, data_to_item_format
 from tests.pipeline.utils import (
     assert_data_table_counts,
@@ -39,7 +40,6 @@ from tests.pipeline.utils import (
     select_data,
 )
 from tests.load.utils import (
-    TABLE_ROW_ALL_DATA_TYPES,
     TABLE_UPDATE_COLUMNS_SCHEMA,
     assert_all_data_types_row,
     delete_dataset,
@@ -844,7 +844,7 @@ def test_parquet_loading(destination_config: DestinationTestConfiguration) -> No
     def other_data():
         yield [1, 2, 3, 4, 5]
 
-    data_types = deepcopy(TABLE_ROW_ALL_DATA_TYPES)
+    data_types = deepcopy(TABLE_ROW_ALL_DATA_TYPES_DATETIMES)
     column_schemas = deepcopy(TABLE_UPDATE_COLUMNS_SCHEMA)
 
     # parquet on bigquery and clickhouse does not support JSON but we still want to run the test

--- a/tests/load/test_insert_job_client.py
+++ b/tests/load/test_insert_job_client.py
@@ -55,12 +55,18 @@ def test_simple_load(client: InsertValuesJobClient, file_storage: FileStorage) -
         f" '{str(pendulum.now())}'"
         + post
     )
-    expect_load_file(client, file_storage, insert_sql + insert_values + ";", user_table_name)
+    expect_load_file(
+        client,
+        file_storage,
+        insert_sql + insert_values + ";",
+        user_table_name,
+        file_format="insert_values",
+    )
     rows_count = client.sql_client.execute_sql(f"SELECT COUNT(1) FROM {canonical_name}")[0][0]
     assert rows_count == 1
     # insert 100 more rows
     query = insert_sql + (insert_values + sep) * 99 + insert_values + ";"
-    expect_load_file(client, file_storage, query, user_table_name)
+    expect_load_file(client, file_storage, query, user_table_name, file_format="insert_values")
     rows_count = client.sql_client.execute_sql(f"SELECT COUNT(1) FROM {canonical_name}")[0][0]
     assert rows_count == 101
     # insert null value (single-record insert has same syntax for both writer types)
@@ -69,7 +75,13 @@ def test_simple_load(client: InsertValuesJobClient, file_storage: FileStorage) -
         f"('{uniq_id()}', '{uniq_id()}', '90238094809sajlkjxoiewjhduuiuehd',"
         f" '{str(pendulum.now())}', NULL);"
     )
-    expect_load_file(client, file_storage, insert_sql_nc + insert_values_nc, user_table_name)
+    expect_load_file(
+        client,
+        file_storage,
+        insert_sql_nc + insert_values_nc,
+        user_table_name,
+        file_format="insert_values",
+    )
     rows_count = client.sql_client.execute_sql(f"SELECT COUNT(1) FROM {canonical_name}")[0][0]
     assert rows_count == 102
 
@@ -94,7 +106,7 @@ def test_loading_errors(client: InsertValuesJobClient, file_storage: FileStorage
         if dtype == "redshift":
             # redshift does not know or psycopg does not recognize those correctly
             TNotNullViolation = psycopg2.errors.InternalError_
-    elif dtype == "duckdb":
+    elif dtype in ("duckdb", "motherduck"):
         import duckdb
 
         TUndefinedColumn = duckdb.BinderException
@@ -115,14 +127,24 @@ def test_loading_errors(client: InsertValuesJobClient, file_storage: FileStorage
         f" '{str(pendulum.now())}', NULL);"
     )
     job = expect_load_file(
-        client, file_storage, insert_sql + insert_values, user_table_name, "failed"
+        client,
+        file_storage,
+        insert_sql + insert_values,
+        user_table_name,
+        "failed",
+        file_format="insert_values",
     )
     assert type(job._exception.dbapi_exception) is TUndefinedColumn  # type: ignore
     # insert null value
     insert_sql = "INSERT INTO {}(_dlt_id, _dlt_root_id, sender_id, timestamp)\nVALUES\n"
     insert_values = f"('{uniq_id()}', '{uniq_id()}', '90238094809sajlkjxoiewjhduuiuehd', NULL);"
     job = expect_load_file(
-        client, file_storage, insert_sql + insert_values, user_table_name, "failed"
+        client,
+        file_storage,
+        insert_sql + insert_values,
+        user_table_name,
+        "failed",
+        file_format="insert_values",
     )
     assert type(job._exception.dbapi_exception) is TNotNullViolation  # type: ignore
     # insert wrong type
@@ -132,7 +154,12 @@ def test_loading_errors(client: InsertValuesJobClient, file_storage: FileStorage
         f" {client.capabilities.escape_literal(True)});"
     )
     job = expect_load_file(
-        client, file_storage, insert_sql + insert_values, user_table_name, "failed"
+        client,
+        file_storage,
+        insert_sql + insert_values,
+        user_table_name,
+        "failed",
+        file_format="insert_values",
     )
     assert type(job._exception.dbapi_exception) is TDatatypeMismatch  # type: ignore
     # numeric overflow on bigint
@@ -145,7 +172,12 @@ def test_loading_errors(client: InsertValuesJobClient, file_storage: FileStorage
         f" '{str(pendulum.now())}', {2**64//2});"
     )
     job = expect_load_file(
-        client, file_storage, insert_sql + insert_values, user_table_name, "failed"
+        client,
+        file_storage,
+        insert_sql + insert_values,
+        user_table_name,
+        "failed",
+        file_format="insert_values",
     )
     assert type(job._exception) == DatabaseTerminalException  # type: ignore
     # numeric overflow on NUMERIC
@@ -162,14 +194,25 @@ def test_loading_errors(client: InsertValuesJobClient, file_storage: FileStorage
         f"('{uniq_id()}', '{uniq_id()}', '90238094809sajlkjxoiewjhduuiuehd',"
         f" '{str(pendulum.now())}', {below_limit});"
     )
-    expect_load_file(client, file_storage, insert_sql + insert_values, user_table_name)
+    expect_load_file(
+        client,
+        file_storage,
+        insert_sql + insert_values,
+        user_table_name,
+        file_format="insert_values",
+    )
     # this will raise
     insert_values = (
         f"('{uniq_id()}', '{uniq_id()}', '90238094809sajlkjxoiewjhduuiuehd',"
         f" '{str(pendulum.now())}', {above_limit});"
     )
     job = expect_load_file(
-        client, file_storage, insert_sql + insert_values, user_table_name, "failed"
+        client,
+        file_storage,
+        insert_sql + insert_values,
+        user_table_name,
+        "failed",
+        file_format="insert_values",
     )
     assert type(job._exception) == DatabaseTerminalException  # type: ignore
 
@@ -200,7 +243,9 @@ def test_query_split(client: InsertValuesJobClient, file_storage: FileStorage) -
     # this guarantees that we execute inserts line by line
     with patch.object(client.sql_client, "execute_fragments") as mocked_fragments:
         user_table_name = prepare_table(client)
-        expect_load_file(client, file_storage, insert_sql, user_table_name)
+        expect_load_file(
+            client, file_storage, insert_sql, user_table_name, file_format="insert_values"
+        )
         # print(mocked_fragments.mock_calls)
     # split in 10 lines
     assert mocked_fragments.call_count == 10
@@ -224,7 +269,9 @@ def test_query_split(client: InsertValuesJobClient, file_storage: FileStorage) -
     client.sql_client.capabilities.max_query_length = query_length
     with patch.object(client.sql_client, "execute_fragments") as mocked_fragments:
         user_table_name = prepare_table(client)
-        expect_load_file(client, file_storage, insert_sql, user_table_name)
+        expect_load_file(
+            client, file_storage, insert_sql, user_table_name, file_format="insert_values"
+        )
     # split in 2 on ','
     assert mocked_fragments.call_count == 2
 
@@ -233,7 +280,9 @@ def test_query_split(client: InsertValuesJobClient, file_storage: FileStorage) -
     client.sql_client.capabilities.max_query_length = query_length
     with patch.object(client.sql_client, "execute_fragments") as mocked_fragments:
         user_table_name = prepare_table(client)
-        expect_load_file(client, file_storage, insert_sql, user_table_name)
+        expect_load_file(
+            client, file_storage, insert_sql, user_table_name, file_format="insert_values"
+        )
     # split in 2 on separator ("," or " UNION ALL")
     assert mocked_fragments.call_count == 2
 
@@ -246,7 +295,9 @@ def test_query_split(client: InsertValuesJobClient, file_storage: FileStorage) -
     client.sql_client.capabilities.max_query_length = query_length
     with patch.object(client.sql_client, "execute_fragments") as mocked_fragments:
         user_table_name = prepare_table(client)
-        expect_load_file(client, file_storage, insert_sql, user_table_name)
+        expect_load_file(
+            client, file_storage, insert_sql, user_table_name, file_format="insert_values"
+        )
     # split in 2 on ','
     assert mocked_fragments.call_count == 1
 
@@ -263,7 +314,7 @@ def assert_load_with_max_query(
     insert_sql = prepare_insert_statement(
         insert_lines, client.capabilities.insert_values_writer_type
     )
-    expect_load_file(client, file_storage, insert_sql, user_table_name)
+    expect_load_file(client, file_storage, insert_sql, user_table_name, file_format="insert_values")
     canonical_name = client.sql_client.make_qualified_table_name(user_table_name)
     rows_count = client.sql_client.execute_sql(f"SELECT COUNT(1) FROM {canonical_name}")[0][0]
     assert rows_count == insert_lines

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -35,7 +35,6 @@ from tests.common.utils import load_json_case
 from tests.load.utils import (
     TABLE_UPDATE,
     TABLE_UPDATE_COLUMNS_SCHEMA,
-    TABLE_ROW_ALL_DATA_TYPES,
     expect_load_file,
     load_table,
     yield_client_with_storage,
@@ -489,7 +488,7 @@ def test_data_writer_load(naming: str, client: SqlJobClientBase, file_storage: F
     # write only first row
     with io.BytesIO() as f:
         write_dataset(client, f, [rows[0]], client.schema.get_table(table_name)["columns"])
-        query = f.getvalue().decode()
+        query = f.getvalue()
     expect_load_file(client, file_storage, query, table_name)
     db_row = client.sql_client.execute_sql(f"SELECT * FROM {canonical_name}")[0]
     # content must equal
@@ -497,7 +496,7 @@ def test_data_writer_load(naming: str, client: SqlJobClientBase, file_storage: F
     # write second row that contains two nulls
     with io.BytesIO() as f:
         write_dataset(client, f, [rows[1]], client.schema.get_table(table_name)["columns"])
-        query = f.getvalue().decode()
+        query = f.getvalue()
     expect_load_file(client, file_storage, query, table_name)
     f_int_name = client.schema.naming.normalize_identifier("f_int")
     f_int_name_quoted = client.sql_client.escape_column_name(f_int_name)
@@ -522,7 +521,7 @@ def test_data_writer_string_escape(client: SqlJobClientBase, file_storage: FileS
     row["f_str"] = inj_str
     with io.BytesIO() as f:
         write_dataset(client, f, [rows[0]], client.schema.get_table(table_name)["columns"])
-        query = f.getvalue().decode()
+        query = f.getvalue()
     expect_load_file(client, file_storage, query, table_name)
     db_row = client.sql_client.execute_sql(f"SELECT * FROM {canonical_name}")[0]
     assert list(db_row) == list(row.values())
@@ -540,7 +539,7 @@ def test_data_writer_string_escape_edge(
     canonical_name = client.sql_client.make_qualified_table_name(table_name)
     with io.BytesIO() as f:
         write_dataset(client, f, rows, client.schema.get_table(table_name)["columns"])
-        query = f.getvalue().decode()
+        query = f.getvalue()
     expect_load_file(client, file_storage, query, table_name)
     for i in range(1, len(rows) + 1):
         db_row = client.sql_client.execute_sql(f"SELECT str FROM {canonical_name} WHERE idx = {i}")
@@ -562,11 +561,7 @@ def test_load_with_all_types(
     if not client.capabilities.preferred_loader_file_format:
         pytest.skip("preferred loader file format not set, destination will only work with staging")
     table_name = "event_test_table" + uniq_id()
-    column_schemas, data_row = table_update_and_row(
-        exclude_types=(
-            ["time"] if client.config.destination_type in ["databricks", "clickhouse"] else None
-        ),
-    )
+    column_schemas, data_row = get_columns_and_row_all_types(client.config.destination_type)
 
     # we should have identical content with all disposition types
     partial = client.schema.update_table(
@@ -595,9 +590,11 @@ def test_load_with_all_types(
     ):
         canonical_name = client.sql_client.make_qualified_table_name(table_name)
     # write row
+    print(data_row)
     with io.BytesIO() as f:
         write_dataset(client, f, [data_row], column_schemas)
-        query = f.getvalue().decode()
+        query = f.getvalue()
+    print(client.schema.to_pretty_yaml())
     expect_load_file(client, file_storage, query, table_name)
     db_row = list(client.sql_client.execute_sql(f"SELECT * FROM {canonical_name}")[0])
     assert len(db_row) == len(data_row)
@@ -636,13 +633,14 @@ def test_write_dispositions(
     os.environ["DESTINATION__REPLACE_STRATEGY"] = replace_strategy
 
     table_name = "event_test_table" + uniq_id()
+    column_schemas, data_row = get_columns_and_row_all_types(client.config.destination_type)
     client.schema.update_table(
-        new_table(table_name, write_disposition=write_disposition, columns=TABLE_UPDATE)
+        new_table(table_name, write_disposition=write_disposition, columns=column_schemas.values())
     )
     child_table = client.schema.naming.make_path(table_name, "child")
     # add child table without write disposition so it will be inferred from the parent
     client.schema.update_table(
-        new_table(child_table, columns=TABLE_UPDATE, parent_table_name=table_name)
+        new_table(child_table, columns=column_schemas.values(), parent_table_name=table_name)
     )
     client.schema._bump_version()
     client.update_stored_schema()
@@ -663,11 +661,10 @@ def test_write_dispositions(
 
         for t in [table_name, child_table]:
             # write row, use col1 (INT) as row number
-            table_row = deepcopy(TABLE_ROW_ALL_DATA_TYPES)
-            table_row["col1"] = idx
+            data_row["col1"] = idx
             with io.BytesIO() as f:
-                write_dataset(client, f, [table_row], TABLE_UPDATE_COLUMNS_SCHEMA)
-                query = f.getvalue().decode()
+                write_dataset(client, f, [data_row], column_schemas)
+                query = f.getvalue()
             if client.should_load_data_to_staging_dataset(client.schema.tables[table_name]):  # type: ignore[attr-defined]
                 # load to staging dataset on merge
                 with client.with_staging_dataset():  # type: ignore[attr-defined]
@@ -715,11 +712,12 @@ def test_get_resumed_job(client: SqlJobClientBase, file_storage: FileStorage) ->
         "_dlt_id": uniq_id(),
         "_dlt_root_id": uniq_id(),
         "sender_id": "90238094809sajlkjxoiewjhduuiuehd",
-        "timestamp": str(pendulum.now()),
+        "timestamp": pendulum.now(),
     }
+    print(client.schema.get_table(user_table_name)["columns"])
     with io.BytesIO() as f:
         write_dataset(client, f, [load_json], client.schema.get_table(user_table_name)["columns"])
-        dataset = f.getvalue().decode()
+        dataset = f.getvalue()
     job = expect_load_file(client, file_storage, dataset, user_table_name)
     # now try to retrieve the job
     # TODO: we should re-create client instance as this call is intended to be run after some disruption ie. stopped loader process
@@ -810,7 +808,7 @@ def test_get_stored_state(
         with io.BytesIO() as f:
             # use normalized columns
             write_dataset(client, f, [norm_doc], partial["columns"])
-            query = f.getvalue().decode()
+            query = f.getvalue()
         expect_load_file(client, file_storage, query, partial["name"])
         client.complete_load("_load_id")
 
@@ -833,12 +831,20 @@ def test_many_schemas_single_dataset(
             # "_dlt_load_id": "load_id",
             "event": "user",
             "sender_id": "sender_id",
-            "timestamp": str(pendulum.now()),
+            "timestamp": pendulum.now(),
         }
         with io.BytesIO() as f:
-            write_dataset(_client, f, [user_row], _client.schema.tables["event_user"]["columns"])
-            query = f.getvalue().decode()
-        expect_load_file(_client, file_storage, query, "event_user")
+            write_dataset(
+                _client,
+                f,
+                [user_row],
+                _client.schema.tables["event_user"]["columns"],
+                file_format=destination_config.file_format,
+            )
+            query = f.getvalue()
+        expect_load_file(
+            _client, file_storage, query, "event_user", file_format=destination_config.file_format
+        )
         qual_table_name = _client.sql_client.make_qualified_table_name("event_user")
         db_rows = list(_client.sql_client.execute_sql(f"SELECT * FROM {qual_table_name}"))
         assert len(db_rows) == expected_rows
@@ -891,6 +897,8 @@ def test_many_schemas_single_dataset(
         # no were detected - even if the schema is new. all the tables overlap and change in nullability does not do any updates
         assert schema_update == {}
         # 3 rows because we load to the same table
+        if destination_config.file_format == "parquet":
+            event_3_schema.tables["event_user"]["columns"]["input_channel"]["nullable"] = True
         _load_something(client, 3)
 
         # adding new non null column will generate sync error, except for clickhouse, there it will work
@@ -929,3 +937,13 @@ def normalize_rows(rows: List[Dict[str, Any]], naming: NamingConvention) -> None
     for row in rows:
         for k in list(row.keys()):
             row[naming.normalize_identifier(k)] = row.pop(k)
+
+
+def get_columns_and_row_all_types(destination_type: str):
+    return table_update_and_row(
+        # TIME + parquet is actually a duckdb problem: https://github.com/duckdb/duckdb/pull/13283
+        exclude_types=(
+            ["time"] if destination_type in ["databricks", "clickhouse", "motherduck"] else None
+        ),
+        exclude_columns=["col4_precision"] if destination_type in ["motherduck"] else None,
+    )

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -897,7 +897,10 @@ def test_many_schemas_single_dataset(
         # no were detected - even if the schema is new. all the tables overlap and change in nullability does not do any updates
         assert schema_update == {}
         # 3 rows because we load to the same table
-        if destination_config.file_format == "parquet":
+        if (
+            destination_config.file_format == "parquet"
+            or client.capabilities.preferred_loader_file_format == "parquet"
+        ):
             event_3_schema.tables["event_user"]["columns"]["input_channel"]["nullable"] = True
         _load_something(client, 3)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,7 +56,6 @@ NON_SQL_DESTINATIONS = {
     "filesystem",
     "weaviate",
     "dummy",
-    "motherduck",
     "qdrant",
     "lancedb",
     "destination",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. adds full CI for Motherduck
2. updates docs
3. enables multi statement txs and sets parallelism to 8 threads for Motherduck
4. matches parquet by column name to table columns in load job. fixes #1553
5. loads jsonl with `read_json` without using COPY FROM which allows skipping of the fields
6. drops internal locks for loading parquet files to the same table from multiple threads