### PR TITLE
fix: if name of distribution is None

### DIFF
--- a/dlt/common/configuration/plugins.py
+++ b/dlt/common/configuration/plugins.py
@@ -48,7 +48,7 @@ def load_setuptools_entrypoints(m: pluggy.PluginManager) -> None:
 
     for dist in list(importlib.metadata.distributions()):
         # skip named dists that do not start with dlt-
-        if hasattr(dist, "name") and not dist.name.startswith("dlt-"):
+        if hasattr(dist, "name") and (dist.name is None or not dist.name.startswith("dlt-")):
             continue
         for ep in dist.entry_points:
             if (


### PR DESCRIPTION
### Description
I am getting this [exception](https://github.com/dlt-hub/dlt/issues/2023) starting with dlt version 1.3.0. 
I do not know how to reproduce it but the underlying issue seems to be that the `name` attribute  of `Distribution` can be `None`.