### PR TITLE
add session token to duckdb s3 secret

### DIFF
--- a/dlt/destinations/impl/filesystem/sql_client.py
+++ b/dlt/destinations/impl/filesystem/sql_client.py
@@ -90,6 +90,9 @@ class FilesystemSqlClient(DuckDbSqlClient):
         # add secrets required for creating views
         if self.fs_client.config.protocol == "s3":
             aws_creds = cast(AwsCredentials, self.fs_client.config.credentials)
+            session_token = (
+                "" if aws_creds.aws_session_token is None else aws_creds.aws_session_token
+            )
             endpoint = (
                 aws_creds.endpoint_url.replace("https://", "")
                 if aws_creds.endpoint_url
@@ -100,6 +103,7 @@ class FilesystemSqlClient(DuckDbSqlClient):
                 TYPE S3,
                 KEY_ID '{aws_creds.aws_access_key_id}',
                 SECRET '{aws_creds.aws_secret_access_key}',
+                SESSION_TOKEN '{session_token}',
                 REGION '{aws_creds.region_name}',
                 ENDPOINT '{endpoint}',
                 SCOPE '{scope}'


### PR DESCRIPTION
Issue: `FilesystemSqlClient` could not access S3 bucket with temporary access keys (i.e. `ASIA..` instead of `AKIA...`) because the session token was disregarded. This caused a problem when running on AWS Lambda and using IAM roles.

Fix: include session token when creating duckdb secret.