### PR TITLE
Add core sources extras to requirements in `dlt init`

### DIFF
--- a/.github/workflows/test_local_destinations.yml
+++ b/.github/workflows/test_local_destinations.yml
@@ -110,15 +110,14 @@ jobs:
       - name: Run tests Linux
         run: |
           eval "$(ssh-agent -s)"
-          poetry run pytest --durations=0 tests/load --ignore tests/load/sources
-          poetry run pytest --durations=0 tests/cli
+          poetry run pytest tests/load --ignore tests/load/sources
+          poetry run pytest tests/cli
         env:
           DESTINATION__POSTGRES__CREDENTIALS: postgresql://loader:loader@localhost:5432/dlt_data
           DESTINATION__QDRANT__CREDENTIALS__location: http://localhost:6333
           DESTINATION__FILESYSTEM__CREDENTIALS__SFTP_PORT: 2222
           DESTINATION__FILESYSTEM__CREDENTIALS__SFTP_USERNAME: foo
           DESTINATION__FILESYSTEM__CREDENTIALS__SFTP_PASSWORD: pass
-
 
       - name: Stop weaviate
         if: always()

--- a/.github/workflows/test_local_destinations.yml
+++ b/.github/workflows/test_local_destinations.yml
@@ -110,8 +110,8 @@ jobs:
       - name: Run tests Linux
         run: |
           eval "$(ssh-agent -s)"
-          poetry run pytest tests/load --ignore tests/load/sources
-          poetry run pytest tests/cli
+          poetry run pytest --durations=0 tests/load --ignore tests/load/sources
+          poetry run pytest --durations=0 tests/cli
         env:
           DESTINATION__POSTGRES__CREDENTIALS: postgresql://loader:loader@localhost:5432/dlt_data
           DESTINATION__QDRANT__CREDENTIALS__location: http://localhost:6333

--- a/dlt/cli/init_command.py
+++ b/dlt/cli/init_command.py
@@ -383,11 +383,12 @@ def init_command(
                 core_sources_storage, source_name
             )
             from importlib.metadata import Distribution
+
             dist = Distribution.from_name(DLT_PKG_NAME)
-            extras = dist.metadata.get_all('Provides-Extra') or []
+            extras = dist.metadata.get_all("Provides-Extra") or []
 
             # Match the extra name to the source name
-            canonical_source_name = source_name.replace('_', '-').lower()
+            canonical_source_name = source_name.replace("_", "-").lower()
 
             if canonical_source_name in extras:
                 source_configuration.requirements.update_dlt_extras(canonical_source_name)

