### PR TITLE
chore: devenv environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/82c0147677e510b247d8b9165c54f73d32dfd899/direnvrc" "sha256-7u4iDd1nZpxL4tCzmPG0dQgC5V+/44Ba+tHkPob1v2k="
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,12 @@ local_cache/
 
 # test file for examples are generated and should not be committed
 docs/examples/**/test*.py
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,152 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1732121232,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "6ff1e5f92c0d74bbb12f7454a239ca2f02e05ea1",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716977621,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-python": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730716553,
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "8fcdb8ec34a1c2bae3f5326873a41b310e948ccc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1731797254,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1732021966,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,57 @@
+{ pkgs, lib, config, inputs, ... }:
+
+{
+  # https://devenv.sh/packages/
+  packages = [
+    pkgs.git
+    pkgs.gnumake
+  ];
+
+  # https://devenv.sh/languages/
+  languages.python.enable = true;
+  languages.python.poetry.enable = true;
+  languages.python.poetry.activate.enable = true;
+  # languages.python.version = "3.8";
+
+  # https://devenv.sh/scripts/
+  scripts.hello.exec = ''
+    echo "Run 'setup' to prepare this repository for development"
+  '';
+  scripts.setup.exec = ''
+    make dev
+    make help
+  '';
+
+  enterShell = ''
+    hello
+  '';
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    echo "Running tests"
+    git --version | grep --color=auto "${pkgs.git.version}"
+    make has-poetry
+  '';
+
+  # https://devenv.sh/pre-commit-hooks/
+  git-hooks.hooks.lint = {
+    enable = true;
+
+    # The name of the hook (appears on the report table):
+    name = "Lint";
+
+    # The command to execute (mandatory):
+    entry = "make lint";
+
+    # The language of the hook - tells pre-commit
+    # how to install the hook (default: "system")
+    # see also https://pre-commit.com/#supported-languages
+    language = "system";
+
+    # Set this to false to not pass the changed files
+    # to the command (default: true):
+    pass_filenames = false;
+  };
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This adds a [Devenv](https://devenv.sh/) environment to the repository which allows immediate development w/o have to worry about local installation of dependencies (make, python, poetry, etc.).
Devenv is using [`nix`](https://nix.dev/index.html) under the hood, which provides a reproducible environment due to the fact that it controls the whole dependency closure. That means that the files in this PR would ensure that all developers would use the same version of make, python, poetry, etc. for their local development of dlt, which reduces a whole bunch of problems when talking about issues, opening pull requests, etc.

If the system has `direnv` and `devenv` installed everything is automatic.
After activating the environment, `setup` can be run, which calls out to `make dev`.

Also happy to swap this for a raw [nix flake](https://nixos.wiki/wiki/Flakes) or even a [nix-shell](https://nixos.wiki/wiki/Development_environment_with_nix-shell) if devenv is too bleeding edge.