### PR TITLE
Added extended jsonpath_ng parser

### DIFF
--- a/dlt/common/jsonpath.py
+++ b/dlt/common/jsonpath.py
@@ -3,8 +3,8 @@ from itertools import chain
 
 from dlt.common.typing import DictStrAny
 
-from jsonpath_ng import parse as _parse, JSONPath, Fields as JSONPathFields
-
+from jsonpath_ng import JSONPath, Fields as JSONPathFields
+from jsonpath_ng.ext import parse as _parse
 
 TJsonPath = Union[str, JSONPath]  # Jsonpath compiled or str
 TAnyJsonPath = Union[TJsonPath, Iterable[TJsonPath]]  # A single or multiple jsonpaths


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR introduce the `jsonpath_ng` extended parser, which is more compliant with the JsonPath standard.

An example of the lack of features of the standard parser is here: [Filters not implmented](https://github.com/h2non/jsonpath-ng/issues/8)

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

<!--
Provide any additional context about the PR here.
-->
### Additional Context
This was discussed in the slack community [here](https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1728335837644989).

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
