### PR TITLE
Fix config sections for synching destinations and accessing destination clients

### DIFF
--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -678,7 +678,7 @@ class Pipeline(SupportsPipeline):
             and not self._state_restored
             and (self.destination or destination)
         ):
-            self.sync_destination(destination, staging, dataset_name)
+            self._sync_destination(destination, staging, dataset_name)
             # sync only once
             self._state_restored = True
         # normalize and load pending data
@@ -712,7 +712,7 @@ class Pipeline(SupportsPipeline):
         else:
             return None
 
-    @with_schemas_sync
+    @with_config_section(())
     def sync_destination(
         self,
         destination: TDestinationReferenceArg = None,
@@ -730,6 +730,17 @@ class Pipeline(SupportsPipeline):
         Note: this method is executed by the `run` method before any operation on data. Use `restore_from_destination` configuration option to disable that behavior.
 
         """
+        return self._sync_destination(
+            destination=destination, staging=staging, dataset_name=dataset_name
+        )
+
+    @with_schemas_sync
+    def _sync_destination(
+        self,
+        destination: TDestinationReferenceArg = None,
+        staging: TDestinationReferenceArg = None,
+        dataset_name: str = None,
+    ) -> None:
         self._set_destinations(destination=destination, staging=staging)
         self._set_dataset_name(dataset_name)
 

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -969,6 +969,7 @@ class Pipeline(SupportsPipeline):
             state = self._get_state()
         return state["_local"][key]  # type: ignore
 
+    @with_config_section(())
     def sql_client(self, schema_name: str = None) -> SqlClientBase[Any]:
         """Returns a sql client configured to query/change the destination and dataset that were used to load the data.
         Use the client with `with` statement to manage opening and closing connection to the destination:
@@ -1008,6 +1009,7 @@ class Pipeline(SupportsPipeline):
             return client
         raise FSClientNotAvailable(self.pipeline_name, self.destination.destination_name)
 
+    @with_config_section(())
     def destination_client(self, schema_name: str = None) -> JobClientBase:
         """Get the destination job client for the configured destination
         Use the client with `with` statement to manage opening and closing connection to the destination:

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -257,13 +257,17 @@ def with_runtime_trace(send_state: bool = False) -> Callable[[TFun], TFun]:
     return decorator
 
 
-def with_config_section(sections: Tuple[str, ...]) -> Callable[[TFun], TFun]:
+def with_config_section(
+    sections: Tuple[str, ...], merge_func: ConfigSectionContext.TMergeFunc = None
+) -> Callable[[TFun], TFun]:
     def decorator(f: TFun) -> TFun:
         @wraps(f)
         def _wrap(self: "Pipeline", *args: Any, **kwargs: Any) -> Any:
             # add section context to the container to be used by all configuration without explicit sections resolution
             with inject_section(
-                ConfigSectionContext(pipeline_name=self.pipeline_name, sections=sections)
+                ConfigSectionContext(
+                    pipeline_name=self.pipeline_name, sections=sections, merge_style=merge_func
+                )
             ):
                 return f(self, *args, **kwargs)
 
@@ -712,7 +716,7 @@ class Pipeline(SupportsPipeline):
         else:
             return None
 
-    @with_config_section(())
+    @with_config_section(sections=None, merge_func=ConfigSectionContext.prefer_existing)
     def sync_destination(
         self,
         destination: TDestinationReferenceArg = None,
@@ -980,7 +984,7 @@ class Pipeline(SupportsPipeline):
             state = self._get_state()
         return state["_local"][key]  # type: ignore
 
-    @with_config_section(())
+    @with_config_section(sections=None, merge_func=ConfigSectionContext.prefer_existing)
     def sql_client(self, schema_name: str = None) -> SqlClientBase[Any]:
         """Returns a sql client configured to query/change the destination and dataset that were used to load the data.
         Use the client with `with` statement to manage opening and closing connection to the destination:
@@ -1020,7 +1024,7 @@ class Pipeline(SupportsPipeline):
             return client
         raise FSClientNotAvailable(self.pipeline_name, self.destination.destination_name)
 
-    @with_config_section(())
+    @with_config_section(sections=None, merge_func=ConfigSectionContext.prefer_existing)
     def destination_client(self, schema_name: str = None) -> JobClientBase:
         """Get the destination job client for the configured destination
         Use the client with `with` statement to manage opening and closing connection to the destination:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Resolving of destination credentials was missing the pipeline name section when access the destination_client of a pipeline. This PR fixes this.

Ticket: https://github.com/dlt-hub/dlt/issues/1886