### PR TITLE
supports adding DltResource in RESTAPIConfig dict

### DIFF
--- a/dlt/sources/rest_api/__init__.py
+++ b/dlt/sources/rest_api/__init__.py
@@ -211,7 +211,7 @@ def rest_api_resources(config: RESTAPIConfig) -> List[DltResource]:
 def create_resources(
     client_config: ClientConfig,
     dependency_graph: graphlib.TopologicalSorter,
-    endpoint_resource_map: Dict[str, EndpointResource],
+    endpoint_resource_map: Dict[str, Union[EndpointResource, DltResource]],
     resolved_param_map: Dict[str, Optional[ResolvedParam]],
 ) -> Dict[str, DltResource]:
     resources = {}
@@ -219,6 +219,10 @@ def create_resources(
     for resource_name in dependency_graph.static_order():
         resource_name = cast(str, resource_name)
         endpoint_resource = endpoint_resource_map[resource_name]
+        if isinstance(endpoint_resource, DltResource):
+            resources[resource_name] = endpoint_resource
+            continue
+
         endpoint_config = cast(Endpoint, endpoint_resource["endpoint"])
         request_params = endpoint_config.get("params", {})
         request_json = endpoint_config.get("json", None)

--- a/dlt/sources/rest_api/typing.py
+++ b/dlt/sources/rest_api/typing.py
@@ -34,6 +34,7 @@ from dlt.common.schema.typing import (
 
 from dlt.extract.items import TTableHintTemplate
 from dlt.extract.incremental.typing import LastValueFunc
+from dlt.extract.resource import DltResource
 
 from requests import Session
 
@@ -276,7 +277,7 @@ class EndpointResource(EndpointResourceBase, total=False):
 
 class RESTAPIConfigBase(TypedDict):
     client: ClientConfig
-    resources: List[Union[str, EndpointResource]]
+    resources: List[Union[str, EndpointResource, DltResource]]
 
 
 class RESTAPIConfig(RESTAPIConfigBase, total=False):

--- a/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
@@ -647,30 +647,33 @@ In the following example, we want to load the issues belonging to three reposito
 Instead of defining now three different issues resources, one for each of the paths `dlt-hub/dlt/issues/`, `dlt-hub/verified-sources/issues/`, `dlt-hub/dlthub-education/issues/`, we have a resource `repositories` which yields a list of repository names which will be fetched by the dependent resource `issues`.
 
 ```py
- @dlt.resource()
-    def repositories() -> Generator[List[Dict[str, Any]]]:
-        """A seed list of repositories to fetch"""
-        yield [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
+from dlt.sources.rest_api import RESTAPIConfig
 
-    config: RESTAPIConfig = {
-        "client": {"base_url": "https://github.com/api/v2"},
-        "resources": [
-            {
-                "name": "issues",
-                "endpoint": {
-                    "path": "dlt-hub/{repository}/issues/",
-                    "params": {
-                        "repository": {
-                            "type": "resolve",
-                            "resource": "repositories",
-                            "field": "name",
-                        },
+@dlt.resource()
+def repositories() -> Generator[List[Dict[str, Any]]]:
+    """A seed list of repositories to fetch"""
+    yield [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
+
+
+config: RESTAPIConfig = {
+    "client": {"base_url": "https://github.com/api/v2"},
+    "resources": [
+        {
+            "name": "issues",
+            "endpoint": {
+                "path": "dlt-hub/{repository}/issues/",
+                "params": {
+                    "repository": {
+                        "type": "resolve",
+                        "resource": "repositories",
+                        "field": "name",
                     },
                 },
             },
-            repositories(),
-        ],
-    }
+        },
+        repositories(),
+    ],
+}
 ```
 
 Be careful that the parent resource needs to return `Generator[List[Dict[str, Any]]]`. Thus, the following will NOT work:

--- a/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
@@ -677,9 +677,9 @@ Be careful that the parent resource needs to return `Generator[List[Dict[str, An
 
 ```py
  @dlt.resource()
-    def repositories() -> Generator[Dict[str, Any]]:
-        """Not working seed list of repositories to fetch"""
-        yield from [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
+def repositories() -> Generator[Dict[str, Any]]:
+    """Not working seed list of repositories to fetch"""
+    yield from [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
 ```
 
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
@@ -679,7 +679,7 @@ config: RESTAPIConfig = {
 Be careful that the parent resource needs to return `Generator[List[Dict[str, Any]]]`. Thus, the following will NOT work:
 
 ```py
- @dlt.resource()
+@dlt.resource
 def repositories() -> Generator[Dict[str, Any]]:
     """Not working seed list of repositories to fetch"""
     yield from [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]

--- a/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
@@ -638,6 +638,51 @@ The `field` value can be specified as a [JSONPath](https://github.com/h2non/json
 
 Under the hood, dlt handles this by using a [transformer resource](../../../general-usage/resource.md#process-resources-with-dlttransformer).
 
+#### Define a resource which is not a REST endpoint
+
+Sometimes, we want to request endpoints with specific values that are not returned by another endpoint.
+Thus, you can also include arbitrary dlt resources in your `RESTAPIConfig` instead of defining a resource for every path!
+
+In the following example, we want to load the issues belonging to three repositories.
+Instead of defining now three different issues resources, one for each of the paths `dlt-hub/dlt/issues/`, `dlt-hub/verified-sources/issues/`, `dlt-hub/dlthub-education/issues/`, we have a resource `repositories` which yields a list of repository names which will be fetched by the dependent resource `issues`.
+
+```py
+ @dlt.resource()
+    def repositories() -> Generator[List[Dict[str, Any]]]:
+        """A seed list of repositories to fetch"""
+        yield [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
+
+    config: RESTAPIConfig = {
+        "client": {"base_url": "https://github.com/api/v2"},
+        "resources": [
+            {
+                "name": "issues",
+                "endpoint": {
+                    "path": "dlt-hub/{repository}/issues/",
+                    "params": {
+                        "repository": {
+                            "type": "resolve",
+                            "resource": "repositories",
+                            "field": "name",
+                        },
+                    },
+                },
+            },
+            repositories(),
+        ],
+    }
+```
+
+Be careful that the parent resource needs to return `Generator[List[Dict[str, Any]]]`. Thus, the following will NOT work:
+
+```py
+ @dlt.resource()
+    def repositories() -> Generator[Dict[str, Any]]:
+        """Not working seed list of repositories to fetch"""
+        yield from [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
+```
+
+
 #### Include fields from the parent resource
 
 You can include data from the parent resource in the child resource by using the `include_from_parent` field in the resource configuration. For example:

--- a/tests/sources/rest_api/configurations/source_configs.py
+++ b/tests/sources/rest_api/configurations/source_configs.py
@@ -113,6 +113,12 @@ class CustomOAuthAuth(OAuth2AuthBase):
     pass
 
 
+@dlt.resource(name="repositories", selected=False)
+def repositories():
+    """A seed list of repositories to fetch"""
+    yield from [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
+
+
 VALID_CONFIGS: List[RESTAPIConfig] = [
     {
         "client": {"base_url": "https://api.example.com"},
@@ -310,19 +316,42 @@ VALID_CONFIGS: List[RESTAPIConfig] = [
         ],
     },
     {
-        "client": {
-            "base_url": "https://example.com",
-            "session": requests.Session(),
-        },
-        "resources": ["users"],
+        "client": {"base_url": "https://github.com/api/v2"},
+        "resources": [
+            {
+                "name": "issues",
+                "endpoint": {
+                    "path": "dlt-hub/{repository}/issues/",
+                    "params": {
+                        "repository": {
+                            "type": "resolve",
+                            "resource": "repositories",
+                            "field": "name",
+                        },
+                    },
+                },
+            },
+            repositories(),
+        ],
     },
     {
-        "client": {
-            "base_url": "https://example.com",
-            # This is a subclass of requests.Session and is thus also allowed
-            "session": dlt.sources.helpers.requests.Session(),
-        },
-        "resources": ["users"],
+        "client": {"base_url": "https://github.com/api/v2"},
+        "resources": [
+            {
+                "name": "issues",
+                "endpoint": {
+                    "path": "dlt-hub/{repository}/issues/",
+                    "params": {
+                        "repository": {
+                            "type": "resolve",
+                            "resource": "repositories",
+                            "field": "name",
+                        },
+                    },
+                },
+            },
+            repositories(),
+        ],
     },
 ]
 

--- a/tests/sources/rest_api/configurations/source_configs.py
+++ b/tests/sources/rest_api/configurations/source_configs.py
@@ -116,7 +116,7 @@ class CustomOAuthAuth(OAuth2AuthBase):
 @dlt.resource(name="repositories", selected=False)
 def repositories():
     """A seed list of repositories to fetch"""
-    yield from [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
+    yield [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
 
 
 VALID_CONFIGS: List[RESTAPIConfig] = [

--- a/tests/sources/rest_api/configurations/test_configuration.py
+++ b/tests/sources/rest_api/configurations/test_configuration.py
@@ -407,11 +407,7 @@ def test_accepts_DltResource_in_resources() -> None:
     @dlt.resource(selected=False)
     def repositories():
         """A seed list of repositories to fetch"""
-        yield from [
-            [{"name": "dlt"}],
-            [{"name": "verified-sources"}],
-            [{"name": "dlthub-education"}],
-        ]
+        yield [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
 
     config: RESTAPIConfig = {
         "client": {"base_url": "https://github.com/api/v2"},
@@ -442,11 +438,7 @@ def test_resource_defaults_dont_apply_to_DltResource() -> None:
     @dlt.resource()
     def repositories():
         """A seed list of repositories to fetch"""
-        yield from [
-            [{"name": "dlt"}],
-            [{"name": "verified-sources"}],
-            [{"name": "dlthub-education"}],
-        ]
+        yield [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
 
     config: RESTAPIConfig = {
         "client": {"base_url": "https://github.com/api/v2"},
@@ -473,4 +465,7 @@ def test_resource_defaults_dont_apply_to_DltResource() -> None:
 
     source = rest_api_source(config)
     assert source.resources["issues"].write_disposition == "replace"
-    assert source.resources["repositories"].write_disposition != "replace", "DltResource defined outside of RESTAPIConfig should not be influenced by RESTAPIConfig"
+    assert source.resources["repositories"].write_disposition != "replace", (
+        "DltResource defined outside of the RESTAPIConfig object is influenced by the content of"
+        " the RESTAPIConfig"
+    )

--- a/tests/sources/rest_api/configurations/test_configuration.py
+++ b/tests/sources/rest_api/configurations/test_configuration.py
@@ -401,3 +401,76 @@ def test_resource_defaults_no_params() -> None:
         "per_page": 50,
         "sort": "updated",
     }
+
+
+def test_accepts_DltResource_in_resources() -> None:
+    @dlt.resource(selected=False)
+    def repositories():
+        """A seed list of repositories to fetch"""
+        yield from [
+            [{"name": "dlt"}],
+            [{"name": "verified-sources"}],
+            [{"name": "dlthub-education"}],
+        ]
+
+    config: RESTAPIConfig = {
+        "client": {"base_url": "https://github.com/api/v2"},
+        "resources": [
+            {
+                "name": "issues",
+                "endpoint": {
+                    "path": "dlt-hub/{repository}/issues/",
+                    "params": {
+                        "repository": {
+                            "type": "resolve",
+                            "resource": "repositories",
+                            "field": "name",
+                        },
+                    },
+                },
+            },
+            repositories(),
+        ],
+    }
+
+    source = rest_api_source(config)
+    assert list(source.resources.keys()) == ["repositories", "issues"]
+    assert list(source.selected_resources.keys()) == ["issues"]
+
+
+def test_resource_defaults_dont_apply_to_DltResource() -> None:
+    @dlt.resource()
+    def repositories():
+        """A seed list of repositories to fetch"""
+        yield from [
+            [{"name": "dlt"}],
+            [{"name": "verified-sources"}],
+            [{"name": "dlthub-education"}],
+        ]
+
+    config: RESTAPIConfig = {
+        "client": {"base_url": "https://github.com/api/v2"},
+        "resource_defaults": {
+            "write_disposition": "replace",
+        },
+        "resources": [
+            {
+                "name": "issues",
+                "endpoint": {
+                    "path": "dlt-hub/{repository}/issues/",
+                    "params": {
+                        "repository": {
+                            "type": "resolve",
+                            "resource": "repositories",
+                            "field": "name",
+                        },
+                    },
+                },
+            },
+            repositories(),
+        ],
+    }
+
+    source = rest_api_source(config)
+    assert source.resources["issues"].write_disposition == "replace"
+    assert source.resources["repositories"].write_disposition != "replace", "DltResource defined outside of RESTAPIConfig should not be influenced by RESTAPIConfig"

--- a/tests/sources/rest_api/integration/test_offline.py
+++ b/tests/sources/rest_api/integration/test_offline.py
@@ -358,3 +358,41 @@ def test_multiple_response_actions_on_every_response(mock_api_server, mocker):
 
     mocked_send.assert_called_once()
     assert mocked_send.call_args[0][0].url == "https://api.example.com/posts"
+
+
+def test_DltResource_gets_called(mock_api_server, mocker) -> None:
+    @dlt.resource()
+    def post_list():
+        yield from [[{"id": "0"}], [{"id": "1"}], [{"id": "2"}]]
+
+    config: RESTAPIConfig = {
+        "client": {"base_url": "http://api.example.com/"},
+        "resource_defaults": {
+            "write_disposition": "replace",
+        },
+        "resources": [
+            {
+                "name": "posts",
+                "endpoint": {
+                    "path": "posts/{post_id}/comments",
+                    "params": {
+                        "post_id": {
+                            "type": "resolve",
+                            "resource": "post_list",
+                            "field": "id",
+                        },
+                    },
+                },
+            },
+            post_list(),
+        ],
+    }
+
+    RESTClient = dlt.sources.helpers.rest_client.RESTClient
+    with mock.patch.object(RESTClient, "paginate") as mock_paginate:
+        source = rest_api_source(config)
+        _ = list(source)
+        assert mock_paginate.call_count == 3
+        for i in range(3):
+            _, kwargs = mock_paginate.call_args_list[i]
+            assert kwargs["path"] == f"posts/{i}/comments"

--- a/tests/sources/rest_api/integration/test_offline.py
+++ b/tests/sources/rest_api/integration/test_offline.py
@@ -363,7 +363,7 @@ def test_multiple_response_actions_on_every_response(mock_api_server, mocker):
 def test_DltResource_gets_called(mock_api_server, mocker) -> None:
     @dlt.resource()
     def post_list():
-        yield from [[{"id": "0"}], [{"id": "1"}], [{"id": "2"}]]
+        yield [{"id": "0"}, {"id": "1"}, {"id": "2"}]
 
     config: RESTAPIConfig = {
         "client": {"base_url": "http://api.example.com/"},


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

### Related Issues

- Resolves #1837 

### TODO before merging

- [x] write documentation
- [ ] discuss: some kind of error message in case people implement a resource returning `Generator[dict[str, Any]]` instead of `Generator[list[dict[str, Any]]]? Or is documentation enough?

Crashes: process_parent_data_item because `item` is a `str` instead of `Dict[str, Any]`:
```py
 def repositories():
        """A seed list of repositories to fetch"""
        yield from [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
```

Correct: 
```py
 def repositories():
        """A seed list of repositories to fetch"""
        yield [{"name": "dlt"}, {"name": "verified-sources"}, {"name": "dlthub-education"}]
```

Also correct: 
```py
def repositories():
    """A seed list of repositories to fetch"""
    yield [
        [{"name": "dlt"}],
        [{"name": "verified-sources"}],
        [{"name": "dlthub-education"}],
    ]
```
