### PR TITLE
Update branch naming guide in contributing doc to add a "keep" prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ feat/4922-add-avro-support
 * **exp** - an experiment where we are testing a new  idea or want to demonstrate something to the team, might turn into a `feat` later (ticket encouraged)
 * **test** - anything related to the tests (ticket encouraged)
 * **docs** - a change to our docs (ticket optional)
+* **keep** - branches we want to keep an revisit later (ticket encouraged)
 
 #### Ticket Numbers
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Some branches we want to keep around for reference or for working on later but close the pr. For this we add a keep prefix.
