### PR TITLE
`scd2` custom "valid from" / "valid to" value feature 

### DIFF
--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -187,6 +187,7 @@ class TMergeDispositionDict(TWriteDispositionDict, total=False):
     strategy: Optional[TLoaderMergeStrategy]
     validity_column_names: Optional[List[str]]
     active_record_timestamp: Optional[TAnyDateTime]
+    boundary_timestamp: Optional[TAnyDateTime]
     row_version_column_name: Optional[str]
 
 

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -123,7 +123,8 @@ class RangePaginator(BasePaginator):
         super().__init__()
         if total_path is None and maximum_value is None and not stop_after_empty_page:
             raise ValueError(
-                "Either `total_path` or `maximum_value` or `stop_after_empty_page` must be provided."
+                "Either `total_path` or `maximum_value` or `stop_after_empty_page` must be"
+                " provided."
             )
         self.param_name = param_name
         self.current_value = initial_value
@@ -164,7 +165,7 @@ class RangePaginator(BasePaginator):
             ):
                 self._has_next_page = False
 
-    def _stop_after_this_page(self, data: Optional[List[Any]]=None) -> bool:
+    def _stop_after_this_page(self, data: Optional[List[Any]] = None) -> bool:
         return self.stop_after_empty_page and not data
 
     def _handle_missing_total(self, response_json: Dict[str, Any]) -> None:
@@ -371,7 +372,8 @@ class OffsetPaginator(RangePaginator):
         """
         if total_path is None and maximum_offset is None and not stop_after_empty_page:
             raise ValueError(
-                "Either `total_path` or `maximum_offset` or `stop_after_empty_page` must be provided."
+                "Either `total_path` or `maximum_offset` or `stop_after_empty_page` must be"
+                " provided."
             )
         super().__init__(
             param_name=offset_param,

--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -348,7 +348,23 @@ You can configure the literal used to indicate an active record with `active_rec
     write_disposition={
         "disposition": "merge",
         "strategy": "scd2",
-        "active_record_timestamp": "9999-12-31",  # e.g. datetime.datetime(9999, 12, 31) is also accepted
+        # accepts various types of date/datetime objects
+        "active_record_timestamp": "9999-12-31",
+    }
+)
+def dim_customer():
+    ...
+```
+
+#### Example: configure boundary timestamp
+You can configure the "boundary timestamp" used for record validity windows with `boundary_timestamp`. The provided date(time) value is used as "valid from" for new records and as "valid to" for retired records. The timestamp at which a load package is created is used if `boundary_timestamp` is omitted.
+```py
+@dlt.resource(
+    write_disposition={
+        "disposition": "merge",
+        "strategy": "scd2",
+        # accepts various types of date/datetime objects
+        "boundary_timestamp": "2024-08-21T12:15:00+00:00",
     }
 )
 def dim_customer():

--- a/tests/load/pipeline/test_scd2.py
+++ b/tests/load/pipeline/test_scd2.py
@@ -69,20 +69,6 @@ def get_table(
         return table
     return sorted(table, key=lambda d: d[sort_column])
 
-    return sorted(
-        [
-            {
-                k: strip_timezone(v) if isinstance(v, datetime) else v
-                for k, v in r.items()
-                if not k.startswith("_dlt")
-                or k in DEFAULT_VALIDITY_COLUMN_NAMES
-                or (k == "_dlt_root_id" if include_root_id else False)
-            }
-            for r in load_tables_to_dicts(pipeline, table_name)[table_name]
-        ],
-        key=lambda d: d[sort_column],
-    )
-
 
 @pytest.mark.essential
 @pytest.mark.parametrize(

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -347,7 +347,9 @@ class TestOffsetPaginator:
                 total_path=None,
                 stop_after_empty_page=False,
             )
-        assert e.match("`total_path` or `maximum_offset` or `stop_after_empty_page` must be provided")
+        assert e.match(
+            "`total_path` or `maximum_offset` or `stop_after_empty_page` must be provided"
+        )
 
         with pytest.raises(ValueError) as e:
             OffsetPaginator(
@@ -356,7 +358,9 @@ class TestOffsetPaginator:
                 stop_after_empty_page=False,
                 maximum_offset=None,
             )
-        assert e.match("`total_path` or `maximum_offset` or `stop_after_empty_page` must be provided")
+        assert e.match(
+            "`total_path` or `maximum_offset` or `stop_after_empty_page` must be provided"
+        )
 
 
 @pytest.mark.usefixtures("mock_api_server")


### PR DESCRIPTION
### Description
Adds `boundary_timestamp` argument that's interpreted for `scd2` merge strategy. Lets users configure the timestamp value used in record validity windows (i.e. the value used as "valid from" for new records and as "valid to" for retired records).

### Related Issues

Closes #1601
