### PR TITLE
adds engine adapter and passes incremental and engine to query adapter

### DIFF
--- a/dlt/common/configuration/specs/azure_credentials.py
+++ b/dlt/common/configuration/specs/azure_credentials.py
@@ -22,6 +22,8 @@ class AzureCredentialsWithoutDefaults(CredentialsConfiguration):
     azure_storage_sas_token: TSecretStrValue = None
     azure_sas_token_permissions: str = "racwdl"
     """Permissions to use when generating a SAS token. Ignored when sas token is provided directly"""
+    azure_account_host: Optional[str] = None
+    """Alternative host when accessing blob storage endpoint ie. my_account.dfs.core.windows.net"""
 
     def to_adlfs_credentials(self) -> Dict[str, Any]:
         """Return a dict that can be passed as kwargs to adlfs"""
@@ -29,6 +31,7 @@ class AzureCredentialsWithoutDefaults(CredentialsConfiguration):
             account_name=self.azure_storage_account_name,
             account_key=self.azure_storage_account_key,
             sas_token=self.azure_storage_sas_token,
+            account_host=self.azure_account_host,
         )
 
     def to_object_store_rs_credentials(self) -> Dict[str, str]:
@@ -68,10 +71,13 @@ class AzureServicePrincipalCredentialsWithoutDefaults(CredentialsConfiguration):
     azure_tenant_id: str = None
     azure_client_id: str = None
     azure_client_secret: TSecretStrValue = None
+    azure_account_host: Optional[str] = None
+    """Alternative host when accessing blob storage endpoint ie. my_account.dfs.core.windows.net"""
 
     def to_adlfs_credentials(self) -> Dict[str, Any]:
         return dict(
             account_name=self.azure_storage_account_name,
+            account_host=self.azure_account_host,
             tenant_id=self.azure_tenant_id,
             client_id=self.azure_client_id,
             client_secret=self.azure_client_secret,

--- a/dlt/common/configuration/specs/azure_credentials.py
+++ b/dlt/common/configuration/specs/azure_credentials.py
@@ -9,21 +9,36 @@ from dlt.common.configuration.specs import (
     configspec,
 )
 from dlt import version
+from dlt.common.utils import without_none
 
 _AZURE_STORAGE_EXTRA = f"{version.DLT_PKG_NAME}[az]"
 
 
 @configspec
-class AzureCredentialsWithoutDefaults(CredentialsConfiguration):
+class AzureCredentialsBase(CredentialsConfiguration):
+    azure_storage_account_name: str = None
+    azure_account_host: Optional[str] = None
+    """Alternative host when accessing blob storage endpoint ie. my_account.dfs.core.windows.net"""
+
+    def to_adlfs_credentials(self) -> Dict[str, Any]:
+        pass
+
+    def to_object_store_rs_credentials(self) -> Dict[str, str]:
+        # https://docs.rs/object_store/latest/object_store/azure
+        creds: Dict[str, Any] = without_none(self.to_adlfs_credentials())  # type: ignore[assignment]
+        # only string options accepted
+        creds.pop("anon", None)
+        return creds
+
+
+@configspec
+class AzureCredentialsWithoutDefaults(AzureCredentialsBase):
     """Credentials for Azure Blob Storage, compatible with adlfs"""
 
-    azure_storage_account_name: str = None
     azure_storage_account_key: Optional[TSecretStrValue] = None
     azure_storage_sas_token: TSecretStrValue = None
     azure_sas_token_permissions: str = "racwdl"
     """Permissions to use when generating a SAS token. Ignored when sas token is provided directly"""
-    azure_account_host: Optional[str] = None
-    """Alternative host when accessing blob storage endpoint ie. my_account.dfs.core.windows.net"""
 
     def to_adlfs_credentials(self) -> Dict[str, Any]:
         """Return a dict that can be passed as kwargs to adlfs"""
@@ -33,15 +48,6 @@ class AzureCredentialsWithoutDefaults(CredentialsConfiguration):
             sas_token=self.azure_storage_sas_token,
             account_host=self.azure_account_host,
         )
-
-    def to_object_store_rs_credentials(self) -> Dict[str, str]:
-        # https://docs.rs/object_store/latest/object_store/azure
-        creds = self.to_adlfs_credentials()
-        if creds["sas_token"] is None:
-            creds.pop("sas_token")
-        if creds["account_key"] is None:
-            creds.pop("account_key")
-        return creds
 
     def create_sas_token(self) -> None:
         try:
@@ -66,13 +72,10 @@ class AzureCredentialsWithoutDefaults(CredentialsConfiguration):
 
 
 @configspec
-class AzureServicePrincipalCredentialsWithoutDefaults(CredentialsConfiguration):
-    azure_storage_account_name: str = None
+class AzureServicePrincipalCredentialsWithoutDefaults(AzureCredentialsBase):
     azure_tenant_id: str = None
     azure_client_id: str = None
     azure_client_secret: TSecretStrValue = None
-    azure_account_host: Optional[str] = None
-    """Alternative host when accessing blob storage endpoint ie. my_account.dfs.core.windows.net"""
 
     def to_adlfs_credentials(self) -> Dict[str, Any]:
         return dict(
@@ -82,10 +85,6 @@ class AzureServicePrincipalCredentialsWithoutDefaults(CredentialsConfiguration):
             client_id=self.azure_client_id,
             client_secret=self.azure_client_secret,
         )
-
-    def to_object_store_rs_credentials(self) -> Dict[str, str]:
-        # https://docs.rs/object_store/latest/object_store/azure
-        return self.to_adlfs_credentials()
 
 
 @configspec

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -443,8 +443,9 @@ class RunnableLoadJob(LoadJob, ABC):
             self._finished_at = pendulum.now()
             # sanity check
             assert self._state in ("completed", "retry", "failed")
