### PR TITLE
Deltalake dedup_sort support

### DIFF
--- a/dlt/common/libs/deltalake.py
+++ b/dlt/common/libs/deltalake.py
@@ -131,15 +131,13 @@ def merge_delta_table(
         else:
             primary_keys = get_columns_names_with_prop(schema, "primary_key")
             predicate = " AND ".join([f"target.{c} = source.{c}" for c in primary_keys])
-            
         dedup_tuple = get_dedup_sort_tuple(schema)
         if dedup_tuple:
             dedup_column, dedup_sort = dedup_tuple
             dedup_operator = ">" if dedup_sort == "desc" else "<"
             dedup_query = f"target.{dedup_column} {dedup_operator} source.{dedup_column}"
         else:
-            dedup_query = None
-            
+            dedup_query = None            
         partition_by = get_columns_names_with_prop(schema, "partition")
         qry = (
             table.merge(


### PR DESCRIPTION
### Description

Deltalake is ignoring `dedup_sort` column and always overriding rows with matching ids. This PR added support to dedup_sort

### Additional Context

This is my first PR, and I am very unfamiliar with the code base. So, I expected that this PR might need a few interactions of reviews to get it right. Per example, I didn't not find an easy way to test it. I am very open to make changes if someone point's me the right direction. 