### PR TITLE
Fix `delta` table dangling Parquet file bug

### DIFF
--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -36,6 +36,7 @@ from dlt.common.destination.exceptions import DestinationUndefinedEntity
 from dlt.destinations.job_impl import (
     ReferenceFollowupJob,
     FinalizedLoadJob,
+    FinalizedLoadJobWithFollowupJobs,
 )
 from dlt.destinations.impl.filesystem.configuration import FilesystemDestinationClientConfiguration
 from dlt.destinations import path_utils
@@ -366,7 +367,7 @@ class FilesystemClient(FSClientBase, JobClientBase, WithStagingDataset, WithStat
             if ReferenceFollowupJob.is_reference_job(file_path):
                 return DeltaLoadFilesystemJob(file_path)
             # otherwise just continue
-            return FilesystemLoadJobWithFollowup(file_path)
+            return FinalizedLoadJobWithFollowupJobs(file_path)
 
         cls = FilesystemLoadJobWithFollowup if self.config.as_staging else FilesystemLoadJob
         return cls(file_path)


### PR DESCRIPTION
### Description
We silently started moving Parquet job files into the Delta table folder as part of the refactoring in https://github.com/dlt-hub/dlt/pull/1494. This PR fixes that and adds a test to prevent future regressions.

### Related Issues

Fixes #1693
