### PR TITLE
Incremental table hints and incremental in resource decorator

### DIFF
--- a/dlt/common/destination/typing.py
+++ b/dlt/common/destination/typing.py
@@ -13,5 +13,4 @@ class PreparedTableSchema(_TTableSchemaBase, total=False):
 
     write_disposition: TWriteDisposition
     references: Optional[TTableReferenceParam]
-    incremental: Optional[IncrementalArgs]
     _x_prepared: bool  # needed for the type checker

--- a/dlt/common/destination/typing.py
+++ b/dlt/common/destination/typing.py
@@ -1,6 +1,11 @@
 from typing import Optional
 
-from dlt.common.schema.typing import _TTableSchemaBase, TWriteDisposition, TTableReferenceParam
+from dlt.common.schema.typing import (
+    _TTableSchemaBase,
+    TWriteDisposition,
+    TTableReferenceParam,
+    IncrementalArgs,
+)
 
 
 class PreparedTableSchema(_TTableSchemaBase, total=False):
@@ -8,4 +13,5 @@ class PreparedTableSchema(_TTableSchemaBase, total=False):
 
     write_disposition: TWriteDisposition
     references: Optional[TTableReferenceParam]
+    incremental: Optional[IncrementalArgs]
     _x_prepared: bool  # needed for the type checker

--- a/dlt/common/destination/typing.py
+++ b/dlt/common/destination/typing.py
@@ -4,7 +4,6 @@ from dlt.common.schema.typing import (
     _TTableSchemaBase,
     TWriteDisposition,
     TTableReferenceParam,
-    IncrementalArgs,
 )
 
 

--- a/dlt/common/incremental/typing.py
+++ b/dlt/common/incremental/typing.py
@@ -2,9 +2,7 @@ from typing_extensions import TypedDict
 
 from typing import Any, Callable, List, Literal, Optional, Sequence, TypeVar, Union
 
-from dlt.common.schema.typing import TColumnNames
-from dlt.common.typing import TSortOrder
-from dlt.extract.items import TTableHintTemplate
+from dlt.common.typing import TSortOrder, TTableHintTemplate, TColumnNames
 
 TCursorValue = TypeVar("TCursorValue", bound=Any)
 LastValueFunc = Callable[[Sequence[TCursorValue]], Any]
@@ -19,10 +17,12 @@ class IncrementalColumnState(TypedDict):
 
 class IncrementalArgs(TypedDict, total=False):
     cursor_path: str
-    initial_value: Optional[str]
-    last_value_func: Optional[LastValueFunc[str]]
+    initial_value: Optional[Any]
+    last_value_func: Optional[Union[LastValueFunc[str], Literal["min", "max"]]]
+    """Last value callable or name of built in function"""
     primary_key: Optional[TTableHintTemplate[TColumnNames]]
-    end_value: Optional[str]
+    end_value: Optional[Any]
     row_order: Optional[TSortOrder]
     allow_external_schedulers: Optional[bool]
     lag: Optional[Union[float, int]]
+    on_cursor_value_missing: Optional[OnCursorValueMissing]

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -628,7 +628,14 @@ def row_tuples_to_arrow(
                 " extracting an SQL VIEW that selects with cast."
             )
             json_str_array = pa.array(
-                [None if s is None else json.dumps(s) if not issubclass(type(s), set) else json.dumps(list(s)) for s in columnar_known_types[field.name]]
+                [
+                    (
+                        None
+                        if s is None
+                        else json.dumps(s) if not issubclass(type(s), set) else json.dumps(list(s))
+                    )
+                    for s in columnar_known_types[field.name]
+                ]
             )
             columnar_known_types[field.name] = json_str_array
 

