### PR TITLE
Fix/1849 Do Not Parse Ignored Empty Responses

### DIFF
--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -506,7 +506,7 @@ def _create_response_action_hook(
         elif action_type == "ignore":
             logger.info(
                 f"Ignoring response with code {response.status_code} "
-                f"and content '{response.json()}'."
+                f"and content '{response.text}'."
             )
             raise IgnoreResponseException
 

--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -505,8 +505,7 @@ def _create_response_action_hook(
                 hook(response)
         elif action_type == "ignore":
             logger.info(
-                f"Ignoring response with code {response.status_code} "
-                f"and content '{response.text}'."
+                f"Ignoring response with code {response.status_code} and content '{response.text}'."
             )
             raise IgnoreResponseException
 

--- a/tests/sources/rest_api/conftest.py
+++ b/tests/sources/rest_api/conftest.py
@@ -140,9 +140,9 @@ def mock_api_server():
             else:
                 context.status_code = 404
                 return {"error": "Post not found"}
-        
+
         @router.get(r"/posts/\d+/some_details_204")
-        def post_detail_404(request, context):
+        def post_detail_204(request, context):
             """Return 204  No Content for post with id > 0. Used to test ignoring 204 responses."""
             post_id = int(request.url.split("/")[-2])
             if post_id < 1:

--- a/tests/sources/rest_api/conftest.py
+++ b/tests/sources/rest_api/conftest.py
@@ -140,6 +140,16 @@ def mock_api_server():
             else:
                 context.status_code = 404
                 return {"error": "Post not found"}
+        
+        @router.get(r"/posts/\d+/some_details_204")
+        def post_detail_404(request, context):
+            """Return 204  No Content for post with id > 0. Used to test ignoring 204 responses."""
+            post_id = int(request.url.split("/")[-2])
+            if post_id < 1:
+                return {"id": post_id, "body": f"Post body {post_id}"}
+            else:
+                context.status_code = 204
+                return None
 
         @router.get(r"/posts_under_a_different_key$")
         def posts_with_results_key(request, context):

--- a/tests/sources/rest_api/integration/test_offline.py
+++ b/tests/sources/rest_api/integration/test_offline.py
@@ -139,6 +139,45 @@ def test_ignoring_endpoint_returning_404(mock_api_server):
         {"id": 3, "title": "Post 3"},
     ]
 
+def test_ignoring_endpoint_returning_204(mock_api_server):
+    mock_source = rest_api_source(
+        {
+            "client": {"base_url": "https://api.example.com"},
+            "resources": [
+                "posts",
+                {
+                    "name": "post_details",
+                    "endpoint": {
+                        "path": "posts/{post_id}/some_details_204",
+                        "params": {
+                            "post_id": {
+                                "type": "resolve",
+                                "resource": "posts",
+                                "field": "id",
+                            }
+                        },
+                        "response_actions": [
+                            {
+                                "status_code": 204,
+                                "action": "ignore",
+                            },
+                        ],
+                    },
+                },
+            ],
+        }
+    )
+
+    res = list(mock_source.with_resources("posts", "post_details").add_limit(1))
+
+    assert res[:5] == [
+        {"id": 0, "body": "Post body 0"},
+        {"id": 0, "title": "Post 0"},
+        {"id": 1, "title": "Post 1"},
+        {"id": 2, "title": "Post 2"},
+        {"id": 3, "title": "Post 3"},
+    ]
+
 
 def test_source_with_post_request(mock_api_server):
     class JSONBodyPageCursorPaginator(BaseReferencePaginator):

--- a/tests/sources/rest_api/integration/test_offline.py
+++ b/tests/sources/rest_api/integration/test_offline.py
@@ -139,6 +139,7 @@ def test_ignoring_endpoint_returning_404(mock_api_server):
         {"id": 3, "title": "Post 3"},
     ]
 
+
 def test_ignoring_endpoint_returning_204(mock_api_server):
     mock_source = rest_api_source(
         {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Simple fix to remove the call to `response.json()` when logging the execution of an `"ignore"` response action, instead calls `response.text`. Included a test based off of the existing one for ignoring 404 errors. 

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #1849 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
Message lines were moved into a single line to meet with linter requirements.
