### PR TITLE
rest_api: allow specifying custom session (feat/1843)

### DIFF
--- a/dlt/sources/rest_api/__init__.py
+++ b/dlt/sources/rest_api/__init__.py
@@ -245,6 +245,7 @@ def create_resources(
             headers=client_config.get("headers"),
             auth=create_auth(client_config.get("auth")),
             paginator=create_paginator(client_config.get("paginator")),
+            session=client_config.get("session"),
         )
 
         hooks = create_response_hooks(endpoint_config.get("response_actions"))

--- a/dlt/sources/rest_api/typing.py
+++ b/dlt/sources/rest_api/typing.py
@@ -35,7 +35,7 @@ from dlt.common.schema.typing import (
 from dlt.extract.items import TTableHintTemplate
 from dlt.extract.incremental.typing import LastValueFunc
 
-from dlt.sources.helpers.requests import Session
+from requests import Session
 
 from dlt.sources.helpers.rest_client.typing import HTTPMethodBasic
 

--- a/dlt/sources/rest_api/typing.py
+++ b/dlt/sources/rest_api/typing.py
@@ -35,6 +35,8 @@ from dlt.common.schema.typing import (
 from dlt.extract.items import TTableHintTemplate
 from dlt.extract.incremental.typing import LastValueFunc
 
+from dlt.sources.helpers.requests import Session
+
 from dlt.sources.helpers.rest_client.typing import HTTPMethodBasic
 
 from dlt.sources.helpers.rest_client.paginators import (
@@ -187,6 +189,7 @@ class ClientConfig(TypedDict, total=False):
     headers: Optional[Dict[str, str]]
     auth: Optional[AuthConfig]
     paginator: Optional[PaginatorConfig]
+    session: Optional[Session]
 
 
 class IncrementalRESTArgs(IncrementalArgs, total=False):

--- a/tests/sources/rest_api/configurations/source_configs.py
+++ b/tests/sources/rest_api/configurations/source_configs.py
@@ -2,9 +2,13 @@ from collections import namedtuple
 from typing import cast, List
 
 import dlt
+import dlt.common
 from dlt.common.typing import TSecretStrValue
 from dlt.common.exceptions import DictValidationException
 from dlt.common.configuration.specs import configspec
+import dlt.helpers
+import dlt.sources.helpers
+import dlt.sources.helpers.requests
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
 from dlt.sources.helpers.rest_client.auth import OAuth2AuthBase
 
@@ -303,6 +307,13 @@ VALID_CONFIGS: List[RESTAPIConfig] = [
                 },
             },
         ],
+    },
+    {
+        "client": {
+            "base_url": "https://example.com",
+            "session": dlt.sources.helpers.requests.Session(),
+        },
+        "resources": ["users"],
     },
 ]
 

--- a/tests/sources/rest_api/configurations/source_configs.py
+++ b/tests/sources/rest_api/configurations/source_configs.py
@@ -1,12 +1,13 @@
 from collections import namedtuple
 from typing import cast, List
 
+import requests
 import dlt
 import dlt.common
 from dlt.common.typing import TSecretStrValue
 from dlt.common.exceptions import DictValidationException
 from dlt.common.configuration.specs import configspec
-import dlt.helpers
+
 import dlt.sources.helpers
 import dlt.sources.helpers.requests
 from dlt.sources.helpers.rest_client.paginators import HeaderLinkPaginator
@@ -311,6 +312,14 @@ VALID_CONFIGS: List[RESTAPIConfig] = [
     {
         "client": {
             "base_url": "https://example.com",
+            "session": requests.Session(),
+        },
+        "resources": ["users"],
+    },
+    {
+        "client": {
+            "base_url": "https://example.com",
+            # This is a subclass of requests.Session and is thus also allowed
             "session": dlt.sources.helpers.requests.Session(),
         },
         "resources": ["users"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Allows passing a custom session object into the RESTAPIConfig. This enables us to use OAuth 1.0 and OAuth 2.0 via [requests-oauthlib](https://github.com/requests/requests-oauthlib).

### Related Issues

- Resolves #1843 

