### PR TITLE
add workflow for running plus tests

### DIFF
--- a/.github/workflows/test_doc_snippets.yml
+++ b/.github/workflows/test_doc_snippets.yml
@@ -87,6 +87,9 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
+      - name: Install dlt-plus nightly devel build without cache
+        run: poetry run pip install --upgrade --force-reinstall --no-cache-dir https://dlt-packages.fra1.digitaloceanspaces.com/dlt-plus/dlt_plus-0.0.0+nightly-py3-none-any.whl
+
       - name: run docs preprocessor
         run: make preprocess-docs
 
@@ -100,11 +103,10 @@ jobs:
       - name: create secrets.toml for snippets
         run: pwd && echo "$DLT_SECRETS_TOML" > docs/website/docs/.dlt/secrets.toml
 
-      - name: Run linter and tests on examples
-        run: make lint-and-test-examples
-
       - name: Run linter and tests on snippets
         run: make lint-and-test-snippets
 
+      - name: Run linter and tests on examples
+        run: make lint-and-test-examples
 
 

--- a/.github/workflows/test_plus.yml
+++ b/.github/workflows/test_plus.yml
@@ -43,8 +43,6 @@ jobs:
         include:
           - python-version: "3.10.x"
             os: "ubuntu-latest"
-          - python-version: "3.11.x"
-            os: "ubuntu-latest"
           - python-version: "3.12.x"
             os: "ubuntu-latest"
 
@@ -75,6 +73,7 @@ jobs:
       - name: Install ODBC driver for SQL Server
         run: |
           sudo ACCEPT_EULA=Y apt-get install --yes msodbcsql18
+        if: matrix.os == 'ubuntu-latest'
 
       # NOTE: do not cache. we want to have a clean state each run and we upgrade depdendencies later
       # - name: Load cached venv
@@ -94,6 +93,11 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest tests/plus
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Run tests on mac on win without mssql driver
+        run: poetry run pytest tests/plus -m "not mssql"
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
 
   matrix_job_required_check:
     name: common | common tests

--- a/.github/workflows/test_plus.yml
+++ b/.github/workflows/test_plus.yml
@@ -32,14 +32,18 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.11.x"]
+        python-version: ["3.10.x", "3.11.x", "3.12.x"]
         plus_dep: ["dlt-plus", "https://dlt-packages.fra1.digitaloceanspaces.com/dlt-plus/dlt_plus-0.0.0+nightly-py3-none-any.whl"]
         # Test all python versions on ubuntu only
-        include:
-          - python-version: "3.10.x"
-            os: "ubuntu-latest"
-          - python-version: "3.12.x"
-            os: "ubuntu-latest"
+        exclude:
+        - os: "macos-latest"
+          python-version: "3.10.x"
+        - os: "macos-latest"
+          python-version: "3.12.x"
+        - os: "windows-latest"
+          python-version: "3.10.x"
+        - os: "windows-latest"
+          python-version: "3.12.x"
 
     defaults:
       run:

--- a/.github/workflows/test_plus.yml
+++ b/.github/workflows/test_plus.yml
@@ -71,6 +71,11 @@ jobs:
           installer-parallel: true
           version: 1.8.5
 
+      # NOTE: needed for mssql source tests in plus
+      - name: Install ODBC driver for SQL Server
+        run: |
+          sudo ACCEPT_EULA=Y apt-get install --yes msodbcsql18
+
       # NOTE: do not cache. we want to have a clean state each run and we upgrade depdendencies later
       # - name: Load cached venv
       #   id: cached-poetry-dependencies

--- a/.github/workflows/test_plus.yml
+++ b/.github/workflows/test_plus.yml
@@ -19,12 +19,6 @@ env:
   RUNTIME__LOG_LEVEL: ERROR
   RUNTIME__DLTHUB_TELEMETRY_ENDPOINT: ${{ secrets.RUNTIME__DLTHUB_TELEMETRY_ENDPOINT }}
 
-  # we need the secrets only for the rest_api_pipeline tests which are in tests/sources
-  # so we inject them only at the end
-  SOURCES__GITHUB__ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # and also for the github_api_pipeline tests
-  SOURCES__GITHUB_API_PIPELINE__ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   get_docs_changes:
     name: docs changes
@@ -39,6 +33,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.11.x"]
+        plus_dep: ["dlt-plus", "https://dlt-packages.fra1.digitaloceanspaces.com/dlt-plus/dlt_plus-0.0.0+nightly-py3-none-any.whl"]
         # Test all python versions on ubuntu only
         include:
           - python-version: "3.10.x"
@@ -89,7 +84,7 @@ jobs:
 
 
       - name: Install dlt-plus nightly devel build without cache
-        run: poetry run pip install --upgrade --force-reinstall --no-cache-dir https://dlt-packages.fra1.digitaloceanspaces.com/dlt-plus/dlt_plus-0.0.0+nightly-py3-none-any.whl
+        run: poetry run pip install --upgrade --force-reinstall --no-cache-dir ${{ matrix.plus_dep }}
 
       - name: Run tests
         run: poetry run pytest tests/plus

