### PR TITLE
Enable `scd2` record reinsert

### DIFF
--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -465,11 +465,16 @@ class DltResourceHints:
                     "x-valid-to": True,
                     "x-active-record-timestamp": mddict.get("active_record_timestamp"),
                 }
+                # unique constraint is dropped for C_DLT_ID when used to store
+                # SCD2 row hash (only applies to root table)
                 hash_ = mddict.get("row_version_column_name", DataItemNormalizer.C_DLT_ID)
                 dict_["columns"][hash_] = {
                     "name": hash_,
                     "nullable": False,
                     "x-row-version": True,
+                    # duplicate value in row hash column is possible in case
+                    # of insert-delete-reinsert pattern
+                    "unique": False,
                 }
 
     @staticmethod

--- a/tests/load/pipeline/test_scd2.py
+++ b/tests/load/pipeline/test_scd2.py
@@ -709,6 +709,8 @@ def test_user_provided_row_hash(destination_config: DestinationTestConfiguration
     table = p.default_schema.get_table("dim_test")
     assert table["columns"]["row_hash"]["x-row-version"]  # type: ignore[typeddict-item]
     assert "x-row-version" not in table["columns"]["_dlt_id"]
+    # _dlt_id unique constraint should not be dropped when users bring their own hash
+    assert table["columns"]["_dlt_id"]["unique"]
 
     # load 2 — update and delete a record
     dim_snap = [


### PR DESCRIPTION
### Description
- enables the _insert-delete-reinsert_ pattern (see https://github.com/dlt-hub/dlt/pull/1707/commits/55850de5500b23b9c40e794947308d4a6540ff44) for `scd2`
- drops `unique` constraint on `_dlt_id` in root tables (except when users bring their own hash)

### Related Issues

Fixes #1683
