### PR TITLE
Add open/closed range arguments for incremental

### DIFF
--- a/dlt/common/incremental/typing.py
+++ b/dlt/common/incremental/typing.py
@@ -28,3 +28,5 @@ class IncrementalArgs(TypedDict, total=False):
     allow_external_schedulers: Optional[bool]
     lag: Optional[Union[float, int]]
     on_cursor_value_missing: Optional[OnCursorValueMissing]
+    range_start: Optional[TIncrementalRange]
+    range_end: Optional[TIncrementalRange]

--- a/dlt/common/incremental/typing.py
+++ b/dlt/common/incremental/typing.py
@@ -8,6 +8,8 @@ TCursorValue = TypeVar("TCursorValue", bound=Any)
 LastValueFunc = Callable[[Sequence[TCursorValue]], Any]
 OnCursorValueMissing = Literal["raise", "include", "exclude"]
 
+TIncrementalRange = Literal["open", "closed"]
+
 
 class IncrementalColumnState(TypedDict):
     initial_value: Optional[Any]

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -105,6 +105,11 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
             Note that if logical "end date" is present then also "end_value" will be set which means that resource state is not used and exactly this range of date will be loaded
         on_cursor_value_missing: Specify what happens when the cursor_path does not exist in a record or a record has `None` at the cursor_path: raise, include, exclude
         lag: Optional value used to define a lag or attribution window. For datetime cursors, this is interpreted as seconds. For other types, it uses the + or - operator depending on the last_value_func.