-            # wake up waiting threads
-            signals.wake_all()
+            if self._state != "retry":
+                # wake up waiting threads
+                signals.wake_all()
 
     @abstractmethod
     def run(self) -> None:

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -593,7 +593,7 @@ def row_tuples_to_arrow(
         pivoted_rows = np.asarray(rows, dtype="object", order="k").T  # type: ignore[call-overload]
 
     columnar = {
-        col: dat.ravel() for col, dat in zip(columns, np.vsplit(pivoted_rows, len(columns)))
+        col: dat.ravel() for col, dat in zip(columns, np.vsplit(pivoted_rows, len(pivoted_rows)))
     }
     columnar_known_types = {
         col["name"]: columnar[col["name"]]

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -669,7 +669,7 @@ def row_tuples_to_arrow(
                     pa.field(
                         key,
                         arrow_col.type,
-                        nullable=columns[key]["nullable"],
+                        nullable=columns[key].get("nullable", True),
                     )
                 )
 

--- a/dlt/common/libs/sql_alchemy.py
+++ b/dlt/common/libs/sql_alchemy.py
@@ -4,7 +4,8 @@ from dlt import version
 try:
     from sqlalchemy import MetaData, Table, Column, create_engine
     from sqlalchemy.engine import Engine, URL, make_url, Row
-    from sqlalchemy.sql import sqltypes, Select
+    from sqlalchemy.sql import sqltypes, Select, Executable
+    from sqlalchemy.sql.elements import TextClause
     from sqlalchemy.sql.sqltypes import TypeEngine
     from sqlalchemy.exc import CompileError
     import sqlalchemy as sa

--- a/dlt/common/libs/sql_alchemy.py
+++ b/dlt/common/libs/sql_alchemy.py
@@ -19,3 +19,22 @@ except ModuleNotFoundError:
 
 # TODO: maybe use sa.__version__?
 IS_SQL_ALCHEMY_20 = hasattr(sa, "Double")
+
+__all__ = [
+    "IS_SQL_ALCHEMY_20",
+    "MetaData",
+    "Table",
+    "Column",
+    "create_engine",
+    "Engine",
+    "URL",
+    "make_url",
+    "Row",
+    "sqltypes",
+    "Select",
+    "Executable",
+    "TextClause",
+    "TypeEngine",
+    "CompileError",
+    "sa",
+]

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -63,7 +63,7 @@ def ensure_canonical_az_url(
 ) -> str:
     """Converts any of the forms of azure blob storage into canonical form of {target_scheme}://<container_name>@<storage_account_name>.{account_host}/<path>
 
-    `azure_storage_account_name` is optional only if not present in bucket_url, `account_host` assumes "dfs.core.windows.net" by default
+    `azure_storage_account_name` is optional only if not present in bucket_url, `account_host` assumes "<azure_storage_account_name>.dfs.core.windows.net" by default
     """
     parsed_bucket_url = urlparse(bucket_url)
     # Converts an az://<container_name>/<path> to abfss://<container_name>@<storage_account_name>.dfs.core.windows.net/<path>
@@ -80,13 +80,16 @@ def ensure_canonical_az_url(
         )
 
     account_host = account_host or f"{storage_account_name}.dfs.core.windows.net"
+    netloc = (
+        f"{parsed_bucket_url.netloc}@{account_host}" if parsed_bucket_url.netloc else account_host
+    )
 
     # as required by databricks
     _path = parsed_bucket_url.path
     return urlunparse(
         parsed_bucket_url._replace(
             scheme=target_scheme,
-            netloc=f"{parsed_bucket_url.netloc}@{account_host}",
+            netloc=netloc,
             path=_path,
         )
     )

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -14,6 +14,7 @@ from dlt.common.configuration.specs import (
     BaseConfiguration,
     SFTPCredentials,
 )
+from dlt.common.exceptions import TerminalValueError
 from dlt.common.typing import DictStrAny
 from dlt.common.utils import digest128
 
@@ -55,6 +56,40 @@ FileSystemCredentials = Union[
     GcpOAuthCredentials,
     SFTPCredentials,
 ]
+
+
+def ensure_canonical_az_url(
+    bucket_url: str, target_scheme: str, storage_account_name: str = None, account_host: str = None
+) -> str:
+    """Converts any of the forms of azure blob storage into canonical form of {target_scheme}://<container_name>@<storage_account_name>.{account_host}/<path>
+
+    `azure_storage_account_name` is optional only if not present in bucket_url, `account_host` assumes "dfs.core.windows.net" by default
+    """
+    parsed_bucket_url = urlparse(bucket_url)
+    # Converts an az://<container_name>/<path> to abfss://<container_name>@<storage_account_name>.dfs.core.windows.net/<path>
+    if parsed_bucket_url.username:
+        # has the right form, ensure abfss schema
+        return urlunparse(parsed_bucket_url._replace(scheme=target_scheme))
+
+    if not storage_account_name and not account_host:
+        raise TerminalValueError(
+            f"Could not convert azure blob storage url {bucket_url} into canonical form "
+            f" ({target_scheme}://<container_name>@<storage_account_name>.dfs.core.windows.net/<path>)"
+            f" because storage account name is not known. Please use {target_scheme}:// canonical"
+            " url as bucket_url in filesystem credentials"
+        )
+
+    account_host = account_host or f"{storage_account_name}.dfs.core.windows.net"
+
+    # as required by databricks
+    _path = parsed_bucket_url.path
+    return urlunparse(
+        parsed_bucket_url._replace(
+            scheme=target_scheme,
+            netloc=f"{parsed_bucket_url.netloc}@{account_host}",
+            path=_path,
+        )
+    )
 
 
 def _make_sftp_url(scheme: str, fs_path: str, bucket_url: str) -> str:

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -61,7 +61,7 @@ FileSystemCredentials = Union[
 def ensure_canonical_az_url(
     bucket_url: str, target_scheme: str, storage_account_name: str = None, account_host: str = None
 ) -> str:
-    """Converts any of the forms of azure blob storage into canonical form of {target_scheme}://<container_name>@<storage_account_name>.{account_host}/<path>
+    """Converts any of the forms of azure blob storage into canonical form of {target_scheme}://<container_name>@<storage_account_name>.{account_host}/path
 
     `azure_storage_account_name` is optional only if not present in bucket_url, `account_host` assumes "<azure_storage_account_name>.dfs.core.windows.net" by default
     """

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -646,4 +646,4 @@ def is_typeerror_due_to_wrong_call(exc: Exception, func: AnyFun) -> bool:
         return False
     func_name = func.__name__
     message = str(exc)
-    return message.startswith(f"{func_name}()")
+    return message.__contains__(f"{func_name}()")

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -635,3 +635,15 @@ def make_defunct_class(cls: TObj) -> Type[TObj]:
                 raise RuntimeError("This instance has been dropped and cannot be used anymore.")
 
     return DefunctClass
+
+
+def is_typeerror_due_to_wrong_call(exc: Exception, func: AnyFun) -> bool:
+    """
+    Determine if a TypeError is due to a wrong call to the function (incorrect arguments)
+    by inspecting the exception message.
+    """
+    if not isinstance(exc, TypeError):
+        return False
+    func_name = func.__name__
+    message = str(exc)
+    return message.startswith(f"{func_name}()")

--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -29,7 +29,8 @@ from dlt.common.schema.typing import (
 )
 from dlt.common.schema.utils import is_nullable_column
 from dlt.common.storages import FileStorage
-from dlt.common.storages.configuration import FilesystemConfiguration
+from dlt.common.storages.configuration import FilesystemConfiguration, ensure_canonical_az_url
+from dlt.common.storages.fsspec_filesystem import AZURE_BLOB_STORAGE_PROTOCOLS
 from dlt.destinations.exceptions import LoadJobTerminalException
 from dlt.destinations.impl.clickhouse.configuration import (
     ClickHouseClientConfiguration,
@@ -140,7 +141,7 @@ class ClickHouseLoadJob(RunnableLoadJob, HasFollowupJobs):
                 f"s3('{bucket_http_url}',{auth},'{clickhouse_format}','auto','{compression}')"
             )
 
-        elif bucket_scheme in ("az", "abfs"):
+        elif bucket_scheme in AZURE_BLOB_STORAGE_PROTOCOLS:
             if not isinstance(self._staging_credentials, AzureCredentialsWithoutDefaults):
                 raise LoadJobTerminalException(
                     self._file_path,
@@ -149,7 +150,10 @@ class ClickHouseLoadJob(RunnableLoadJob, HasFollowupJobs):
 
             # Authenticated access.
             account_name = self._staging_credentials.azure_storage_account_name
-            storage_account_url = f"https://{self._staging_credentials.azure_storage_account_name}.blob.core.windows.net"
+            account_host = self._staging_credentials.azure_account_host
+            storage_account_url = ensure_canonical_az_url(
+                bucket_path, "https", account_name, account_host
+            )
             account_key = self._staging_credentials.azure_storage_account_key
 
             # build table func

--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -150,10 +150,11 @@ class ClickHouseLoadJob(RunnableLoadJob, HasFollowupJobs):
 
             # Authenticated access.
             account_name = self._staging_credentials.azure_storage_account_name
-            account_host = self._staging_credentials.azure_account_host
-            storage_account_url = ensure_canonical_az_url(
-                bucket_path, "https", account_name, account_host
+            account_host = (
+                self._staging_credentials.azure_account_host
+                or f"{account_name}.blob.core.windows.net"
             )
+            storage_account_url = ensure_canonical_az_url("", "https", account_name, account_host)
             account_key = self._staging_credentials.azure_storage_account_key
 
             # build table func

--- a/dlt/destinations/impl/databricks/databricks.py
+++ b/dlt/destinations/impl/databricks/databricks.py
@@ -18,11 +18,16 @@ from dlt.common.configuration.specs import (
     AzureCredentialsWithoutDefaults,
 )
 from dlt.common.exceptions import TerminalValueError
+from dlt.common.storages.configuration import ensure_canonical_az_url
 from dlt.common.storages.file_storage import FileStorage
+from dlt.common.storages.fsspec_filesystem import (
+    AZURE_BLOB_STORAGE_PROTOCOLS,
+    S3_PROTOCOLS,
+    GCS_PROTOCOLS,
+)
 from dlt.common.schema import TColumnSchema, Schema
 from dlt.common.schema.typing import TColumnType
 from dlt.common.storages import FilesystemConfiguration, fsspec_from_config
-
 
 from dlt.destinations.insert_job_client import InsertValuesJobClient
 from dlt.destinations.exceptions import LoadJobTerminalException
@@ -32,8 +37,8 @@ from dlt.destinations.sql_jobs import SqlMergeFollowupJob
 from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.utils import is_compression_disabled
 
-AZURE_BLOB_STORAGE_PROTOCOLS = ["az", "abfss", "abfs"]
-SUPPORTED_BLOB_STORAGE_PROTOCOLS = AZURE_BLOB_STORAGE_PROTOCOLS + ["s3", "gs", "gcs"]
+
+SUPPORTED_BLOB_STORAGE_PROTOCOLS = AZURE_BLOB_STORAGE_PROTOCOLS + S3_PROTOCOLS + GCS_PROTOCOLS
 
 
 class DatabricksLoadJob(RunnableLoadJob, HasFollowupJobs):
@@ -106,7 +111,9 @@ class DatabricksLoadJob(RunnableLoadJob, HasFollowupJobs):
                     # Explicit azure credentials are needed to load from bucket without a named stage
                     credentials_clause = f"""WITH(CREDENTIAL(AZURE_SAS_TOKEN='{staging_credentials.azure_storage_sas_token}'))"""
                     bucket_path = self.ensure_databricks_abfss_url(
-                        bucket_path, staging_credentials.azure_storage_account_name
+                        bucket_path,
+                        staging_credentials.azure_storage_account_name,
+                        staging_credentials.azure_account_host,
                     )
                 else:
                     raise LoadJobTerminalException(
@@ -124,7 +131,9 @@ class DatabricksLoadJob(RunnableLoadJob, HasFollowupJobs):
                     ),
                 )
                 bucket_path = self.ensure_databricks_abfss_url(
-                    bucket_path, staging_credentials.azure_storage_account_name
+                    bucket_path,
+                    staging_credentials.azure_storage_account_name,
+                    staging_credentials.azure_account_host,
                 )
 
             # always add FROM clause
@@ -165,30 +174,10 @@ class DatabricksLoadJob(RunnableLoadJob, HasFollowupJobs):
 
     @staticmethod
     def ensure_databricks_abfss_url(
-        bucket_path: str, azure_storage_account_name: str = None
+        bucket_path: str, azure_storage_account_name: str = None, account_host: str = None
     ) -> str:
-        bucket_url = urlparse(bucket_path)
-        # Converts an az://<container_name>/<path> to abfss://<container_name>@<storage_account_name>.dfs.core.windows.net/<path>
-        if bucket_url.username:
-            # has the right form, ensure abfss schema
-            return urlunparse(bucket_url._replace(scheme="abfss"))
-
-        if not azure_storage_account_name:
-            raise TerminalValueError(
-                f"Could not convert azure blob storage url {bucket_path} into form required by"
-                " Databricks"
-                " (abfss://<container_name>@<storage_account_name>.dfs.core.windows.net/<path>)"
-                " because storage account name is not known. Please use Databricks abfss://"
-                " canonical url as bucket_url in staging credentials"
-            )
-        # as required by databricks
-        _path = bucket_url.path
-        return urlunparse(
-            bucket_url._replace(
-                scheme="abfss",
-                netloc=f"{bucket_url.netloc}@{azure_storage_account_name}.dfs.core.windows.net",
-                path=_path,
-            )
+        return ensure_canonical_az_url(
+            bucket_path, "abfss", azure_storage_account_name, account_host
         )
 
 

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -597,7 +597,10 @@ WHERE """
                         for c in new_columns
                         if c.get(hint, False)
                     ]
-                    if hint == "null":
+                    if hint in ["hard_delete", "dedup_sort", "merge_key"]:
+                        # you may add those
+                        pass
+                    elif hint == "null":
                         logger.warning(
                             f"Column(s) {hint_columns} with NOT NULL are being added to existing"
                             f" table {table_name}. If there's data in the table the operation"

--- a/dlt/destinations/sql_client.py
+++ b/dlt/destinations/sql_client.py
@@ -399,6 +399,7 @@ class DBApiCursorImpl(DBApiCursor):
             or DestinationCapabilitiesContext.generic_capabilities()
         )
 
+        # note that columns_schema is inferred from the cursor and is not normalized
         if not chunk_size:
             result = self.fetchall()
             yield row_tuples_to_arrow(result, caps, self.columns_schema, tz="UTC")

--- a/dlt/sources/_core_source_templates/sql_database_pipeline.py
+++ b/dlt/sources/_core_source_templates/sql_database_pipeline.py
@@ -121,12 +121,13 @@ def select_columns() -> None:
         full_refresh=True,
     )
 
-    def table_adapter(table: Table) -> None:
+    def table_adapter(table: Table) -> Table:
         print(table.name)
         if table.name == "family":
             # this is SqlAlchemy table. _columns are writable
             # let's drop updated column
             table._columns.remove(table.columns["updated"])  # type: ignore
+        return table
 
     family = sql_table(
         credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam",
@@ -184,11 +185,12 @@ def my_sql_via_pyarrow() -> None:
         dataset_name="rfam_data_arrow_4",
     )
 
-    def _double_as_decimal_adapter(table: sa.Table) -> None:
+    def _double_as_decimal_adapter(table: sa.Table) -> sa.Table:
         """Return double as double, not decimals, only works if you are using sqlalchemy 2.0"""
         for column in table.columns.values():
             if hasattr(sa, "Double") and isinstance(column.type, sa.Double):
                 column.type.asdecimal = False
+        return table
 
     sql_alchemy_source = sql_database(
         "mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam?&binary_prefix=true",
@@ -277,11 +279,12 @@ def test_pandas_backend_verbatim_decimals() -> None:
         dataset_name="rfam_data_pandas_2",
     )
 
-    def _double_as_decimal_adapter(table: sa.Table) -> None:
+    def _double_as_decimal_adapter(table: sa.Table) -> sa.Table:
         """Emits decimals instead of floats."""
         for column in table.columns.values():
             if isinstance(column.type, sa.Float):
                 column.type.asdecimal = True
+        return table
 
     sql_alchemy_source = sql_database(
         "mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam?&binary_prefix=true",

--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -13,6 +13,7 @@ from .helpers import (
     _execute_table_adapter,
     table_rows,
     engine_from_credentials,
+    remove_nullability_adapter,
     TableBackend,
     SqlTableResourceConfiguration,
     _detect_precision_hints_deprecated,
@@ -62,8 +63,8 @@ def sql_database(
         detect_precision_hints (bool): Deprecated. Use `reflection_level`. Set column precision and scale hints for supported data types in the target schema based on the columns in the source tables.
             This is disabled by default.
         reflection_level: (ReflectionLevel): Specifies how much information should be reflected from the source database schema.
-            "minimal": Only table names, nullability and primary keys are reflected. Data types are inferred from the data.
-            "full": Data types will be reflected on top of "minimal". `dlt` will coerce the data into reflected types if necessary. This is the default option.
+            "minimal": Only table names, nullability and primary keys are reflected. Data types are inferred from the data. This is the default option.
+            "full": Data types will be reflected on top of "minimal". `dlt` will coerce the data into reflected types if necessary.
             "full_with_precision": Sets precision and scale on supported data types (ie. decimal, text, binary). Creates big and regular integer types.
         defer_table_reflect (bool): Will connect and reflect table schema only when yielding data. Requires table_names to be explicitly passed.
             Enable this option when running on Airflow. Available on dlt 0.4.4 and later.
@@ -175,8 +176,8 @@ def sql_table(
             "sqlalchemy" is the default and does not require additional dependencies, "pyarrow" creates stable destination schemas with correct data types,
             "connectorx" is typically the fastest but ignores the "chunk_size" so you must deal with large tables yourself.
         reflection_level: (ReflectionLevel): Specifies how much information should be reflected from the source database schema.
-            "minimal": Only table names, nullability and primary keys are reflected. Data types are inferred from the data.
-            "full": Data types will be reflected on top of "minimal". `dlt` will coerce the data into reflected types if necessary. This is the default option.
+            "minimal": Only table names, nullability and primary keys are reflected. Data types are inferred from the data. This is the default option.
+            "full": Data types will be reflected on top of "minimal". `dlt` will coerce the data into reflected types if necessary.
             "full_with_precision": Sets precision and scale on supported data types (ie. decimal, text, binary). Creates big and regular integer types.
         detect_precision_hints (bool): Deprecated. Use `reflection_level`. Set column precision and scale hints for supported data types in the target schema based on the columns in the source tables.
             This is disabled by default.
@@ -248,3 +249,16 @@ def sql_table(
         query_adapter_callback=query_adapter_callback,
         resolve_foreign_keys=resolve_foreign_keys,
     )
+
+
+__all__ = [
+    "sql_database",
+    "sql_table",
+    "ReflectionLevel",
+    "TTypeAdapter",
+    "engine_from_credentials",
+    "remove_nullability_adapter",
+    "TableBackend",
+    "TQueryAdapter",
+    "TTableAdapter",
+]

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -52,7 +52,7 @@ TQueryAdapter = Union[
     Callable[[SelectAny, Table], SelectClause],
     Callable[[SelectAny, Table, Incremental[Any], Engine], SelectClause],
 ]
-TTableAdapter = Callable[[Table], Optional[SelectAny]]
+TTableAdapter = Callable[[Table], Optional[Union[SelectAny, Table]]]
 
 
 class TableLoader:
@@ -327,6 +327,15 @@ def unwrap_json_connector_x(field: str) -> TDataItem:
         return table.set_column(col_index, table.schema.field(col_index), column)
 
     return _unwrap
+
+
+def remove_nullability_adapter(table: Table) -> Table:
+    """A table adapter that removes nullability from columns."""
+    for col in table.columns:
+        # subqueries may not have nullable attr
+        if hasattr(col, "nullable"):
+            col.nullable = None
+    return table
 
 
 def _add_missing_columns(

--- a/dlt/sources/sql_database/schema_types.py
+++ b/dlt/sources/sql_database/schema_types.py
@@ -71,9 +71,11 @@ def sqla_col_to_column_schema(
     """
     col: TColumnSchema = {
         "name": sql_col.name,
-        # NOTE: nullability info may not be available for subquery columns
-        "nullable": getattr(sql_col, "nullable", True),
     }
+    # NOTE: nullability info may not be available for subquery columns
+    if hasattr(sql_col, "nullable") and sql_col.nullable is not None:
+        col["nullable"] = sql_col.nullable
+
     if reflection_level == "minimal":
         # normalized into subtables
         if isinstance(sql_col.type, sqltypes.JSON) and skip_nested_columns_on_minimal:

--- a/dlt/sources/sql_database/schema_types.py
+++ b/dlt/sources/sql_database/schema_types.py
@@ -71,7 +71,8 @@ def sqla_col_to_column_schema(
     """
     col: TColumnSchema = {
         "name": sql_col.name,
-        "nullable": sql_col.nullable,
+        # NOTE: nullability info may not be available for subquery columns
+        "nullable": getattr(sql_col, "nullable", True),
     }
     if reflection_level == "minimal":
         # normalized into subtables

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -122,13 +122,20 @@ endpoint_url = "https://<account_id>.r2.cloudflarestorage.com" # copy your endpo
 
 #### Adding additional configuration
 
-To pass any additional arguments to `fsspec`, you may supply `kwargs` and `client_kwargs` in the config as a **stringified dictionary**:
+To pass any additional arguments to `fsspec`, you may supply `kwargs` and `client_kwargs` in toml config.
 
 ```toml
-[destination.filesystem]
-kwargs = '{"use_ssl": true, "auto_mkdir": true}'
-client_kwargs = '{"verify": "public.crt"}'
+[destination.filesystem.kwargs]
+use_ssl=true
+auto_mkdir=true
+
+[destination.filesystem.client_kwargs]
+verify="public.crt"
 ```
+
+To pass additional arguments via env variables, use **stringified dictionary**:
+`DESTINATION__FILESYSTEM__KWARGS='{"use_ssl": true, "auto_mkdir": true}`
+
 
 ### Google storage
 Run `pip install "dlt[gs]"` which will install the `gcfs` package.
@@ -159,6 +166,30 @@ Run `pip install "dlt[az]"` which will install the `adlfs` package to interface 
 
 Edit the credentials in `.dlt/secrets.toml`, you'll see AWS credentials by default; replace them with your Azure credentials.
 
+`dlt` supports both forms of the blob storage urls:
+```toml
+[destination.filesystem]
+bucket_url = "az://<container_name>/path" # replace with your container name and path
+```
+
+and
+
+```toml
+[destination.filesystem]
+bucket_url = "abfss://<container_name>@<storage_account_name>.dfs.core.windows.net/path"
+```
+
+You can use `az`, `abfss`, `azure` and `abfs` url schemes.
+
+If you need to use a custom host for your account you can set it up like below:
+```toml
+[destination.filesystem.credentials]
+# The storage account name is always required
+azure_account_host = "<storage_account_name>.<host_base>"
+```
+Remember to include `storage_account_name` with your base host: `dlt_ci.blob.core.usgovcloudapi.net`.
+
+
 Two forms of Azure credentials are supported:
 
 #### SAS token credentials
@@ -166,9 +197,6 @@ Two forms of Azure credentials are supported:
 Supply storage account name and either SAS token or storage account key
 
 ```toml
-[destination.filesystem]
-bucket_url = "az://[your_container name]" # replace with your container name
-
 [destination.filesystem.credentials]
 # The storage account name is always required
 azure_storage_account_name = "account_name" # please set me up!
@@ -181,14 +209,13 @@ If you have the correct Azure credentials set up on your machine (e.g., via Azur
 you can omit both `azure_storage_account_key` and `azure_storage_sas_token` and `dlt` will fall back to the available default.
 Note that `azure_storage_account_name` is still required as it can't be inferred from the environment.
 
+`dlt` supports the
+
 #### Service principal credentials
 
 Supply a client ID, client secret, and a tenant ID for a service principal authorized to access your container.
 
 ```toml
-[destination.filesystem]
-bucket_url = "az://[your_container name]" # replace with your container name
-
 [destination.filesystem.credentials]
 azure_client_id = "client_id" # please set me up!
 azure_client_secret = "client_secret"
@@ -203,6 +230,8 @@ azure_tenant_id = "tenant_id" # please set me up!
 max_concurrency=3
 ```
 :::
+
+
 
 ### Local file system
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/configuration.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/configuration.md
@@ -75,7 +75,7 @@ Read more about sources and resources here: [General usage: source](../../../gen
 
     ```
 
-    :::note 
+    :::note
     When using the `sql_database` source, specifying table names directly in the source arguments (e.g., `sql_database(table_names=["family", "clan"])`) ensures that only those tables are reflected and turned into resources. In contrast, if you use `.with_resources("family", "clan")`, the entire schema is reflected first, and resources are generated for all tables before filtering for the specified ones. For large schemas, specifying `table_names` can improve performance.
     :::
 
@@ -199,11 +199,12 @@ pipeline = dlt.pipeline(
     pipeline_name="rfam_cx", destination="postgres", dataset_name="rfam_data_arrow"
 )
 
-def _double_as_decimal_adapter(table: sa.Table) -> None:
+def _double_as_decimal_adapter(table: sa.Table) -> sa.Table:
     """Emits decimals instead of floats."""
     for column in table.columns.values():
         if isinstance(column.type, sa.Float):
             column.type.asdecimal = False
+    return table
 
 sql_alchemy_source = sql_database(
     "mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam?&binary_prefix=true",
@@ -215,7 +216,7 @@ sql_alchemy_source = sql_database(
 info = pipeline.run(sql_alchemy_source)
 print(info)
 ```
-For more information on the `tz` parameter within `backend_kwargs` supported by PyArrow, please refer to the 
+For more information on the `tz` parameter within `backend_kwargs` supported by PyArrow, please refer to the
 [official documentation.](https://arrow.apache.org/docs/python/generated/pyarrow.timestamp.html)
 
 ### Pandas
@@ -242,11 +243,12 @@ pipeline = dlt.pipeline(
     pipeline_name="rfam_cx", destination="postgres", dataset_name="rfam_data_pandas_2"
 )
 
-def _double_as_decimal_adapter(table: sa.Table) -> None:
+def _double_as_decimal_adapter(table: sa.Table) -> sa.Table:
     """Emits decimals instead of floats."""
     for column in table.columns.values():
         if isinstance(column.type, sa.Float):
             column.type.asdecimal = True
+    return table
 
 sql_alchemy_source = sql_database(
     "mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam?&binary_prefix=true",

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/usage.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/usage.md
@@ -93,14 +93,15 @@ table = sql_table(
 You can add computed columns to the table definition by converting it into a subquery:
 ```py
 def add_max_timestamp(table):
-    computed_max_timestamp = sa.func.greatest(table.c.created_at, table.c.updated_at).label('max_timestamp')
-    subquery = sa.select(
-        [table, computed_max_timestamp]
-    ).subquery()
+    computed_max_timestamp = sa.sql.type_coerce(
+        sa.func.greatest(table.c.created_at, table.c.updated_at),
+        sqltypes.DateTime,
+    ).label("max_timestamp")
+    subquery = sa.select(*table.c, computed_max_timestamp).subquery()
     return subquery
 ```
-We add new `max_timestamp` column that is a MIN of `created_at` and `updated_at` columns and then convert it into a subquery
-because we intend to use it for incremental loading.
+We add new `max_timestamp` column that is a MAX of `created_at` and `updated_at` columns and then we convert it into a subquery
+because we intend to use it for incremental loading which will attach a `WHERE` clause to it.
 
 ```py
 import dlt

--- a/docs/website/docs/tutorial/sql-database.md
+++ b/docs/website/docs/tutorial/sql-database.md
@@ -271,6 +271,6 @@ Congratulations on completing the tutorial! You learned how to set up a SQL Data
 
 Interested in learning more about dlt? Here are some suggestions:
 - Learn more about the SQL Database source configuration in [the SQL Database source reference](../dlt-ecosystem/verified-sources/sql_database)
-- Learn more about different credential types in [Built-in credentials](../general-usage/credentials/complex_types#built-in-credentials)
+- Learn how to extract [single tables and use fast `arrow` and `connectorx` backends](../dlt-ecosystem/verified-sources/sql_database/configuration.md)
+- Learn how to [rewrite table schemas and queries](../dlt-ecosystem/verified-sources/sql_database/usage.md)
 - Learn how to [create a custom source](./load-data-from-an-api.md) in the advanced tutorial
-

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/deploy_snippets/deploy-with-modal-snippets.py
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/deploy_snippets/deploy-with-modal-snippets.py
@@ -21,11 +21,7 @@ def test_modal_snippet() -> None:
     # @@@DLT_SNIPPET_END modal_image
 
     # @@@DLT_SNIPPET_START modal_function
-    @app.function(
-        volumes={"/data/": vol},
-        schedule=modal.Period(days=1),
-        serialized=True
-    )
+    @app.function(volumes={"/data/": vol}, schedule=modal.Period(days=1), serialized=True)
     def load_tables() -> None:
         import dlt
         import os

--- a/mypy.ini
+++ b/mypy.ini
@@ -126,3 +126,6 @@ ignore_missing_imports = True
 
 [mypy-adlfs.*]
 ignore_missing_imports = True
+
+[mypy-snowflake.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -120,3 +120,9 @@ ignore_missing_imports = True
 
 [mypy-pytz.*]
 ignore_missing_imports = True
+
+[mypy-tornado.*]
+ignore_missing_imports = True
+
+[mypy-adlfs.*]
+ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,13 +13,13 @@ files = [
 
 [[package]]
 name = "adlfs"
-version = "2024.4.1"
+version = "2024.7.0"
 description = "Access Azure Datalake Gen1 with fsspec and dask"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "adlfs-2024.4.1-py3-none-any.whl", hash = "sha256:acea94612ddacaa34ea8c6babcc95b8da6982f930cdade7a86fbd17382403e16"},
-    {file = "adlfs-2024.4.1.tar.gz", hash = "sha256:75530a45447f358ae53c5c39c298b8d966dae684be84db899f63b94cd96fc000"},
+    {file = "adlfs-2024.7.0-py3-none-any.whl", hash = "sha256:2005c8e124fda3948f2a6abb2dbebb2c936d2d821acaca6afd61932edfa9bc07"},
+    {file = "adlfs-2024.7.0.tar.gz", hash = "sha256:106995b91f0eb5e775bcd5957d180d9a14faef3271a063b1f65c66fd5ab05ddf"},
 ]
 
 [package.dependencies]

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -407,7 +407,7 @@ def test_group_dict_of_lists_various_length_lists():
     assert sizes == sorted(sizes, reverse=True), "Sizes of decomposed dicts are not decreasing"
 
 
-def function_test(a, b):
+def function_typeerror_exc(a, b):
     raise TypeError("wrong type")
 
 
@@ -431,12 +431,12 @@ def test_is_typeerror_due_to_wrong_call() -> None:
         assert is_typeerror_due_to_wrong_call(exc, _function_test) is False
 
     try:
-        function_test()  # type: ignore[call-arg]
+        function_typeerror_exc()  # type: ignore[call-arg]
     except Exception as exc:
-        assert is_typeerror_due_to_wrong_call(exc, function_test) is True
+        assert is_typeerror_due_to_wrong_call(exc, function_typeerror_exc) is True
 
     try:
-        function_test("a", "b")
+        function_typeerror_exc("a", "b")
     except Exception as exc:
         assert str(exc) == "wrong type"
-        assert is_typeerror_due_to_wrong_call(exc, function_test) is False
+        assert is_typeerror_due_to_wrong_call(exc, function_typeerror_exc) is False

--- a/tests/load/filesystem/test_azure_credentials.py
+++ b/tests/load/filesystem/test_azure_credentials.py
@@ -126,6 +126,7 @@ def test_azure_credentials_from_default(environment: Dict[str, str]) -> None:
         "account_key": None,
         "sas_token": None,
         "anon": False,
+        "account_host": None,
     }
 
 
@@ -143,6 +144,7 @@ def test_azure_service_principal_credentials(environment: Dict[str, str]) -> Non
 
     assert config.to_adlfs_credentials() == {
         "account_name": environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"],
+        "account_host": None,
         "client_id": environment["CREDENTIALS__AZURE_CLIENT_ID"],
         "client_secret": environment["CREDENTIALS__AZURE_CLIENT_SECRET"],
         "tenant_id": environment["CREDENTIALS__AZURE_TENANT_ID"],

--- a/tests/load/filesystem/test_filesystem_common.py
+++ b/tests/load/filesystem/test_filesystem_common.py
@@ -14,8 +14,9 @@ from dlt.common import json, pendulum
 from dlt.common.configuration import resolve
 from dlt.common.configuration.inject import with_config
 from dlt.common.configuration.specs import AnyAzureCredentials
+from dlt.common.exceptions import TerminalValueError
 from dlt.common.storages import fsspec_from_config, FilesystemConfiguration
-from dlt.common.storages.configuration import make_fsspec_url
+from dlt.common.storages.configuration import ensure_canonical_az_url, make_fsspec_url
 from dlt.common.storages.fsspec_filesystem import MTIME_DISPATCH, glob_files
 from dlt.common.utils import custom_environ, uniq_id
 from dlt.destinations import filesystem
@@ -72,6 +73,36 @@ def test_remote_url(bucket_url: str) -> None:
     fs_path = fs_class._strip_protocol(bucket_url)
     # reconstitute url
     assert make_fsspec_url(scheme, fs_path, bucket_url) == bucket_url
+
+
+def test_make_az_url() -> None:
+    url = make_fsspec_url(
+        "azure", "/dlt-ci/path", "abfss://dlt-ci-test-bucket@dlt_ci.blob.core.usgovcloudapi.net"
+    )
+    assert url == "azure://@dlt_ci.blob.core.usgovcloudapi.net/dlt-ci/path"
+
+
+def test_ensure_az_canonical_url() -> None:
+    url = ensure_canonical_az_url(
+        "abfss://dlt-ci-test-bucket@dlt_ci.blob.core.usgovcloudapi.net", "https"
+    )
+    assert url == "https://dlt-ci-test-bucket@dlt_ci.blob.core.usgovcloudapi.net"
+
+    with pytest.raises(TerminalValueError):
+        ensure_canonical_az_url("abfss://dlt-ci-test-bucket/path/path", "https")
+
+    url = ensure_canonical_az_url(
+        "abfss://dlt-ci-test-bucket/path/path", "https", storage_account_name="fake_dlt"
+    )
+    assert url == "https://dlt-ci-test-bucket@fake_dlt.dfs.core.windows.net/path/path"
+
+    url = ensure_canonical_az_url(
+        "abfss://dlt-ci-test-bucket/path/path",
+        "https",
+        storage_account_name="fake_dlt",
+        account_host="dlt_ci.blob.core.usgovcloudapi.net",
+    )
+    assert url == "https://dlt-ci-test-bucket@dlt_ci.blob.core.usgovcloudapi.net/path/path"
 
 
 def test_filesystem_instance(with_gdrive_buckets_env: str) -> None:

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from urllib3.util import parse_url
 
 from dlt.common.configuration.utils import add_config_to_env
+from dlt.common.exceptions import TerminalValueError
+from dlt.destinations.impl.snowflake.snowflake import SnowflakeLoadJob
 from tests.utils import TEST_DICT_CONFIG_PROVIDER
 
 pytest.importorskip("snowflake")
@@ -271,3 +273,27 @@ def test_snowflake_configuration() -> None:
         explicit_value="snowflake://user1:pass@host1/db1?warehouse=warehouse1&role=role1",
     )
     assert SnowflakeClientConfiguration(credentials=c).fingerprint() == digest128("host1")
+
+
+def test_snowflake_azure_converter() -> None:
+    with pytest.raises(TerminalValueError):
+        SnowflakeLoadJob.ensure_snowflake_azure_url("az://dlt-ci-test-bucket")
+
+    azure_url = SnowflakeLoadJob.ensure_snowflake_azure_url("az://dlt-ci-test-bucket", "my_account")
+    assert azure_url == "azure://my_account.blob.core.windows.net/dlt-ci-test-bucket"
+
+    azure_url = SnowflakeLoadJob.ensure_snowflake_azure_url(
+        "az://dlt-ci-test-bucket/path/to/file.parquet", "my_account"
+    )
+    assert (
+        azure_url
+        == "azure://my_account.blob.core.windows.net/dlt-ci-test-bucket/path/to/file.parquet"
+    )
+
+    azure_url = SnowflakeLoadJob.ensure_snowflake_azure_url(
+        "abfss://dlt-ci-test-bucket@my_account.blob.core.windows.net/path/to/file.parquet"
+    )
+    assert (
+        azure_url
+        == "azure://my_account.blob.core.windows.net/dlt-ci-test-bucket/path/to/file.parquet"
+    )

--- a/tests/load/sources/sql_database/test_helpers.py
+++ b/tests/load/sources/sql_database/test_helpers.py
@@ -1,9 +1,7 @@
 import pytest
 
-
 import dlt
 from dlt.common.typing import TDataItem
-
 
 from dlt.common.exceptions import MissingDependencyException
 

--- a/tests/sources/sql_database/test_schema_types.py
+++ b/tests/sources/sql_database/test_schema_types.py
@@ -68,7 +68,7 @@ def test_get_table_references() -> None:
     refs = get_table_references(child)
     refs = sorted(refs, key=lambda x: x["referenced_table"])
     assert refs[0]["referenced_table"] == "parent"
-    # Sqla aonstraints are not in fixed order
+    # Sqla constraints are not in fixed order
     assert set(refs[0]["columns"]) == {"parent_id", "parent_country"}
     assert set(refs[0]["referenced_columns"]) == {"id", "country"}
     # Ensure columns and referenced columns are the same order


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. adds engine adapter callback to modify engine settings before connection is opened (hopefully fixes #1920)
2. allows to return a subquery for table adapter, adds example that fixes #2076 
3. passes Incremental and Engine instances to query adapter callback
4. allows to return text query from engine adapter #1997 
5. arrow backend now infers not reflected columns from the data
6. supports custom account host for azure (#2073 ) and fixes various edge cases for abfss