### PR TITLE
bug: `@dlt.transformer` ignores `write_disposition="replace"`

### DIFF
--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -1607,7 +1607,7 @@ def test_transformer_replace() -> None:
 
     current_page = 0
     @dlt.transformer(
-        data_from=gen_pages_of_ids, write_disposition="replace", primary_key="id", merge_key="id"
+        data_from=gen_pages_of_ids, write_disposition="replace", primary_key="id"
     )
     def transformed_ids(
         page: List[TDataItem],


### PR DESCRIPTION
### Description

When a transformer yields duplicates, they are not merged as defined in the given `write_disposition`.
See attached test, which is expected to pass, however it fails.

### Expected

multiple yields overwrite each other. Last yield wins.

Thus the expected resulting table should look like this:

| id | current_pass |
| -- | -- |
| 1 | 2 |
| 2 | 2 |

however, it looks like this:

| id | current_pass |
| -- | -- |
| 1 | 1 |
| 2 | 1 |
| 1 | 2 |
| 2 | 2 |

even though `primary_key` has been defined and `write_disposition` is `"replace"`
