### PR TITLE
fix bigquery autodetect

### DIFF
--- a/dlt/destinations/impl/bigquery/sql_client.py
+++ b/dlt/destinations/impl/bigquery/sql_client.py
@@ -274,7 +274,7 @@ class BigQuerySqlClient(SqlClientBase[bigquery.Client], DBTransaction):
         # anything else is transient
         return DatabaseTransientException(ex)
 
-    def truncate_tables(self, *tables: str) -> None:
+    def truncate_tables_if_exist(self, *tables: str) -> None:
         """NOTE: We only truncate tables that exist, for auto-detect schema we don't know which tables exist"""
         statements: List[str] = ["DECLARE table_exists BOOL;"]
         for t in tables:

--- a/dlt/destinations/impl/bigquery/sql_client.py
+++ b/dlt/destinations/impl/bigquery/sql_client.py
@@ -199,7 +199,6 @@ class BigQuerySqlClient(SqlClientBase[bigquery.Client], DBTransaction):
     def execute_sql(
         self, sql: AnyStr, *args: Any, **kwargs: Any
     ) -> Optional[Sequence[Sequence[Any]]]:
-        print(sql)
         with self.execute_query(sql, *args, **kwargs) as curr:
             if not curr.description:
                 return None

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -501,6 +501,12 @@ class SqlMergeFollowupJob(SqlFollowupJob):
             root_table["name"]
         )
 
+        # NOTE: this is bigquery specific code! Move to bigquery merge job
+        # NOTE: we also need to create all child tables
+        # NOTE: this will not work if the schema of the staging table changes in the next run..
+        # in some cases we need to create final tables here
+        sql.append(f"CREATE TABLE IF NOT EXISTS {root_table_name} LIKE {staging_root_table_name};")
+
         # get merge and primary keys from top level
         primary_keys = cls._escape_list(
             get_columns_names_with_prop(root_table, "primary_key"),

--- a/tests/load/pipeline/test_bigquery.py
+++ b/tests/load/pipeline/test_bigquery.py
@@ -360,3 +360,40 @@ def test_adapter_autodetect_schema_with_hints(
         table: Table = nc.get_table(table_fqtn)  # type: ignore[no-redef]
         assert table.time_partitioning.field == "my_date_column"
         assert table.time_partitioning.type_ == "DAY"
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["bigquery"]),
+    ids=lambda x: x.name,
+)
+def test_adapter_autodetect_schema_with_merge(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """simple test that merging works with autodetect schema"""
+    pipeline = destination_config.setup_pipeline(
+        f"bigquery_autodetect_schema_with_merge",
+        dev_mode=True,
+    )
+
+    @dlt.resource(primary_key="id", table_name="items", write_disposition="merge")
+    def resource():
+        for id in range(0, 5):
+            yield {"id": id, "value": id, "nested": [{"id": id, "value": id}]}
+
+    bigquery_adapter(resource, autodetect_schema=True)
+    pipeline.run(resource)
+
+    assert len(pipeline._dataset().items.df()) == 5
+    assert len(pipeline._dataset().items__nested.df()) == 5
+
+    @dlt.resource(primary_key="id", table_name="items", write_disposition="merge")
+    def resource2():
+        for id in range(2, 7):
+            yield {"id": id, "value": id, "nested": [{"id": id, "value": id}]}
+
+    bigquery_adapter(resource2, autodetect_schema=True)
+    pipeline.run(resource2)
+
+    assert len(pipeline._dataset().items.df()) == 7
+    assert len(pipeline._dataset().items__nested.df()) == 7

--- a/tests/load/pipeline/test_bigquery.py
+++ b/tests/load/pipeline/test_bigquery.py
@@ -372,14 +372,14 @@ def test_adapter_autodetect_schema_with_merge(
 ) -> None:
     """simple test that merging works with autodetect schema"""
     pipeline = destination_config.setup_pipeline(
-        f"bigquery_autodetect_schema_with_merge",
+        "bigquery_autodetect_schema_with_merge",
         dev_mode=True,
     )
 
     @dlt.resource(primary_key="id", table_name="items", write_disposition="merge")
     def resource():
-        for id in range(0, 5):
-            yield {"id": id, "value": id, "nested": [{"id": id, "value": id}]}
+        for _id in range(0, 5):
+            yield {"id": _id, "value": _id, "nested": [{"id": _id, "value": _id}]}
 
     bigquery_adapter(resource, autodetect_schema=True)
     pipeline.run(resource)
@@ -389,8 +389,8 @@ def test_adapter_autodetect_schema_with_merge(
 
     @dlt.resource(primary_key="id", table_name="items", write_disposition="merge")
     def resource2():
-        for id in range(2, 7):
-            yield {"id": id, "value": id, "nested": [{"id": id, "value": id}]}
+        for _id in range(2, 7):
+            yield {"id": _id, "value": _id, "nested": [{"id": _id, "value": _id}]}
 
     bigquery_adapter(resource2, autodetect_schema=True)
     pipeline.run(resource2)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->

### Description
When using autodetect_schema on bigquery, merge and replace with "insert-from-staging" will fail, because dlt is:
1. Trying to truncate non-existing tables (this is solveable fairly easy, see first commit)
2. On the first load trying to insert data into a non existing table (also easily solvable by creating the correct final table from the staging table before the merge is run)

Problems: The suggested approach in this ticket will not work if the schema of the table changes, because bigquery has no commands to update the schema of an existing table to match the schema of another existing table. So the staging table will auto evolve but it's not easy to have the main table follow this without directly inserting data there.

Possible solutions:
* Disallow schema evolutions when merge and autodetect is enabled. The users would have to manually do this.
* Write a bit of code that can update the main table to match the staging table by reflecting the information schema. This probably is fairly time consuming to do on every load. We'd have to insert some update commands between loading the staging jobs which change the schema and executing the merge sql
* Update the schemas of all tables, staging and final, by inserting data from a parquet file and selecting a partition that does not exist with auto schema updates enabled. This way, according to my research, the schema will be updated but no data is loaded. 