### PR TITLE
edit snippet to make more runnable

### DIFF
--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/deploy_snippets/deploy-with-modal-snippets.py
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/deploy_snippets/deploy-with-modal-snippets.py
@@ -1,18 +1,16 @@
-import os
-
-import modal
-
 from tests.pipeline.utils import assert_load_info
 
 
 def test_modal_snippet() -> None:
     # @@@DLT_SNIPPET_START modal_image
+    import modal
+
     # Define the Modal Image
     image = modal.Image.debian_slim().pip_install(
         "dlt>=1.1.0",
         "dlt[duckdb]",  # destination
         "dlt[sql_database]",  # source (MySQL)
-        "dlt[parquet]",  # file format dependency 
+        "dlt[parquet]",  # file format dependency
         "pymysql",  # database driver for MySQL source
     )
 
@@ -26,9 +24,11 @@ def test_modal_snippet() -> None:
     @app.function(
         volumes={"/data/": vol},
         schedule=modal.Period(days=1),
+        serialized=True
     )
     def load_tables() -> None:
         import dlt
+        import os
         from dlt.sources.sql_database import sql_database
 
         # Define the source database credentials; in production, you would save this as a Modal Secret which can be referenced here as an environment variable


### PR DESCRIPTION
### Description
Tried running the example as is and ran into a few issues:
* dlt[parquet] missing dependency
* missing secret (removed since it's not used in this example)
* removed serialized flag (this is kind of an advanced feature and not really needed here)
* added minimal reflection level, otherwise if you run this script twice in a row you get a "column constraint not supported" kind of error

Another thing I noticed is that the way the snippets are used in the example excludes information that prevents the code from being truly runnable e.g. `import modal` statement
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/9512ef3e-cb14-4b61-9882-46fe859a67f4">

At a high level, if this is my first time coming to this page, I'd expect to be able to copy / paste the code as is here and run it right away and given how the snippets are set up, that's not the case and I'm not sure how to make it so. Open to ideas!



<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
