### PR TITLE
Fix BigQueryLoadJob hiding root cause exception

### DIFF
--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -123,15 +123,17 @@ class BigQueryLoadJob(RunnableLoadJob, HasFollowupJobs):
                 )
 
     def exception(self) -> str:
-        return json.dumps(
-            {
-                "error_result": self._bq_load_job.error_result,
-                "errors": self._bq_load_job.errors,
-                "job_start": self._bq_load_job.started,
-                "job_end": self._bq_load_job.ended,
-                "job_id": self._bq_load_job.job_id,
-            }
-        )
+        if self._bq_load_job:
+            return json.dumps(
+                {
+                    "error_result": self._bq_load_job.error_result,
+                    "errors": self._bq_load_job.errors,
+                    "job_start": self._bq_load_job.started,
+                    "job_end": self._bq_load_job.ended,
+                    "job_id": self._bq_load_job.job_id,
+                }
+            )
+        return super().exception()
 
     @staticmethod
     def get_job_id_from_file_path(file_path: str) -> str:


### PR DESCRIPTION
…parents exception() method.

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Explicitly check that _bg_load_job is not None otherwise fallback to parents exception() method.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
- Fixes #1989

<!--
Provide any additional context about the PR here.
-->
### Additional Context
The detailed description is provided in the issue

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
