### PR TITLE
rest_api: add tests for query string parameters

### DIFF
--- a/tests/sources/rest_api/conftest.py
+++ b/tests/sources/rest_api/conftest.py
@@ -64,7 +64,7 @@ def paginate_by_page_number(
     return response
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def mock_api_server():
     with requests_mock.Mocker() as m:
 
@@ -74,11 +74,7 @@ def mock_api_server():
 
         @router.get(r"/posts(\?.*)?$")
         def posts(request, context):
-            response = paginate_by_page_number(request, generate_posts())
-
-            if request.qs:
-                response["query_string_params"] = request.qs
-            return response
+            return paginate_by_page_number(request, generate_posts())
 
         @router.get(r"/posts_zero_based(\?page=\d+)?$")
         def posts_zero_based(request, context):
@@ -128,12 +124,7 @@ def mock_api_server():
         @router.get(r"/posts/(\d+)/comments(\?.*)?$")
         def post_comments(request, context):
             post_id = int(request.url.split("/")[-2])
-            response = paginate_by_page_number(request, generate_comments(post_id))
-
-            if request.qs:
-                response["query_string_params"] = request.qs
-
-            return response
+            return paginate_by_page_number(request, generate_comments(post_id))
 
         @router.get(r"/posts/\d+$")
         def post_detail(request, context):

--- a/tests/sources/rest_api/conftest.py
+++ b/tests/sources/rest_api/conftest.py
@@ -72,9 +72,13 @@ def mock_api_server():
         def posts_no_key(request, context):
             return paginate_by_page_number(request, generate_posts(), records_key=None)
 
-        @router.get(r"/posts(\?page=\d+)?$")
+        @router.get(r"/posts(\?.*)?$")
         def posts(request, context):
-            return paginate_by_page_number(request, generate_posts())
+            response = paginate_by_page_number(request, generate_posts())
+
+            if request.qs:
+                response["query_string_params"] = request.qs
+            return response
 
         @router.get(r"/posts_zero_based(\?page=\d+)?$")
         def posts_zero_based(request, context):
@@ -121,10 +125,15 @@ def mock_api_server():
                 **paginator.metadata,
             }
 
-        @router.get(r"/posts/(\d+)/comments")
+        @router.get(r"/posts/(\d+)/comments(\?.*)?$")
         def post_comments(request, context):
             post_id = int(request.url.split("/")[-2])
-            return paginate_by_page_number(request, generate_comments(post_id))
+            response = paginate_by_page_number(request, generate_comments(post_id))
+
+            if request.qs:
+                response["query_string_params"] = request.qs
+
+            return response
 
         @router.get(r"/posts/\d+$")
         def post_detail(request, context):

--- a/tests/sources/rest_api/integration/test_offline.py
+++ b/tests/sources/rest_api/integration/test_offline.py
@@ -180,7 +180,7 @@ def test_load_mock_api(mock_api_server):
                         "type": "incremental",
                         "cursor_path": "id",
                         "initial_value": 1,
-                    }
+                    },
                 },
             },
             {"since": ["1"], "sort": ["desc"]},
@@ -188,7 +188,9 @@ def test_load_mock_api(mock_api_server):
         ),
     ],
 )
-def test_single_resource_query_string_params(mock_api_server, endpoint_params, expected_static_params):
+def test_single_resource_query_string_params(
+    mock_api_server, endpoint_params, expected_static_params
+):
     page_counter = 1
 
     def response_hook(response):
@@ -268,7 +270,12 @@ def test_single_resource_query_string_params(mock_api_server, endpoint_params, e
         pytest.param(
             {
                 "path": "posts/{post_id}/comments",
-                "params": {"post_id": {"type": "resolve", "resource": "posts", "field": "id"}, "sort": "desc", "locale": "en", "page": "100"},
+                "params": {
+                    "post_id": {"type": "resolve", "resource": "posts", "field": "id"},
+                    "sort": "desc",
+                    "locale": "en",
+                    "page": "100",
+                },
             },
             {"sort": ["desc"], "locale": ["en"]},
             id="explicit_page_param",
@@ -293,7 +300,11 @@ def test_single_resource_query_string_params(mock_api_server, endpoint_params, e
         pytest.param(
             {
                 "path": "posts/{post_id}/comments",
-                "params": {"post_id": {"type": "resolve", "resource": "posts", "field": "id"}, "sort": "desc", "locale": "en"},
+                "params": {
+                    "post_id": {"type": "resolve", "resource": "posts", "field": "id"},
+                    "sort": "desc",
+                    "locale": "en",
+                },
                 "incremental": {
                     "start_param": "since",
                     "end_param": "until",
@@ -315,7 +326,7 @@ def test_single_resource_query_string_params(mock_api_server, endpoint_params, e
                         "type": "incremental",
                         "cursor_path": "id",
                         "initial_value": 1,
-                    }
+                    },
                 },
             },
             {"since": ["1"]},


### PR DESCRIPTION
The PR expands the offline integration tests for the rest_api source to verify that query string parameters are correctly sent to the server.

Related issue: #2264