### PR TITLE
Correct wrong code example for apply_hints( incremental(xx) )

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database.md
@@ -351,7 +351,7 @@ certain range.
    ```py
    source = sql_database().with_resources("family")
    #using the "updated" field as an incremental field using initial value of January 1, 2022, at midnight
-   source.family.apply_hints(incremental=dlt.sources.incremental("updated"),initial_value=pendulum.DateTime(2022, 1, 1, 0, 0, 0))
+   source.family.apply_hints(incremental=dlt.sources.incremental("updated", initial_value=pendulum.DateTime(2022, 1, 1, 0, 0, 0)))
    #running the pipeline
    info = pipeline.run(source, write_disposition="merge")
    print(info)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

A slight typo in the code example of `sql_database` source regarding incremental hints:

the `initial_value` is an arg of `dlt.sources.incremental` instead of an arg of `apply_hints`.


