### PR TITLE
fixes load job counter

### DIFF
--- a/dlt/common/runtime/collector.py
+++ b/dlt/common/runtime/collector.py
@@ -170,6 +170,7 @@ class LogCollector(Collector):
                 total=total,
             )
             self.messages[counter_key] = None
+            self.last_log_time = None
 
         self.counters[counter_key] += inc
         if message is not None:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Load job counters were incorrectly increased (absolute value was used). This also will skip loading full package details on each completed job decreasing cpu usage on large packages
