### PR TITLE
fix: unravel Optional to inner generic arg from instance

### DIFF
--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -438,9 +438,8 @@ def get_generic_type_argument_from_instance(
     """
     orig_param_type = Any
     if cls_ := getattr(instance, "__orig_class__", None):
-        # unfurl Optional[Incremental[...]] to Incremental[...]
         if is_optional_type(cls_):
-            cls_ = get_args(cls_)[0]
+            cls_ = extract_inner_type(cls_)
 
         # instance of generic class
         pass

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -438,11 +438,7 @@ def get_generic_type_argument_from_instance(
     """
     orig_param_type = Any
     if cls_ := getattr(instance, "__orig_class__", None):
-        if is_optional_type(cls_):
-            cls_ = extract_inner_type(cls_)
-
-        # instance of generic class
-        pass
+        cls_ = extract_inner_type(cls_)
     elif bases_ := get_original_bases(instance.__class__):
         # instance of class deriving from generic
         cls_ = bases_[0]

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -438,6 +438,10 @@ def get_generic_type_argument_from_instance(
     """
     orig_param_type = Any
     if cls_ := getattr(instance, "__orig_class__", None):
+        # unfurl Optional[Incremental[...]] to Incremental[...]
+        if is_optional_type(cls_):
+            cls_ = get_args(cls_)[0]
+
         # instance of generic class
         pass
     elif bases_ := get_original_bases(instance.__class__):

--- a/tests/common/test_typing.py
+++ b/tests/common/test_typing.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     ClassVar,
     Final,
+    Generic,
     List,
     Literal,
     Mapping,
@@ -48,7 +49,6 @@ from dlt.common.typing import (
     add_value_to_literal,
     get_generic_type_argument_from_instance,
 )
-from dlt.extract import Incremental
 
 
 class TTestTyDi(TypedDict):
@@ -317,14 +317,19 @@ def test_add_value_to_literal() -> None:
 
 
 def test_get_generic_type_argument_from_instance() -> None:
+    T = TypeVar("T")
+
+    class Foo(Generic[T]):
+        pass
+
     # generic contains hint
-    instance = SimpleNamespace(__orig_class__=Incremental[str])
+    instance = SimpleNamespace(__orig_class__=Foo[str])
     assert get_generic_type_argument_from_instance(instance) is str
-    instance = SimpleNamespace(__orig_class__=Optional[Incremental[str]])
+    instance = SimpleNamespace(__orig_class__=Optional[Foo[str]])
     assert get_generic_type_argument_from_instance(instance) is str
 
     # with sample values
-    instance = SimpleNamespace(__orig_class__=Incremental[Any])
+    instance = SimpleNamespace(__orig_class__=Foo[Any])
     assert get_generic_type_argument_from_instance(instance, 1) is int
-    instance = SimpleNamespace(__orig_class__=Optional[Incremental[Any]])
+    instance = SimpleNamespace(__orig_class__=Optional[Foo[Any]])
     assert get_generic_type_argument_from_instance(instance, 1) is int

--- a/tests/common/test_typing.py
+++ b/tests/common/test_typing.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from dataclasses import dataclass
 from typing import (
@@ -44,7 +46,9 @@ from dlt.common.typing import (
     is_annotated,
     is_callable_type,
     add_value_to_literal,
+    get_generic_type_argument_from_instance,
 )
+from dlt.extract import Incremental
 
 
 class TTestTyDi(TypedDict):
@@ -310,3 +314,17 @@ def test_add_value_to_literal() -> None:
     add_value_to_literal(TestSingleLiteral, "green")
     add_value_to_literal(TestSingleLiteral, "blue")
     assert get_args(TestSingleLiteral) == ("red", "green", "blue")
+
+
+def test_get_generic_type_argument_from_instance() -> None:
+    # generic contains hint
+    instance = SimpleNamespace(__orig_class__=Incremental[str])
+    assert get_generic_type_argument_from_instance(instance) is str
+    instance = SimpleNamespace(__orig_class__=Optional[Incremental[str]])
+    assert get_generic_type_argument_from_instance(instance) is str
+
+    # with sample values
+    instance = SimpleNamespace(__orig_class__=Incremental[Any])
+    assert get_generic_type_argument_from_instance(instance, 1) is int
+    instance = SimpleNamespace(__orig_class__=Optional[Incremental[Any]])
+    assert get_generic_type_argument_from_instance(instance, 1) is int


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->

Addresses resources created by the `rest_api_resources` factory function exiting prematurely when trying to _join_external_scheduler and not inferring start/end dates from Airflow.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

Closes #2171 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
