### PR TITLE
skips tables without jobs when merging delta tables

### DIFF
--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -188,7 +188,7 @@ class ClickHouseMergeJob(SqlMergeFollowupJob):
         key_clauses: Sequence[str],
         for_delete: bool,
     ) -> List[str]:
-        join_conditions = " AND ".join([c.format(d="d", s="s") for c in key_clauses])
+        join_conditions = " OR ".join([c.format(d="d", s="s") for c in key_clauses])
         return [
             f"FROM {root_table_name} AS d JOIN {staging_root_table_name} AS s ON {join_conditions}"
         ]

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -1,5 +1,5 @@
-from copy import deepcopy
 from typing import TypedDict, cast, Any, Optional, Dict
+from typing_extensions import Self
 
 from dlt.common import logger
 from dlt.common.schema.typing import (
@@ -222,7 +222,7 @@ class DltResourceHints:
         table_format: TTableHintTemplate[TTableFormat] = None,
         file_format: TTableHintTemplate[TFileFormat] = None,
         create_table_variant: bool = False,
-    ) -> None:
+    ) -> Self:
         """Creates or modifies existing table schema by setting provided hints. Accepts both static and dynamic hints based on data.
 
         If `create_table_variant` is specified, the `table_name` must be a string and hints will be used to create a separate set of hints
@@ -238,6 +238,8 @@ class DltResourceHints:
 
         Please note that for efficient incremental loading, the resource must be aware of the Incremental by accepting it as one if its arguments and then using are to skip already loaded data.
         In non-aware resources, `dlt` will filter out the loaded values, however, the resource will yield all the values again.
+
+        Returns: self for chaining
         """
         if create_table_variant:
             if not isinstance(table_name, str):
@@ -344,6 +346,7 @@ class DltResourceHints:
             t["incremental"] = incremental
 
         self._set_hints(t, create_table_variant)
+        return self
 
     def _set_hints(
         self, hints_template: TResourceHints, create_table_variant: bool = False
@@ -403,7 +406,6 @@ class DltResourceHints:
         if hints_template is None:
             return None
         # creates a deep copy of dict structure without actually copying the objects
-        # deepcopy(hints_template) #
         return clone_dict_nested(hints_template)  # type: ignore[type-var]
 
     @staticmethod

--- a/tests/destinations/test_custom_destination.py
+++ b/tests/destinations/test_custom_destination.py
@@ -186,6 +186,19 @@ def test_instantiation() -> None:
     # local func does not create entry in destinations
     assert "local_sink_func" not in _DESTINATIONS
 
+    def local_sink_func_no_params(items: TDataItems, table: TTableSchema) -> None:
+        # consume data
+        pass
+
+    p = dlt.pipeline(
+        "sink_test",
+        destination=Destination.from_reference(
+            "destination", destination_callable=local_sink_func_no_params
+        ),
+        dev_mode=True,
+    )
+    p.run([1, 2, 3], table_name="items")
+
     # test passing string reference
     global global_calls
     global_calls = []

--- a/tests/load/pipeline/test_filesystem_pipeline.py
+++ b/tests/load/pipeline/test_filesystem_pipeline.py
@@ -489,6 +489,16 @@ def test_delta_table_child_tables(
     assert len(rows_dict["nested_table__child"]) == 3
     assert len(rows_dict["nested_table__child__grandchild"]) == 5
 
+    # now drop children and grandchildren, use merge write disposition to create and pass full table chain
+    # also for tables that do not have jobs
+    info = pipeline.run(
+        [{"foo": 3}] * 10000,
+        table_name="nested_table",
+        primary_key="foo",
+        write_disposition="merge",
+    )
+    assert_load_info(info)
+
 
 @pytest.mark.parametrize(
     "destination_config",
@@ -735,9 +745,21 @@ def test_delta_table_empty_source(
         ensure_delta_compatible_arrow_data(empty_arrow_table).schema
     )
 
+    # now run the empty frame again
+    info = pipeline.run(delta_table(empty_arrow_table))
+    assert_load_info(info)
+
+    # use materialized list
+    # NOTE: this will create an empty parquet file with a schema takes from dlt schema.
+    # the original parquet file had a nested (struct) type in `json` field that is now
+    # in the delta table schema. the empty parquet file lost this information and had
+    # string type (converted from dlt `json`)
+    info = pipeline.run([dlt.mark.materialize_table_schema()], table_name="delta_table")
+    assert_load_info(info)
+
     # test `dlt.mark.materialize_table_schema()`
     users_materialize_table_schema.apply_hints(table_format="delta")
-    info = pipeline.run(users_materialize_table_schema())
+    info = pipeline.run(users_materialize_table_schema(), loader_file_format="parquet")
     assert_load_info(info)
     dt = get_delta_tables(pipeline, "users")["users"]
     assert dt.version() == 0

--- a/tests/load/postgres/postgres/Dockerfile
+++ b/tests/load/postgres/postgres/Dockerfile
@@ -1,2 +1,2 @@
-FROM postgres:14
+FROM postgres:15
 COPY 01_init.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. it was assumed that all tables in table chain will have a job. that is not true for nested tables where child tables have no rows
2. schema evolution: presence is checked via names, not full schema comparison
3. "heavy" object are explicitly deleted. not sure if that helps a lot... internally delta does a lot of unnecessary conversions on the arrow objects
