### PR TITLE
fix s3 credentials environment variable names

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/filesystem/basic.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/filesystem/basic.md
@@ -252,8 +252,8 @@ bucket_url='~\Documents\csv_files\'
 You can also specify the credentials using environment variables. The name of the corresponding environment variable should be slightly different from the corresponding name in the TOML file. Simply replace dots `.` with double underscores `__`:
 
 ```sh
-export SOURCES__FILESYSTEM__AWS_ACCESS_KEY_ID = "Please set me up!"
-export SOURCES__FILESYSTEM__AWS_SECRET_ACCESS_KEY = "Please set me up!"
+export SOURCES__FILESYSTEM__CREDENTIALS__AWS_ACCESS_KEY_ID = "Please set me up!"
+export SOURCES__FILESYSTEM__CREDENTIALS__AWS_SECRET_ACCESS_KEY = "Please set me up!"
 ```
 
 :::tip


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
aws s3 credentials environment variables names in the [dlt docs](https://dlthub.com/docs/dlt-ecosystem/verified-sources/filesystem/basic#add-credentials-to-dlt-pipeline) is incorrect.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
None

<!--
Provide any additional context about the PR here.
-->
### Additional Context
None

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
