### PR TITLE
Add missing mention of the required `endpoint_url` config in GCS

### DIFF
--- a/docs/website/docs/dlt-ecosystem/destinations/clickhouse.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/clickhouse.md
@@ -229,8 +229,7 @@ To set up GCS staging with HMAC authentication in dlt:
 
 1. Create HMAC keys for your GCS service account by following the [Google Cloud guide](https://cloud.google.com/storage/docs/authentication/managing-hmackeys#create).
 
-2. Configure the HMAC keys (`aws_access_key_id` and `aws_secret_access_key`) in your dlt project's ClickHouse destination settings in `config.toml`, similar to how you would configure AWS S3
-   credentials:
+2. Configure the HMAC keys (`aws_access_key_id` and `aws_secret_access_key`) as well as `endpoint_url` in your dlt project's ClickHouse destination settings in `config.toml`, similar to how you would configure AWS S3 credentials:
 
 ```toml
 [destination.filesystem]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This config is mentioned in [another place](https://dlthub.com/docs/dlt-ecosystem/destinations/filesystem#using-s3-compatible-storage) discussing S3-compatible storage, but omitted [here](https://dlthub.com/docs/dlt-ecosystem/destinations/clickhouse#using-google-cloud-or-s3-compatible-storage-as-a-staging-area) from the text (only included in the example).
