### PR TITLE
SQL Database: Support including/excluding NULL cursor values

### DIFF
--- a/tests/load/sources/sql_database/test_helpers.py
+++ b/tests/load/sources/sql_database/test_helpers.py
@@ -1,5 +1,7 @@
 import pytest
 
+import sqlalchemy as sa
+
 import dlt
 from dlt.common.typing import TDataItem
 
@@ -42,6 +44,7 @@ def test_make_query_incremental_max(
         cursor_path = "created_at"
         row_order = "asc"
         end_value = None
+        on_cursor_value_missing = "raise"
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -72,6 +75,7 @@ def test_make_query_incremental_min(
         cursor_path = "created_at"
         row_order = "desc"
         end_value = None
+        on_cursor_value_missing = "raise"
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -93,17 +97,17 @@ def test_make_query_incremental_min(
 
 
 @pytest.mark.parametrize("backend", ["sqlalchemy", "pyarrow", "pandas", "connectorx"])
-def test_make_query_incremental_end_value(
-    sql_source_db: SQLAlchemySourceDB, backend: TableBackend
+@pytest.mark.parametrize("with_end_value", [True, False])
+def test_make_query_incremental_include_none(
+    sql_source_db: SQLAlchemySourceDB, backend: TableBackend, with_end_value: bool
 ) -> None:
-    now = dlt.common.pendulum.now()
-
     class MockIncremental:
-        last_value = now
-        last_value_func = min
+        last_value = dlt.common.pendulum.now()
+        last_value_func = max
         cursor_path = "created_at"
-        end_value = now.add(hours=1)
-        row_order = None
+        row_order = "asc"
+        end_value = None if not with_end_value else dlt.common.pendulum.now().add(hours=1)
+        on_cursor_value_missing = "include"
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -115,10 +119,52 @@ def test_make_query_incremental_end_value(
     )
 
     query = loader.make_query()
-    expected = (
-        table.select()
-        .where(table.c.created_at <= MockIncremental.last_value)
-        .where(table.c.created_at > MockIncremental.end_value)
+    if with_end_value:
+        where_clause = sa.or_(
+            sa.and_(
+                table.c.created_at >= MockIncremental.last_value,
+                table.c.created_at < MockIncremental.end_value,
+            ),
+            table.c.created_at.is_(None),
+        )
+    else:
+        where_clause = sa.or_(
+            table.c.created_at >= MockIncremental.last_value,
+            table.c.created_at.is_(None),
+        )
+    expected = table.select().order_by(table.c.created_at.asc()).where(where_clause)
+    assert query.compare(expected)
+
+
+@pytest.mark.parametrize("backend", ["sqlalchemy", "pyarrow", "pandas", "connectorx"])
+def test_make_query_incremental_end_value(
+    sql_source_db: SQLAlchemySourceDB, backend: TableBackend
+) -> None:
+    now = dlt.common.pendulum.now()
+
+    class MockIncremental:
+        last_value = now
+        last_value_func = min
+        cursor_path = "created_at"
+        end_value = now.add(hours=1)
+        row_order = None
+        on_cursor_value_missing = "raise"
+
+    table = sql_source_db.get_table("chat_message")
+    loader = TableLoader(
+        sql_source_db.engine,
+        backend,
+        table,
+        table_to_columns(table),
+        incremental=MockIncremental(),  # type: ignore[arg-type]
+    )
+
+    query = loader.make_query()
+    expected = table.select().where(
+        sa.and_(
+            table.c.created_at <= MockIncremental.last_value,
+            table.c.created_at > MockIncremental.end_value,
+        )
     )
 
     assert query.compare(expected)
@@ -134,6 +180,7 @@ def test_make_query_incremental_any_fun(
         cursor_path = "created_at"
         row_order = "asc"
         end_value = dlt.common.pendulum.now()
+        on_cursor_value_missing = "raise"
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(

--- a/tests/load/sources/sql_database/test_helpers.py
+++ b/tests/load/sources/sql_database/test_helpers.py
@@ -1,6 +1,5 @@
 import pytest
 
-import sqlalchemy as sa
 
 import dlt
 from dlt.common.typing import TDataItem
@@ -12,7 +11,8 @@ try:
     from dlt.sources.sql_database.helpers import TableLoader, TableBackend
     from dlt.sources.sql_database.schema_types import table_to_columns
     from tests.load.sources.sql_database.sql_source import SQLAlchemySourceDB
-except MissingDependencyException:
+    import sqlalchemy as sa
+except (MissingDependencyException, ModuleNotFoundError):
     pytest.skip("Tests require sql alchemy", allow_module_level=True)
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Respect the `on_cursor_value_missing` incremental setting in sqlalchemy source.
Generating WHERE clause equvialent to:

```sql
-- include None
WHERE cursor_col >= :last_value OR cursor_col IS NULL

-- exclude None
WHERE cursor_col >= :last_value AND cursor_col IS NOT NULL
```
I'm not sure if the `exclude` case needs to be handled but thought I'd include explicitly anyway in case any databases interpret `>= NULL` differently.



<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #1935 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