--- a/dlt/common/pipeline.py
+++ b/dlt/common/pipeline.py
@@ -48,7 +48,6 @@ from dlt.common.metrics import (
 )
 from dlt.common.schema import Schema
 from dlt.common.schema.typing import (
-    TColumnNames,
     TColumnSchema,
     TWriteDispositionConfig,
     TSchemaContract,
@@ -56,7 +55,7 @@ from dlt.common.schema.typing import (
 from dlt.common.storages.load_package import ParsedLoadJobFileName
 from dlt.common.storages.load_storage import LoadPackageInfo
 from dlt.common.time import ensure_pendulum_datetime, precise_time
-from dlt.common.typing import DictStrAny, REPattern, StrAny, SupportsHumanize
+from dlt.common.typing import DictStrAny, REPattern, StrAny, SupportsHumanize, TColumnNames
 from dlt.common.jsonpath import delete_matches, TAnyJsonPath
 from dlt.common.data_writers.writers import TLoaderFileFormat
 from dlt.common.utils import RowCounts, merge_row_counts

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -20,6 +20,7 @@ from typing_extensions import Never
 from dlt.common.data_types import TDataType
 from dlt.common.normalizers.typing import TNormalizersConfig
 from dlt.common.typing import TSortOrder, TAnyDateTime, TLoaderFileFormat
+from dlt.common.incremental.typing import IncrementalArgs
 
 try:
     from pydantic import BaseModel as _PydanticBaseModel
@@ -132,8 +133,6 @@ TTypeDetections = Literal[
     "timestamp", "iso_timestamp", "iso_date", "large_integer", "hexbytes_to_text", "wei_to_double"
 ]
 TTypeDetectionFunc = Callable[[Type[Any], Any], Optional[TDataType]]
-TColumnNames = Union[str, Sequence[str]]
-"""A string representing a column name or a list of"""
 
 
 class TColumnType(TypedDict, total=False):
@@ -279,6 +278,7 @@ class TTableSchema(_TTableSchemaBase, total=False):
 
     write_disposition: Optional[TWriteDisposition]
     references: Optional[TTableReferenceParam]
+    incremental: Optional[IncrementalArgs]
 
 
 class TPartialTableSchema(TTableSchema):

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -279,7 +279,6 @@ class TTableSchema(_TTableSchemaBase, total=False):
 
     write_disposition: Optional[TWriteDisposition]
     references: Optional[TTableReferenceParam]
-    incremental: Optional[IncrementalArgs]
 
 
 class TPartialTableSchema(TTableSchema):

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -165,6 +165,7 @@ class TColumnSchema(TColumnSchemaBase, total=False):
     variant: Optional[bool]
     hard_delete: Optional[bool]
     dedup_sort: Optional[TSortOrder]
+    incremental: Optional[IncrementalArgs]
 
 
 TTableSchemaColumns = Dict[str, TColumnSchema]

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -19,8 +19,7 @@ from typing_extensions import Never
 
 from dlt.common.data_types import TDataType
 from dlt.common.normalizers.typing import TNormalizersConfig
-from dlt.common.typing import TSortOrder, TAnyDateTime, TLoaderFileFormat
-from dlt.common.incremental.typing import IncrementalArgs
+from dlt.common.typing import TSortOrder, TAnyDateTime, TLoaderFileFormat, TColumnNames
 
 try:
     from pydantic import BaseModel as _PydanticBaseModel

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -165,7 +165,7 @@ class TColumnSchema(TColumnSchemaBase, total=False):
     variant: Optional[bool]
     hard_delete: Optional[bool]
     dedup_sort: Optional[TSortOrder]
-    incremental: Optional[IncrementalArgs]
+    incremental: Optional[bool]
 
 
 TTableSchemaColumns = Dict[str, TColumnSchema]

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -432,7 +432,6 @@ def merge_columns(
     if columns_partial is False:
         raise NotImplementedError("columns_partial must be False for merge_columns")
 
-
     # remove incomplete columns in table that are complete in diff table
     for col_name, column_b in columns_b.items():
         column_a = columns_a.get(col_name)
@@ -549,11 +548,15 @@ def merge_diff(table: TTableSchema, table_diff: TPartialTableSchema) -> TPartial
     * nothing gets deleted
     """
 
-    incremental_a_col = get_first_column_name_with_prop(table, 'incremental', include_incomplete=True)
+    incremental_a_col = get_first_column_name_with_prop(
+        table, "incremental", include_incomplete=True
+    )
     if incremental_a_col:
-        incremental_b_col = get_first_column_name_with_prop(table_diff, 'incremental', include_incomplete=True)
+        incremental_b_col = get_first_column_name_with_prop(
+            table_diff, "incremental", include_incomplete=True
+        )
         if incremental_b_col:
-            table['columns'][incremental_a_col].pop('incremental')
+            table["columns"][incremental_a_col].pop("incremental")
 
     # add new columns when all checks passed
     updated_columns = merge_columns(table["columns"], table_diff["columns"])

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -432,6 +432,7 @@ def merge_columns(
     if columns_partial is False:
         raise NotImplementedError("columns_partial must be False for merge_columns")
 
+
     # remove incomplete columns in table that are complete in diff table
     for col_name, column_b in columns_b.items():
         column_a = columns_a.get(col_name)
@@ -547,6 +548,13 @@ def merge_diff(table: TTableSchema, table_diff: TPartialTableSchema) -> TPartial
     * table hints are added or replaced from diff
     * nothing gets deleted
     """
+
+    incremental_a_col = get_first_column_name_with_prop(table, 'incremental', include_incomplete=True)
+    if incremental_a_col:
+        incremental_b_col = get_first_column_name_with_prop(table_diff, 'incremental', include_incomplete=True)
+        if incremental_b_col:
+            table['columns'][incremental_a_col].pop('incremental')
+
     # add new columns when all checks passed
     updated_columns = merge_columns(table["columns"], table_diff["columns"])
     table.update(table_diff)

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -29,6 +29,7 @@ from typing import (
     Iterator,
     Generator,
     NamedTuple,
+    Sequence,
 )
 
 from typing_extensions import (
@@ -112,6 +113,8 @@ else:
 
 TSecretStrValue = Annotated[str, SecretSentinel]
 
+TColumnNames = Union[str, Sequence[str]]
+"""A string representing a column name or a list of"""
 TDataItem: TypeAlias = Any
 """A single data item as extracted from data source"""
 TDataItems: TypeAlias = Union[TDataItem, List[TDataItem]]
@@ -125,6 +128,10 @@ TFileOrPath = Union[str, PathLike, IO[Any]]
 TSortOrder = Literal["asc", "desc"]
 TLoaderFileFormat = Literal["jsonl", "typed-jsonl", "insert_values", "parquet", "csv", "reference"]
 """known loader file formats"""
+
+TDynHintType = TypeVar("TDynHintType")
+TFunHintTemplate = Callable[[TDataItem], TDynHintType]
+TTableHintTemplate = Union[TDynHintType, TFunHintTemplate[TDynHintType]]
 
 
 class ConfigValueSentinel(NamedTuple):

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -647,4 +647,3 @@ def is_typeerror_due_to_wrong_call(exc: Exception, func: AnyFun) -> bool:
     func_name = func.__name__
     message = str(exc)
     return message.__contains__(f"{func_name}()")
-

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -647,3 +647,4 @@ def is_typeerror_due_to_wrong_call(exc: Exception, func: AnyFun) -> bool:
     func_name = func.__name__
     message = str(exc)
     return message.__contains__(f"{func_name}()")
+

--- a/dlt/destinations/impl/bigquery/bigquery_adapter.py
+++ b/dlt/destinations/impl/bigquery/bigquery_adapter.py
@@ -4,10 +4,8 @@ from dateutil import parser
 
 from dlt.common.destination import PreparedTableSchema
 from dlt.common.pendulum import timezone
-from dlt.common.schema.typing import (
-    TColumnNames,
-    TTableSchemaColumns,
-)
+from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.common.typing import TColumnNames
 from dlt.destinations.utils import get_resource_for_adapter
 from dlt.extract import DltResource
 from dlt.extract.items import TTableHintTemplate

--- a/dlt/destinations/impl/lancedb/lancedb_adapter.py
+++ b/dlt/destinations/impl/lancedb/lancedb_adapter.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
-from dlt.common.schema.typing import TColumnNames, TTableSchemaColumns
+from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.common.typing import TColumnNames
 from dlt.destinations.utils import get_resource_for_adapter
 from dlt.extract import DltResource
 from dlt.extract.items import TTableHintTemplate

--- a/dlt/destinations/impl/qdrant/qdrant_adapter.py
+++ b/dlt/destinations/impl/qdrant/qdrant_adapter.py
@@ -1,6 +1,7 @@
 from typing import Any
 
-from dlt.common.schema.typing import TColumnNames, TTableSchemaColumns
+from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.common.typing import TColumnNames
 from dlt.extract import DltResource
 from dlt.destinations.utils import get_resource_for_adapter
 

--- a/dlt/destinations/impl/weaviate/weaviate_adapter.py
+++ b/dlt/destinations/impl/weaviate/weaviate_adapter.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, Literal, Set, get_args
 
-from dlt.common.schema.typing import TColumnNames, TTableSchemaColumns
+from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.common.typing import TColumnNames
 from dlt.extract import DltResource, resource as make_resource
 from dlt.destinations.utils import get_resource_for_adapter
 

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -70,7 +70,7 @@ from dlt.extract.source import (
     TSourceFunParams,
 )
 from dlt.extract.resource import DltResource, TUnboundDltResource, TDltResourceImpl
-from dlt.extract.incremental import TIncrementalConfig
+from dlt.extract.incremental import TIncrementalConfig, Incremental
 
 
 @configspec
@@ -627,6 +627,9 @@ def resource(
         TDltResourceImpl instance which may be loaded, iterated or combined with other resources into a pipeline.
     """
 
+    if incremental is not None:
+        incremental = Incremental.ensure_instance(incremental)
+
     def make_resource(_name: str, _section: str, _data: Any) -> TDltResourceImpl:
         table_template = make_hints(
             table_name,
@@ -691,7 +694,7 @@ def resource(
         return _wrap
 
     def decorator(
-        f: Callable[TResourceFunParams, Any]
+        f: Callable[TResourceFunParams, Any],
     ) -> Callable[TResourceFunParams, TDltResourceImpl]:
         if not callable(f):
             if data_from:
@@ -1033,7 +1036,7 @@ TDeferredFunParams = ParamSpec("TDeferredFunParams")
 
 
 def defer(
-    f: Callable[TDeferredFunParams, TBoundItems]
+    f: Callable[TDeferredFunParams, TBoundItems],
 ) -> Callable[TDeferredFunParams, TDeferred[TBoundItems]]:
     @wraps(f)
     def _wrap(*args: Any, **kwargs: Any) -> TDeferred[TBoundItems]:

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -655,6 +655,7 @@ def resource(
         )
 
         if incremental:
+            # Reset the flag to allow overriding by incremental argument
             resource.incremental._from_hints = False
         # If custom nesting level was specified then
         # we need to add it to table hints so that

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -32,7 +32,6 @@ from dlt.common.reflection.spec import spec_from_signature
 from dlt.common.schema.utils import DEFAULT_WRITE_DISPOSITION
 from dlt.common.schema.schema import Schema
 from dlt.common.schema.typing import (
-    TColumnNames,
     TFileFormat,
     TWriteDisposition,
     TWriteDispositionConfig,
@@ -43,7 +42,8 @@ from dlt.common.schema.typing import (
 )
 from dlt.common.storages.exceptions import SchemaNotFoundError
 from dlt.common.storages.schema_storage import SchemaStorage
-from dlt.common.typing import AnyFun, ParamSpec, Concatenate, TDataItem, TDataItems
+from dlt.common.typing import AnyFun, ParamSpec, Concatenate, TDataItem, TDataItems, TColumnNames
+
 from dlt.common.utils import get_callable_name, get_module_name, is_inner_callable
 
 from dlt.extract.hints import make_hints
@@ -70,6 +70,7 @@ from dlt.extract.source import (
     TSourceFunParams,
 )
 from dlt.extract.resource import DltResource, TUnboundDltResource, TDltResourceImpl
+from dlt.extract.incremental import TIncrementalConfig
 
 
 @configspec
@@ -446,6 +447,7 @@ def resource(
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
     parallelized: bool = False,
+    incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
 ) -> TDltResourceImpl: ...
 
@@ -468,6 +470,7 @@ def resource(
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
     parallelized: bool = False,
+    incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
 ) -> Callable[[Callable[TResourceFunParams, Any]], TDltResourceImpl]: ...
 
@@ -490,6 +493,7 @@ def resource(
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
     parallelized: bool = False,
+    incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     standalone: Literal[True] = True,
 ) -> Callable[
@@ -515,6 +519,7 @@ def resource(
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
     parallelized: bool = False,
+    incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
 ) -> TDltResourceImpl: ...
 
@@ -536,6 +541,7 @@ def resource(
     selected: bool = True,
     spec: Type[BaseConfiguration] = None,
     parallelized: bool = False,
+    incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     standalone: bool = False,
     data_from: TUnboundDltResource = None,
@@ -642,7 +648,9 @@ def resource(
             selected,
             cast(DltResource, data_from),
             True,
+            incremental=incremental,
         )
+
         # If custom nesting level was specified then
         # we need to add it to table hints so that
         # later in normalizer dlt/common/normalizers/json/relational.py

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -638,6 +638,7 @@ def resource(
             table_format=table_format,
             file_format=file_format,
             references=references,
+            incremental=incremental
         )
 
         resource = _impl_cls.from_data(
@@ -648,9 +649,10 @@ def resource(
             selected,
             cast(DltResource, data_from),
             True,
-            incremental=incremental,
         )
 
+        if incremental:
+            resource.incremental._from_hints = False
         # If custom nesting level was specified then
         # we need to add it to table hints so that
         # later in normalizer dlt/common/normalizers/json/relational.py

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -638,7 +638,7 @@ def resource(
             table_format=table_format,
             file_format=file_format,
             references=references,
-            incremental=incremental
+            incremental=incremental,
         )
 
         resource = _impl_cls.from_data(

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -70,7 +70,7 @@ from dlt.extract.source import (
     TSourceFunParams,
 )
 from dlt.extract.resource import DltResource, TUnboundDltResource, TDltResourceImpl
-from dlt.extract.incremental import TIncrementalConfig, Incremental
+from dlt.extract.incremental import TIncrementalConfig
 
 
 @configspec
@@ -626,9 +626,6 @@ def resource(
     Returns:
         TDltResourceImpl instance which may be loaded, iterated or combined with other resources into a pipeline.
     """
-
-    if incremental is not None:
-        incremental = Incremental.ensure_instance(incremental)
 
     def make_resource(_name: str, _section: str, _data: Any) -> TDltResourceImpl:
         table_template = make_hints(

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -240,7 +240,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                         if isinstance(hint, Incremental):
                             hints[name] = hint.to_table_hint()
                         else:
-                            hints[name] = dict(hint)
+                            hints[name] = dict(hint)  # type: ignore[call-overload]
                     continue
                 if name == "original_columns":
                     # this is original type of the columns ie. Pydantic model

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -240,7 +240,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                         if isinstance(hint, Incremental):
                             hints[name] = hint.to_table_hint()
                         else:
-                            hints[name] = dict(hint)  # type: ignore[call-overload]
+                            hints[name] = hint
                     continue
                 if name == "original_columns":
                     # this is original type of the columns ie. Pydantic model

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -237,7 +237,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                         hint = hint.incremental
                     # sometimes internal incremental is not bound
                     if hint:
-                        hints[name] = hint.to_table_hint()
+                        hints[name] = hint.to_table_hint()  # type: ignore[attr-defined]
                     continue
                 if name == "original_columns":
                     # this is original type of the columns ie. Pydantic model

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -237,10 +237,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                         hint = hint.incremental
                     # sometimes internal incremental is not bound
                     if hint:
-                        if isinstance(hint, Incremental):
-                            hints[name] = hint.to_table_hint()
-                        else:
-                            hints[name] = hint
+                        hints[name] = hint.to_table_hint()
                     continue
                 if name == "original_columns":
                     # this is original type of the columns ie. Pydantic model

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -237,7 +237,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                         hint = hint.incremental
                     # sometimes internal incremental is not bound
                     if hint:
-                        hints[name] = hint.to_table_hint()  # type: ignore[attr-defined]
+                        hints[name] = dict(hint)  # type: ignore[call-overload]
                     continue
                 if name == "original_columns":
                     # this is original type of the columns ie. Pydantic model

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -228,7 +228,7 @@ class DltResourceHints:
         columns: TTableHintTemplate[TAnySchemaColumns] = None,
         primary_key: TTableHintTemplate[TColumnNames] = None,
         merge_key: TTableHintTemplate[TColumnNames] = None,
-        incremental: Incremental[Any] = None,
+        incremental: Union[Incremental[Any], IncrementalArgs] = None,
         schema_contract: TTableHintTemplate[TSchemaContract] = None,
         additional_table_hints: Optional[Dict[str, TTableHintTemplate[Any]]] = None,
         table_format: TTableHintTemplate[TTableFormat] = None,
@@ -367,7 +367,7 @@ class DltResourceHints:
 
         # set properties that can't be passed to make_hints
         if incremental is not None:
-            t["incremental"] = incremental
+            t["incremental"] = Incremental.ensure_instance(incremental)
 
         self._set_hints(t, create_table_variant)
         return self

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -85,6 +85,7 @@ def make_hints(
     table_format: TTableHintTemplate[TTableFormat] = None,
     file_format: TTableHintTemplate[TFileFormat] = None,
     references: TTableHintTemplate[TTableReferenceParam] = None,
+    incremental: Incremental[Any] = None,
 ) -> TResourceHints:
     """A convenience function to create resource hints. Accepts both static and dynamic hints based on data.
 
@@ -118,6 +119,8 @@ def make_hints(
     if validator:
         new_template["validator"] = validator
     DltResourceHints.validate_dynamic_hints(new_template)
+    if incremental is not None:  # TODO: Validate
+        new_template["incremental"] = incremental
     return new_template
 
 

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -4,7 +4,6 @@ from typing_extensions import Self
 from dlt.common import logger
 from dlt.common.schema.typing import (
     C_DLT_ID,
-    TColumnNames,
     TColumnProp,
     TFileFormat,
     TPartialTableSchema,
@@ -28,7 +27,7 @@ from dlt.common.schema.utils import (
     new_column,
     new_table,
 )
-from dlt.common.typing import TDataItem
+from dlt.common.typing import TDataItem, TColumnNames
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.utils import clone_dict_nested
 from dlt.common.normalizers.json.relational import DataItemNormalizer
@@ -204,6 +203,10 @@ class DltResourceHints:
             for k, v in table_template.items()
             if k not in NATURAL_CALLABLES
         }  # type: ignore
+        if "incremental" in table_template:
+            incremental = table_template["incremental"]
+            if isinstance(incremental, Incremental) and incremental is not Incremental.EMPTY:
+                resolved_template["incremental"] = incremental
         table_schema = self._create_table_schema(resolved_template, self.name)
         migrate_complex_types(table_schema, warn=True)
         validate_dict_ignoring_xkeys(
@@ -518,6 +521,9 @@ class DltResourceHints:
                     "disposition": resource_hints["write_disposition"]
                 }  # wrap in dict
             DltResourceHints._merge_write_disposition_dict(resource_hints)  # type: ignore[arg-type]
+        if "incremental" in resource_hints:
+            if isinstance(resource_hints["incremental"], Incremental):
+                resource_hints["incremental"] = resource_hints["incremental"].to_table_hint()  # type: ignore[typeddict-item]
         dict_ = cast(TTableSchema, resource_hints)
         dict_["resource"] = resource_name
         return dict_

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -519,6 +519,9 @@ class DltResourceHints:
         if isinstance(incremental, Incremental):
             incremental_hint = incremental.to_table_hint()
         col_name = incremental.get_cursor_column_name()
+        if not col_name:
+            # cursor cannot resolve to a single column, no hint added
+            return
         incremental_col = dict_["columns"].get(col_name)
         if not incremental_col:
             incremental_col = {"name": col_name}

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, cast, Any, Optional, Dict, Sequence, Mapping
+from typing import TypedDict, cast, Any, Optional, Dict, Sequence, Mapping, Union
 from typing_extensions import Self
 
 from dlt.common import logger
@@ -18,6 +18,7 @@ from dlt.common.schema.typing import (
     DEFAULT_VALIDITY_COLUMN_NAMES,
     MERGE_STRATEGIES,
     TTableReferenceParam,
+    IncrementalArgs,
 )
 from dlt.common.schema.utils import (
     DEFAULT_WRITE_DISPOSITION,

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -18,7 +18,6 @@ from dlt.common.schema.typing import (
     DEFAULT_VALIDITY_COLUMN_NAMES,
     MERGE_STRATEGIES,
     TTableReferenceParam,
-    IncrementalArgs,
 )
 from dlt.common.schema.utils import (
     DEFAULT_WRITE_DISPOSITION,
@@ -37,7 +36,7 @@ from dlt.extract.exceptions import (
     DataItemRequiredForDynamicTableHints,
     InconsistentTableTemplate,
 )
-from dlt.extract.incremental import Incremental
+from dlt.extract.incremental import Incremental, TIncrementalConfig
 from dlt.extract.items import TFunHintTemplate, TTableHintTemplate, TableNameMeta, ValidateItem
 from dlt.extract.utils import ensure_table_schema_columns, ensure_table_schema_columns_hint
 from dlt.extract.validation import create_item_validator
@@ -86,7 +85,7 @@ def make_hints(
     table_format: TTableHintTemplate[TTableFormat] = None,
     file_format: TTableHintTemplate[TFileFormat] = None,
     references: TTableHintTemplate[TTableReferenceParam] = None,
-    incremental: Incremental[Any] = None,
+    incremental: TIncrementalConfig = None,
 ) -> TResourceHints:
     """A convenience function to create resource hints. Accepts both static and dynamic hints based on data.
 
@@ -121,7 +120,7 @@ def make_hints(
         new_template["validator"] = validator
     DltResourceHints.validate_dynamic_hints(new_template)
     if incremental is not None:  # TODO: Validate
-        new_template["incremental"] = incremental
+        new_template["incremental"] = Incremental.ensure_instance(incremental)
     return new_template
 
 
@@ -228,7 +227,7 @@ class DltResourceHints:
         columns: TTableHintTemplate[TAnySchemaColumns] = None,
         primary_key: TTableHintTemplate[TColumnNames] = None,
         merge_key: TTableHintTemplate[TColumnNames] = None,
-        incremental: Union[Incremental[Any], IncrementalArgs] = None,
+        incremental: TIncrementalConfig = None,
         schema_contract: TTableHintTemplate[TSchemaContract] = None,
         additional_table_hints: Optional[Dict[str, TTableHintTemplate[Any]]] = None,
         table_format: TTableHintTemplate[TTableFormat] = None,

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -515,8 +515,8 @@ class DltResourceHints:
     @staticmethod
     def _merge_incremental_column_hint(dict_: Dict[str, Any]) -> None:
         incremental = dict_.pop("incremental")
-        if isinstance(incremental, Incremental):
-            incremental_hint = incremental.to_table_hint()
+        if incremental is None:
+            return
         col_name = incremental.get_cursor_column_name()
         if not col_name:
             # cursor cannot resolve to a single column, no hint added
@@ -525,7 +525,7 @@ class DltResourceHints:
         if not incremental_col:
             incremental_col = {"name": col_name}
 
-        incremental_col["incremental"] = incremental_hint
+        incremental_col["incremental"] = True
         dict_["columns"][col_name] = incremental_col
 
     @staticmethod

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -181,7 +181,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
     def to_table_hint(self) -> Optional[IncrementalArgs]:
         """Table hint is only returned when all properties are serializable"""
         if self.last_value_func not in (min, max):
-            logger.warning(
+            logger.info(
                 "Custom last_value_func %s is not serializable. Incremental hint will not be saved"
                 " in schema.",
                 self.last_value_func,

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime  # noqa: I251
-from typing import Generic, ClassVar, Any, Optional, Type, Dict, Union
+from typing import Generic, ClassVar, Any, Optional, Type, Dict, Union, Literal, Tuple
 from typing_extensions import get_args
 
 import inspect
@@ -19,8 +19,8 @@ from dlt.common.typing import (
     get_generic_type_argument_from_instance,
     is_optional_type,
     is_subclass,
+    TColumnNames,
 )
-from dlt.common.schema.typing import TColumnNames
 from dlt.common.configuration import configspec, ConfigurationValueError
 from dlt.common.configuration.specs import BaseConfiguration
 from dlt.common.pipeline import resource_state
@@ -29,17 +29,19 @@ from dlt.common.data_types.type_helpers import (
     coerce_value,
     py_type_to_sc_type,
 )
+from dlt.common.utils import without_none
 
 from dlt.extract.exceptions import IncrementalUnboundError
 from dlt.extract.incremental.exceptions import (
     IncrementalCursorPathMissing,
     IncrementalPrimaryKeyMissing,
 )
-from dlt.extract.incremental.typing import (
+from dlt.common.incremental.typing import (
     IncrementalColumnState,
     TCursorValue,
     LastValueFunc,
     OnCursorValueMissing,
+    IncrementalArgs,
 )
 from dlt.extract.items import SupportsPipe, TTableHintTemplate, ItemTransform
 from dlt.extract.incremental.transform import (
@@ -123,7 +125,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         self,
         cursor_path: str = None,
         initial_value: Optional[TCursorValue] = None,
-        last_value_func: Optional[LastValueFunc[TCursorValue]] = max,
+        last_value_func: Optional[Union[LastValueFunc[TCursorValue], Literal["min", "max"]]] = max,
         primary_key: Optional[TTableHintTemplate[TColumnNames]] = None,
         end_value: Optional[TCursorValue] = None,
         row_order: Optional[TSortOrder] = None,
@@ -135,6 +137,16 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         if cursor_path:
             compile_path(cursor_path)
         self.cursor_path = cursor_path
+        if isinstance(last_value_func, str):
+            if last_value_func == "min":
+                last_value_func = min
+            elif last_value_func == "max":
+                last_value_func = max
+            else:
+                raise ValueError(
+                    f"Unknown last_value_func '{last_value_func}' passed as string. Provide a"
+                    " callable to use a custom function."
+                )
         self.last_value_func = last_value_func
         self.initial_value = initial_value
         """Initial value of last_value"""
@@ -165,6 +177,17 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         self._transformers: Dict[str, IncrementalTransform] = {}
         self._bound_pipe: SupportsPipe = None
         """Bound pipe"""
+
+    def to_table_hint(self) -> Optional[IncrementalArgs]:
+        """Table hint is only returned when all properties are serializable"""
+        if self.last_value_func not in (min, max):
+            logger.warning(
+                "Custom last_value_func %s is not serializable. Incremental hint will not be saved"
+                " in schema.",
+                self.last_value_func,
+            )
+            return None
+        return without_none(dict(self, last_value_func=self.last_value_func.__name__))  # type: ignore[return-value]
 
     @property
     def primary_key(self) -> Optional[TTableHintTemplate[TColumnNames]]:
@@ -491,6 +514,12 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
             and self.start_out_of_range
         )
 
+    @classmethod
+    def ensure_instance(cls, value: "TIncrementalConfig") -> "Incremental[TCursorValue]":
+        if isinstance(value, Incremental):
+            return value
+        return cls(**value)
+
     def __str__(self) -> str:
         return (
             f"Incremental at 0x{id(self):x} for resource {self.resource_name} with cursor path:"
@@ -556,6 +585,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
 Incremental.EMPTY = Incremental[Any]()
 Incremental.EMPTY.__is_resolved__ = True
 
+TIncrementalConfig = Union[Incremental[Any], IncrementalArgs]
+
 
 class IncrementalResourceWrapper(ItemTransform[TDataItem]):
     placement_affinity: ClassVar[float] = 1  # stick to end
@@ -594,6 +625,34 @@ class IncrementalResourceWrapper(ItemTransform[TDataItem]):
                 incremental_param = p
                 break
         return incremental_param
+
+    @staticmethod
+    def inject_implicit_incremental_arg(
+        incremental: Optional[Union[Incremental[Any], "IncrementalResourceWrapper"]],
+        sig: inspect.Signature,
+        func_args: Tuple[Any],
+        func_kwargs: Dict[str, Any],
+        fallback: Optional[Incremental[Any]] = None,
+    ) -> Tuple[Tuple[Any], Dict[str, Any], Optional[Incremental[Any]]]:
+        """Inject the incremental instance into function arguments
+        if the function has an incremental argument without default in its signature and it is not already set in the arguments.
+
+        Returns:
+            Tuple of the new args, kwargs and the incremental instance that was injected (if any)
+        """
+        if isinstance(incremental, IncrementalResourceWrapper):
+            incremental = incremental.incremental
+        if not incremental:
+            if not fallback:
+                return func_args, func_kwargs, None
+            incremental = fallback
+        incremental_param = IncrementalResourceWrapper.get_incremental_arg(sig)
+        if incremental_param:
+            bound_args = sig.bind_partial(*func_args, **func_kwargs)
+            if not bound_args.arguments.get(incremental_param.name):
+                bound_args.arguments[incremental_param.name] = incremental
+                return bound_args.args, bound_args.kwargs, incremental
+        return func_args, func_kwargs, None
 
     def wrap(self, sig: inspect.Signature, func: TFun) -> TFun:
         """Wrap the callable to inject an `Incremental` object configured for the resource."""
@@ -666,12 +725,14 @@ class IncrementalResourceWrapper(ItemTransform[TDataItem]):
         return self._incremental
 
     def set_incremental(
-        self, incremental: Optional[Incremental[Any]], from_hints: bool = False
+        self, incremental: Optional[TIncrementalConfig], from_hints: bool = False
     ) -> None:
         """Sets the incremental. If incremental was set from_hints, it can only be changed in the same manner"""
         if self._from_hints and not from_hints:
             # do not accept incremental if apply hints were used
             return
+        if incremental is not None:
+            incremental = Incremental.ensure_instance(incremental)
         self._from_hints = from_hints
         self._incremental = incremental
 
@@ -710,6 +771,12 @@ class IncrementalResourceWrapper(ItemTransform[TDataItem]):
         return self._incremental(item, meta)
 
 
+def incremental_config_to_instance(cfg: TIncrementalConfig) -> Incremental[Any]:
+    if isinstance(cfg, Incremental):
+        return cfg
+    return Incremental(**cfg)
+
+
 __all__ = [
     "Incremental",
     "IncrementalResourceWrapper",
@@ -717,6 +784,7 @@ __all__ = [
     "IncrementalCursorPathMissing",
     "IncrementalPrimaryKeyMissing",
     "IncrementalUnboundError",
+    "TIncrementalconfig",
     "LastValueFunc",
     "TCursorValue",
 ]

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -9,7 +9,7 @@ from functools import wraps
 from dlt.common import logger
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.pendulum import pendulum
-from dlt.common.jsonpath import compile_path
+from dlt.common.jsonpath import compile_path, extract_simple_field_name
 from dlt.common.typing import (
     TDataItem,
     TDataItems,
@@ -269,6 +269,11 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
     def copy(self) -> "Incremental[TCursorValue]":
         # merge creates a copy
         return self.merge(self)
+
+    def get_cursor_column_name(self) -> Optional[str]:
+        """Return the name of the cursor column if the cursor path resolves to a single column
+        """
+        return extract_simple_field_name(self.cursor_path)
 
     def on_resolved(self) -> None:
         compile_path(self.cursor_path)

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -271,8 +271,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         return self.merge(self)
 
     def get_cursor_column_name(self) -> Optional[str]:
-        """Return the name of the cursor column if the cursor path resolves to a single column
-        """
+        """Return the name of the cursor column if the cursor path resolves to a single column"""
         return extract_simple_field_name(self.cursor_path)
 
     def on_resolved(self) -> None:

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -545,7 +545,6 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
     def __call__(self, rows: TDataItems, meta: Any = None) -> Optional[TDataItems]:
         if rows is None:
             return rows
-
         transformer = self._get_transformer(rows)
         if isinstance(rows, list):
             rows = [

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -178,17 +178,6 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         self._bound_pipe: SupportsPipe = None
         """Bound pipe"""
 
-    def to_table_hint(self) -> Optional[IncrementalArgs]:
-        """Table hint is only returned when all properties are serializable"""
-        if self.last_value_func not in (min, max):
-            logger.info(
-                "Custom last_value_func %s is not serializable. Incremental hint will not be saved"
-                " in schema.",
-                self.last_value_func,
-            )
-            return None
-        return without_none(dict(self, last_value_func=self.last_value_func.__name__))  # type: ignore[return-value]
-
     @property
     def primary_key(self) -> Optional[TTableHintTemplate[TColumnNames]]:
         return self._primary_key

--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -5,7 +5,7 @@ from dlt.common.exceptions import MissingDependencyException
 from dlt.common.utils import digest128
 from dlt.common.json import json
 from dlt.common.pendulum import pendulum
-from dlt.common.typing import TDataItem
+from dlt.common.typing import TDataItem, TColumnNames
 from dlt.common.jsonpath import find_values, compile_path, extract_simple_field_name
 from dlt.extract.incremental.exceptions import (
     IncrementalCursorInvalidCoercion,
@@ -13,10 +13,9 @@ from dlt.extract.incremental.exceptions import (
     IncrementalPrimaryKeyMissing,
     IncrementalCursorPathHasValueNone,
 )
-from dlt.extract.incremental.typing import TCursorValue, LastValueFunc, OnCursorValueMissing
+from dlt.common.incremental.typing import TCursorValue, LastValueFunc, OnCursorValueMissing
 from dlt.extract.utils import resolve_column_value
 from dlt.extract.items import TTableHintTemplate
-from dlt.common.schema.typing import TColumnNames
 
 try:
     from dlt.common.libs import pyarrow

--- a/dlt/extract/items.py
+++ b/dlt/extract/items.py
@@ -19,7 +19,14 @@ from typing import (
 )
 from concurrent.futures import Future
 
-from dlt.common.typing import TAny, TDataItem, TDataItems
+from dlt.common.typing import (
+    TAny,
+    TDataItem,
+    TDataItems,
+    TTableHintTemplate,
+    TFunHintTemplate,
+    TDynHintType,
+)
 
 
 TDecompositionStrategy = Literal["none", "scc"]
@@ -27,9 +34,6 @@ TDeferredDataItems = Callable[[], TDataItems]
 TAwaitableDataItems = Awaitable[TDataItems]
 TPipedDataItems = Union[TDataItems, TDeferredDataItems, TAwaitableDataItems]
 
-TDynHintType = TypeVar("TDynHintType")
-TFunHintTemplate = Callable[[TDataItem], TDynHintType]
-TTableHintTemplate = Union[TDynHintType, TFunHintTemplate[TDynHintType]]
 
 if TYPE_CHECKING:
     TItemFuture = Future[TPipedDataItems]

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -11,7 +11,7 @@ from typing import (
     Union,
     Any,
     Optional,
-    Mapping
+    Mapping,
 )
 from typing_extensions import TypeVar, Self
 
@@ -451,7 +451,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
 
     def set_incremental(
         self,
-        new_incremental: Union[Incremental[Any], IncrementalResourceWrapper, IncrementalArgs],
+        new_incremental: Union[Incremental[Any], IncrementalResourceWrapper],
         from_hints: bool = False,
     ) -> Optional[Union[Incremental[Any], IncrementalResourceWrapper]]:
         """Set/replace the incremental transform for the resource.
@@ -464,9 +464,9 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
             new_incremental = None
         incremental = self.incremental
         if incremental is not None:
-            if isinstance(new_incremental, Mapping):
-                new_incremental = Incremental.ensure_instance(new_incremental)
-            
+            # if isinstance(new_incremental, Mapping):
+            #     new_incremental = Incremental.ensure_instance(new_incremental)
+
             if isinstance(new_incremental, IncrementalResourceWrapper):
                 # Completely replace the wrapper
                 self._remove_incremental_step()
@@ -497,7 +497,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
                     table_schema_template["incremental"], from_hints=True
                 )
             else:
-                incremental = self.incremental  # type: ignore[assignment]
+                incremental = self.incremental
 
             if incremental:
                 primary_key = table_schema_template.get("primary_key", incremental.primary_key)

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -515,7 +515,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
             if isinstance(incremental, IncrementalResourceWrapper):
                 incremental = incremental.incremental
                 if incremental:
-                    self._set_hints(make_hints(incremental=incremental))
+                    self._hints['incremental'] = incremental
 
         table_schema = super().compute_table_schema(item, meta)
 

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -449,7 +449,9 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
             self._pipe.remove_step(step_no)
 
     def set_incremental(
-        self, new_incremental: Union[Incremental[Any], IncrementalResourceWrapper], from_hints: bool = False
+        self,
+        new_incremental: Union[Incremental[Any], IncrementalResourceWrapper],
+        from_hints: bool = False,
     ) -> Optional[Incremental[Any]]:
         """Set/replace the incremental transform for the resource.
 
@@ -507,11 +509,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
                 incremental = incremental.incremental
                 if incremental:
                     self._set_hints(make_hints(incremental=incremental))
-                
-                
 
-                    
-            
         table_schema = super().compute_table_schema(item, meta)
         # if self.incremental and "incremental" not in table_schema:
         #     incremental = self.incremental
@@ -647,7 +645,9 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
                 return True
         return False
 
-    def _inject_config(self, incremental_from_hints_override: Optional[bool] = None) -> "DltResource":
+    def _inject_config(
+        self, incremental_from_hints_override: Optional[bool] = None
+    ) -> "DltResource":
         """Wraps the pipe generation step in incremental and config injection wrappers and adds pipe step with
         Incremental transform.
         """
@@ -660,7 +660,14 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         if IncrementalResourceWrapper.should_wrap(sig):
             incremental = IncrementalResourceWrapper(self._hints.get("primary_key"))
             if incr_hint := self._hints.get("incremental"):
-                incremental.set_incremental(incr_hint, from_hints=incremental_from_hints_override if incremental_from_hints_override is not None else True)
+                incremental.set_incremental(
+                    incr_hint,
+                    from_hints=(
+                        incremental_from_hints_override
+                        if incremental_from_hints_override is not None
+                        else True
+                    ),
+                )
             incr_f = incremental.wrap(sig, gen)
             self.set_incremental(incremental)
         else:

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -515,7 +515,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
             if isinstance(incremental, IncrementalResourceWrapper):
                 incremental = incremental.incremental
                 if incremental:
-                    self._hints['incremental'] = incremental
+                    self._hints["incremental"] = incremental
 
         table_schema = super().compute_table_schema(item, meta)
 

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -493,7 +493,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
                     table_schema_template["incremental"], from_hints=True
                 )
             else:
-                incremental = self.incremental
+                incremental = self.incremental  # type: ignore[assignment]
 
             if incremental:
                 primary_key = table_schema_template.get("primary_key", incremental.primary_key)

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -29,7 +29,7 @@ from dlt.common.pipeline import (
     pipeline_state,
 )
 from dlt.common.utils import flatten_list_or_items, get_callable_name, uniq_id
-from dlt.common.schema.typing import TTableSchema, IncrementalArgs
+from dlt.common.schema.typing import TTableSchema
 from dlt.extract.utils import wrap_async_iterator, wrap_parallel_iterator
 
 from dlt.extract.items import (
@@ -45,7 +45,7 @@ from dlt.extract.items import (
 from dlt.extract.pipe_iterator import ManagedPipeIterator
 from dlt.extract.pipe import Pipe, TPipeStep
 from dlt.extract.hints import DltResourceHints, HintsMeta, TResourceHints, make_hints
-from dlt.extract.incremental import Incremental, IncrementalResourceWrapper, TIncrementalConfig
+from dlt.extract.incremental import Incremental, IncrementalResourceWrapper
 from dlt.extract.exceptions import (
     InvalidTransformerDataTypeGeneratorFunctionRequired,
     InvalidParentResourceDataType,

--- a/dlt/extract/utils.py
+++ b/dlt/extract/utils.py
@@ -22,8 +22,15 @@ from functools import wraps, partial
 from dlt.common.data_writers import TDataItemFormat
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.pipeline import reset_resource_state
-from dlt.common.schema.typing import TColumnNames, TAnySchemaColumns, TTableSchemaColumns
-from dlt.common.typing import AnyFun, DictStrAny, TDataItem, TDataItems, TAnyFunOrGenerator
+from dlt.common.schema.typing import TAnySchemaColumns, TTableSchemaColumns
+from dlt.common.typing import (
+    AnyFun,
+    DictStrAny,
+    TDataItem,
+    TDataItems,
+    TAnyFunOrGenerator,
+    TColumnNames,
+)
 from dlt.common.utils import get_callable_name
 
 from dlt.extract.exceptions import (

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -38,7 +38,6 @@ from dlt.common.destination.exceptions import (
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.runtime import signals, apply_runtime_config
 from dlt.common.schema.typing import (
-    TColumnNames,
     TSchemaTables,
     TTableFormat,
     TWriteDispositionConfig,
@@ -47,7 +46,7 @@ from dlt.common.schema.typing import (
 )
 from dlt.common.schema.utils import normalize_schema_name
 from dlt.common.storages.exceptions import LoadPackageNotFound
-from dlt.common.typing import ConfigValue, TFun, TSecretStrValue, is_optional_type
+from dlt.common.typing import ConfigValue, TFun, TSecretStrValue, is_optional_type, TColumnNames
 from dlt.common.runners import pool_runner as runner
 from dlt.common.storages import (
     LiveSchemaStorage,

--- a/dlt/sources/rest_api/typing.py
+++ b/dlt/sources/rest_api/typing.py
@@ -15,7 +15,7 @@ from dlt.common import jsonpath
 from dlt.common.schema.typing import (
     TAnySchemaColumns,
 )
-from dlt.extract.incremental.typing import IncrementalArgs
+from dlt.common.incremental.typing import IncrementalArgs
 from dlt.extract.items import TTableHintTemplate
 from dlt.extract.hints import TResourceHintsBase
 from dlt.sources.helpers.rest_client.auth import AuthConfigBase, TApiKeyLocation
@@ -23,9 +23,8 @@ from dlt.sources.helpers.rest_client.auth import AuthConfigBase, TApiKeyLocation
 from dataclasses import dataclass, field
 
 from dlt.common import jsonpath
-from dlt.common.typing import TSortOrder
+from dlt.common.typing import TSortOrder, TColumnNames
 from dlt.common.schema.typing import (
-    TColumnNames,
     TTableFormat,
     TAnySchemaColumns,
     TWriteDispositionConfig,
@@ -33,7 +32,7 @@ from dlt.common.schema.typing import (
 )
 
 from dlt.extract.items import TTableHintTemplate
-from dlt.extract.incremental.typing import LastValueFunc
+from dlt.common.incremental.typing import LastValueFunc
 from dlt.extract.resource import DltResource
 
 from requests import Session

--- a/tests/common/test_jsonpath.py
+++ b/tests/common/test_jsonpath.py
@@ -1,0 +1,43 @@
+import pytest
+
+from dlt.common import jsonpath as jp
+
+
+@pytest.mark.parametrize("compiled", [True, False])
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("col_a", "col_a"),
+        ("'col.a'", "col.a"),
+        ("'$col_a'", "$col_a"),
+        ("'col|a'", "col|a"),
+    ],
+)
+def test_extract_simple_field_name_positive(path, expected, compiled):
+    if compiled:
+        path = jp.compile_path(path)
+
+    result = jp.extract_simple_field_name(path)
+    assert result == expected
+
+
+@pytest.mark.parametrize("compiled", [True, False])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "$.col_a",
+        "$.col_a.items",
+        "$.col_a.items[0]",
+        "$.col_a.items[*]",
+        "col_a|col_b",
+    ],
+)
+def test_extract_simple_field_name_negative(path, compiled):
+    if compiled:
+        path = jp.compile_path(path)
+
+    result = jp.extract_simple_field_name(path)
+    assert result is None
+
+
+# TODO: Test all jsonpath utils

--- a/tests/common/test_validation.py
+++ b/tests/common/test_validation.py
@@ -19,13 +19,13 @@ from typing import (
 from dlt.common import Decimal, jsonpath
 from dlt.common.exceptions import DictValidationException
 from dlt.common.schema.typing import (
-    TColumnNames,
     TStoredSchema,
     TColumnSchema,
     TWriteDispositionConfig,
 )
 from dlt.common.schema.utils import simple_regex_validator
-from dlt.common.typing import DictStrStr, StrStr, TDataItem, TSortOrder
+from dlt.common.typing import DictStrStr, StrStr, TDataItem, TSortOrder, TColumnNames
+
 from dlt.common.validation import validate_dict, validate_dict_ignoring_xkeys
 
 

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -3675,7 +3675,7 @@ def test_incremental_table_hint_datetime_column(
     if incremental_settings.get("row_order"):
         expected["row_order"] = incremental_settings["row_order"]
 
-    assert table_schema["incremental"] == expected
+    assert table_schema["columns"]["updated_at"]["incremental"] == expected
 
 
 def incremental_instance_or_dict(use_dict: bool, **kwargs):

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -3766,18 +3766,18 @@ def test_incremental_table_hint_merged_columns(use_dict: bool) -> None:
         )
     )
     def some_data():
-        yield [{"col_a": i, "foo": i+ 2, "col_b": i + 1, "bar": i+3} for i in range(10)]
+        yield [{"col_a": i, "foo": i + 2, "col_b": i + 1, "bar": i + 3} for i in range(10)]
 
     pipeline = dlt.pipeline(pipeline_name=uniq_id())
     pipeline.extract(some_data())
 
     table_schema = pipeline.default_schema.tables["some_data"]
-    assert table_schema['columns']['col_a']['incremental'] == {
+    assert table_schema["columns"]["col_a"]["incremental"] == {
         "allow_external_schedulers": False,
         "cursor_path": "col_a",
         "initial_value": 3,
         "last_value_func": "min",
-        "on_cursor_value_missing": "raise"
+        "on_cursor_value_missing": "raise",
     }
 
     rs = some_data()
@@ -3792,13 +3792,13 @@ def test_incremental_table_hint_merged_columns(use_dict: bool) -> None:
     table_schema_2 = pipeline.default_schema.tables["some_data"]
 
     # Only one column should have the hint
-    assert 'incremental' not in table_schema_2['columns']['col_a']
-    assert table_schema_2['columns']['col_b']['incremental'] == {
+    assert "incremental" not in table_schema_2["columns"]["col_a"]
+    assert table_schema_2["columns"]["col_b"]["incremental"] == {
         "allow_external_schedulers": False,
         "cursor_path": "col_b",
         "initial_value": 5,
         "last_value_func": "max",
-        "on_cursor_value_missing": "raise"
+        "on_cursor_value_missing": "raise",
     }
 
 
@@ -3810,7 +3810,7 @@ def test_incremental_column_hint_cursor_is_not_column(use_dict: bool):
         )
     )
     def some_data():
-        yield [{"col_a": i, "foo": i+ 2, "col_b": i + 1, "bar": i+3} for i in range(10)]
+        yield [{"col_a": i, "foo": i + 2, "col_b": i + 1, "bar": i + 3} for i in range(10)]
 
     pipeline = dlt.pipeline(pipeline_name=uniq_id())
 
@@ -3818,5 +3818,5 @@ def test_incremental_column_hint_cursor_is_not_column(use_dict: bool):
 
     table_schema = pipeline.default_schema.tables["some_data"]
 
-    for col in table_schema['columns'].values():
-        assert 'incremental' not in col
+    for col in table_schema["columns"].values():
+        assert "incremental" not in col

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -3684,24 +3684,24 @@ def incremental_instance_or_dict(use_dict: bool, **kwargs):
     return dlt.sources.incremental(**kwargs)
 
 
-@pytest.mark.parametrize("use_dict", [True, False])
+@pytest.mark.parametrize("use_dict", [False])
 def test_incremental_in_resource_decorator(use_dict: bool) -> None:
-    @dlt.resource(
-        incremental=incremental_instance_or_dict(
-            use_dict, cursor_path="value", initial_value=5, last_value_func=min
-        )
-    )
-    def with_required_incremental_arg(incremental: dlt.sources.incremental[int]):
-        assert incremental.last_value == 5
-        assert incremental.last_value_func == min
-        yield [{"value": i} for i in range(10)]
+    # @dlt.resource(
+    #     incremental=incremental_instance_or_dict(
+    #         use_dict, cursor_path="value", initial_value=5, last_value_func=min
+    #     )
+    # )
+    # def with_required_incremental_arg(incremental: dlt.sources.incremental[int]):
+    #     assert incremental.last_value == 5
+    #     assert incremental.last_value_func == min
+    #     yield [{"value": i} for i in range(10)]
 
-    # Don't pass the argument, use the decorator settings
-    result = list(with_required_incremental_arg())
-    assert result == [{"value": i} for i in range(0, 6)]
+    # # Don't pass the argument, use the decorator settings
+    # result = list(with_required_incremental_arg())
+    # assert result == [{"value": i} for i in range(0, 6)]
 
-    result = list(with_required_incremental_arg(incremental=None))
-    assert result == [{"value": i} for i in range(0, 6)]
+    # result = list(with_required_incremental_arg(incremental=None))
+    # assert result == [{"value": i} for i in range(0, 6)]
 
     # Incremental set in decorator, without any arguments
     @dlt.resource(
@@ -3740,7 +3740,7 @@ def test_incremental_in_resource_decorator(use_dict: bool) -> None:
     assert result == [{"value": i} for i in range(0, 6)]
 
 
-@pytest.mark.parametrize("use_dict", [True, False])
+@pytest.mark.parametrize("use_dict", [False])
 def test_incremental_in_resource_decorator_default_arg(use_dict: bool) -> None:
     @dlt.resource(
         incremental=incremental_instance_or_dict(


### PR DESCRIPTION
* Extract incremental settings to a dict in table schema
* Support passing incremental settings to @resource decorator

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
* Add `incremental` hint to table schema, containing all incremental settings used in extract
* Accept `incremental` in `@resource` decorator. Either as dict (`IncrementalArgs` typeddict or incremental instance)
* Decorator incremental is injected to resource func if argument is in signature
* Explicit argument overrides decorator incremental

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #1974 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
