### PR TITLE
fix failing test due to performance improvements

### DIFF
--- a/tests/load/test_dummy_client.py
+++ b/tests/load/test_dummy_client.py
@@ -130,7 +130,7 @@ def test_big_loadpackages() -> None:
     duration = float(time() - start_time)
 
     # sanity check
-    assert duration > 3
+    assert duration > 2
     # we want 1000 empty processed jobs to need less than 15 seconds total (locally it runs in 5)
     assert duration < 15
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
apparently dlt got much faster, so we need to adjust one test that is timed and runs faster now.