### PR TITLE
fix upsert primary key selection bug

### DIFF
--- a/dlt/common/normalizers/json/relational.py
+++ b/dlt/common/normalizers/json/relational.py
@@ -257,9 +257,7 @@ class DataItemNormalizer(DataItemNormalizerBase[RelationalNormalizerConfig]):
         # infer record hash or leave existing primary key if present
         row_id = flattened_row.get(self.c_dlt_id, None)
         if not row_id:
-            row_id = self._add_row_id(
-                table, dict_row, flattened_row, parent_row_id, pos, is_root
-            )
+            row_id = self._add_row_id(table, dict_row, flattened_row, parent_row_id, pos, is_root)
 
         # find fields to propagate to nested tables in config
         extend.update(self._get_propagated_values(table, flattened_row, is_root))

--- a/dlt/common/normalizers/json/typing.py
+++ b/dlt/common/normalizers/json/typing.py
@@ -1,6 +1,7 @@
-from typing import Dict, Optional, TypedDict
+from typing import Dict, Optional
 
 from dlt.common.schema.typing import TColumnName
+from dlt.common.typing import TypedDict
 
 
 class RelationalNormalizerConfigPropagation(TypedDict, total=False):

--- a/dlt/common/normalizers/json/typing.py
+++ b/dlt/common/normalizers/json/typing.py
@@ -1,0 +1,13 @@
+from typing import Dict, Optional, TypedDict
+
+from dlt.common.schema.typing import TColumnName
+
+
+class RelationalNormalizerConfigPropagation(TypedDict, total=False):
+    root: Optional[Dict[TColumnName, TColumnName]]
+    tables: Optional[Dict[str, Dict[TColumnName, TColumnName]]]
+
+
+class RelationalNormalizerConfig(TypedDict, total=False):
+    max_nesting: Optional[int]
+    propagation: Optional[RelationalNormalizerConfigPropagation]

--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -518,7 +518,6 @@ Nested tables, if any, do not contain validity columns. Validity columns are onl
 must be unique for a root table. We are working to allow `updated_at` style tracking.
 * We do not detect changes in nested tables (except new records) if the row hash of the corresponding parent row does not change. Use `updated_at` or a similar
 column in the root table to stamp changes in nested data.
-* `merge_key(s)` are (for now) ignored.
 
 ### `upsert` strategy
 

