### PR TITLE
Added troubleshooting section to filesystem docs

### DIFF
--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -719,9 +719,9 @@ pipeline = dlt.pipeline(
 )
 ```
 
-**Notes**
+:::note
 - `max_identifier_length` truncates all identifiers (tables, columns). Ensure the length maintains uniqueness to avoid collisions.
-
 - Adjust `max_identifier_length` based on your data structure and filesystem limits.
+:::
 
 <!--@@@DLT_TUBA filesystem-->

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -700,7 +700,7 @@ You will also notice `init` files being present in the root folder and the speci
 **Note:** When a load generates a new state, for example when using incremental loads, a new state file appears in the `_dlt_pipeline_state` folder at the destination. To prevent data accumulation, state cleanup mechanisms automatically remove old state files, retaining only the latest 100 by default. This cleanup process can be customized or disabled using the filesystem configuration `max_state_files`, which determines the maximum number of pipeline state files to retain (default is 100). Setting this value to 0 or a negative number disables the cleanup of old states.
 
 ## Troubleshooting
-When running your pipeline, you might encounter an error like `[Errno 36] File name too long Error`. This error occurs because the generated filename exceeds the maximum allowed length on your filesystem.
+When running your pipeline, you might encounter an error like `[Errno 36] File name too long Error`. This error occurs because the generated file name exceeds the maximum allowed length on your filesystem.
 
 ### Solution
 To prevent this, you can set the `max_identifier_length` parameter for your destination. This truncates all identifiers (including filenames) to a specified maximum length.

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -697,7 +697,9 @@ This destination fully supports [dlt state sync](../../general-usage/state#synci
 
 You will also notice `init` files being present in the root folder and the special `dlt` folders. In the absence of the concepts of schemas and tables in blob storages and directories, `dlt` uses these special files to harmonize the behavior of the `filesystem` destination with the other implemented destinations.
 
-**Note:** When a load generates a new state, for example when using incremental loads, a new state file appears in the `_dlt_pipeline_state` folder at the destination. To prevent data accumulation, state cleanup mechanisms automatically remove old state files, retaining only the latest 100 by default. This cleanup process can be customized or disabled using the filesystem configuration `max_state_files`, which determines the maximum number of pipeline state files to retain (default is 100). Setting this value to 0 or a negative number disables the cleanup of old states.
+:::note
+When a load generates a new state, for example when using incremental loads, a new state file appears in the `_dlt_pipeline_state` folder at the destination. To prevent data accumulation, state cleanup mechanisms automatically remove old state files, retaining only the latest 100 by default. This cleanup process can be customized or disabled using the filesystem configuration `max_state_files`, which determines the maximum number of pipeline state files to retain (default is 100). Setting this value to 0 or a negative number disables the cleanup of old states.
+:::
 
 ## Troubleshooting
 When running your pipeline, you might encounter an error like `[Errno 36] File name too long Error`. This error occurs because the generated file name exceeds the maximum allowed length on your filesystem.

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -703,7 +703,7 @@ You will also notice `init` files being present in the root folder and the speci
 When running your pipeline, you might encounter an error like `[Errno 36] File name too long Error`. This error occurs because the generated file name exceeds the maximum allowed length on your filesystem.
 
 ### Solution
-To prevent this, you can set the `max_identifier_length` parameter for your destination. This truncates all identifiers (including filenames) to a specified maximum length.
+To prevent the file name length error, set the `max_identifier_length` parameter for your destination. This truncates all identifiers (including filenames) to a specified maximum length.
 For example: 
 
 ```py

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -699,4 +699,27 @@ You will also notice `init` files being present in the root folder and the speci
 
 **Note:** When a load generates a new state, for example when using incremental loads, a new state file appears in the `_dlt_pipeline_state` folder at the destination. To prevent data accumulation, state cleanup mechanisms automatically remove old state files, retaining only the latest 100 by default. This cleanup process can be customized or disabled using the filesystem configuration `max_state_files`, which determines the maximum number of pipeline state files to retain (default is 100). Setting this value to 0 or a negative number disables the cleanup of old states.
 
+## Troubleshooting
+When running your pipeline, you might encounter an error like `[Errno 36] File name too long Error`. This error occurs because the generated filename exceeds the maximum allowed length on your filesystem.
+
+### Solution
+To prevent this, you can set the `max_identifier_length` parameter for your destination. This truncates all identifiers (including filenames) to a specified maximum length.
+For example: 
+
+```py
+from dlt.destinations import duckdb
+
+pipeline = dlt.pipeline(
+    pipeline_name="your_pipeline_name",
+    destination=duckdb(
+        max_identifier_length=200,  # Adjust the length as needed
+    ),
+)
+```
+
+**Notes**
+- `max_identifier_length` truncates all identifiers (tables, columns). Ensure the length maintains uniqueness to avoid collisions.
+
+- Adjust `max_identifier_length` based on your data structure and filesystem limits.
+
 <!--@@@DLT_TUBA filesystem-->

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -702,9 +702,9 @@ When a load generates a new state, for example when using incremental loads, a n
 :::
 
 ## Troubleshooting
+### File Name Too Long Error
 When running your pipeline, you might encounter an error like `[Errno 36] File name too long Error`. This error occurs because the generated file name exceeds the maximum allowed length on your filesystem.
 
-### Solution
 To prevent the file name length error, set the `max_identifier_length` parameter for your destination. This truncates all identifiers (including filenames) to a specified maximum length.
 For example: 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Issue:
Running dlt with deeply nested resources results in [Errno 36] File name too long errors due to long intermediate filenames.

Cause:
Long identifiers from nested data structures exceed the filesystem's maximum filename length.

Workaround:
Set max_identifier_length=200 in the destination configuration to truncate identifiers and prevent filename length issues.

FIx:
Added info to the "Troubleshooting" section of the docs. 

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Closes #1697 


