### PR TITLE
Add engine_adapter_callback

### DIFF
--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -37,6 +37,7 @@ from dlt.common.libs.sql_alchemy import Engine, CompileError, create_engine
 
 TableBackend = Literal["sqlalchemy", "pyarrow", "pandas", "connectorx"]
 TQueryAdapter = Callable[[SelectAny, Table], SelectAny]
+TEngineAdapter = Callable[[Engine], Engine]
 
 
 class TableLoader:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

- Adds `engine_adapter_callback` that is executed after the SQLAlchemy engine is constructed
- This allows developers to apply any arbitrary statements before subsequent queries are issued
- In particular, I want to be able to run `SET workload = "olap";` to connect to a Planetscale DB without bumping into[ 100k rows returned system limits](https://planetscale.com/docs/reference/planetscale-system-limits#query-limits).

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
