### PR TITLE
Enabling available subcommands when cli isn't installed

### DIFF
--- a/dlt/cli/deploy_command_helpers.py
+++ b/dlt/cli/deploy_command_helpers.py
@@ -18,7 +18,7 @@ try:
     import cron_descriptor
 except ImportError:
     cron_descriptor = None
-    
+
 import dlt
 
 from dlt.common import git

--- a/dlt/cli/deploy_command_helpers.py
+++ b/dlt/cli/deploy_command_helpers.py
@@ -9,9 +9,16 @@ from itertools import chain
 from typing import List, Optional, Sequence, Tuple, Any, Dict
 
 # optional dependencies
-import pipdeptree
-import cron_descriptor
+try:
+    import pipdeptree
+except ImportError:
+    pipdeptree = None
 
+try:
+    import cron_descriptor
+except ImportError:
+    cron_descriptor = None
+    
 import dlt
 
 from dlt.common import git

--- a/dlt/cli/plugins.py
+++ b/dlt/cli/plugins.py
@@ -26,15 +26,17 @@ from dlt.cli.command_wrappers import (
     DLT_DEPLOY_DOCS_URL,
 )
 
-try:
-    from dlt.cli.deploy_command import (
-        DeploymentMethods,
-        COMMAND_DEPLOY_REPO_LOCATION,
-        SecretFormats,
-    )
+from dlt.cli.deploy_command import (
+    DeploymentMethods,
+    COMMAND_DEPLOY_REPO_LOCATION,
+    SecretFormats,
+)
 
+try:
+    import pipdeptree
+    import cron_descriptor
     deploy_command_available = True
-except ModuleNotFoundError:
+except ImportError:
     deploy_command_available = False
 
 
@@ -480,9 +482,6 @@ The `dlt deploy` command prepares your pipeline for deployment and gives you ste
         deploy_cmd.add_argument(
             "pipeline_script_path", metavar="pipeline-script-path", help="Path to a pipeline script"
         )
-
-        if not deploy_command_available:
-            return
 
         deploy_comm.add_argument(
             "--location",

--- a/dlt/cli/plugins.py
+++ b/dlt/cli/plugins.py
@@ -35,6 +35,7 @@ from dlt.cli.deploy_command import (
 try:
     import pipdeptree
     import cron_descriptor
+
     deploy_command_available = True
 except ImportError:
     deploy_command_available = False


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
The `Available Subcommands` for `dlt deploy`, including github-action and airflow-composer, are displayed in help even when the `dlt[cli]` extra is not installed.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Doesn't directly fix, but is related to #2195 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

Basically, now the pipdeptree and cron_descriptor imports in `deploy_command_helpers.py` do not fail, and `plugins.py` directly checks if they can be available in order to decide whether the `deploy_command_available` resolves to True - instead of depending on a ModuleNotFound error that stems from these imports in `deploy_command_helpers.py`.