--- a/dlt/cli/init_command.py
+++ b/dlt/cli/init_command.py
@@ -382,6 +382,15 @@ def init_command(
             source_configuration = files_ops.get_core_source_configuration(
                 core_sources_storage, source_name
             )
+            from importlib.metadata import Distribution
+            dist = Distribution.from_name(DLT_PKG_NAME)
+            extras = dist.metadata.get_all('Provides-Extra') or []
+
+            # Match the extra name to the source name
+            canonical_source_name = source_name.replace('_', '-').lower()
+
+            if canonical_source_name in extras:
+                source_configuration.requirements.update_dlt_extras(canonical_source_name)
         else:
             if not is_valid_schema_name(source_name):
                 raise InvalidSchemaName(source_name)

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -55,7 +55,12 @@ from tests.utils import IMPLEMENTED_DESTINATIONS, clean_test_storage
 
 # we hardcode the core sources here so we can check that the init script picks
 # up the right source
-CORE_SOURCES = ["filesystem", "rest_api", "sql_database"]
+CORE_SOURCES_CONFIG = {
+    "rest_api": {"requires_extra": False},
+    "sql_database": {"requires_extra": True},
+    "filesystem": {"requires_extra": True},
+}
+CORE_SOURCES = list(CORE_SOURCES_CONFIG.keys())
 
 # we also hardcode all the templates here for testing
 TEMPLATES = ["debug", "default", "arrow", "requests", "dataframe", "fruitshop", "github_api"]
@@ -165,6 +170,37 @@ def test_init_list_sources(repo_dir: str) -> None:
 
     for source in SOME_KNOWN_VERIFIED_SOURCES + TEMPLATES + CORE_SOURCES:
         assert source in _out
+
+
+@pytest.mark.parametrize(
+    "source_name",
+    [name for name in CORE_SOURCES_CONFIG if CORE_SOURCES_CONFIG[name]["requires_extra"]],
+)
+def test_init_command_core_source_requirements_with_extras(
+    source_name: str, repo_dir: str, project_files: FileStorage
+) -> None:
+    init_command.init_command(source_name, "duckdb", repo_dir)
+    source_requirements = SourceRequirements.from_string(
+        project_files.load(cli_utils.REQUIREMENTS_TXT)
+    )
+    canonical_name = source_name.replace("_", "-")
+    assert canonical_name in source_requirements.dlt_requirement.extras
+
+
+@pytest.mark.parametrize(
+    "source_name",
+    [name for name in CORE_SOURCES_CONFIG if not CORE_SOURCES_CONFIG[name]["requires_extra"]],
+)
+def test_init_command_core_source_requirements_without_extras(
+    source_name: str, repo_dir: str, project_files: FileStorage
+) -> None:
+    init_command.init_command(source_name, "duckdb", repo_dir)
+    source_requirements = SourceRequirements.from_string(
+        project_files.load(cli_utils.REQUIREMENTS_TXT)
+    )
+    assert source_requirements.dlt_requirement.extras == {
+        "duckdb"
+    }, "Only duckdb should be in extras"
 
 
 def test_init_list_sources_update_warning(repo_dir: str, project_files: FileStorage) -> None:
@@ -571,7 +607,7 @@ def assert_requirements_txt(project_files: FileStorage, destination_name: str) -
         project_files.load(cli_utils.REQUIREMENTS_TXT)
     )
     assert destination_name in source_requirements.dlt_requirement.extras
-    # Check that atleast some version range is specified
+    # Check that at least some version range is specified
     assert len(source_requirements.dlt_requirement.specifier) >= 1
 
 

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -4,7 +4,7 @@ import hashlib
 import os
 import contextlib
 from subprocess import CalledProcessError
-from typing import Any, List, Tuple, Optional
+from typing import List, Tuple, Optional
 from hexbytes import HexBytes
 import pytest
 from unittest import mock

--- a/tests/load/conftest.py
+++ b/tests/load/conftest.py
@@ -42,3 +42,12 @@ def all_buckets_env(request) -> Iterator[str]:
         bucket_url = request.param
     os.environ["DESTINATION__FILESYSTEM__BUCKET_URL"] = bucket_url
     yield bucket_url
+
+
+# temporary log duration of each test
+def pytest_runtest_logreport(report):
+    if report.when == 'call':
+        duration = report.duration
+        nodeid = report.nodeid
+        status = report.outcome
+        print(f"\n{nodeid} {status.upper()} in {duration:.2f} seconds")

--- a/tests/load/conftest.py
+++ b/tests/load/conftest.py
@@ -42,12 +42,3 @@ def all_buckets_env(request) -> Iterator[str]:
         bucket_url = request.param
     os.environ["DESTINATION__FILESYSTEM__BUCKET_URL"] = bucket_url
     yield bucket_url
-
-
-# temporary log duration of each test
-def pytest_runtest_logreport(report):
-    if report.when == 'call':
-        duration = report.duration
-        nodeid = report.nodeid
-        status = report.outcome
-        print(f"\n{nodeid} {status.upper()} in {duration:.2f} seconds")


### PR DESCRIPTION
Implements #1794

Not sure if this is the best way to do it as there's a lot of implicit stuff and assumptions. Mostly this is to handle missing extra for the `rest_api` source.

The alternatives to reading package metadata are:
- explicitly define the core sources and their dependencies. 
- have a `requirements.txt` as in verified sources and handle it the same way.