### PR TITLE
fix intermittent `delta` panic issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ has-poetry:
 	poetry --version
 
 dev: has-poetry
-	poetry install --all-extras --with docs,providers,pipeline,sources,sentry-sdk
+	poetry install --all-extras --with docs,providers,pipeline,sources,sentry-sdk,airflow
 
 lint:
 	./tools/check-package.sh

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -164,9 +164,12 @@ class DeltaLoadFilesystemJob(FilesystemLoadJob):
         return _deltalake_storage_options(self._job_client.config)
 
     def _delta_table(self) -> Optional["DeltaTable"]:  # type: ignore[name-defined] # noqa: F821
-        from dlt.common.libs.deltalake import try_get_deltatable
+        from dlt.common.libs.deltalake import DeltaTable
 
-        return try_get_deltatable(self.make_remote_url(), storage_options=self._storage_options)
+        if DeltaTable.is_deltatable(self.make_remote_url(), storage_options=self._storage_options):
+            return DeltaTable(self.make_remote_url(), storage_options=self._storage_options)
+        else:
+            return None
 
     @property
     def _partition_columns(self) -> List[str]:


### PR DESCRIPTION
### Description
Avoiding `try_get_deltatable` solves the issue.

I tested by running `pipeline.py` in a loop:

```py
import os
import dlt
from dlt.destinations import filesystem

os.environ["RUST_BACKTRACE"] = "full"

num_resources = 5
resources = [
    dlt.resource([{"foo": "bar"}], name=f"r{n}")
    for n in range(num_resources)
]
pipe = dlt.pipeline(
    pipeline_name="delta_source",
    pipelines_dir="_storage",
    destination=filesystem("_storage"),
)

pipe.run(resources, table_format="delta")
```

```sh
for run in {1..100}; do python pipeline.py; done
```

Results:
- old impl with `try_get_deltatable`: 100 runs, 16 panics
- new impl: 100 runs, 0 panics

Old impl used `try_get_deltatable` because `DeltaTable.is_deltatable()` did not yet exist. It got added after I opened a [ticket](https://github.com/delta-io/delta-rs/issues/2662) in the `delta-rs` repo.

### Related Issues

Fixes #1808

<!--
Provide any additional context about the PR here.
-->
### Additional Context
- also brings `airflow` back to `make dev` to prevent `mypy` errors