### PR TITLE
exp: pygwalker data explorer in streamlit

### DIFF
--- a/dlt/helpers/streamlit_app/blocks/explorer.py
+++ b/dlt/helpers/streamlit_app/blocks/explorer.py
@@ -1,0 +1,43 @@
+import dlt
+import pygwalker
+import streamlit as st
+from pygwalker.api.streamlit import StreamlitRenderer
+
+st.set_page_config(layout="wide")
+
+
+
+
+
+@st.cache_resource
+def pygwalker_renderer(pipeline_name: str, table_name: str) -> StreamlitRenderer:
+    pipeline = dlt.attach(pipeline_name)
+    dataset = pipeline.dataset()
+    df = dataset[table_name].df()
+    return StreamlitRenderer(
+        df,
+        kernel_computation=True,  # use duckdb under the hood
+        default_tab="vis"
+    )
+
+
+def select_table_name(pipeline: dlt.Pipeline) -> str:
+    current_schema = pipeline.default_schema
+    if schema_name := st.session_state.get("schema_name"):
+        current_schema = pipeline.schemas[schema_name]
+
+    selected_table = st.selectbox(
+        label="Active table",
+        options=current_schema.data_tables(),
+        format_func=lambda t: t["name"]
+    )
+    return selected_table["name"]
+
+
+def show_explorer(pipeline: dlt.Pipeline) -> None:
+    selected_table_name = select_table_name(pipeline)
+    renderer = pygwalker_renderer(
+        pipeline_name=pipeline.pipeline_name,
+        table_name=selected_table_name,
+    )
+    renderer.explorer()

--- a/dlt/helpers/streamlit_app/blocks/menu.py
+++ b/dlt/helpers/streamlit_app/blocks/menu.py
@@ -10,5 +10,6 @@ def menu(pipeline: dlt.Pipeline) -> None:
     mode_selector()
     logo()
     st.page_link(f"{HERE}/pages/dashboard.py", label="Explore data", icon="🕹️")
+    st.page_link(f"{HERE}/pages/explorer.py", label="Visualize data", icon="📊")
     st.page_link(f"{HERE}/pages/load_info.py", label="Load info", icon="💾")
     pipeline_summary(pipeline)

--- a/dlt/helpers/streamlit_app/pages/explorer.py
+++ b/dlt/helpers/streamlit_app/pages/explorer.py
@@ -1,0 +1,17 @@
+import dlt
+import streamlit as st
+
+from dlt.helpers.streamlit_app.blocks.explorer import show_explorer
+from dlt.helpers.streamlit_app.blocks.menu import menu
+from dlt.helpers.streamlit_app.utils import render_with_pipeline
+
+
+def show(pipeline: dlt.Pipeline) -> None:
+    with st.sidebar:
+        menu(pipeline)
+
+    show_explorer(pipeline)
+
+
+if __name__ == "__main__":
+    render_with_pipeline(show)


### PR DESCRIPTION
### Description

Add a page to the streamlit dashboard available via `dlt pipeline NAME show`. It uses the recent `Pipeline.dataset` interface to pass a dataframe to `pygwalker`. 


https://github.com/user-attachments/assets/e8b6dca7-49b4-40a7-af39-fdb6469cf08e



### Goals

When first loading a pipeline, I want to know the properties of the data (null, distribution, outliers). It's reducing the friction of having to create temporary notebooks and install `ipykernel/jupyter` dependencies


### Implementation

- [pygwalker](https://github.com/Kanaries/pygwalker) is an open-source Python library that produces an interactive widget to explore dataframes (works in Jupyter, VSCode, Streamlit, Marimo) based on Vega. 

- Integration surface area is small; only assumes that you can pull the data locally via the `Pipeline.dataset` feature.
  - Deeper integration could use `Pipeline.dataset` to query data or pass an `sqlalchemy` connection to `pygwalker` to handle data loading.
  - pygwalker can use `duckdb` for efficient processing of data

### TODO
- add useful message for optional/missing dependencies
