### PR TITLE
rest_api: documents pluggable custom auth

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/rest_api.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/rest_api.md
@@ -553,6 +553,19 @@ Available authentication types:
 
 For more complex authentication methods, you can implement a [custom authentication class](../../general-usage/http/rest-client.md#implementing-custom-authentication) and use it in the configuration.
 
+You can use the dictionary configuration syntax also for custom authentication classes after registering them as follows:
+
+```py
+rest_api.config_setup.register_auth("custom_auth", CustomAuth)
+
+{
+    # ...
+    "auth": {
+        "type": "custom_auth",
+        "api_key": dlt.secrets["sources.my_source.my_api_key"],
+    }
+}
+```
 
 
 ### Define resource relationships


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Documents new possibility to register custom auth classes and then use the config dict syntax for them.

### Related Issues

- Implements https://github.com/dlt-hub/verified-sources/issues/524

### Additional Context