--- a/.github/workflows/test_plus.yml
+++ b/.github/workflows/test_plus.yml
@@ -1,0 +1,102 @@
+name: plus | plus
+
+#
+# dlt-plus smoke tests against the nightly build.
+#
+
+on:
+  pull_request:
+    branches:
+      - master
+      - devel
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUNTIME__LOG_LEVEL: ERROR
+  RUNTIME__DLTHUB_TELEMETRY_ENDPOINT: ${{ secrets.RUNTIME__DLTHUB_TELEMETRY_ENDPOINT }}
+
+  # we need the secrets only for the rest_api_pipeline tests which are in tests/sources
+  # so we inject them only at the end
+  SOURCES__GITHUB__ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # and also for the github_api_pipeline tests
+  SOURCES__GITHUB_API_PIPELINE__ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  get_docs_changes:
+    name: docs changes
+    uses: ./.github/workflows/get_docs_changes.yml
+
+  run_common:
+    name: test
+    needs: get_docs_changes
+    if: needs.get_docs_changes.outputs.changes_outside_docs == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.11.x"]
+        # Test all python versions on ubuntu only
+        include:
+          - python-version: "3.10.x"
+            os: "ubuntu-latest"
+          - python-version: "3.11.x"
+            os: "ubuntu-latest"
+          - python-version: "3.12.x"
+            os: "ubuntu-latest"
+
+    defaults:
+      run:
+        shell: bash
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@master
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        # https://github.com/snok/install-poetry#running-on-windows
+        uses: snok/install-poetry@v1.3.2
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+          version: 1.8.5
+
+      # NOTE: do not cache. we want to have a clean state each run and we upgrade depdendencies later
+      # - name: Load cached venv
+      #   id: cached-poetry-dependencies
+      #   uses: actions/cache@v3
+      #   with:
+      #     # path: ${{ steps.pip-cache.outputs.dir }}
+      #     path: .venv
+      #     key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install all dependencies
+        run: make dev
+
+
+      - name: Install dlt-plus nightly devel build without cache
+        run: poetry run pip install --upgrade --force-reinstall --no-cache-dir https://dlt-packages.fra1.digitaloceanspaces.com/dlt-plus/dlt_plus-0.0.0+nightly-py3-none-any.whl
+
+      - name: Run tests
+        run: poetry run pytest tests/plus
+
+  matrix_job_required_check:
+    name: common | common tests
+    needs: run_common
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix job results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One or more matrix job tests failed or were cancelled. You may need to re-run them." && exit 1

--- a/docs/examples/partial_loading/partial_loading.py
+++ b/docs/examples/partial_loading/partial_loading.py
@@ -55,6 +55,9 @@ def chess_com_source(username: str, months: List[Dict[str, str]]) -> Iterator[Dl
                     "write_disposition": "append",
                     "endpoint": {
                         "path": f"player/{username}/games/{year}/{month_str}",  # API endpoint path
+                        "response_actions": [
+                            {"status_code": 404, "action": "ignore"},
+                        ],
                     },
                     "primary_key": ["url"],  # Primary key to prevent duplicates
                 }

--- a/docs/examples/partial_loading/partial_loading.py
+++ b/docs/examples/partial_loading/partial_loading.py
@@ -135,9 +135,10 @@ def load_chess_data():
     """
     Sets up and runs the dlt pipeline to load chess game data, then manages backfills.
     """
-    # Initialize the dlt pipeline with filesystem destination
+    # Initialize the dlt pipeline with filesystem destination, here we use local storage
+    dest_ = dlt.destinations.filesystem("_storage")
     pipeline = dlt.pipeline(
-        pipeline_name="chess_com_data", destination="filesystem", dataset_name="chess_games"
+        pipeline_name="chess_com_data", destination=dest_, dataset_name="chess_games"
     )
 
     # Generate the list of months for the desired date range

--- a/tests/plus/__init__.py
+++ b/tests/plus/__init__.py
@@ -1,0 +1,4 @@
+"""
+A few basic tests that guard against the worst regeressions between dlt and dlt+
+dlt-plus needs to be installed to run these tests, a license is not required at this point.
+"""

--- a/tests/plus/test_cli.py
+++ b/tests/plus/test_cli.py
@@ -1,0 +1,8 @@
+from pytest_console_scripts import ScriptRunner
+
+
+def test_project_command(script_runner: ScriptRunner) -> None:
+    result = script_runner.run(["dlt", "project", "-h"])
+    assert result.returncode == 0
+
+    assert "Usage: dlt project" in result.stdout

--- a/tests/plus/test_destinations.py
+++ b/tests/plus/test_destinations.py
@@ -1,0 +1,11 @@
+from dlt.common.destination.reference import DestinationReference
+
+
+def test_iceberg_destination() -> None:
+    # check that iceberg destination is available
+    assert DestinationReference.find("iceberg") is not None
+
+
+def test_delta_destination() -> None:
+    # check that delta destination is available
+    assert DestinationReference.find("delta") is not None

--- a/tests/plus/test_sources.py
+++ b/tests/plus/test_sources.py
@@ -1,0 +1,3 @@
+def test_mssql_source() -> None:
+    # we just test wether the mssql source may be imported
+    from dlt_plus.sources import mssql

--- a/tests/plus/test_sources.py
+++ b/tests/plus/test_sources.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.mssql
 def test_mssql_source() -> None:
     # we just test wether the mssql source may be imported

--- a/tests/plus/test_sources.py
+++ b/tests/plus/test_sources.py
@@ -1,3 +1,6 @@
+import pytest
+
+@pytest.mark.mssql
 def test_mssql_source() -> None:
     # we just test wether the mssql source may be imported
     from dlt_plus.sources import mssql


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Runs some basic tests against a nightly build of dlt+. It also adds dlt_plus to the depedencies when linting docs snippets, so these should be properly linted now!