### PR TITLE
Fix: Support azure default credentials

### DIFF
--- a/dlt/common/configuration/specs/azure_credentials.py
+++ b/dlt/common/configuration/specs/azure_credentials.py
@@ -29,6 +29,15 @@ class AzureCredentialsBase(CredentialsConfiguration, WithObjectStoreRsCredential
         creds: Dict[str, Any] = without_none(self.to_adlfs_credentials())  # type: ignore[assignment]
         # only string options accepted
         creds.pop("anon", None)
+
+        if isinstance(self, CredentialsWithDefault) and self.has_default_credentials():
+            dc = self.default_credentials()
+
+            # https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory#microsoft-authentication-library-msal
+            creds["azure_storage_token"] = dc.get_token("https://storage.azure.com/.default").token
+
+            return creds
+
         return creds
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Currently, Azure default credentials are not properly passed down to `deltalake` when dealing with delta write_format. See also https://github.com/dlt-hub/dlt/issues/2055.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #2055 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
I only started working with `dlt` last week, so it is _very_ possible I'm cutting a lot of corners here. Furthermore, I will need contributor access to work on the tests. I could actually use some help there, as someone more experienced than me with `dlt` will probably code that up in no time.

I still have some tests failing, but I doubt this is because of the changes I've made. We will need to test this against actual Azure storage, so in parallel will reach out to get access to run those tests. Already making this PR, worst case it will act as a reference.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
