### PR TITLE
feat: adding HeaderCursorPaginator

### DIFF
--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -672,7 +672,7 @@ class HeaderCursorPaginator(BaseReferencePaginator):
     for pagination.
 
     A good example of this is the Finom Invoices API:
-        BaseReferencePaginator
+        https://app.finom.co/pa/index.html#section/Overview/Pagination
 
     For example, consider an API response that includes 'NextPageToken' header:
 

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -665,3 +665,68 @@ class JSONResponseCursorPaginator(BaseReferencePaginator):
             super().__str__()
             + f": cursor_path: {self.cursor_path} cursor_param: {self.cursor_param}"
         )
+
+
+class HeaderCursorPaginator(BaseReferencePaginator):
+    """A paginator that uses a cursor in the HTTP responses header
+    for pagination.
+
+    A good example of this is the Finom Invoices API:
+        BaseReferencePaginator
+
+    For example, consider an API response that includes 'NextPageToken' header:
+
+        ...
+        Content-Type: application/json
+        NextPageToken: 123456"
+
+        [
+            {"id": 1, "name": "item1"},
+            {"id": 2, "name": "item2"},
+            ...
+        ]
+
+    In this scenario, the parameter to construct the URL for the next page (`https://api.example.com/items?page=123456`)
+    is identified by the `NextPageToken` header. `HeaderCursorPaginator` extracts
+    this parameter from the header and uses it to fetch the next page of results:
+
+        from dlt.sources.helpers.rest_client import RESTClient
+        client = RESTClient(
+            base_url="https://api.example.com",
+            paginator=HeaderCursorPaginator()
+        )
+
+        @dlt.resource
+        def get_issues():
+            for page in client.paginate("/items"):
+                yield page
+    """
+
+    def __init__(self, cursor_key: str = "next", cursor_param: str = "cursor") -> None:
+        """
+        Args:
+            cursor_key (str, optional): The key in the header
+                that contains the next page cursor value. Defaults to 'next'.
+            cursor_param (str, optional): The param name to pass the token to
+                for the next request. Defaults to 'cursor'.
+        """
+        super().__init__()
+        self.cursor_key = cursor_key
+        self.cursor_param = cursor_param
+
+    def update_state(self, response: Response, data: Optional[List[Any]] = None) -> None:
+        """Extracts the next page cursor from the header in the response."""
+        self._next_reference = response.headers.get(self.cursor_key)
+
+    def update_request(self, request: Request) -> None:
+        """Updates the request with the cursor query parameter."""
+        if request.params is None:
+            request.params = {}
+
+        request.params[self.cursor_param] = self._next_reference
+
+    def __str__(self) -> str:
+        return (
+            super().__str__()
+            + f": cursor_value: {self._next_reference} cursor_param: {self.cursor_param}"
+        )

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -671,9 +671,6 @@ class HeaderCursorPaginator(BaseReferencePaginator):
     """A paginator that uses a cursor in the HTTP responses header
     for pagination.
 
-    A good example of this is the Finom Invoices API:
-        https://app.finom.co/pa/index.html#section/Overview/Pagination
-
     For example, consider an API response that includes 'NextPageToken' header:
 
         ...

--- a/tests/sources/rest_api/conftest.py
+++ b/tests/sources/rest_api/conftest.py
@@ -94,6 +94,19 @@ def mock_api_server():
 
             return response
 
+        @router.get(r"/posts_header_cursor(\?page=\d+)?$")
+        def posts_header_cursor(request, context):
+            records = generate_posts()
+            page_number = get_page_number(request.qs)
+            paginator = PageNumberPaginator(records, page_number)
+
+            response = paginator.page_records
+
+            if paginator.next_page_url_params:
+                context.headers["cursor"] = f"{page_number+1}"
+
+            return response
+
         @router.get(r"/posts_relative_next_url(\?page=\d+)?$")
         def posts_relative_next_url(request, context):
             return paginate_by_page_number(request, generate_posts(), use_absolute_url=False)


### PR DESCRIPTION
### Description
Adds a RestAPI Paginator that can paginate through responses that contain a next page cursor in the response header

### Related Issues

- Fixes [#2280](https://github.com/dlt-hub/dlt/issues/2280)
