### PR TITLE
Fix pagination issue in `JSONResponseCursorPaginator` with empty string cursor value

### DIFF
--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -651,7 +651,7 @@ class JSONResponseCursorPaginator(BaseReferencePaginator):
     def update_state(self, response: Response, data: Optional[List[Any]] = None) -> None:
         """Extracts the cursor value from the JSON response."""
         values = jsonpath.find_values(self.cursor_path, response.json())
-        self._next_reference = values[0] if values else None
+        self._next_reference = values[0] if values and values[0] else None
 
     def update_request(self, request: Request) -> None:
         """Updates the request with the cursor query parameter."""

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -530,6 +530,12 @@ class TestJSONResponseCursorPaginator:
         assert paginator._next_reference == "cursor-2"
         assert paginator.has_next_page is True
 
+    def test_update_state_when_cursor_path_is_empty_string(self):
+        paginator = JSONResponseCursorPaginator(cursor_path="next_cursor")
+        response = Mock(Response, json=lambda: {"next_cursor": "", "results": []})
+        paginator.update_state(response)
+        assert paginator.has_next_page is False
+
     def test_update_request(self):
         paginator = JSONResponseCursorPaginator(cursor_path="next_cursor")
         paginator._next_reference = "cursor-2"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Adjusts the `update_state()` method to set `_next_reference` to None
when the cursor value extracted from the JSON response is an empty
string, preventing unintended pagination requests.


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #2012

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
