### PR TITLE
Make `make lint` fail on `black` format diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lint:
 	poetry run mypy --config-file mypy.ini dlt tests
 	poetry run flake8 --max-line-length=200 dlt
 	poetry run flake8 --max-line-length=200 tests --exclude tests/reflection/module_cases
-	poetry run black dlt docs tests --diff --extend-exclude=".*syntax_error.py"
+	poetry run black dlt docs tests --check --diff --color --extend-exclude=".*syntax_error.py"
 	# poetry run isort ./ --diff
 	# $(MAKE) lint-security
 

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -123,7 +123,8 @@ class RangePaginator(BasePaginator):
         super().__init__()
         if total_path is None and maximum_value is None and not stop_after_empty_page:
             raise ValueError(
-                "Either `total_path` or `maximum_value` or `stop_after_empty_page` must be provided."
+                "Either `total_path` or `maximum_value` or `stop_after_empty_page` must be"
+                " provided."
             )
         self.param_name = param_name
         self.current_value = initial_value
@@ -164,7 +165,7 @@ class RangePaginator(BasePaginator):
             ):
                 self._has_next_page = False
 
-    def _stop_after_this_page(self, data: Optional[List[Any]]=None) -> bool:
+    def _stop_after_this_page(self, data: Optional[List[Any]] = None) -> bool:
         return self.stop_after_empty_page and not data
 
     def _handle_missing_total(self, response_json: Dict[str, Any]) -> None:
@@ -371,7 +372,8 @@ class OffsetPaginator(RangePaginator):
         """
         if total_path is None and maximum_offset is None and not stop_after_empty_page:
             raise ValueError(
-                "Either `total_path` or `maximum_offset` or `stop_after_empty_page` must be provided."
+                "Either `total_path` or `maximum_offset` or `stop_after_empty_page` must be"
+                " provided."
             )
         super().__init__(
             param_name=offset_param,

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -347,7 +347,9 @@ class TestOffsetPaginator:
                 total_path=None,
                 stop_after_empty_page=False,
             )
-        assert e.match("`total_path` or `maximum_offset` or `stop_after_empty_page` must be provided")
+        assert e.match(
+            "`total_path` or `maximum_offset` or `stop_after_empty_page` must be provided"
+        )
 
         with pytest.raises(ValueError) as e:
             OffsetPaginator(
@@ -356,7 +358,9 @@ class TestOffsetPaginator:
                 stop_after_empty_page=False,
                 maximum_offset=None,
             )
-        assert e.match("`total_path` or `maximum_offset` or `stop_after_empty_page` must be provided")
+        assert e.match(
+            "`total_path` or `maximum_offset` or `stop_after_empty_page` must be provided"
+        )
 
 
 @pytest.mark.usefixtures("mock_api_server")


### PR DESCRIPTION
### Description
- makes `make lint` exit with error code 1 (and thus makes the `lint.yml` workflow fail) when `black` detects a formatting diff—this should lead to less unformatted code in the `devel` branch
- adds coloring to diff output

see it in action here: https://github.com/dlt-hub/dlt/actions/runs/10502842793/job/29095135609?pr=1716#step:7:100

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
Slack chat: https://dlthub-community.slack.com/archives/C06EYJ2Q37C/p1724234001980989
