### PR TITLE
Docs: fix credentials link (add slash)

### DIFF
--- a/dlt/cli/deploy_command_helpers.py
+++ b/dlt/cli/deploy_command_helpers.py
@@ -239,7 +239,7 @@ class BaseDeployment(abc.ABC):
             " available configuration ie. secrets.toml file. Please run the deploy command from"
             " the same working directory you ran your pipeline script. If you pass the"
             " credentials in code we will not be able to display them here. See"
-            " https://dlthub.com/docs/general-usage/credentials"
+            " https://dlthub.com/docs/general-usage/credentials/"
         )
 
     def _lookup_secret_value(self, trace: LookupTrace) -> Any:

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -75,7 +75,7 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
                     " run your script from some other folder, secrets/configs will not be found\n"
                 )
         msg += (
-            "Please refer to https://dlthub.com/docs/general-usage/credentials for more"
+            "Please refer to https://dlthub.com/docs/general-usage/credentials/ for more"
             " information\n"
         )
         return msg

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -374,7 +374,7 @@ def source(
     >>> list(chess("magnuscarlsen"))
 
     Here `username` is a required, explicit python argument, `chess_url` is a required argument, that if not explicitly passed will be taken from configuration ie. `config.toml`, `api_secret` is a required argument, that if not explicitly passed will be taken from dlt secrets ie. `secrets.toml`.
-    See https://dlthub.com/docs/general-usage/credentials for details.
+    See https://dlthub.com/docs/general-usage/credentials/ for details.
 
     Args:
         func: A function that returns a dlt resource or a list of those or a list of any data items that can be loaded by `dlt`.
@@ -564,7 +564,7 @@ def resource(
     >>> list(user_games("magnuscarlsen"))
 
     Here `username` is a required, explicit python argument, `chess_url` is a required argument, that if not explicitly passed will be taken from configuration ie. `config.toml`, `api_secret` is a required argument, that if not explicitly passed will be taken from dlt secrets ie. `secrets.toml`.
-    See https://dlthub.com/docs/general-usage/credentials for details.
+    See https://dlthub.com/docs/general-usage/credentials/ for details.
     Note that if decorated function is an inner function, passing of the credentials will be disabled.
 
     Args:

--- a/docs/website/docs/general-usage/credentials/setup.md
+++ b/docs/website/docs/general-usage/credentials/setup.md
@@ -665,7 +665,7 @@ dlt.common.configuration.exceptions.ConfigFieldMissingException: Following field
                 In secrets.toml key destination.postgres.credentials.password was not found.
                 In secrets.toml key destination.credentials.password was not found.
                 In secrets.toml key credentials.password was not found.
-Please refer to https://dlthub.com/docs/general-usage/credentials for more information
+Please refer to https://dlthub.com/docs/general-usage/credentials/ for more information
 ```
 
 It tells you exactly which paths `dlt` looked at, via which config providers and in which order.

--- a/docs/website/docs/walkthroughs/run-a-pipeline.md
+++ b/docs/website/docs/walkthroughs/run-a-pipeline.md
@@ -186,7 +186,7 @@ dlt.common.configuration.exceptions.ConfigFieldMissingException: Following field
         In secrets.toml key destination.postgres.credentials.password was not found.
         In secrets.toml key destination.credentials.password was not found.
         In secrets.toml key credentials.password was not found.
-Please refer to https://dlthub.com/docs/general-usage/credentials for more information
+Please refer to https://dlthub.com/docs/general-usage/credentials/ for more information
 ```
 
 What does this exception tell you?


### PR DESCRIPTION
>there seems to be a difference in wether there is a slash at the end of the url