+        range_start: Decide whether the incremental filtering range is `open` or `closed` on the start value side. Default is `closed`.
+            Setting this to `open` means that items with the same cursor value as the last value from the previous run (or `initial_value`) are excluded from the result.
+            The `open` range disables deduplication logic so it can serve as an optimization when you know cursors don't overlap between pipeline runs.
+        range_end: Decide whether the incremental filtering range is `open` or `closed` on the end value side. Default is `open` (exact `end_value` is excluded).
+            Setting this to `closed` means that items with the exact same cursor value as the `end_value` are included in the result.
     """
 
     # this is config/dataclass so declare members

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -517,7 +517,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
             f" {self.last_value_func}"
         )
 
-    def _make_transformer(self, cls: Type[IncrementalTransform]) -> IncrementalTransform:
+    def _make_or_get_transformer(self, cls: Type[IncrementalTransform]) -> IncrementalTransform:
         if transformer := self._transformers.get(cls):
             return transformer
         transformer = self._transformers[cls] = cls(
@@ -540,11 +540,11 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         # Assume list is all of the same type
         for item in items if isinstance(items, list) else [items]:
             if is_arrow_item(item):
-                return self._make_transformer(ArrowIncremental)
+                return self._make_or_get_transformer(ArrowIncremental)
             elif pandas is not None and isinstance(item, pandas.DataFrame):
-                return self._make_transformer(ArrowIncremental)
-            return self._make_transformer(JsonIncremental)
-        return self._make_transformer(JsonIncremental)
+                return self._make_or_get_transformer(ArrowIncremental)
+            return self._make_or_get_transformer(JsonIncremental)
+        return self._make_or_get_transformer(JsonIncremental)
 
     def __call__(self, rows: TDataItems, meta: Any = None) -> Optional[TDataItems]:
         if rows is None:

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -42,6 +42,7 @@ from dlt.common.incremental.typing import (
     LastValueFunc,
     OnCursorValueMissing,
     IncrementalArgs,
+    TIncrementalRange,
 )
 from dlt.extract.items import SupportsPipe, TTableHintTemplate, ItemTransform
 from dlt.extract.incremental.transform import (
@@ -116,6 +117,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
     on_cursor_value_missing: OnCursorValueMissing = "raise"
     lag: Optional[float] = None
     duplicate_cursor_warning_threshold: ClassVar[int] = 200
+    range_start: TIncrementalRange = "closed"
+    range_end: TIncrementalRange = "open"
 
     # incremental acting as empty
     EMPTY: ClassVar["Incremental[Any]"] = None
@@ -132,6 +135,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         allow_external_schedulers: bool = False,
         on_cursor_value_missing: OnCursorValueMissing = "raise",
         lag: Optional[float] = None,
+        range_start: TIncrementalRange = "closed",
+        range_end: TIncrementalRange = "open",
     ) -> None:
         # make sure that path is valid
         if cursor_path:
@@ -177,6 +182,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         self._transformers: Dict[str, IncrementalTransform] = {}
         self._bound_pipe: SupportsPipe = None
         """Bound pipe"""
+        self.range_start = range_start
+        self.range_end = range_end
 
     @property
     def primary_key(self) -> Optional[TTableHintTemplate[TColumnNames]]:
@@ -204,6 +211,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
                 set(self._cached_state["unique_hashes"]),
                 self.on_cursor_value_missing,
                 self.lag,
+                self.range_start,
+                self.range_end,
             )
 
     @classmethod

--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -117,6 +117,8 @@ class IncrementalTransform:
     def deduplication_disabled(self) -> bool:
         """Skip deduplication when length of the key is 0 or if lag is applied."""
         # disable deduplication if end value is set - state is not saved
+        if self.range_start == "open":
+            return True
         if self.end_value is not None:
             return True
         # disable deduplication if lag is applied - destination must deduplicate ranges
@@ -232,6 +234,7 @@ class JsonIncremental(IncrementalTransform):
         # new_value is "less" or equal to last_value (the actual max)
         if last_value == new_value:
             if self.range_start == "open":
+                # We only want greater than last_value
                 return None, False, False
             # use func to compute row_value into last_value compatible
             processed_row_value = last_value_func((row_value,))

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -94,12 +94,16 @@ class TableLoader:
             self.end_value = incremental.end_value
             self.row_order: TSortOrder = self.incremental.row_order
             self.on_cursor_value_missing = self.incremental.on_cursor_value_missing
+            self.range_start = self.incremental.range_start
+            self.range_end = self.incremental.range_end
         else:
             self.cursor_column = None
             self.last_value = None
             self.end_value = None
             self.row_order = None
             self.on_cursor_value_missing = None
+            self.range_start = None
+            self.range_end = None
 
     def _make_query(self) -> SelectAny:
         table = self.table
@@ -110,11 +114,11 @@ class TableLoader:
 
         # generate where
         if last_value_func is max:  # Query ordered and filtered according to last_value function
-            filter_op = operator.ge
-            filter_op_end = operator.lt
+            filter_op = operator.ge if self.range_start == "closed" else operator.gt
+            filter_op_end = operator.lt if self.range_end == "open" else operator.le
         elif last_value_func is min:
-            filter_op = operator.le
-            filter_op_end = operator.gt
+            filter_op = operator.le if self.range_start == "closed" else operator.lt
+            filter_op_end = operator.gt if self.range_end == "open" else operator.ge
         else:  # Custom last_value, load everything and let incremental handle filtering
             return query  # type: ignore[no-any-return]
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
@@ -98,7 +98,7 @@ This ensures there are no gaps in the extracted sequence. But it does come with 
 both due to the deduplication processing and the cost of fetching redundant records from the database.
 
 This is not always needed. If you know that your data does not contain overlapping cursor values then you
-can optimize extraction by passing `start_range="open"` to incremental.
+can optimize extraction by passing `range_start="open"` to incremental.
 
 This both disables the deduplication process and changes the operator used in the SQL `WHERE` clause from `>=` (greater-or-equal) to `>` (greater than), so that no overlapping rows are fetched.
 
@@ -110,7 +110,7 @@ table = sql_table(
     incremental=dlt.sources.incremental(
         'last_modified',  # Cursor column name
         initial_value=pendulum.DateTime(2024, 1, 1, 0, 0, 0),  # Initial cursor value
-        start_range="open",  # exclude the start value
+        range_start="open",  # exclude the start value
     )
 )
 ```

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
@@ -16,7 +16,7 @@ Efficient data management often requires loading only new or updated data from y
 
 Incremental loading uses a cursor column (e.g., timestamp or auto-incrementing ID) to load only data newer than a specified initial value, enhancing efficiency by reducing processing time and resource use. Read [here](../../../walkthroughs/sql-incremental-configuration) for more details on incremental loading with `dlt`.
 
-#### How to configure
+### How to configure
 1. **Choose a cursor column**: Identify a column in your SQL table that can serve as a reliable indicator of new or updated rows. Common choices include timestamp columns or auto-incrementing IDs.
 1. **Set an initial value**: Choose a starting value for the cursor to begin loading data. This could be a specific timestamp or ID from which you wish to start loading data.
 1. **Deduplication**: When using incremental loading, the system automatically handles the deduplication of rows based on the primary key (if available) or row hash for tables without a primary key.
@@ -27,7 +27,7 @@ Incremental loading uses a cursor column (e.g., timestamp or auto-incrementing I
 If your cursor column name contains special characters (e.g., `$`) you need to escape it when passing it to the `incremental` function. For example, if your cursor column is `example_$column`, you should pass it as `"'example_$column'"` or `'"example_$column"'` to the `incremental` function: `incremental("'example_$column'", initial_value=...)`.
 :::
 
-#### Examples
+### Examples
 
 1. **Incremental loading with the resource `sql_table`**.
 
@@ -52,7 +52,7 @@ If your cursor column name contains special characters (e.g., `$`) you need to e
   print(extract_info)
   ```
 
-  Behind the scene, the loader generates a SQL query filtering rows with `last_modified` values greater than the incremental value. In the first run, this is the initial value (midnight (00:00:00) January 1, 2024).
+  Behind the scene, the loader generates a SQL query filtering rows with `last_modified` values greater or equal to the incremental value. In the first run, this is the initial value (midnight (00:00:00) January 1, 2024).
   In subsequent runs, it is the latest value of `last_modified` that `dlt` stores in [state](../../../general-usage/state).
 
 2. **Incremental loading with the source `sql_database`**.
@@ -77,6 +77,49 @@ If your cursor column name contains special characters (e.g., `$`) you need to e
     * When using "merge" write disposition, the source table needs a primary key, which `dlt` automatically sets up.
     * `apply_hints` is a powerful method that enables schema modifications after resource creation, like adjusting write disposition and primary keys. You can choose from various tables and use `apply_hints` multiple times to create pipelines with merged, appended, or replaced resources.
   :::
+
+### Inclusive and exclusive filtering
+
+By default the incremental filtering is inclusive on the start value side so that
+rows with cursor equal to the last run's cursor are fetched again from the database.
+
+The SQL query generated looks something like this (assuming `last_value_func` is `max`):
+
+```sql
+SELECT * FROM family
+WHERE last_modified >= :start_value
+ORDER BY last_modified ASC
+```
+
+That means some rows overlapping with the previous load are fetched from the database.
+Duplicates are then filtered out by dlt using either the primary key or a hash of the row's contents.
+
+This ensures there are no gaps in the extracted sequence. But it does come with some performance overhead,
+both due to the deduplication processing and the cost of fetching redundant records from the database.
+
+This is not always needed. If you know that your data does not contain overlapping cursor values then you
+can optimize extraction by passing `start_range="open"` to incremental.
+
+This both disables the deduplication process and changes the operator used in the SQL `WHERE` clause from `>=` (greater-or-equal) to `>` (greater than), so that no overlapping rows are fetched.
+
+E.g.
+
+```py
+table = sql_table(
+    table='family',
+    incremental=dlt.sources.incremental(
+        'last_modified',  # Cursor column name
+        initial_value=pendulum.DateTime(2024, 1, 1, 0, 0, 0),  # Initial cursor value
+        start_range="open",  # exclude the start value
+    )
+)
+```
+
+It's a good option if:
+
+* The cursor is an auto incrementing ID
+* The cursor is a high precision timestamp and two records are never created at exactly the same time
+* Your pipeline runs are timed in such a way that new data is not generated during the load
 
 ## Parallelized extraction
 

--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -693,7 +693,7 @@ august_issues = repo_issues(
 ...
 ```
 
-Note that dlt's incremental filtering considers the ranges half-closed. `initial_value` is inclusive, `end_value` is exclusive, so chaining ranges like above works without overlaps.
+Note that dlt's incremental filtering considers the ranges half-closed. `initial_value` is inclusive, `end_value` is exclusive, so chaining ranges like above works without overlaps. This behaviour can be changed with the `start_range` (default `"closed"`) and `end_range` (default `"open"`) arguments.
 
 ### Declare row order to not request unnecessary data
 
@@ -792,6 +792,9 @@ def some_data(last_timestamp=dlt.sources.incremental("item.ts", primary_key=()))
     for i in range(-10, 10):
         yield {"delta": i, "item": {"ts": pendulum.now().timestamp()}}
 ```
+
+This deduplication process is always enabled when `start_range` is set to `"closed"` (default).
+When you pass `start_range="open"` no deduplication is done as it is not needed as rows with the previous cursor value are excluded. This can be a useful optimization to avoid the performance overhead of deduplication if the cursor field is guaranteed to be unique.
 
 ### Using `dlt.sources.incremental` with dynamically created resources
 

--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -693,7 +693,7 @@ august_issues = repo_issues(
 ...
 ```
 
-Note that dlt's incremental filtering considers the ranges half-closed. `initial_value` is inclusive, `end_value` is exclusive, so chaining ranges like above works without overlaps. This behaviour can be changed with the `start_range` (default `"closed"`) and `end_range` (default `"open"`) arguments.
+Note that dlt's incremental filtering considers the ranges half-closed. `initial_value` is inclusive, `end_value` is exclusive, so chaining ranges like above works without overlaps. This behaviour can be changed with the `range_start` (default `"closed"`) and `range_end` (default `"open"`) arguments.
 
 ### Declare row order to not request unnecessary data
 
@@ -793,8 +793,8 @@ def some_data(last_timestamp=dlt.sources.incremental("item.ts", primary_key=()))
         yield {"delta": i, "item": {"ts": pendulum.now().timestamp()}}
 ```
 
-This deduplication process is always enabled when `start_range` is set to `"closed"` (default).
-When you pass `start_range="open"` no deduplication is done as it is not needed as rows with the previous cursor value are excluded. This can be a useful optimization to avoid the performance overhead of deduplication if the cursor field is guaranteed to be unique.
+This deduplication process is always enabled when `range_start` is set to `"closed"` (default).
+When you pass `range_start="open"` no deduplication is done as it is not needed as rows with the previous cursor value are excluded. This can be a useful optimization to avoid the performance overhead of deduplication if the cursor field is guaranteed to be unique.
 
 ### Using `dlt.sources.incremental` with dynamically created resources
 

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -3864,7 +3864,7 @@ def test_start_range_open(item_type: TestDataItemFormat, last_value_func: Any) -
         expected_items = list(range(6, 12))
         order_dir = "ASC"
     elif last_value_func == min:
-        data_range = reversed(data_range)
+        data_range = reversed(data_range)  # type: ignore[call-overload]
         initial_value = 5
         # Only items lower than inital extracted
         expected_items = list(reversed(range(1, 5)))

--- a/tests/load/sources/sql_database/test_helpers.py
+++ b/tests/load/sources/sql_database/test_helpers.py
@@ -1,3 +1,6 @@
+from typing import Callable, Any, TYPE_CHECKING
+from dataclasses import dataclass
+
 import pytest
 
 import dlt
@@ -12,6 +15,18 @@ try:
     import sqlalchemy as sa
 except (MissingDependencyException, ModuleNotFoundError):
     pytest.skip("Tests require sql alchemy", allow_module_level=True)
+
+
+@dataclass
+class MockIncremental:
+    last_value: Any
+    last_value_func: Callable[[Any], Any]
+    cursor_path: str
+    row_order: str = None
+    end_value: Any = None
+    on_cursor_value_missing: str = "raise"
+    range_start: str = "closed"
+    range_end: str = "open"
 
 
 @pytest.mark.parametrize("backend", ["sqlalchemy", "pyarrow", "pandas", "connectorx"])
@@ -36,13 +51,12 @@ def test_make_query_incremental_max(
 ) -> None:
     """Verify query is generated according to incremental settings"""
 
-    class MockIncremental:
-        last_value = dlt.common.pendulum.now()
-        last_value_func = max
-        cursor_path = "created_at"
-        row_order = "asc"
-        end_value = None
-        on_cursor_value_missing = "raise"
+    incremental = MockIncremental(
+        last_value=dlt.common.pendulum.now(),
+        last_value_func=max,
+        cursor_path="created_at",
+        row_order="asc",
+    )
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -50,14 +64,14 @@ def test_make_query_incremental_max(
         backend,
         table,
         table_to_columns(table),
-        incremental=MockIncremental(),  # type: ignore[arg-type]
+        incremental=incremental,  # type: ignore[arg-type]
     )
 
     query = loader.make_query()
     expected = (
         table.select()
         .order_by(table.c.created_at.asc())
-        .where(table.c.created_at >= MockIncremental.last_value)
+        .where(table.c.created_at >= incremental.last_value)
     )
 
     assert query.compare(expected)
@@ -67,13 +81,14 @@ def test_make_query_incremental_max(
 def test_make_query_incremental_min(
     sql_source_db: SQLAlchemySourceDB, backend: TableBackend
 ) -> None:
-    class MockIncremental:
-        last_value = dlt.common.pendulum.now()
-        last_value_func = min
-        cursor_path = "created_at"
-        row_order = "desc"
-        end_value = None
-        on_cursor_value_missing = "raise"
+    incremental = MockIncremental(
+        last_value=dlt.common.pendulum.now(),
+        last_value_func=min,
+        cursor_path="created_at",
+        row_order="desc",
+        end_value=None,
+        on_cursor_value_missing="raise",
+    )
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -81,14 +96,14 @@ def test_make_query_incremental_min(
         backend,
         table,
         table_to_columns(table),
-        incremental=MockIncremental(),  # type: ignore[arg-type]
+        incremental=incremental,  # type: ignore[arg-type]
     )
 
     query = loader.make_query()
     expected = (
         table.select()
         .order_by(table.c.created_at.asc())  # `min` func swaps order
-        .where(table.c.created_at <= MockIncremental.last_value)
+        .where(table.c.created_at <= incremental.last_value)
     )
 
     assert query.compare(expected)
@@ -103,13 +118,14 @@ def test_make_query_incremental_on_cursor_value_missing_set(
     with_end_value: bool,
     cursor_value_missing: str,
 ) -> None:
-    class MockIncremental:
-        last_value = dlt.common.pendulum.now()
-        last_value_func = max
-        cursor_path = "created_at"
-        row_order = "asc"
-        end_value = None if not with_end_value else dlt.common.pendulum.now().add(hours=1)
-        on_cursor_value_missing = cursor_value_missing
+    incremental = MockIncremental(
+        last_value=dlt.common.pendulum.now(),
+        last_value_func=max,
+        cursor_path="created_at",
+        row_order="asc",
+        end_value=None if not with_end_value else dlt.common.pendulum.now().add(hours=1),
+        on_cursor_value_missing=cursor_value_missing,
+    )
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -117,7 +133,7 @@ def test_make_query_incremental_on_cursor_value_missing_set(
         backend,
         table,
         table_to_columns(table),
-        incremental=MockIncremental(),  # type: ignore[arg-type]
+        incremental=incremental,  # type: ignore[arg-type]
     )
 
     query = loader.make_query()
@@ -131,14 +147,14 @@ def test_make_query_incremental_on_cursor_value_missing_set(
     if with_end_value:
         where_clause = operator(
             sa.and_(
-                table.c.created_at >= MockIncremental.last_value,
-                table.c.created_at < MockIncremental.end_value,
+                table.c.created_at >= incremental.last_value,
+                table.c.created_at < incremental.end_value,
             ),
             missing_cond,
         )
     else:
         where_clause = operator(
-            table.c.created_at >= MockIncremental.last_value,
+            table.c.created_at >= incremental.last_value,
             missing_cond,
         )
     expected = table.select().order_by(table.c.created_at.asc()).where(where_clause)
@@ -152,13 +168,14 @@ def test_make_query_incremental_on_cursor_value_missing_no_last_value(
     backend: TableBackend,
     cursor_value_missing: str,
 ) -> None:
-    class MockIncremental:
-        last_value = None
-        last_value_func = max
-        cursor_path = "created_at"
-        row_order = "asc"
-        end_value = None
-        on_cursor_value_missing = cursor_value_missing
+    incremental = MockIncremental(
+        last_value=None,
+        last_value_func=max,
+        cursor_path="created_at",
+        row_order="asc",
+        end_value=None,
+        on_cursor_value_missing=cursor_value_missing,
+    )
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -166,7 +183,7 @@ def test_make_query_incremental_on_cursor_value_missing_no_last_value(
         backend,
         table,
         table_to_columns(table),
-        incremental=MockIncremental(),  # type: ignore[arg-type]
+        incremental=incremental,  # type: ignore[arg-type]
     )
 
     query = loader.make_query()
@@ -189,13 +206,14 @@ def test_make_query_incremental_end_value(
 ) -> None:
     now = dlt.common.pendulum.now()
 
-    class MockIncremental:
-        last_value = now
-        last_value_func = min
-        cursor_path = "created_at"
-        end_value = now.add(hours=1)
-        row_order = None
-        on_cursor_value_missing = "raise"
+    incremental = MockIncremental(
+        last_value=now,
+        last_value_func=min,
+        cursor_path="created_at",
+        end_value=now.add(hours=1),
+        row_order=None,
+        on_cursor_value_missing="raise",
+    )
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -203,14 +221,14 @@ def test_make_query_incremental_end_value(
         backend,
         table,
         table_to_columns(table),
-        incremental=MockIncremental(),  # type: ignore[arg-type]
+        incremental=incremental,  # type: ignore[arg-type]
     )
 
     query = loader.make_query()
     expected = table.select().where(
         sa.and_(
-            table.c.created_at <= MockIncremental.last_value,
-            table.c.created_at > MockIncremental.end_value,
+            table.c.created_at <= incremental.last_value,
+            table.c.created_at > incremental.end_value,
         )
     )
 
@@ -221,13 +239,14 @@ def test_make_query_incremental_end_value(
 def test_make_query_incremental_any_fun(
     sql_source_db: SQLAlchemySourceDB, backend: TableBackend
 ) -> None:
-    class MockIncremental:
-        last_value = dlt.common.pendulum.now()
-        last_value_func = lambda x: x[-1]
-        cursor_path = "created_at"
-        row_order = "asc"
-        end_value = dlt.common.pendulum.now()
-        on_cursor_value_missing = "raise"
+    incremental = MockIncremental(
+        last_value=dlt.common.pendulum.now(),
+        last_value_func=lambda x: x[-1],
+        cursor_path="created_at",
+        row_order="asc",
+        end_value=dlt.common.pendulum.now(),
+        on_cursor_value_missing="raise",
+    )
 
     table = sql_source_db.get_table("chat_message")
     loader = TableLoader(
@@ -235,7 +254,7 @@ def test_make_query_incremental_any_fun(
         backend,
         table,
         table_to_columns(table),
-        incremental=MockIncremental(),  # type: ignore[arg-type]
+        incremental=incremental,  # type: ignore[arg-type]
     )
 
     query = loader.make_query()
@@ -256,12 +275,11 @@ def test_cursor_path_field_name_with_a_special_chars(
     if special_field_name not in table.c:
         table.append_column(sa.Column(special_field_name, sa.String))
 
-    class MockIncremental:
-        cursor_path = "'id$field'"
-        last_value = None
-        end_value = None
-        row_order = None
-        on_cursor_value_missing = None
+    incremental = MockIncremental(
+        cursor_path="'id$field'",
+        last_value=None,
+        last_value_func=max,
+    )
 
     # Should not raise any exception
     loader = TableLoader(
@@ -269,7 +287,7 @@ def test_cursor_path_field_name_with_a_special_chars(
         backend,
         table,
         table_to_columns(table),
-        incremental=MockIncremental(),  # type: ignore[arg-type]
+        incremental=incremental,  # type: ignore[arg-type]
     )
     assert loader.cursor_column == table.c[special_field_name]
 
@@ -281,12 +299,11 @@ def test_cursor_path_multiple_fields(
     """Test that a cursor_path with multiple fields raises a ValueError."""
     table = sql_source_db.get_table("chat_message")
 
-    class MockIncremental:
-        cursor_path = "created_at,updated_at"
-        last_value = None
-        end_value = None
-        row_order = None
-        on_cursor_value_missing = None
+    incremental = MockIncremental(
+        cursor_path="created_at,updated_at",
+        last_value=None,
+        last_value_func=max,
+    )
 
     with pytest.raises(ValueError) as excinfo:
         TableLoader(
@@ -294,7 +311,7 @@ def test_cursor_path_multiple_fields(
             backend,
             table,
             table_to_columns(table),
-            incremental=MockIncremental(),  # type: ignore[arg-type]
+            incremental=incremental,  # type: ignore[arg-type]
         )
     assert "must be a simple column name" in str(excinfo.value)
 
@@ -306,12 +323,11 @@ def test_cursor_path_complex_expression(
     """Test that a complex JSONPath expression in cursor_path raises a ValueError."""
     table = sql_source_db.get_table("chat_message")
 
-    class MockIncremental:
-        cursor_path = "$.users[0].id"
-        last_value = None
-        end_value = None
-        row_order = None
-        on_cursor_value_missing = None
+    incremental = MockIncremental(
+        cursor_path="$.users[0].id",
+        last_value=None,
+        last_value_func=max,
+    )
 
     with pytest.raises(ValueError) as excinfo:
         TableLoader(
@@ -319,9 +335,78 @@ def test_cursor_path_complex_expression(
             backend,
             table,
             table_to_columns(table),
-            incremental=MockIncremental(),  # type: ignore[arg-type]
+            incremental=incremental,  # type: ignore[arg-type]
         )
     assert "must be a simple column name" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("backend", ["sqlalchemy", "pyarrow", "pandas", "connectorx"])
+@pytest.mark.parametrize("last_value_func", [min, max])
+def test_make_query_incremental_range_start_open(
+    sql_source_db: SQLAlchemySourceDB, backend: TableBackend, last_value_func: Callable[[Any], Any]
+) -> None:
+    incremental = MockIncremental(
+        last_value=dlt.common.pendulum.now(),
+        last_value_func=last_value_func,
+        cursor_path="created_at",
+        end_value=None,
+        on_cursor_value_missing="raise",
+        range_start="open",
+    )
+
+    table = sql_source_db.get_table("chat_message")
+
+    loader = TableLoader(
+        sql_source_db.engine,
+        backend,
+        table,
+        table_to_columns(table),
+        incremental=incremental,  # type: ignore[arg-type]
+    )
+
+    query = loader.make_query()
+    expected = table.select()
+
+    if last_value_func == min:
+        expected = expected.where(table.c.created_at < incremental.last_value)
+    else:
+        expected = expected.where(table.c.created_at > incremental.last_value)
+
+    assert query.compare(expected)
+
+
+@pytest.mark.parametrize("backend", ["sqlalchemy", "pyarrow", "pandas", "connectorx"])
+@pytest.mark.parametrize("last_value_func", [min, max])
+def test_make_query_incremental_range_end_closed(
+    sql_source_db: SQLAlchemySourceDB, backend: TableBackend, last_value_func: Callable[[Any], Any]
+) -> None:
+    incremental = MockIncremental(
+        last_value=dlt.common.pendulum.now(),
+        last_value_func=last_value_func,
+        cursor_path="created_at",
+        end_value=None,
+        on_cursor_value_missing="raise",
+        range_end="closed",
+    )
+
+    table = sql_source_db.get_table("chat_message")
+    loader = TableLoader(
+        sql_source_db.engine,
+        backend,
+        table,
+        table_to_columns(table),
+        incremental=incremental,  # type: ignore[arg-type]
+    )
+
+    query = loader.make_query()
+    expected = table.select()
+
+    if last_value_func == min:
+        expected = expected.where(table.c.created_at <= incremental.last_value)
+    else:
+        expected = expected.where(table.c.created_at >= incremental.last_value)
+
+    assert query.compare(expected)
 
 
 def mock_json_column(field: str) -> TDataItem:

--- a/tests/load/sources/sql_database/test_sql_database_source.py
+++ b/tests/load/sources/sql_database/test_sql_database_source.py
@@ -832,8 +832,12 @@ def test_set_primary_key_deferred_incremental(
         else:
             assert _r.incremental.primary_key == ["id"]
         assert _r.incremental._incremental.primary_key == ["id"]
-        assert _r.incremental._incremental._make_or_get_transformer(JsonIncremental).primary_key == ["id"]
-        assert _r.incremental._incremental._make_or_get_transformer(ArrowIncremental).primary_key == ["id"]
+        assert _r.incremental._incremental._make_or_get_transformer(
+            JsonIncremental
+        ).primary_key == ["id"]
+        assert _r.incremental._incremental._make_or_get_transformer(
+            ArrowIncremental
+        ).primary_key == ["id"]
         return item
 
     pipeline = make_pipeline("duckdb")
@@ -842,8 +846,12 @@ def test_set_primary_key_deferred_incremental(
 
     assert resource.incremental.primary_key == ["id"]
     assert resource.incremental._incremental.primary_key == ["id"]
-    assert resource.incremental._incremental._make_or_get_transformer(JsonIncremental).primary_key == ["id"]
-    assert resource.incremental._incremental._make_or_get_transformer(ArrowIncremental).primary_key == ["id"]
+    assert resource.incremental._incremental._make_or_get_transformer(
+        JsonIncremental
+    ).primary_key == ["id"]
+    assert resource.incremental._incremental._make_or_get_transformer(
+        ArrowIncremental
+    ).primary_key == ["id"]
 
 
 @pytest.mark.parametrize("backend", ["sqlalchemy", "pyarrow", "pandas", "connectorx"])

--- a/tests/load/sources/sql_database/test_sql_database_source.py
+++ b/tests/load/sources/sql_database/test_sql_database_source.py
@@ -13,6 +13,7 @@ from dlt.common.schema.typing import TColumnSchema, TSortOrder, TTableSchemaColu
 from dlt.common.utils import uniq_id
 
 from dlt.extract.exceptions import ResourceExtractionError
+from dlt.extract.incremental.transform import JsonIncremental, ArrowIncremental
 from dlt.sources import DltResource
 
 from tests.pipeline.utils import (
@@ -831,8 +832,8 @@ def test_set_primary_key_deferred_incremental(
         else:
             assert _r.incremental.primary_key == ["id"]
         assert _r.incremental._incremental.primary_key == ["id"]
-        assert _r.incremental._incremental._transformers["json"].primary_key == ["id"]
-        assert _r.incremental._incremental._transformers["arrow"].primary_key == ["id"]
+        assert _r.incremental._incremental._make_or_get_transformer(JsonIncremental).primary_key == ["id"]
+        assert _r.incremental._incremental._make_or_get_transformer(ArrowIncremental).primary_key == ["id"]
         return item
 
     pipeline = make_pipeline("duckdb")
@@ -841,8 +842,8 @@ def test_set_primary_key_deferred_incremental(
 
     assert resource.incremental.primary_key == ["id"]
     assert resource.incremental._incremental.primary_key == ["id"]
-    assert resource.incremental._incremental._transformers["json"].primary_key == ["id"]
-    assert resource.incremental._incremental._transformers["arrow"].primary_key == ["id"]
+    assert resource.incremental._incremental._make_or_get_transformer(JsonIncremental).primary_key == ["id"]
+    assert resource.incremental._incremental._make_or_get_transformer(ArrowIncremental).primary_key == ["id"]
 
 
 @pytest.mark.parametrize("backend", ["sqlalchemy", "pyarrow", "pandas", "connectorx"])


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This allows configuring whether the incremental range is open or closed on both sides (start/end value).  
Translates to changing the operators between `> | >=` / `< | <=` in sql database source and in incremental filtering.   

Default is `start_range=closed` and `end_range=open`, meaning the exact initial value is included and the exact end value is excluded.    
With `start_range=open` you get `WHERE cursor > last_value` instead of `>=`.  
With `end_range=closed` you get `... cursor <= end_value` so non-overlapping chunks are still possible without the start_value deduplication logic.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #1948 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
