### PR TITLE
logs warning if deduplication state is large

### DIFF
--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -532,10 +532,11 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
             # add directly computed hashes
             unique_hashes.update(transformer.unique_hashes)
             self._cached_state["unique_hashes"] = list(unique_hashes)
+            dedup_count = len(self._cached_state["unique_hashes"])
             DEDUP_WARNING_THRESHOLD = 200
-            if len(self._cached_state["unique_hashes"]) > 200:
+            if dedup_count > DEDUP_WARNING_THRESHOLD:
                 logger.warning(
-                    f"There are over {DEDUP_WARNING_THRESHOLD} records to be deduplicated because"
+                    f"There are {dedup_count} records to be deduplicated because"
                     f" they share the same primary key `{self.primary_key}`."
                 )
         return rows

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -532,7 +532,12 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
             # add directly computed hashes
             unique_hashes.update(transformer.unique_hashes)
             self._cached_state["unique_hashes"] = list(unique_hashes)
-
+            DEDUP_WARNING_THRESHOLD = 200
+            if len(self._cached_state["unique_hashes"]) > 200:
+                logger.warning(
+                    f"There are over {DEDUP_WARNING_THRESHOLD} records to be deduplicated because"
+                    f" they share the same primary key `{self.primary_key}`."
+                )
         return rows
 
 

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -118,6 +118,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
     EMPTY: ClassVar["Incremental[Any]"] = None
     placement_affinity: ClassVar[float] = 1  # stick to end
 
+    DEFAULT_DUPLICATE_CURSOR_WARNING_THRESHOLD: ClassVar[int] = 200
+
     def __init__(
         self,
         cursor_path: str = None,
@@ -129,6 +131,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         allow_external_schedulers: bool = False,
         on_cursor_value_missing: OnCursorValueMissing = "raise",
         lag: Optional[float] = None,
+        duplicate_cursor_warning_threshold: Optional[int] = None,
     ) -> None:
         # make sure that path is valid
         if cursor_path:
@@ -164,6 +167,12 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         self._transformers: Dict[str, IncrementalTransform] = {}
         self._bound_pipe: SupportsPipe = None
         """Bound pipe"""
+
+        self.duplicate_cursor_warning_threshold = (
+            duplicate_cursor_warning_threshold
+            if duplicate_cursor_warning_threshold is not None
+            else self.DEFAULT_DUPLICATE_CURSOR_WARNING_THRESHOLD
+        )
 
     @property
     def primary_key(self) -> Optional[TTableHintTemplate[TColumnNames]]:
@@ -529,17 +538,27 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
                 transformer.compute_unique_value(row, self.primary_key)
                 for row in transformer.last_rows
             )
+            initial_hash_count = len(self._cached_state.get("unique_hashes", []))
             # add directly computed hashes
             unique_hashes.update(transformer.unique_hashes)
             self._cached_state["unique_hashes"] = list(unique_hashes)
-            dedup_count = len(self._cached_state["unique_hashes"])
-            DEDUP_WARNING_THRESHOLD = 200
-            if dedup_count > DEDUP_WARNING_THRESHOLD:
-                logger.warning(
-                    f"There are {dedup_count} records to be deduplicated because"
-                    f" they share the same primary key `{self.primary_key}`."
-                )
+            final_hash_count = len(self._cached_state["unique_hashes"])
+
+            self._check_duplicate_cursor_threshold(initial_hash_count, final_hash_count)
         return rows
+
+    def _check_duplicate_cursor_threshold(
+        self, initial_hash_count: int, final_hash_count: int
+    ) -> None:
+        if initial_hash_count <= self.duplicate_cursor_warning_threshold < final_hash_count:
+            logger.warning(
+                f"Large number of records ({final_hash_count}) sharing the same value of "
+                f"cursor field '{self.cursor_path}'. This can happen if the cursor "
+                "field has a low resolution (e.g., only stores dates without times), "
+                "causing many records to share the same cursor value. "
+                "Consider using a cursor column with higher resolution to reduce "
+                "the deduplication state size."
+            )
 
 
 Incremental.EMPTY = Incremental[Any]()

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -3541,7 +3541,7 @@ def test_apply_lag() -> None:
     assert apply_lag(2, 2, 1, min) == 2
 
 
-@pytest.mark.parametrize("item_type", ["object"])
+@pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
 @pytest.mark.parametrize("primary_key", ["id", None])
 def test_warning_large_deduplication_state(item_type: TestDataItemFormat, primary_key, mocker):
     @dlt.resource(primary_key=primary_key)
@@ -3556,7 +3556,7 @@ def test_warning_large_deduplication_state(item_type: TestDataItemFormat, primar
     logger_spy = mocker.spy(dlt.common.logger, "warning")
     p = dlt.pipeline(pipeline_name=uniq_id())
     p.extract(some_data(1))
-    logger_spy.assert_called_once_with(
+    logger_spy.assert_any_call(
         "There are over 200 records to be deduplicated because they share the same primary key"
         f" `{primary_key}`."
     )

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -3557,6 +3557,6 @@ def test_warning_large_deduplication_state(item_type: TestDataItemFormat, primar
     p = dlt.pipeline(pipeline_name=uniq_id())
     p.extract(some_data(1))
     logger_spy.assert_any_call(
-        "There are over 200 records to be deduplicated because they share the same primary key"
+        "There are 201 records to be deduplicated because they share the same primary key"
         f" `{primary_key}`."
     )


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

As a first step towards resolving this issue: warns if the deduplication state grows over a large count of hashes of the primary key.

### Related Issues

[#1131 ](https://github.com/dlt-hub/dlt/issues/1131)

