### PR TITLE
docs(rest_client): note about `data_selector`

### DIFF
--- a/dlt/sources/helpers/rest_client/client.py
+++ b/dlt/sources/helpers/rest_client/client.py
@@ -58,7 +58,7 @@ class RESTClient:
         auth (Optional[AuthBase]): Authentication configuration for all requests.
         paginator (Optional[BasePaginator]): Default paginator for handling paginated responses.
         data_selector (Optional[jsonpath.TJsonPath]): JSONPath selector for extracting data from responses.
-            Only used when paginating. Use `extract_response` for other requests.
+            Only used in `paginate`.
         session (BaseSession): HTTP session for making requests.
         paginator_factory (Optional[PaginatorFactory]): Factory for creating paginator instances,
             used for detecting paginators.

--- a/dlt/sources/helpers/rest_client/client.py
+++ b/dlt/sources/helpers/rest_client/client.py
@@ -58,6 +58,7 @@ class RESTClient:
         auth (Optional[AuthBase]): Authentication configuration for all requests.
         paginator (Optional[BasePaginator]): Default paginator for handling paginated responses.
         data_selector (Optional[jsonpath.TJsonPath]): JSONPath selector for extracting data from responses.
+            Only used when paginating. Use `extract_response` for other requests.
         session (BaseSession): HTTP session for making requests.
         paginator_factory (Optional[PaginatorFactory]): Factory for creating paginator instances,
             used for detecting paginators.


### PR DESCRIPTION
I personally think it's a bug and
```py
if self.data_selector:
    return self.extract_response(response, self.data_selector)
```
should be called automatically for all requests (`.get(...).json()`, ...) when given (1), however it would be a breaking change, so updating the documentation is the next best thing.
Might also be possibly worth deprecating the parameter from the global `RESTClient` constructor, given the fact that it is only used inside `.paginate(...)` (2).

Let me know if you want me to open a pull request for (1) and/or (2) instead of this one.

