### PR TITLE
feat/1681 collects load job metrics and adds remote uri

### DIFF
--- a/dlt/common/data_writers/__init__.py
+++ b/dlt/common/data_writers/__init__.py
@@ -1,6 +1,5 @@
 from dlt.common.data_writers.writers import (
     DataWriter,
-    DataWriterMetrics,
     TDataItemFormat,
     FileWriterSpec,
     create_import_spec,
@@ -22,7 +21,6 @@ __all__ = [
     "resolve_best_writer_spec",
     "get_best_writer_spec",
     "is_native_writer",
-    "DataWriterMetrics",
     "TDataItemFormat",
     "BufferedDataWriter",
     "new_file_id",

--- a/dlt/common/data_writers/buffered.py
+++ b/dlt/common/data_writers/buffered.py
@@ -3,6 +3,7 @@ import time
 import contextlib
 from typing import ClassVar, Iterator, List, IO, Any, Optional, Type, Generic
 
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.typing import TDataItem, TDataItems
 from dlt.common.data_writers.exceptions import (
     BufferedDataWriterClosed,
@@ -10,7 +11,7 @@ from dlt.common.data_writers.exceptions import (
     FileImportNotFound,
     InvalidFileNameTemplateException,
 )
-from dlt.common.data_writers.writers import TWriter, DataWriter, DataWriterMetrics, FileWriterSpec
+from dlt.common.data_writers.writers import TWriter, DataWriter, FileWriterSpec
 from dlt.common.schema.typing import TTableSchemaColumns
 from dlt.common.configuration import with_config, known_sections, configspec
 from dlt.common.configuration.specs import BaseConfiguration

--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -34,6 +34,7 @@ from dlt.common.destination import (
     TLoaderFileFormat,
     ALL_SUPPORTED_FILE_FORMATS,
 )
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.schema.typing import TTableSchemaColumns
 from dlt.common.typing import StrAny
 
@@ -57,25 +58,6 @@ class FileWriterSpec(NamedTuple):
     """File format supports changes of schema: True - at any moment, Buffer - in memory buffer before opening file,  False - not at all"""
     requires_destination_capabilities: bool = False
     supports_compression: bool = False
-
-
-class DataWriterMetrics(NamedTuple):
-    file_path: str
-    items_count: int
-    file_size: int
-    created: float
-    last_modified: float
-
-    def __add__(self, other: Tuple[object, ...], /) -> Tuple[object, ...]:
-        if isinstance(other, DataWriterMetrics):
-            return DataWriterMetrics(
-                "",  # path is not known
-                self.items_count + other.items_count,
-                self.file_size + other.file_size,
-                min(self.created, other.created),
-                max(self.last_modified, other.last_modified),
-            )
-        return NotImplemented
 
 
 EMPTY_DATA_WRITER_METRICS = DataWriterMetrics("", 0, 0, 2**32, 0.0)

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -421,7 +421,7 @@ class HasFollowupJobs:
     """Adds a trait that allows to create single or table chain followup jobs"""
 
     def create_followup_jobs(self, final_state: TLoadJobState) -> List[FollowupJobRequest]:
-        """Return list of new jobs. `final_state` is state to which this job transits"""
+        """Return list of jobs requests for jobs that should be created. `final_state` is state to which this job transits"""
         return []
 
 

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -24,10 +24,11 @@ import datetime  # noqa: 251
 from copy import deepcopy
 import inspect
 
-from dlt.common import logger
+from dlt.common import logger, pendulum
 from dlt.common.configuration.specs.base_configuration import extract_inner_hint
 from dlt.common.destination.utils import verify_schema_capabilities
 from dlt.common.exceptions import TerminalValueError
+from dlt.common.metrics import LoadJobMetrics
 from dlt.common.normalizers.naming import NamingConvention
 from dlt.common.schema import Schema, TTableSchema, TSchemaTables
 from dlt.common.schema.utils import (
@@ -284,6 +285,8 @@ class LoadJob(ABC):
         # NOTE: we only accept a full filepath in the constructor
         assert self._file_name != self._file_path
         self._parsed_file_name = ParsedLoadJobFileName.parse(self._file_name)
+        self._started_at: pendulum.DateTime = None
+        self._finished_at: pendulum.DateTime = None
 
     def job_id(self) -> str:
         """The job id that is derived from the file name and does not changes during job lifecycle"""
@@ -305,6 +308,18 @@ class LoadJob(ABC):
     def exception(self) -> str:
         """The exception associated with failed or retry states"""
         pass
+
+    def metrics(self) -> Optional[LoadJobMetrics]:
+        """Returns job execution metrics"""
+        return LoadJobMetrics(
+            self._parsed_file_name.job_id(),
+            self._file_path,
+            self._parsed_file_name.table_name,
+            self._started_at,
+            self._finished_at,
+            self.state(),
+            None,
+        )
 
 
 class RunnableLoadJob(LoadJob, ABC):
@@ -361,6 +376,7 @@ class RunnableLoadJob(LoadJob, ABC):
         # filepath is now moved to running
         try:
             self._state = "running"
+            self._started_at = pendulum.now()
             self._job_client.prepare_load_job_execution(self)
             self.run()
             self._state = "completed"
@@ -371,6 +387,7 @@ class RunnableLoadJob(LoadJob, ABC):
             self._state = "retry"
             self._exception = e
         finally:
+            self._finished_at = pendulum.now()
             # sanity check
             assert self._state in ("completed", "retry", "failed")
 
@@ -391,7 +408,7 @@ class RunnableLoadJob(LoadJob, ABC):
         return str(self._exception)
 
 
-class FollowupJob:
+class FollowupJobRequest:
     """Base class for follow up jobs that should be created"""
 
     @abstractmethod
@@ -403,7 +420,7 @@ class FollowupJob:
 class HasFollowupJobs:
     """Adds a trait that allows to create single or table chain followup jobs"""
 
-    def create_followup_jobs(self, final_state: TLoadJobState) -> List[FollowupJob]:
+    def create_followup_jobs(self, final_state: TLoadJobState) -> List[FollowupJobRequest]:
         """Return list of new jobs. `final_state` is state to which this job transits"""
         return []
 
@@ -479,7 +496,7 @@ class JobClientBase(ABC):
         self,
         table_chain: Sequence[TTableSchema],
         completed_table_chain_jobs: Optional[Sequence[LoadJobInfo]] = None,
-    ) -> List[FollowupJob]:
+    ) -> List[FollowupJobRequest]:
         """Creates a list of followup jobs that should be executed after a table chain is completed"""
         return []
 

--- a/dlt/common/metrics.py
+++ b/dlt/common/metrics.py
@@ -1,4 +1,4 @@
-import datetime
+import datetime  # noqa: I251
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypedDict  # noqa: 251
 
 

--- a/dlt/common/metrics.py
+++ b/dlt/common/metrics.py
@@ -1,0 +1,71 @@
+import datetime
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, TypedDict  # noqa: 251
+
+
+class DataWriterMetrics(NamedTuple):
+    file_path: str
+    items_count: int
+    file_size: int
+    created: float
+    last_modified: float
+
+    def __add__(self, other: Tuple[object, ...], /) -> Tuple[object, ...]:
+        if isinstance(other, DataWriterMetrics):
+            return DataWriterMetrics(
+                self.file_path if self.file_path == other.file_path else "",
+                # self.table_name if self.table_name == other.table_name else "",
+                self.items_count + other.items_count,
+                self.file_size + other.file_size,
+                min(self.created, other.created),
+                max(self.last_modified, other.last_modified),
+            )
+        return NotImplemented
+
+
+class StepMetrics(TypedDict):
+    """Metrics for particular package processed in particular pipeline step"""
+
+    started_at: datetime.datetime
+    """Start of package processing"""
+    finished_at: datetime.datetime
+    """End of package processing"""
+
+
+class ExtractDataInfo(TypedDict):
+    name: str
+    data_type: str
+
+
+class ExtractMetrics(StepMetrics):
+    schema_name: str
+    job_metrics: Dict[str, DataWriterMetrics]
+    """Metrics collected per job id during writing of job file"""
+    table_metrics: Dict[str, DataWriterMetrics]
+    """Job metrics aggregated by table"""
+    resource_metrics: Dict[str, DataWriterMetrics]
+    """Job metrics aggregated by resource"""
+    dag: List[Tuple[str, str]]
+    """A resource dag where elements of the list are graph edges"""
+    hints: Dict[str, Dict[str, Any]]
+    """Hints passed to the resources"""
+
+
+class NormalizeMetrics(StepMetrics):
+    job_metrics: Dict[str, DataWriterMetrics]
+    """Metrics collected per job id during writing of job file"""
+    table_metrics: Dict[str, DataWriterMetrics]
+    """Job metrics aggregated by table"""
+
+
+class LoadJobMetrics(NamedTuple):
+    job_id: str
+    file_path: str
+    table_name: str
+    started_at: datetime.datetime
+    finished_at: datetime.datetime
+    state: Optional[str]
+    remote_uri: Optional[str]
+
+
+class LoadMetrics(StepMetrics):
+    job_metrics: Dict[str, LoadJobMetrics]

--- a/dlt/common/storages/__init__.py
+++ b/dlt/common/storages/__init__.py
@@ -8,7 +8,7 @@ from .load_package import (
     LoadJobInfo,
     LoadPackageInfo,
     PackageStorage,
-    TJobState,
+    TPackageJobState,
     create_load_id,
 )
 from .data_item_storage import DataItemStorage
@@ -40,7 +40,7 @@ __all__ = [
     "LoadJobInfo",
     "LoadPackageInfo",
     "PackageStorage",
-    "TJobState",
+    "TPackageJobState",
     "create_load_id",
     "fsspec_from_config",
     "fsspec_filesystem",

--- a/dlt/common/storages/data_item_storage.py
+++ b/dlt/common/storages/data_item_storage.py
@@ -1,14 +1,13 @@
-from pathlib import Path
-from typing import Dict, Any, List, Sequence
+from typing import Dict, Any, List
 from abc import ABC, abstractmethod
 
 from dlt.common import logger
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.schema import TTableSchemaColumns
-from dlt.common.typing import StrAny, TDataItems
+from dlt.common.typing import TDataItems
 from dlt.common.data_writers import (
     BufferedDataWriter,
     DataWriter,
-    DataWriterMetrics,
     FileWriterSpec,
 )
 

--- a/dlt/common/storages/load_storage.py
+++ b/dlt/common/storages/load_storage.py
@@ -17,7 +17,7 @@ from dlt.common.storages.load_package import (
     LoadPackageInfo,
     PackageStorage,
     ParsedLoadJobFileName,
-    TJobState,
+    TPackageJobState,
     TLoadPackageState,
     TJobFileFormat,
 )
@@ -141,16 +141,16 @@ class LoadStorage(VersionedStorage):
         """Marks schema update as processed and stores the update that was applied at the destination"""
         load_path = self.get_normalized_package_path(load_id)
         schema_update_file = join(load_path, PackageStorage.SCHEMA_UPDATES_FILE_NAME)
-        processed_schema_update_file = join(
+        applied_schema_update_file = join(
             load_path, PackageStorage.APPLIED_SCHEMA_UPDATES_FILE_NAME
         )
         # delete initial schema update
         self.storage.delete(schema_update_file)
         # save applied update
-        self.storage.save(processed_schema_update_file, json.dumps(applied_update))
+        self.storage.save(applied_schema_update_file, json.dumps(applied_update))
 
     def import_new_job(
-        self, load_id: str, job_file_path: str, job_state: TJobState = "new_jobs"
+        self, load_id: str, job_file_path: str, job_state: TPackageJobState = "new_jobs"
     ) -> None:
         """Adds new job by moving the `job_file_path` into `new_jobs` of package `load_id`"""
         # TODO: use normalize storage and add file type checks

--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -46,7 +46,7 @@ from dlt.common.schema.typing import (
 from dlt.common.schema.utils import table_schema_has_type
 from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.destination.reference import LoadJob
-from dlt.common.destination.reference import FollowupJob, SupportsStagingDestination
+from dlt.common.destination.reference import FollowupJobRequest, SupportsStagingDestination
 from dlt.common.data_writers.escape import escape_hive_identifier
 from dlt.destinations.sql_jobs import SqlStagingCopyFollowupJob, SqlMergeFollowupJob
 
@@ -490,7 +490,7 @@ class AthenaClient(SqlJobClientWithStaging, SupportsStagingDestination):
 
     def _create_append_followup_jobs(
         self, table_chain: Sequence[TTableSchema]
-    ) -> List[FollowupJob]:
+    ) -> List[FollowupJobRequest]:
         if self._is_iceberg_table(self.prepare_load_table(table_chain[0]["name"])):
             return [
                 SqlStagingCopyFollowupJob.from_table_chain(
@@ -501,7 +501,7 @@ class AthenaClient(SqlJobClientWithStaging, SupportsStagingDestination):
 
     def _create_replace_followup_jobs(
         self, table_chain: Sequence[TTableSchema]
-    ) -> List[FollowupJob]:
+    ) -> List[FollowupJobRequest]:
         if self._is_iceberg_table(self.prepare_load_table(table_chain[0]["name"])):
             return [
                 SqlStagingCopyFollowupJob.from_table_chain(
@@ -510,7 +510,9 @@ class AthenaClient(SqlJobClientWithStaging, SupportsStagingDestination):
             ]
         return super()._create_replace_followup_jobs(table_chain)
 
-    def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[FollowupJob]:
+    def _create_merge_followup_jobs(
+        self, table_chain: Sequence[TTableSchema]
+    ) -> List[FollowupJobRequest]:
         return [AthenaMergeJob.from_table_chain(table_chain, self.sql_client)]
 
     def _is_iceberg_table(self, table: TTableSchema) -> bool:

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -16,7 +16,7 @@ from dlt.common.json import json
 from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.destination.reference import (
     HasFollowupJobs,
-    FollowupJob,
+    FollowupJobRequest,
     TLoadJobState,
     RunnableLoadJob,
     SupportsStagingDestination,
@@ -51,7 +51,7 @@ from dlt.destinations.impl.bigquery.bigquery_adapter import (
 from dlt.destinations.impl.bigquery.configuration import BigQueryClientConfiguration
 from dlt.destinations.impl.bigquery.sql_client import BigQuerySqlClient, BQ_TERMINAL_REASONS
 from dlt.destinations.job_client_impl import SqlJobClientWithStaging
-from dlt.destinations.job_impl import ReferenceFollowupJob
+from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.sql_jobs import SqlMergeFollowupJob
 from dlt.destinations.type_mapping import TypeMapper
 from dlt.destinations.utils import parse_db_data_type_str_with_precision
@@ -234,7 +234,9 @@ class BigQueryClient(SqlJobClientWithStaging, SupportsStagingDestination):
         self.sql_client: BigQuerySqlClient = sql_client  # type: ignore
         self.type_mapper = BigQueryTypeMapper(self.capabilities)
 
-    def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[FollowupJob]:
+    def _create_merge_followup_jobs(
+        self, table_chain: Sequence[TTableSchema]
+    ) -> List[FollowupJobRequest]:
         return [BigQueryMergeJob.from_table_chain(table_chain, self.sql_client)]
 
     def create_load_job(
@@ -433,8 +435,8 @@ SELECT {",".join(self._get_storage_table_query_columns())}
         # determine whether we load from local or uri
         bucket_path = None
         ext: str = os.path.splitext(file_path)[1][1:]
-        if ReferenceFollowupJob.is_reference_job(file_path):
-            bucket_path = ReferenceFollowupJob.resolve_reference(file_path)
+        if ReferenceFollowupJobRequest.is_reference_job(file_path):
+            bucket_path = ReferenceFollowupJobRequest.resolve_reference(file_path)
             ext = os.path.splitext(bucket_path)[1][1:]
 
         # Select a correct source format

--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -20,7 +20,7 @@ from dlt.common.destination.reference import (
     TLoadJobState,
     HasFollowupJobs,
     RunnableLoadJob,
-    FollowupJob,
+    FollowupJobRequest,
     LoadJob,
 )
 from dlt.common.schema import Schema, TColumnSchema
@@ -52,7 +52,7 @@ from dlt.destinations.job_client_impl import (
     SqlJobClientBase,
     SqlJobClientWithStaging,
 )
-from dlt.destinations.job_impl import ReferenceFollowupJob, FinalizedLoadJobWithFollowupJobs
+from dlt.destinations.job_impl import ReferenceFollowupJobRequest, FinalizedLoadJobWithFollowupJobs
 from dlt.destinations.sql_jobs import SqlMergeFollowupJob
 from dlt.destinations.type_mapping import TypeMapper
 
@@ -141,8 +141,8 @@ class ClickHouseLoadJob(RunnableLoadJob, HasFollowupJobs):
         bucket_path = None
         file_name = self._file_name
 
-        if ReferenceFollowupJob.is_reference_job(self._file_path):
-            bucket_path = ReferenceFollowupJob.resolve_reference(self._file_path)
+        if ReferenceFollowupJobRequest.is_reference_job(self._file_path):
+            bucket_path = ReferenceFollowupJobRequest.resolve_reference(self._file_path)
             file_name = FileStorage.get_file_name_from_file_path(bucket_path)
             bucket_url = urlparse(bucket_path)
             bucket_scheme = bucket_url.scheme
@@ -288,7 +288,9 @@ class ClickHouseClient(SqlJobClientWithStaging, SupportsStagingDestination):
         self.active_hints = deepcopy(HINT_TO_CLICKHOUSE_ATTR)
         self.type_mapper = ClickHouseTypeMapper(self.capabilities)
 
-    def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[FollowupJob]:
+    def _create_merge_followup_jobs(
+        self, table_chain: Sequence[TTableSchema]
+    ) -> List[FollowupJobRequest]:
         return [ClickHouseMergeJob.from_table_chain(table_chain, self.sql_client)]
 
     def _get_column_def_sql(self, c: TColumnSchema, table_format: TTableFormat = None) -> str:

--- a/dlt/destinations/impl/databricks/databricks.py
+++ b/dlt/destinations/impl/databricks/databricks.py
@@ -5,7 +5,7 @@ from dlt import config
 from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.destination.reference import (
     HasFollowupJobs,
-    FollowupJob,
+    FollowupJobRequest,
     TLoadJobState,
     RunnableLoadJob,
     CredentialsConfiguration,
@@ -31,7 +31,7 @@ from dlt.destinations.exceptions import LoadJobTerminalException
 from dlt.destinations.impl.databricks.configuration import DatabricksClientConfiguration
 from dlt.destinations.impl.databricks.sql_client import DatabricksSqlClient
 from dlt.destinations.sql_jobs import SqlMergeFollowupJob
-from dlt.destinations.job_impl import ReferenceFollowupJob
+from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.type_mapping import TypeMapper
 
 
@@ -121,8 +121,8 @@ class DatabricksLoadJob(RunnableLoadJob, HasFollowupJobs):
         staging_credentials = self._staging_config.credentials
         # extract and prepare some vars
         bucket_path = orig_bucket_path = (
-            ReferenceFollowupJob.resolve_reference(self._file_path)
-            if ReferenceFollowupJob.is_reference_job(self._file_path)
+            ReferenceFollowupJobRequest.resolve_reference(self._file_path)
+            if ReferenceFollowupJobRequest.is_reference_job(self._file_path)
             else ""
         )
         file_name = (
@@ -279,7 +279,9 @@ class DatabricksClient(InsertValuesJobClient, SupportsStagingDestination):
             )
         return job
 
-    def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[FollowupJob]:
+    def _create_merge_followup_jobs(
+        self, table_chain: Sequence[TTableSchema]
+    ) -> List[FollowupJobRequest]:
         return [DatabricksMergeJob.from_table_chain(table_chain, self.sql_client)]
 
     def _make_add_column_sql(

--- a/dlt/destinations/impl/dremio/dremio.py
+++ b/dlt/destinations/impl/dremio/dremio.py
@@ -7,7 +7,7 @@ from dlt.common.destination.reference import (
     TLoadJobState,
     RunnableLoadJob,
     SupportsStagingDestination,
-    FollowupJob,
+    FollowupJobRequest,
     LoadJob,
 )
 from dlt.common.schema import TColumnSchema, Schema, TTableSchemaColumns
@@ -19,7 +19,7 @@ from dlt.destinations.impl.dremio.configuration import DremioClientConfiguration
 from dlt.destinations.impl.dremio.sql_client import DremioSqlClient
 from dlt.destinations.job_client_impl import SqlJobClientWithStaging
 from dlt.destinations.job_impl import FinalizedLoadJobWithFollowupJobs
-from dlt.destinations.job_impl import ReferenceFollowupJob
+from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.sql_jobs import SqlMergeFollowupJob
 from dlt.destinations.type_mapping import TypeMapper
 from dlt.destinations.sql_client import SqlClientBase
@@ -101,8 +101,8 @@ class DremioLoadJob(RunnableLoadJob, HasFollowupJobs):
 
         # extract and prepare some vars
         bucket_path = (
-            ReferenceFollowupJob.resolve_reference(self._file_path)
-            if ReferenceFollowupJob.is_reference_job(self._file_path)
+            ReferenceFollowupJobRequest.resolve_reference(self._file_path)
+            if ReferenceFollowupJobRequest.is_reference_job(self._file_path)
             else ""
         )
 
@@ -201,7 +201,9 @@ class DremioClient(SqlJobClientWithStaging, SupportsStagingDestination):
             f"{name} {self.type_mapper.to_db_type(c)} {self._gen_not_null(c.get('nullable', True))}"
         )
 
-    def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[FollowupJob]:
+    def _create_merge_followup_jobs(
+        self, table_chain: Sequence[TTableSchema]
+    ) -> List[FollowupJobRequest]:
         return [DremioMergeJob.from_table_chain(table_chain, self.sql_client)]
 
     def _make_add_column_sql(

--- a/dlt/destinations/impl/dummy/configuration.py
+++ b/dlt/destinations/impl/dummy/configuration.py
@@ -25,7 +25,7 @@ class DummyClientConfiguration(DestinationClientConfiguration):
     retry_prob: float = 0.0
     """probability of job retry"""
     completed_prob: float = 0.0
-    """probablibitly of successful job completion"""
+    """probability of successful job completion"""
     exception_prob: float = 0.0
     """probability of exception transient exception when running job"""
     timeout: float = 10.0

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -104,6 +104,8 @@ class DeltaLoadFilesystemJob(FilesystemLoadJob):
 
     def run(self) -> None:
         # pick local filesystem pathlib or posix for buckets
+        # TODO: since we pass _job_client via run_managed and not set_env_vars it is hard
+        # to write a handler with those two line below only in FilesystemLoadJob
         self.is_local_filesystem = self._job_client.config.protocol == "file"
         self.pathlib = os.path if self.is_local_filesystem else posixpath
         self.destination_file_name = self._job_client.make_remote_uri(

--- a/dlt/destinations/impl/mssql/mssql.py
+++ b/dlt/destinations/impl/mssql/mssql.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional, Sequence, List, Any
 
 from dlt.common.exceptions import TerminalValueError
-from dlt.common.destination.reference import FollowupJob
+from dlt.common.destination.reference import FollowupJobRequest
 from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.schema import TColumnSchema, TColumnHint, Schema
 from dlt.common.schema.typing import TTableSchema, TColumnType, TTableFormat
@@ -160,7 +160,9 @@ class MsSqlJobClient(InsertValuesJobClient):
         self.active_hints = HINT_TO_MSSQL_ATTR if self.config.create_indexes else {}
         self.type_mapper = MsSqlTypeMapper(self.capabilities)
 
-    def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[FollowupJob]:
+    def _create_merge_followup_jobs(
+        self, table_chain: Sequence[TTableSchema]
+    ) -> List[FollowupJobRequest]:
         return [MsSqlMergeJob.from_table_chain(table_chain, self.sql_client)]
 
     def _make_add_column_sql(
@@ -189,7 +191,7 @@ class MsSqlJobClient(InsertValuesJobClient):
 
     def _create_replace_followup_jobs(
         self, table_chain: Sequence[TTableSchema]
-    ) -> List[FollowupJob]:
+    ) -> List[FollowupJobRequest]:
         if self.config.replace_strategy == "staging-optimized":
             return [MsSqlStagingCopyJob.from_table_chain(table_chain, self.sql_client)]
         return super()._create_replace_followup_jobs(table_chain)

--- a/dlt/destinations/impl/postgres/postgres.py
+++ b/dlt/destinations/impl/postgres/postgres.py
@@ -9,7 +9,7 @@ from dlt.common.destination.exceptions import (
 from dlt.common.destination.reference import (
     HasFollowupJobs,
     RunnableLoadJob,
-    FollowupJob,
+    FollowupJobRequest,
     LoadJob,
     TLoadJobState,
 )
@@ -246,7 +246,7 @@ class PostgresClient(InsertValuesJobClient):
 
     def _create_replace_followup_jobs(
         self, table_chain: Sequence[TTableSchema]
-    ) -> List[FollowupJob]:
+    ) -> List[FollowupJobRequest]:
         if self.config.replace_strategy == "staging-optimized":
             return [PostgresStagingCopyJob.from_table_chain(table_chain, self.sql_client)]
         return super()._create_replace_followup_jobs(table_chain)

--- a/dlt/destinations/impl/redshift/redshift.py
+++ b/dlt/destinations/impl/redshift/redshift.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional, Sequence, Any, Tuple
 
 
 from dlt.common.destination.reference import (
-    FollowupJob,
+    FollowupJobRequest,
     CredentialsConfiguration,
     SupportsStagingDestination,
     LoadJob,
@@ -33,7 +33,7 @@ from dlt.destinations.exceptions import DatabaseTerminalException, LoadJobTermin
 from dlt.destinations.job_client_impl import CopyRemoteFileLoadJob
 from dlt.destinations.impl.postgres.sql_client import Psycopg2SqlClient
 from dlt.destinations.impl.redshift.configuration import RedshiftClientConfiguration
-from dlt.destinations.job_impl import ReferenceFollowupJob
+from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.sql_client import SqlClientBase
 from dlt.destinations.type_mapping import TypeMapper
 
@@ -238,7 +238,9 @@ class RedshiftClient(InsertValuesJobClient, SupportsStagingDestination):
         self.config: RedshiftClientConfiguration = config
         self.type_mapper = RedshiftTypeMapper(self.capabilities)
 
-    def _create_merge_followup_jobs(self, table_chain: Sequence[TTableSchema]) -> List[FollowupJob]:
+    def _create_merge_followup_jobs(
+        self, table_chain: Sequence[TTableSchema]
+    ) -> List[FollowupJobRequest]:
         return [RedshiftMergeJob.from_table_chain(table_chain, self.sql_client)]
 
     def _get_column_def_sql(self, c: TColumnSchema, table_format: TTableFormat = None) -> str:
@@ -258,7 +260,7 @@ class RedshiftClient(InsertValuesJobClient, SupportsStagingDestination):
         """Starts SqlLoadJob for files ending with .sql or returns None to let derived classes to handle their specific jobs"""
         job = super().create_load_job(table, file_path, load_id, restore)
         if not job:
-            assert ReferenceFollowupJob.is_reference_job(
+            assert ReferenceFollowupJobRequest.is_reference_job(
                 file_path
             ), "Redshift must use staging to load files"
             job = RedshiftCopyFileLoadJob(

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -29,7 +29,7 @@ from dlt.destinations.exceptions import LoadJobTerminalException
 from dlt.destinations.impl.snowflake.configuration import SnowflakeClientConfiguration
 from dlt.destinations.impl.snowflake.sql_client import SnowflakeSqlClient
 from dlt.destinations.impl.snowflake.sql_client import SnowflakeSqlClient
-from dlt.destinations.job_impl import ReferenceFollowupJob
+from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.type_mapping import TypeMapper
 
 
@@ -98,11 +98,11 @@ class SnowflakeLoadJob(RunnableLoadJob, HasFollowupJobs):
         self._sql_client = self._job_client.sql_client
 
         # resolve reference
-        is_local_file = not ReferenceFollowupJob.is_reference_job(self._file_path)
+        is_local_file = not ReferenceFollowupJobRequest.is_reference_job(self._file_path)
         file_url = (
             self._file_path
             if is_local_file
-            else ReferenceFollowupJob.resolve_reference(self._file_path)
+            else ReferenceFollowupJobRequest.resolve_reference(self._file_path)
         )
         # take file name
         file_name = FileStorage.get_file_name_from_file_path(file_url)

--- a/dlt/destinations/impl/synapse/synapse.py
+++ b/dlt/destinations/impl/synapse/synapse.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 from urllib.parse import urlparse, urlunparse
 
 from dlt.common.destination import DestinationCapabilitiesContext
-from dlt.common.destination.reference import SupportsStagingDestination, FollowupJob, LoadJob
+from dlt.common.destination.reference import SupportsStagingDestination, FollowupJobRequest, LoadJob
 
 from dlt.common.schema import TTableSchema, TColumnSchema, Schema, TColumnHint
 from dlt.common.schema.utils import (
@@ -19,7 +19,7 @@ from dlt.common.configuration.specs import (
     AzureServicePrincipalCredentialsWithoutDefaults,
 )
 
-from dlt.destinations.job_impl import ReferenceFollowupJob
+from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.sql_client import SqlClientBase
 from dlt.destinations.job_client_impl import (
     SqlJobClientBase,
@@ -131,7 +131,7 @@ class SynapseClient(MsSqlJobClient, SupportsStagingDestination):
 
     def _create_replace_followup_jobs(
         self, table_chain: Sequence[TTableSchema]
-    ) -> List[FollowupJob]:
+    ) -> List[FollowupJobRequest]:
         return SqlJobClientBase._create_replace_followup_jobs(self, table_chain)
 
     def prepare_load_table(self, table_name: str, staging: bool = False) -> TTableSchema:
@@ -163,7 +163,7 @@ class SynapseClient(MsSqlJobClient, SupportsStagingDestination):
     ) -> LoadJob:
         job = super().create_load_job(table, file_path, load_id, restore)
         if not job:
-            assert ReferenceFollowupJob.is_reference_job(
+            assert ReferenceFollowupJobRequest.is_reference_job(
                 file_path
             ), "Synapse must use staging to load files"
             job = SynapseCopyFileLoadJob(

--- a/dlt/destinations/job_impl.py
+++ b/dlt/destinations/job_impl.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import os
 import tempfile  # noqa: 251
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 from dlt.common.json import json
 from dlt.common.destination.reference import (
@@ -9,9 +9,10 @@ from dlt.common.destination.reference import (
     TLoadJobState,
     RunnableLoadJob,
     JobClientBase,
-    FollowupJob,
+    FollowupJobRequest,
     LoadJob,
 )
+from dlt.common.metrics import LoadJobMetrics
 from dlt.common.storages.load_package import commit_load_package_state
 from dlt.common.schema import Schema, TTableSchema
 from dlt.common.storages import FileStorage
@@ -56,7 +57,7 @@ class FinalizedLoadJobWithFollowupJobs(FinalizedLoadJob, HasFollowupJobs):
     pass
 
 
-class FollowupJobImpl(FollowupJob):
+class FollowupJobRequestImpl(FollowupJobRequest):
     """
     Class to create a new loadjob, not stateful and not runnable
     """
@@ -79,7 +80,7 @@ class FollowupJobImpl(FollowupJob):
         return self._parsed_file_name.job_id()
 
 
-class ReferenceFollowupJob(FollowupJobImpl):
+class ReferenceFollowupJobRequest(FollowupJobRequestImpl):
     def __init__(self, original_file_name: str, remote_paths: List[str]) -> None:
         file_name = os.path.splitext(original_file_name)[0] + "." + "reference"
         self._remote_paths = remote_paths
@@ -98,7 +99,7 @@ class ReferenceFollowupJob(FollowupJobImpl):
 
     @staticmethod
     def resolve_reference(file_path: str) -> str:
-        refs = ReferenceFollowupJob.resolve_references(file_path)
+        refs = ReferenceFollowupJobRequest.resolve_references(file_path)
         assert len(refs) == 1
         return refs[0]
 

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -21,7 +21,7 @@ from dlt.common.storages.load_package import load_package as current_load_packag
 from dlt.common.utils import uniq_id
 from dlt.common.destination.capabilities import DestinationCapabilitiesContext
 from dlt.destinations.exceptions import MergeDispositionException
-from dlt.destinations.job_impl import FollowupJobImpl
+from dlt.destinations.job_impl import FollowupJobRequestImpl
 from dlt.destinations.sql_client import SqlClientBase
 from dlt.common.destination.exceptions import DestinationTransientException
 
@@ -45,7 +45,7 @@ class SqlJobCreationException(DestinationTransientException):
         )
 
 
-class SqlFollowupJob(FollowupJobImpl):
+class SqlFollowupJob(FollowupJobRequestImpl):
     """Sql base job for jobs that rely on the whole tablechain"""
 
     @classmethod
@@ -54,7 +54,7 @@ class SqlFollowupJob(FollowupJobImpl):
         table_chain: Sequence[TTableSchema],
         sql_client: SqlClientBase[Any],
         params: Optional[SqlJobParams] = None,
-    ) -> FollowupJobImpl:
+    ) -> FollowupJobRequestImpl:
         """Generates a list of sql statements, that will be executed by the sql client when the job is executed in the loader.
 
         The `table_chain` contains a list schemas of a tables with parent-child relationship, ordered by the ancestry (the root of the tree is first on the list).

--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -4,9 +4,9 @@ from typing import Set, Dict, Any, Optional, List, Union
 from dlt.common.configuration import known_sections, resolve_configuration, with_config
 from dlt.common import logger
 from dlt.common.configuration.specs import BaseConfiguration, configspec
-from dlt.common.data_writers import DataWriterMetrics
 from dlt.common.destination.capabilities import DestinationCapabilitiesContext
 from dlt.common.exceptions import MissingDependencyException
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.runtime.collector import Collector, NULL_COLLECTOR
 from dlt.common.typing import TDataItems, TDataItem, TLoaderFileFormat
 from dlt.common.schema import Schema, utils

--- a/dlt/extract/storage.py
+++ b/dlt/extract/storage.py
@@ -1,7 +1,8 @@
 import os
 from typing import Dict, List
 
-from dlt.common.data_writers import TDataItemFormat, DataWriterMetrics, DataWriter, FileWriterSpec
+from dlt.common.data_writers import TDataItemFormat, DataWriter, FileWriterSpec
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.schema import Schema
 from dlt.common.storages import (
     NormalizeStorageConfiguration,

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -5,12 +5,17 @@ from concurrent.futures import Executor
 import os
 
 from dlt.common import logger
+from dlt.common.metrics import LoadJobMetrics
 from dlt.common.runtime.signals import sleep
 from dlt.common.configuration import with_config, known_sections
 from dlt.common.configuration.accessors import config
 from dlt.common.pipeline import LoadInfo, LoadMetrics, SupportsPipeline, WithStepInfo
 from dlt.common.schema.utils import get_top_level_table
-from dlt.common.storages.load_storage import LoadPackageInfo, ParsedLoadJobFileName, TJobState
+from dlt.common.storages.load_storage import (
+    LoadPackageInfo,
+    ParsedLoadJobFileName,
+    TPackageJobState,
+)
 from dlt.common.storages.load_package import (
     LoadPackageStateInjectableContext,
     load_package as current_load_package,
@@ -29,7 +34,7 @@ from dlt.common.destination.reference import (
     Destination,
     RunnableLoadJob,
     LoadJob,
-    FollowupJob,
+    FollowupJobRequest,
     TLoadJobState,
     DestinationClientConfiguration,
     SupportsStagingDestination,
@@ -84,6 +89,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         self.pool = NullExecutor()
         self.load_storage: LoadStorage = self.create_storage(is_storage_owner)
         self._loaded_packages: List[LoadPackageInfo] = []
+        self._job_metrics: Dict[str, LoadJobMetrics] = {}
         self._run_loop_sleep_duration: float = (
             1.0  # amount of time to sleep between querying completed jobs
         )
@@ -308,7 +314,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         where they will be picked up for execution
         """
 
-        jobs: List[FollowupJob] = []
+        jobs: List[FollowupJobRequest] = []
         if isinstance(starting_job, HasFollowupJobs):
             # check for merge jobs only for jobs executing on the destination, the staging destination jobs must be excluded
             # NOTE: we may move that logic to the interface
@@ -392,6 +398,11 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                 # create followup jobs
                 self.create_followup_jobs(load_id, state, job, schema)
 
+                # preserve metrics
+                metrics = job.metrics()
+                if metrics:
+                    self._job_metrics[job.job_id()] = metrics
+
                 # try to get exception message from job
                 failed_message = job.exception()
                 self.load_storage.normalized_packages.fail_job(
@@ -423,7 +434,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                     if r_c > 0 and r_c % self.config.raise_on_max_retries == 0:
                         pending_exception = LoadClientJobRetry(
                             load_id,
-                            job.job_file_info().job_id(),
+                            job.job_id(),
                             r_c,
                             self.config.raise_on_max_retries,
                             retry_message=retry_message,
@@ -431,6 +442,15 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
             elif state == "completed":
                 # create followup jobs
                 self.create_followup_jobs(load_id, state, job, schema)
+
+                # preserve metrics
+                # TODO: metrics should be persisted. this is different vs. all other steps because load step
+                # may be restarted in the middle of execution
+                # NOTE: we could use package state but cases with 100k jobs must be tested
+                metrics = job.metrics()
+                if metrics:
+                    self._job_metrics[job.job_id()] = metrics
+
                 # move to completed folder after followup jobs are created
                 # in case of exception when creating followup job, the loader will retry operation and try to complete again
                 self.load_storage.normalized_packages.complete_job(load_id, job.file_name())
@@ -464,14 +484,18 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         self.load_storage.complete_load_package(load_id, aborted)
         # collect package info
         self._loaded_packages.append(self.load_storage.get_load_package_info(load_id))
-        self._step_info_complete_load_id(load_id, metrics={"started_at": None, "finished_at": None})
+        # TODO: job metrics must be persisted
+        self._step_info_complete_load_id(
+            load_id,
+            metrics={"started_at": None, "finished_at": None, "job_metrics": self._job_metrics},
+        )
         # delete jobs only now
         self.load_storage.maybe_remove_completed_jobs(load_id)
         logger.info(
             f"All jobs completed, archiving package {load_id} with aborted set to {aborted}"
         )
 
-    def update_load_package_info(self, load_id: str) -> None:
+    def init_jobs_counter(self, load_id: str) -> None:
         # update counter we only care about the jobs that are scheduled to be loaded
         package_jobs = self.load_storage.normalized_packages.get_load_package_jobs(load_id)
         total_jobs = reduce(lambda p, c: p + len(c), package_jobs.values(), 0)
@@ -492,7 +516,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         dropped_tables = current_load_package()["state"].get("dropped_tables", [])
         truncated_tables = current_load_package()["state"].get("truncated_tables", [])
 
-        self.update_load_package_info(load_id)
+        self.init_jobs_counter(load_id)
 
         # initialize analytical storage ie. create dataset required by passed schema
         with self.get_destination_client(schema) as job_client:
@@ -606,7 +630,8 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                 )
             ):
                 # the same load id may be processed across multiple runs
-                if not self.current_load_id:
+                if self.current_load_id is None:
+                    self._job_metrics = {}
                     self._step_info_start_load_id(load_id)
                 self.load_single_package(load_id, schema)
 

--- a/dlt/load/utils.py
+++ b/dlt/load/utils.py
@@ -2,7 +2,7 @@ from typing import List, Set, Iterable, Callable, Optional, Tuple, Sequence
 from itertools import groupby
 
 from dlt.common import logger
-from dlt.common.storages.load_package import LoadJobInfo, PackageStorage, TJobState
+from dlt.common.storages.load_package import LoadJobInfo, PackageStorage, TPackageJobState
 from dlt.common.schema.utils import (
     fill_hints_from_parent_and_clone_table,
     get_child_tables,
@@ -19,7 +19,7 @@ from dlt.common.destination import DestinationCapabilitiesContext
 
 def get_completed_table_chain(
     schema: Schema,
-    all_jobs: Iterable[Tuple[TJobState, ParsedLoadJobFileName]],
+    all_jobs: Iterable[Tuple[TPackageJobState, ParsedLoadJobFileName]],
     top_merged_table: TTableSchema,
     being_completed_job_id: str = None,
 ) -> List[TTableSchema]:

--- a/dlt/normalize/items_normalizers.py
+++ b/dlt/normalize/items_normalizers.py
@@ -3,9 +3,9 @@ from abc import abstractmethod
 
 from dlt.common import logger
 from dlt.common.json import json
-from dlt.common.data_writers import DataWriterMetrics
 from dlt.common.data_writers.writers import ArrowToObjectAdapter
 from dlt.common.json import custom_pua_decode, may_have_pua
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.normalizers.json.relational import DataItemNormalizer as RelationalNormalizer
 from dlt.common.runtime import signals
 from dlt.common.schema.typing import TSchemaEvolutionMode, TTableSchemaColumns, TSchemaContractDict

--- a/dlt/normalize/normalize.py
+++ b/dlt/normalize/normalize.py
@@ -4,10 +4,10 @@ from typing import List, Dict, Sequence, Optional, Callable
 from concurrent.futures import Future, Executor
 
 from dlt.common import logger
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.runtime.signals import sleep
 from dlt.common.configuration import with_config, known_sections
 from dlt.common.configuration.accessors import config
-from dlt.common.data_writers import DataWriterMetrics
 from dlt.common.data_writers.writers import EMPTY_DATA_WRITER_METRICS
 from dlt.common.runners import TRunMetrics, Runnable, NullExecutor
 from dlt.common.runtime import signals

--- a/dlt/normalize/worker.py
+++ b/dlt/normalize/worker.py
@@ -4,12 +4,12 @@ from dlt.common import logger
 from dlt.common.configuration.container import Container
 from dlt.common.data_writers import (
     DataWriter,
-    DataWriterMetrics,
     create_import_spec,
     resolve_best_writer_spec,
     get_best_writer_spec,
     is_native_writer,
 )
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.utils import chunks
 from dlt.common.schema.typing import TStoredSchema, TTableSchema
 from dlt.common.storages import (

--- a/dlt/pipeline/trace.py
+++ b/dlt/pipeline/trace.py
@@ -168,7 +168,7 @@ class PipelineTrace(SupportsHumanize, _PipelineTrace):
         """A dictionary representation of PipelineTrace that can be loaded with `dlt`"""
         d = self._asdict()
         # run step is the same as load step
-        d["steps"] = [step.asdict() for step in self.steps]  # if step.step != "run"
+        d["steps"] = [step.asdict() for step in self.steps if step.step != "run"]
         return d
 
     @property

--- a/docs/website/docs/general-usage/pipeline.md
+++ b/docs/website/docs/general-usage/pipeline.md
@@ -85,6 +85,19 @@ You can inspect stored artifacts using the command
 > 💡 You can attach `Pipeline` instance to an existing working folder, without creating a new
 > pipeline with `dlt.attach`.
 
+### Separate working environments with `pipelines_dir`.
+You can run several pipelines with the same name but with different configuration ie. to target development / staging / production environments.
+Set the `pipelines_dir` argument to store all the working folders in specific place. For example:
+```py
+import dlt
+from dlt.common.pipeline import get_dlt_pipelines_dir
+
+dev_pipelines_dir = os.path.join(get_dlt_pipelines_dir(), "dev")
+pipeline = dlt.pipeline(destination="duckdb", dataset_name="sequence", pipelines_dir=dev_pipelines_dir)
+```
+stores pipeline working folder in `~/.dlt/pipelines/dev/<pipeline_name>`. Mind that you need to pass this `~/.dlt/pipelines/dev/`
+in to all cli commands to get info/trace for that pipeline.
+
 ## Do experiments with dev mode
 
 If you [create a new pipeline script](../walkthroughs/create-a-pipeline.md) you will be

--- a/tests/common/data_writers/test_data_writers.py
+++ b/tests/common/data_writers/test_data_writers.py
@@ -5,6 +5,7 @@ from typing import Iterator
 
 from dlt.common import pendulum, json
 from dlt.common.data_writers.exceptions import DataWriterNotFound, SpecLookupFailed
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.typing import AnyFun
 
 from dlt.common.data_writers.escape import (
@@ -25,7 +26,6 @@ from dlt.common.data_writers.writers import (
     ArrowToTypedJsonlListWriter,
     CsvWriter,
     DataWriter,
-    DataWriterMetrics,
     EMPTY_DATA_WRITER_METRICS,
     ImportFileWriter,
     InsertValuesWriter,

--- a/tests/common/data_writers/test_data_writers.py
+++ b/tests/common/data_writers/test_data_writers.py
@@ -180,12 +180,13 @@ def test_data_writer_metrics_add() -> None:
     metrics = DataWriterMetrics("file", 10, 100, now, now + 10)
     add_m: DataWriterMetrics = metrics + EMPTY_DATA_WRITER_METRICS  # type: ignore[assignment]
     assert add_m == DataWriterMetrics("", 10, 100, now, now + 10)
-    assert metrics + metrics == DataWriterMetrics("", 20, 200, now, now + 10)
+    # will keep "file" because it is in both
+    assert metrics + metrics == DataWriterMetrics("file", 20, 200, now, now + 10)
     assert sum((metrics, metrics, metrics), EMPTY_DATA_WRITER_METRICS) == DataWriterMetrics(
         "", 30, 300, now, now + 10
     )
     # time range extends when added
-    add_m = metrics + DataWriterMetrics("file", 99, 120, now - 10, now + 20)  # type: ignore[assignment]
+    add_m = metrics + DataWriterMetrics("fileX", 99, 120, now - 10, now + 20)  # type: ignore[assignment]
     assert add_m == DataWriterMetrics("", 109, 220, now - 10, now + 20)
 
 

--- a/tests/common/storages/utils.py
+++ b/tests/common/storages/utils.py
@@ -16,7 +16,7 @@ from dlt.common.storages import (
     LoadStorageConfiguration,
     FilesystemConfiguration,
     LoadPackageInfo,
-    TJobState,
+    TPackageJobState,
     LoadStorage,
 )
 from dlt.common.storages import DataItemStorage, FileStorage
@@ -195,7 +195,7 @@ def assert_package_info(
     storage: LoadStorage,
     load_id: str,
     package_state: str,
-    job_state: TJobState,
+    job_state: TPackageJobState,
     jobs_count: int = 1,
 ) -> LoadPackageInfo:
     package_info = storage.get_load_package_info(load_id)

--- a/tests/extract/data_writers/test_buffered_writer.py
+++ b/tests/extract/data_writers/test_buffered_writer.py
@@ -7,12 +7,12 @@ from uuid import uuid4
 from dlt.common.data_writers.exceptions import BufferedDataWriterClosed
 from dlt.common.data_writers.writers import (
     DataWriter,
-    DataWriterMetrics,
     InsertValuesWriter,
     JsonlWriter,
     ALL_WRITERS,
 )
 from dlt.common.destination.capabilities import TLoaderFileFormat, DestinationCapabilitiesContext
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.schema.utils import new_column
 from dlt.common.storages.file_storage import FileStorage
 

--- a/tests/extract/data_writers/test_data_item_storage.py
+++ b/tests/extract/data_writers/test_data_item_storage.py
@@ -3,8 +3,9 @@ from typing import Type
 import pytest
 
 from dlt.common.configuration.container import Container
-from dlt.common.data_writers.writers import DataWriterMetrics, DataWriter
+from dlt.common.data_writers.writers import DataWriter
 from dlt.common.destination.capabilities import DestinationCapabilitiesContext
+from dlt.common.metrics import DataWriterMetrics
 from dlt.common.schema.utils import new_column
 from dlt.common.storages.data_item_storage import DataItemStorage
 

--- a/tests/load/pipeline/test_filesystem_pipeline.py
+++ b/tests/load/pipeline/test_filesystem_pipeline.py
@@ -12,6 +12,7 @@ import pytest
 
 from dlt.common import json
 from dlt.common import pendulum
+from dlt.common.storages.configuration import FilesystemConfiguration
 from dlt.common.storages.load_package import ParsedLoadJobFileName
 from dlt.common.utils import uniq_id
 from dlt.common.exceptions import DependencyVersionException
@@ -299,6 +300,17 @@ def test_delta_table_core(
     assert len(rows) == 10
     assert_all_data_types_row(rows[0], schema=column_schemas)
 
+    # make sure remote_uri is in metrics
+    metrics = info.metrics[info.loads_ids[0]][0]
+    # TODO: only final copy job has remote_uri. not the initial (empty) job for particular files
+    # we could implement an empty job for delta that generates correct remote_uri
+    remote_uri = list(metrics["job_metrics"].values())[-1].remote_uri
+    assert remote_uri.endswith("data_types")
+    bucket_uri = destination_config.bucket_url
+    if FilesystemConfiguration.is_local_path(bucket_uri):
+        bucket_uri = FilesystemConfiguration.make_file_uri(bucket_uri)
+    assert remote_uri.startswith(bucket_uri)
+
     # another run should append rows to the table
     info = pipeline.run(data_types())
     assert_load_info(info)
@@ -567,6 +579,7 @@ def test_delta_table_partitioning(
     assert dt.metadata().partition_columns == []
 
 
+@pytest.mark.essential
 @pytest.mark.parametrize(
     "destination_config",
     destinations_configs(

--- a/tests/load/pipeline/test_postgres.py
+++ b/tests/load/pipeline/test_postgres.py
@@ -6,7 +6,6 @@ import pytest
 
 from dlt.common.utils import uniq_id
 
-from dlt.destinations.impl.postgres.sql_client import Psycopg2SqlClient
 from tests.load.utils import destinations_configs, DestinationTestConfiguration
 from tests.pipeline.utils import assert_load_info, load_tables_to_dicts
 from tests.utils import TestDataItemFormat
@@ -52,6 +51,7 @@ def test_postgres_encoded_binary(
 #     ids=lambda x: x.name,
 # )
 # def test_postgres_encoding(destination_config: DestinationTestConfiguration):
+#     from dlt.destinations.impl.postgres.sql_client import Psycopg2SqlClient
 #     pipeline = destination_config.setup_pipeline("postgres_" + uniq_id(), dev_mode=True)
 #     client: Psycopg2SqlClient = pipeline.sql_client()
 #     # client.credentials.query["encoding"] = "ru"

--- a/tests/load/pipeline/test_postgres.py
+++ b/tests/load/pipeline/test_postgres.py
@@ -6,6 +6,7 @@ import pytest
 
 from dlt.common.utils import uniq_id
 
+from dlt.destinations.impl.postgres.sql_client import Psycopg2SqlClient
 from tests.load.utils import destinations_configs, DestinationTestConfiguration
 from tests.pipeline.utils import assert_load_info, load_tables_to_dicts
 from tests.utils import TestDataItemFormat
@@ -42,3 +43,17 @@ def test_postgres_encoded_binary(
     # print(bytes(data["table"][0]["hash"]))
     # data in postgres equals unencoded blob
     assert data["table"][0]["hash"].tobytes() == blob
+
+
+# TODO: uncomment and finalize when we implement encoding for psycopg2
+# @pytest.mark.parametrize(
+#     "destination_config",
+#     destinations_configs(default_sql_configs=True, subset=["postgres"]),
+#     ids=lambda x: x.name,
+# )
+# def test_postgres_encoding(destination_config: DestinationTestConfiguration):
+#     pipeline = destination_config.setup_pipeline("postgres_" + uniq_id(), dev_mode=True)
+#     client: Psycopg2SqlClient = pipeline.sql_client()
+#     # client.credentials.query["encoding"] = "ru"
+#     with client:
+#         print(client.native_connection.encoding)

--- a/tests/load/test_dummy_client.py
+++ b/tests/load/test_dummy_client.py
@@ -898,7 +898,6 @@ def test_load_multiple_packages() -> None:
     load_id_1, _ = prepare_load_package(load.load_storage, NORMALIZED_FILES)
     sleep(0.1)
     load_id_2, _ = prepare_load_package(load.load_storage, NORMALIZED_FILES)
-    load.run(None)
     # assert load._current_load_id is None
     metrics_id_1 = load._job_metrics
     assert len(metrics_id_1) == 2

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -45,6 +45,7 @@ from dlt.common.schema.typing import TTableFormat
 from dlt.common.storages import SchemaStorage, FileStorage, SchemaStorageConfiguration
 from dlt.common.schema.utils import new_table, normalize_table_identifiers
 from dlt.common.storages import ParsedLoadJobFileName, LoadStorage, PackageStorage
+from dlt.common.storages.load_package import create_load_id
 from dlt.common.typing import StrAny
 from dlt.common.utils import uniq_id
 
@@ -712,7 +713,7 @@ def expect_load_file(
         query = query.encode("utf-8")  # type: ignore[assignment]
     file_storage.save(file_name, query)
     table = client.prepare_load_table(table_name)
-    load_id = uniq_id()
+    load_id = create_load_id()
     job = client.create_load_job(table, file_storage.make_full_path(file_name), load_id)
 
     if isinstance(job, RunnableLoadJob):
@@ -873,7 +874,7 @@ def prepare_load_package(
     Create a load package with explicitely provided files
     job_per_case multiplies the amount of load jobs, for big packages use small files
     """
-    load_id = uniq_id()
+    load_id = create_load_id()
     load_storage.new_packages.create_package(load_id)
     for case in cases:
         path = f"./tests/load/cases/loading/{case}"

--- a/tests/pipeline/cases/contracts/trace.schema.yaml
+++ b/tests/pipeline/cases/contracts/trace.schema.yaml
@@ -1,0 +1,755 @@
+version: 4
+version_hash: telivwhq/NZ1Dfe5XZLuGg8uo3USJIHuB6s79BTh76w=
+engine_version: 9
+name: trace
+tables:
+  _dlt_version:
+    columns:
+      version:
+        data_type: bigint
+        nullable: false
+      engine_version:
+        data_type: bigint
+        nullable: false
+      inserted_at:
+        data_type: timestamp
+        nullable: false
+      schema_name:
+        data_type: text
+        nullable: false
+      version_hash:
+        data_type: text
+        nullable: false
+      schema:
+        data_type: text
+        nullable: false
+    write_disposition: skip
+    description: Created by DLT. Tracks schema updates
+  _dlt_loads:
+    columns:
+      load_id:
+        data_type: text
+        nullable: false
+      schema_name:
+        data_type: text
+        nullable: true
+      status:
+        data_type: bigint
+        nullable: false
+      inserted_at:
+        data_type: timestamp
+        nullable: false
+      schema_version_hash:
+        data_type: text
+        nullable: true
+    write_disposition: skip
+    description: Created by DLT. Tracks completed loads
+  trace:
+    columns:
+      transaction_id:
+        data_type: text
+        nullable: true
+      pipeline_name:
+        data_type: text
+        nullable: true
+      execution_context__ci_run:
+        data_type: bool
+        nullable: true
+      execution_context__python:
+        data_type: text
+        nullable: true
+      execution_context__cpu:
+        data_type: bigint
+        nullable: true
+      execution_context__os__name:
+        data_type: text
+        nullable: true
+      execution_context__os__version:
+        data_type: text
+        nullable: true
+      execution_context__library__name:
+        data_type: text
+        nullable: true
+      execution_context__library__version:
+        data_type: text
+        nullable: true
+      started_at:
+        data_type: timestamp
+        nullable: true
+      finished_at:
+        data_type: timestamp
+        nullable: true
+      engine_version:
+        data_type: bigint
+        nullable: true
+      _dlt_load_id:
+        data_type: text
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    write_disposition: append
+  trace__steps:
+    columns:
+      span_id:
+        data_type: text
+        nullable: true
+      step:
+        data_type: text
+        nullable: true
+      started_at:
+        data_type: timestamp
+        nullable: true
+      finished_at:
+        data_type: timestamp
+        nullable: true
+      step_info__pipeline__pipeline_name:
+        data_type: text
+        nullable: true
+      step_info__first_run:
+        data_type: bool
+        nullable: true
+      step_info__started_at:
+        data_type: timestamp
+        nullable: true
+      step_info__finished_at:
+        data_type: timestamp
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      load_info__destination_type:
+        data_type: text
+        nullable: true
+      load_info__destination_displayable_credentials:
+        data_type: text
+        nullable: true
+      load_info__destination_name:
+        data_type: text
+        nullable: true
+      load_info__staging_type:
+        data_type: text
+        nullable: true
+      load_info__staging_name:
+        data_type: text
+        nullable: true
+      load_info__staging_displayable_credentials:
+        data_type: text
+        nullable: true
+      load_info__destination_fingerprint:
+        data_type: text
+        nullable: true
+      step_exception:
+        data_type: text
+        nullable: true
+    parent: trace
+  trace__steps__extract_info__job_metrics:
+    columns:
+      file_path:
+        data_type: text
+        nullable: true
+      items_count:
+        data_type: bigint
+        nullable: true
+      file_size:
+        data_type: bigint
+        nullable: true
+      created:
+        data_type: double
+        nullable: true
+      last_modified:
+        data_type: double
+        nullable: true
+      load_id:
+        data_type: text
+        nullable: true
+      extract_idx:
+        data_type: bigint
+        nullable: true
+      job_id:
+        data_type: text
+        nullable: true
+      table_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps
+  trace__steps__extract_info__table_metrics:
+    columns:
+      file_path:
+        data_type: text
+        nullable: true
+      items_count:
+        data_type: bigint
+        nullable: true
+      file_size:
+        data_type: bigint
+        nullable: true
+      created:
+        data_type: double
+        nullable: true
+      last_modified:
+        data_type: double
+        nullable: true
+      load_id:
+        data_type: text
+        nullable: true
+      extract_idx:
+        data_type: bigint
+        nullable: true
+      table_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps
+  trace__steps__extract_info__resource_metrics:
+    columns:
+      file_path:
+        data_type: text
+        nullable: true
+      items_count:
+        data_type: bigint
+        nullable: true
+      file_size:
+        data_type: bigint
+        nullable: true
+      created:
+        data_type: double
+        nullable: true
+      last_modified:
+        data_type: double
+        nullable: true
+      load_id:
+        data_type: text
+        nullable: true
+      extract_idx:
+        data_type: bigint
+        nullable: true
+      resource_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps
+  trace__steps__extract_info__dag:
+    columns:
+      load_id:
+        data_type: text
+        nullable: true
+      extract_idx:
+        data_type: bigint
+        nullable: true
+      parent_name:
+        data_type: text
+        nullable: true
+      resource_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps
+  trace__steps__extract_info__hints:
+    columns:
+      load_id:
+        data_type: text
+        nullable: true
+      extract_idx:
+        data_type: bigint
+        nullable: true
+      resource_name:
+        data_type: text
+        nullable: true
+      columns:
+        data_type: text
+        nullable: true
+      write_disposition:
+        data_type: text
+        nullable: true
+      schema_contract:
+        data_type: text
+        nullable: true
+      table_format:
+        data_type: text
+        nullable: true
+      file_format:
+        data_type: text
+        nullable: true
+      original_columns:
+        data_type: text
+        nullable: true
+      primary_key:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps
+  trace__steps__step_info__loads_ids:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+    parent: trace__steps
+  trace__steps__step_info__load_packages:
+    columns:
+      load_id:
+        data_type: text
+        nullable: true
+      package_path:
+        data_type: text
+        nullable: true
+      state:
+        data_type: text
+        nullable: true
+      schema_hash:
+        data_type: text
+        nullable: true
+      schema_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      completed_at:
+        data_type: timestamp
+        nullable: true
+    parent: trace__steps
+  trace__steps__step_info__load_packages__jobs:
+    columns:
+      state:
+        data_type: text
+        nullable: true
+      file_path:
+        data_type: text
+        nullable: true
+      file_size:
+        data_type: bigint
+        nullable: true
+      created_at:
+        data_type: timestamp
+        nullable: true
+      elapsed:
+        data_type: double
+        nullable: true
+      table_name:
+        data_type: text
+        nullable: true
+      file_id:
+        data_type: text
+        nullable: true
+      retry_count:
+        data_type: bigint
+        nullable: true
+      file_format:
+        data_type: text
+        nullable: true
+      job_id:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps__step_info__load_packages
+  trace__steps__normalize_info__job_metrics:
+    columns:
+      file_path:
+        data_type: text
+        nullable: true
+      items_count:
+        data_type: bigint
+        nullable: true
+      file_size:
+        data_type: bigint
+        nullable: true
+      created:
+        data_type: double
+        nullable: true
+      last_modified:
+        data_type: double
+        nullable: true
+      load_id:
+        data_type: text
+        nullable: true
+      extract_idx:
+        data_type: bigint
+        nullable: true
+      job_id:
+        data_type: text
+        nullable: true
+      table_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps
+  trace__steps__normalize_info__table_metrics:
+    columns:
+      file_path:
+        data_type: text
+        nullable: true
+      items_count:
+        data_type: bigint
+        nullable: true
+      file_size:
+        data_type: bigint
+        nullable: true
+      created:
+        data_type: double
+        nullable: true
+      last_modified:
+        data_type: double
+        nullable: true
+      load_id:
+        data_type: text
+        nullable: true
+      extract_idx:
+        data_type: bigint
+        nullable: true
+      table_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps
+  trace__steps__load_info__job_metrics:
+    columns:
+      load_id:
+        data_type: text
+        nullable: true
+      job_id:
+        data_type: text
+        nullable: true
+      file_path:
+        data_type: text
+        nullable: true
+      table_name:
+        data_type: text
+        nullable: true
+      state:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      started_at:
+        data_type: timestamp
+        nullable: true
+      finished_at:
+        data_type: timestamp
+        nullable: true
+      remote_uri:
+        data_type: text
+        nullable: true
+    parent: trace__steps
+  trace__steps__step_info__load_packages__tables:
+    columns:
+      write_disposition:
+        data_type: text
+        nullable: true
+      schema_contract:
+        data_type: text
+        nullable: true
+      table_format:
+        data_type: text
+        nullable: true
+      file_format:
+        data_type: text
+        nullable: true
+      name:
+        data_type: text
+        nullable: true
+      resource:
+        data_type: text
+        nullable: true
+      schema_name:
+        data_type: text
+        nullable: true
+      load_id:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      parent:
+        data_type: text
+        nullable: true
+      x_normalizer__seen_data:
+        data_type: bool
+        nullable: true
+    parent: trace__steps__step_info__load_packages
+  trace__steps__step_info__load_packages__tables__columns:
+    columns:
+      name:
+        data_type: text
+        nullable: true
+      data_type:
+        data_type: text
+        nullable: true
+      nullable:
+        data_type: bool
+        nullable: true
+      primary_key:
+        data_type: bool
+        nullable: true
+      table_name:
+        data_type: text
+        nullable: true
+      schema_name:
+        data_type: text
+        nullable: true
+      load_id:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      unique:
+        data_type: bool
+        nullable: true
+      foreign_key:
+        data_type: bool
+        nullable: true
+    parent: trace__steps__step_info__load_packages__tables
+  trace__resolved_config_values:
+    columns:
+      key:
+        data_type: text
+        nullable: true
+      is_secret_hint:
+        data_type: bool
+        nullable: true
+      provider_name:
+        data_type: text
+        nullable: true
+      config_type_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace
+  trace__resolved_config_values__sections:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+    parent: trace__resolved_config_values
+  trace__steps__exception_traces:
+    columns:
+      message:
+        data_type: text
+        nullable: true
+      exception_type:
+        data_type: text
+        nullable: true
+      is_terminal:
+        data_type: bool
+        nullable: true
+      docstring:
+        data_type: text
+        nullable: true
+      load_id:
+        data_type: text
+        nullable: true
+      pipeline_name:
+        data_type: text
+        nullable: true
+      exception_attrs:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+    parent: trace__steps
+  trace__steps__exception_traces__stack_trace:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+    parent: trace__steps__exception_traces
+settings:
+  detections:
+  - iso_timestamp
+  default_hints:
+    not_null:
+    - _dlt_id
+    - _dlt_root_id
+    - _dlt_parent_id
+    - _dlt_list_idx
+    - _dlt_load_id
+    foreign_key:
+    - _dlt_parent_id
+    root_key:
+    - _dlt_root_id
+    unique:
+    - _dlt_id
+normalizers:
+  names: snake_case
+  json:
+    module: dlt.common.normalizers.json.relational
+previous_hashes:
+- NzN2Q/aAzBaBYztixnAXXyly4eqWwCbuXTBU35ELgK4=
+- xvzzEfvRd6VEdwfZjNztqfoJTvGDZPEWFQiuRbkEDjI=
+- RV9jvZSD5dM+ZGjEL3HqokLvtf22K4zMNc3zWRahEw4=

--- a/tests/pipeline/cases/contracts/trace.schema.yaml
+++ b/tests/pipeline/cases/contracts/trace.schema.yaml
@@ -1,5 +1,5 @@
 version: 4
-version_hash: telivwhq/NZ1Dfe5XZLuGg8uo3USJIHuB6s79BTh76w=
+version_hash: JE62zVwqT2T/qHTi2Qdnn2d1A/JzCzyGtDwc+qUmbTs=
 engine_version: 9
 name: trace
 tables:
@@ -90,6 +90,23 @@ tables:
         nullable: false
         unique: true
     write_disposition: append
+  trace__execution_context__exec_info:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        foreign_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+    parent: trace
   trace__steps:
     columns:
       span_id:
@@ -750,6 +767,6 @@ normalizers:
   json:
     module: dlt.common.normalizers.json.relational
 previous_hashes:
-- NzN2Q/aAzBaBYztixnAXXyly4eqWwCbuXTBU35ELgK4=
-- xvzzEfvRd6VEdwfZjNztqfoJTvGDZPEWFQiuRbkEDjI=
+- 9Ysjq/W0xpxkI/vBiYm8Qbr2nDP3JMt6KvGKUS/FCyI=
+- NYeAxJ2r+T+dKFnXFhBEPzBP6SO+ORdhOfgQRo/XqBU=
 - RV9jvZSD5dM+ZGjEL3HqokLvtf22K4zMNc3zWRahEw4=

--- a/tests/pipeline/test_pipeline_trace.py
+++ b/tests/pipeline/test_pipeline_trace.py
@@ -248,6 +248,10 @@ def test_trace_schema() -> None:
     os.environ["DATA_WRITER__DISABLE_COMPRESSION"] = "True"
     os.environ["RESTORE_FROM_DESTINATION"] = "False"
 
+    # mock runtime env
+    os.environ["CIRCLECI"] = "1"
+    os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "lambda"
+
     @dlt.source(section="many_hints")
     def many_hints(
         api_type=dlt.config.value,

--- a/tests/pipeline/test_platform_connection.py
+++ b/tests/pipeline/test_platform_connection.py
@@ -65,7 +65,8 @@ def test_platform_connection() -> None:
         # basic check of trace result
         assert trace_result, "no trace"
         assert trace_result["pipeline_name"] == "platform_test_pipeline"
-        assert len(trace_result["steps"]) == 4
+        # just extract, normalize and load steps. run step is not serialized to trace (it was just a copy of load)
+        assert len(trace_result["steps"]) == 3
         assert trace_result["execution_context"]["library"]["name"] == "dlt"
 
         # basic check of state result

--- a/tests/pipeline/utils.py
+++ b/tests/pipeline/utils.py
@@ -98,6 +98,9 @@ def users_materialize_table_schema():
 
 def assert_load_info(info: LoadInfo, expected_load_packages: int = 1) -> None:
     """Asserts that expected number of packages was loaded and there are no failed jobs"""
+    # make sure we can serialize
+    info.asstr(verbosity=2)
+    info.asdict()
     assert len(info.loads_ids) == expected_load_packages
     # all packages loaded
     assert all(p.completed_at is not None for p in info.load_packages) is True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -189,8 +189,9 @@ def wipe_pipeline(preserve_environ) -> Iterator[None]:
     yield
     if container[PipelineContext].is_active():
         # take existing pipeline
-        p = dlt.pipeline()
-        p._wipe_working_folder()
+        # NOTE: no more needed. test storage is wiped fully when test starts
+        # p = dlt.pipeline()
+        # p._wipe_working_folder()
         # deactivate context
         container[PipelineContext].deactivate()
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
fixes #1681 

also changes shape of the trace and puts contract on it (in tests)
* job_id added to `trace__steps__step_info__load_packages__jobs`
* `run` step removed (is a copy of last step in the pipeline) + corresponding columns in `trace`
* added `table_name` in `job_metrics`
* added `trace__steps__load_info__job_metrics`

also refactors code