--- a/tests/load/pipeline/test_filesystem_pipeline.py
+++ b/tests/load/pipeline/test_filesystem_pipeline.py
@@ -375,7 +375,7 @@ def test_table_format_core(
     destinations_configs(
         table_format_filesystem_configs=True,
         with_table_format=("delta", "iceberg"),
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -427,7 +427,7 @@ def test_preferred_table_format_caps(
         table_format_filesystem_configs=True,
         # job orchestration is same across table formats—no need to test all formats
         with_table_format="delta",
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -473,7 +473,7 @@ def test_table_format_does_not_contain_job_files(
         table_format_filesystem_configs=True,
         # job orchestration is same across table formats—no need to test all formats
         with_table_format="delta",
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -519,7 +519,7 @@ def test_table_format_multiple_files(
     destinations_configs(
         table_format_filesystem_configs=True,
         with_table_format=("delta", "iceberg"),
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -607,7 +607,7 @@ def test_table_format_child_tables(
     destinations_configs(
         table_format_filesystem_configs=True,
         with_table_format=("delta", "iceberg"),
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -707,7 +707,7 @@ def test_table_format_partitioning(
     destinations_configs(
         table_format_filesystem_configs=True,
         with_table_format="delta",
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -759,7 +759,7 @@ def test_delta_table_partitioning_arrow_load_id(
     destinations_configs(
         table_format_filesystem_configs=True,
         with_table_format=("delta", "iceberg"),
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -970,7 +970,7 @@ def test_table_format_empty_source(
         table_format_filesystem_configs=True,
         # job orchestration is same across table formats—no need to test all formats
         with_table_format="delta",
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -1020,7 +1020,7 @@ def test_table_format_mixed_source(
         table_format_filesystem_configs=True,
         # job orchestration is same across table formats—no need to test all formats
         with_table_format="delta",
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -1144,7 +1144,7 @@ def test_table_format_get_tables_helper(
     destinations_configs(
         table_format_filesystem_configs=True,
         with_table_format="delta",
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -161,7 +161,7 @@ def test_merge_on_keys_in_schema(
         local_filesystem_configs=True,
         table_format_filesystem_configs=True,
         supports_merge=True,
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -275,7 +275,126 @@ def test_merge_record_updates(
         local_filesystem_configs=True,
         table_format_filesystem_configs=True,
         supports_merge=True,
-        bucket_subset=(FILE_BUCKET),
+        subset=("postgres", "snowflake"),
+    ),
+    ids=lambda x: x.name,
+)
+@pytest.mark.parametrize("merge_strategy", ("delete-insert", "upsert"))
+def test_merge_primary_key_normalization(
+    destination_config: DestinationTestConfiguration,
+    merge_strategy: TLoaderMergeStrategy,
+) -> None:
+    p = destination_config.setup_pipeline("test_merge_record_updates", dev_mode=True)
+
+    skip_if_not_supported(merge_strategy, p.destination)
+
+    @dlt.resource(
+        table_name="parent",
+        write_disposition={"disposition": "merge", "strategy": merge_strategy},
+        primary_key=("id", "TxId"),
+    )
+    def r(data):
+        yield data
+
+    # initial load, here we check a bug where normalized primary_key columns were checked against
+    # not normalized source data, missing values were ignored leading to duplicate keys
+    # on postgres we have PK violation
+    run_1 = [
+        {"ID": 1, "TxId": "tx1🚀3", "child": [{"bar": 1, "grandchild": [{"baz": 1}]}]},
+        {"ID": 1, "TxId": "tx2Ü+😎üß", "child": [{"bar": 1, "grandchild": [{"baz": 1}]}]},
+    ]
+    info = p.run(r(run_1), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(p, "parent", "parent__child", "parent__child__grandchild") == {
+        "parent": 2,
+        "parent__child": 2,
+        "parent__child__grandchild": 2,
+    }
+    if merge_strategy == "delete-insert":
+        tables = load_tables_to_dicts(p, "parent", exclude_system_cols=True)
+        assert_records_as_set(
+            tables["parent"],
+            [
+                {"id": 1, "tx_id": "tx1🚀3"},
+                {"id": 1, "tx_id": "tx2Ü+😎üß"},
+            ],
+        )
+    else:
+        tables = load_tables_to_dicts(
+            p, "parent", "parent__child", "parent__child__grandchild", exclude_system_cols=False
+        )
+        # remove _dlt_load_id
+        parent_data = [
+            {k: v for k, v in parent_dict.items() if k != "_dlt_load_id"}
+            for parent_dict in tables["parent"]
+        ]
+        # _dlt_id is created deterministically from values of the PK so we can hardcode it
+        # NOTE: this should NEVER change or you will break user data that is already loaded
+        assert_records_as_set(
+            parent_data,
+            [
+                {"_dlt_id": "19GAeLNivYhDqg", "id": 1, "tx_id": "tx1🚀3"},
+                {"_dlt_id": "wg/EKJyC+CXo/g", "id": 1, "tx_id": "tx2Ü+😎üß"},
+            ],
+        )
+        child_data = [
+            {k: v for k, v in dict_.items() if k != "_dlt_load_id"}
+            for dict_ in tables["parent__child"]
+        ]
+        assert_records_as_set(
+            child_data,
+            [
+                {
+                    "bar": 1,
+                    "_dlt_root_id": "19GAeLNivYhDqg",
+                    "_dlt_parent_id": "19GAeLNivYhDqg",
+                    "_dlt_list_idx": 0,
+                    "_dlt_id": "hhWFugO13PeLBQ",
+                },
+                {
+                    "bar": 1,
+                    "_dlt_root_id": "wg/EKJyC+CXo/g",
+                    "_dlt_parent_id": "wg/EKJyC+CXo/g",
+                    "_dlt_list_idx": 0,
+                    "_dlt_id": "U+o+nLvOjp5DLA",
+                },
+            ],
+        )
+        # grandchild refers to child via parent_id and to root table via root_id, all ids are deterministic for upsert
+        grandchild_data = [
+            {k: v for k, v in dict_.items() if k != "_dlt_load_id"}
+            for dict_ in tables["parent__child__grandchild"]
+        ]
+        assert_records_as_set(
+            grandchild_data,
+            [
+                {
+                    "baz": 1,
+                    "_dlt_root_id": "19GAeLNivYhDqg",
+                    "_dlt_parent_id": "hhWFugO13PeLBQ",
+                    "_dlt_list_idx": 0,
+                    "_dlt_id": "rsgPU8Q0nJ4QVg",
+                },
+                {
+                    "baz": 1,
+                    "_dlt_root_id": "wg/EKJyC+CXo/g",
+                    "_dlt_parent_id": "U+o+nLvOjp5DLA",
+                    "_dlt_list_idx": 0,
+                    "_dlt_id": "8anfRKWjVjQ7ag",
+                },
+            ],
+        )
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_sql_configs=True,
+        local_filesystem_configs=True,
+        table_format_filesystem_configs=True,
+        supports_merge=True,
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -412,7 +531,7 @@ def test_merge_nested_records_inserted_deleted(
         local_filesystem_configs=True,
         table_format_filesystem_configs=True,
         supports_merge=True,
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -519,7 +638,7 @@ def test_bring_your_own_dlt_id(
         local_filesystem_configs=True,
         table_format_filesystem_configs=True,
         supports_merge=True,
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -974,7 +1093,7 @@ def test_no_deduplicate_only_merge_key(destination_config: DestinationTestConfig
         local_filesystem_configs=True,
         table_format_filesystem_configs=True,
         supports_merge=True,
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )
@@ -1534,7 +1653,7 @@ def test_merge_key_null_values(destination_config: DestinationTestConfiguration)
         local_filesystem_configs=True,
         table_format_filesystem_configs=True,
         supports_merge=True,
-        bucket_subset=(FILE_BUCKET),
+        bucket_subset=(FILE_BUCKET,),
     ),
     ids=lambda x: x.name,
 )

--- a/tests/load/pipeline/test_scd2.py
+++ b/tests/load/pipeline/test_scd2.py
@@ -55,6 +55,7 @@ def get_table(
     table_name: str,
     sort_column: str = None,
     include_root_id: bool = True,
+    include_dlt_id: bool = False,
     ts_columns: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Returns destination table contents as list of dictionaries."""
@@ -71,6 +72,7 @@ def get_table(
             if not k.startswith("_dlt")
             or k in DEFAULT_VALIDITY_COLUMN_NAMES
             or (k == "_dlt_root_id" if include_root_id else False)
+            or (k == "_dlt_id" if include_dlt_id else False)
         }
         for r in load_tables_to_dicts(pipeline, table_name)[table_name]
     ]
@@ -134,15 +136,18 @@ def test_core_functionality(
     assert not table["columns"]["_dlt_id"]["unique"]
 
     # assert load results
+    # NOTE: we are also testing deterministic dlt ids. they should NEVER change or
+    #  we are going to break user's loaded data. so don't fix the test fix the code if that happens
     ts_1 = get_load_package_created_at(p, info)
     assert_load_info(info)
-    assert get_table(p, "dim_test", "c2__nc1", ts_columns=[from_, to]) == [
+    assert get_table(p, "dim_test", "c2__nc1", ts_columns=[from_, to], include_dlt_id=True) == [
         {
             from_: ts_1,
             to: None,
             "nk": 2,
             "c1": "bar",
             "c2__nc1": "bar",
+            "_dlt_id": "S41QIpRa9Fwh0w",
         },
         {
             from_: ts_1,
@@ -150,38 +155,49 @@ def test_core_functionality(
             "nk": 1,
             "c1": "foo",
             "c2__nc1": "foo",
+            "_dlt_id": "OTPbGyxWlJzmpA",
         },
     ]
 
     # load 2 — update a record
+    # NOTE: key
     dim_snap = [
-        {"nk": 1, "c1": "foo", "c2": {"nc1": "foo_updated"}},
+        {"nk": 1, "c1": "foo", "c2": {"nc1": "foo_🚀updated"}},
         {"nk": 2, "c1": "bar", "c2": {"nc1": "bar"}},
     ]
     info = p.run(r(dim_snap), **destination_config.run_kwargs)
     ts_2 = get_load_package_created_at(p, info)
     assert_load_info(info)
-    assert get_table(p, "dim_test", "c2__nc1", ts_columns=[from_, to]) == [
+    assert get_table(p, "dim_test", "c2__nc1", ts_columns=[from_, to], include_dlt_id=True) == [
         {
             from_: ts_1,
             to: None,
             "nk": 2,
             "c1": "bar",
             "c2__nc1": "bar",
+            "_dlt_id": "S41QIpRa9Fwh0w",
         },
-        {from_: ts_1, to: ts_2, "nk": 1, "c1": "foo", "c2__nc1": "foo"},
+        {
+            from_: ts_1,
+            to: ts_2,
+            "nk": 1,
+            "c1": "foo",
+            "c2__nc1": "foo",
+            "_dlt_id": "OTPbGyxWlJzmpA",
+        },
         {
             from_: ts_2,
             to: None,
             "nk": 1,
             "c1": "foo",
-            "c2__nc1": "foo_updated",
+            "c2__nc1": "foo_🚀updated",
+            "_dlt_id": "Z/zzrOzuLRhhWw",
         },
     ]
 
     # load 3 — delete a record
     dim_snap = [
-        {"nk": 1, "c1": "foo", "c2": {"nc1": "foo_updated"}},
+        {"nk": 1, "c1": "foo", "c2": {"nc1": "foo_🚀updated"}},
     ]
     info = p.run(r(dim_snap), **destination_config.run_kwargs)
     ts_3 = get_load_package_created_at(p, info)
@@ -194,13 +210,13 @@ def test_core_functionality(
             to: None,
             "nk": 1,
             "c1": "foo",
-            "c2__nc1": "foo_updated",
+            "c2__nc1": "foo_🚀updated",
         },
     ]
 
     # load 4 — insert a record
     dim_snap = [
-        {"nk": 1, "c1": "foo", "c2": {"nc1": "foo_updated"}},
+        {"nk": 1, "c1": "foo", "c2": {"nc1": "foo_🚀updated"}},
         {"nk": 3, "c1": "baz", "c2": {"nc1": "baz"}},
     ]
     info = p.run(r(dim_snap), **destination_config.run_kwargs)
@@ -221,7 +237,7 @@ def test_core_functionality(
             to: None,
             "nk": 1,
             "c1": "foo",
-            "c2__nc1": "foo_updated",
+            "c2__nc1": "foo_🚀updated",
         },
     ]
 
@@ -255,10 +271,25 @@ def test_child_table(destination_config: DestinationTestConfiguration, simple: b
         {FROM: ts_1, TO: None, "nk": 1, "c1": "foo"},
     ]
     cname = "value" if simple else "cc1"
-    assert get_table(p, "dim_test__c2", cname) == [
-        {"_dlt_root_id": get_row_hash(l1_1), cname: 1},
-        {"_dlt_root_id": get_row_hash(l1_2), cname: 2},
-        {"_dlt_root_id": get_row_hash(l1_2), cname: 3},
+    # _dlt_id for child table are deterministic, and must stay the same forever
+    # or you will break user data
+    print(get_table(p, "dim_test__c2", cname, include_dlt_id=True))
+    assert get_table(p, "dim_test__c2", cname, include_dlt_id=True) == [
+        {
+            "_dlt_root_id": get_row_hash(l1_1),
+            "_dlt_id": "DVp8ashfqPeSOA" if simple else "sjy4J8zAS+i32w",
+            cname: 1,
+        },
+        {
+            "_dlt_root_id": get_row_hash(l1_2),
+            "_dlt_id": "fnGe0kXmwR/ncw" if simple else "+WoC2dwHIVolng",
+            cname: 2,
+        },
+        {
+            "_dlt_root_id": get_row_hash(l1_2),
+            "_dlt_id": "HScKaAcv1HMq3Q" if simple else "P60aqq9jQtVwRQ",
+            cname: 3,
+        },
     ]
 
     # load 2 — update a record — change not in nested column


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. fixes `get_row_hash` that didn't check if elements belonging to primary key are in the actual data item.
2. fixes `_add_row_id` by passing normalized data item (flattened dict) when key_hash (based on primary key) is computed - to always use normalized field/column names. for `row_hash` - based on full data item - a version before normalization is still used
3. now normalizer always checks if table is a nested table or not and is able to generate "root" table also when it is recurring in the nested lists (enables nested hints PR)
4. other small optimizations: computes hashes using dumpb (faster). calls helper method directly
5. tests that hardcode deterministic keys for fixture data, include nested records. those values must never change in the future.
6. tests that do upsert for data and PKs whose names must be normalized
