### PR TITLE
Display exception message on deploy command failure

### DIFF
--- a/dlt/cli/plugins.py
+++ b/dlt/cli/plugins.py
@@ -32,9 +32,9 @@ try:
         SecretFormats,
     )
 
-    deploy_command_available = True
-except ModuleNotFoundError:
-    deploy_command_available = False
+    deploy_command_import_exception = None
+except ModuleNotFoundError as exc:
+    deploy_command_import_exception = exc
 
 
 @plugins.hookspec()
@@ -316,7 +316,7 @@ class DeployCommand(SupportsCliCommand):
             "pipeline_script_path", metavar="pipeline-script-path", help="Path to a pipeline script"
         )
 
-        if not deploy_command_available:
+        if deploy_command_import_exception:
             return
 
         deploy_comm.add_argument(
@@ -375,7 +375,8 @@ class DeployCommand(SupportsCliCommand):
 
     def execute(self, args: argparse.Namespace) -> None:
         # exit if deploy command is not available
-        if not deploy_command_available:
+        if deploy_command_import_exception:
+            fmt.error(str(deploy_command_import_exception))
             fmt.warning(
                 "Please install additional command line dependencies to use deploy command:"
             )


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
When the deploy command fails due to a missing import, output the exception message to the terminal. This way the user has the necessary information to resolve the error.

Previous output:
```bash
WARNING: Please install additional command line dependencies to use deploy command:
pip install "dlt[cli]"
We ask you to install those dependencies separately to keep our core library small and make it work everywhere.
NOTE: Please refer to our docs at 'https://dlthub.com/docs/walkthroughs/deploy-a-pipeline' for further assistance.
```

After fix:
```bash
ERROR: No module named 'pipdeptree'
WARNING: Please install additional command line dependencies to use deploy command:
pip install "dlt[cli]"
We ask you to install those dependencies separately to keep our core library small and make it work everywhere.
NOTE: Please refer to our docs at 'https://dlthub.com/docs/walkthroughs/deploy-a-pipeline' for further assistance.
```

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

Fixes (#2203)


<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
