### PR TITLE
use a dummy operator at the start of parallel pipelines

### DIFF
--- a/dlt/helpers/airflow_helper.py
+++ b/dlt/helpers/airflow_helper.py
@@ -448,10 +448,10 @@ class PipelineTasksGroup(TaskGroup):
                 tasks = []
                 sources = data.decompose("scc")
                 t_name = self._task_name(pipeline, data)
-                start = make_task(pipeline, sources[0])
+                start = DummyOperator(task_id=f"{t_name}_start")
 
                 # parallel tasks
-                for source in sources[1:]:
+                for source in sources:
                     for resource in source.resources.values():
                         if resource.incremental:
                             logger.warn(
@@ -485,14 +485,10 @@ class PipelineTasksGroup(TaskGroup):
                 tasks = []
                 naming = SnakeCaseNamingConvention()
                 sources = data.decompose("scc")
-                start = make_task(
-                    pipeline,
-                    sources[0],
-                    naming.normalize_identifier(self._task_name(pipeline, sources[0])),
-                )
+                start = DummyOperator(task_id=f"{t_name}_start")
 
                 # parallel tasks
-                for source in sources[1:]:
+                for source in sources:
                     # name pipeline the same as task
                     new_pipeline_name = naming.normalize_identifier(
                         self._task_name(pipeline, source)

--- a/dlt/helpers/airflow_helper.py
+++ b/dlt/helpers/airflow_helper.py
@@ -18,7 +18,7 @@ try:
     from airflow.configuration import conf
     from airflow.models import TaskInstance
     from airflow.utils.task_group import TaskGroup
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.empty import EmptyOperator
     from airflow.operators.python import PythonOperator, get_current_context
 except ModuleNotFoundError:
     raise MissingDependencyException("Airflow", ["apache-airflow>=2.5"])
@@ -448,7 +448,7 @@ class PipelineTasksGroup(TaskGroup):
                 tasks = []
                 sources = data.decompose("scc")
                 t_name = self._task_name(pipeline, data)
-                start = DummyOperator(task_id=f"{t_name}_start")
+                start = EmptyOperator(task_id=f"{t_name}_start")
 
                 # parallel tasks
                 for source in sources:
@@ -466,7 +466,7 @@ class PipelineTasksGroup(TaskGroup):
 
                     tasks.append(make_task(pipeline, source))
 
-                end = DummyOperator(task_id=f"{t_name}_end")
+                end = EmptyOperator(task_id=f"{t_name}_end")
 
                 if tasks:
                     start >> tasks >> end
@@ -485,7 +485,7 @@ class PipelineTasksGroup(TaskGroup):
                 tasks = []
                 naming = SnakeCaseNamingConvention()
                 sources = data.decompose("scc")
-                start = DummyOperator(task_id=f"{t_name}_start")
+                start = EmptyOperator(task_id=f"{t_name}_start")
 
                 # parallel tasks
                 for source in sources:
@@ -496,7 +496,7 @@ class PipelineTasksGroup(TaskGroup):
                     tasks.append(make_task(pipeline, source, new_pipeline_name))
 
                 t_name = self._task_name(pipeline, data)
-                end = DummyOperator(task_id=f"{t_name}_end")
+                end = EmptyOperator(task_id=f"{t_name}_end")
 
                 if tasks:
                     start >> tasks >> end


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Used a `DummyOperator` instead of the first source to parallelize all sources, including the first one.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #2196 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
The first source can take a long time to run, this can make pipelines faster by parallelizing even the first source.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
