### PR TITLE
Improved `"decimal"` to `pyarrow` conversion

### DIFF
--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -152,7 +152,7 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
 
         try:
             import streamlit as st
-            import streamlit.runtime as st_r
+            import streamlit.runtime as st_r  # type: ignore
 
             if not st_r.exists():
                 return None

--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -152,7 +152,7 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
 
         try:
             import streamlit as st
-            import streamlit.runtime as st_r  # type: ignore
+            import streamlit.runtime as st_r
 
             if not st_r.exists():
                 return None

--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -2,7 +2,7 @@ import os
 import base64
 import dataclasses
 from datetime import date, datetime, time  # noqa: I251
-from typing import Any, Callable, List, Protocol, IO, Union
+from typing import Any, Callable, List, Protocol, IO, Union, Dict
 from uuid import UUID
 from hexbytes import HexBytes
 from enum import Enum
@@ -22,7 +22,8 @@ from dlt.common.utils import map_nested_in_place
 TPuaDecoders = List[Callable[[Any], Any]]
 
 
-def custom_encode(obj: Any) -> str:
+def custom_encode(obj: Any) -> Union[str, Dict[Any, Any]]:
+    """Returns a JSON-serializable representation of `obj`"""
     if isinstance(obj, Decimal):
         # always return decimals as string so they are not deserialized back to float
         return str(obj)
@@ -44,7 +45,7 @@ def custom_encode(obj: Any) -> str:
     elif hasattr(obj, "_asdict"):
         return obj._asdict()  # type: ignore
     elif PydanticBaseModel and isinstance(obj, PydanticBaseModel):
-        return obj.dict()  # type: ignore[return-value]
+        return obj.model_dump()
     elif dataclasses.is_dataclass(obj):
         return dataclasses.asdict(obj)  # type: ignore
     elif isinstance(obj, Enum):

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -101,7 +101,7 @@ class UnsupportedArrowTypeException(DltException):
         self._update_message()
 
 
-class PyToArrowConversionException(Exception):
+class PyToArrowConversionException(DltException):
     """Exception raised when converting data to Arrow based on a TableSchema"""
 
     def __init__(

--- a/dlt/sources/sql_database/arrow_helpers.py
+++ b/dlt/sources/sql_database/arrow_helpers.py
@@ -6,7 +6,6 @@ from dlt.common.configuration.container import Container
 from dlt.common.destination import DestinationCapabilitiesContext
 
 
-@with_config
 def row_tuples_to_arrow(
     rows: Sequence[Any],
     columns: TTableSchemaColumns = None,

--- a/dlt/sources/sql_database/arrow_helpers.py
+++ b/dlt/sources/sql_database/arrow_helpers.py
@@ -20,7 +20,9 @@ def row_tuples_to_arrow(
 
     return _row_tuples_to_arrow(
         rows=rows,
-        caps=Container().get(DestinationCapabilitiesContext) or DestinationCapabilitiesContext.generic_capabilities(),
+        caps=Container().get(DestinationCapabilitiesContext)
+        or DestinationCapabilitiesContext.generic_capabilities(),
         columns=columns,
-        tz=tz
+        tz=tz,
+        safe_arrow_conversion=True,
     )

--- a/dlt/sources/sql_database/arrow_helpers.py
+++ b/dlt/sources/sql_database/arrow_helpers.py
@@ -1,15 +1,14 @@
 from typing import Any, Sequence
 
 from dlt.common.schema.typing import TTableSchemaColumns
-
 from dlt.common.configuration import with_config
+from dlt.common.configuration.container import Container
 from dlt.common.destination import DestinationCapabilitiesContext
 
 
 @with_config
 def row_tuples_to_arrow(
     rows: Sequence[Any],
-    caps: DestinationCapabilitiesContext = None,
     columns: TTableSchemaColumns = None,
     tz: str = None,
 ) -> Any:
@@ -20,5 +19,8 @@ def row_tuples_to_arrow(
     from dlt.common.libs.pyarrow import row_tuples_to_arrow as _row_tuples_to_arrow
 
     return _row_tuples_to_arrow(
-        rows, caps or DestinationCapabilitiesContext.generic_capabilities(), columns, tz
+        rows=rows,
+        caps=Container().get(DestinationCapabilitiesContext) or DestinationCapabilitiesContext.generic_capabilities(),
+        columns=columns,
+        tz=tz
     )

--- a/tests/sources/sql_database/test_arrow_helpers.py
+++ b/tests/sources/sql_database/test_arrow_helpers.py
@@ -336,6 +336,7 @@ def test_row_tuples_to_arrow_error_for_decimals() -> None:
 
 pytest.importorskip("sqlalchemy", minversion="2.0")
 
+
 def test_row_tuples_to_arrow_detects_range_type() -> None:
     from sqlalchemy.dialects.postgresql import Range  # type: ignore[attr-defined]
 

--- a/tests/sources/sql_database/test_arrow_helpers.py
+++ b/tests/sources/sql_database/test_arrow_helpers.py
@@ -334,6 +334,8 @@ def test_row_tuples_to_arrow_error_for_decimals() -> None:
     assert arrow_field_type.scale == column_with_precision_and_scale[col_name]["scale"]
 
 
+pytest.importorskip("sqlalchemy", minversion="2.0")
+
 def test_row_tuples_to_arrow_detects_range_type() -> None:
     from sqlalchemy.dialects.postgresql import Range  # type: ignore[attr-defined]
 

--- a/tests/sources/sql_database/test_arrow_helpers.py
+++ b/tests/sources/sql_database/test_arrow_helpers.py
@@ -1,9 +1,11 @@
 from datetime import date, datetime, timezone  # noqa: I251
+from decimal import Decimal
 from uuid import uuid4
 
 import pyarrow as pa
 import pytest
 
+from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.sources.sql_database.arrow_helpers import row_tuples_to_arrow
 
 
@@ -21,6 +23,10 @@ def test_row_tuples_to_arrow_unknown_types(all_unknown: bool) -> None:
             uuid4(),
             datetime.now(timezone.utc),
             [1, 2, 3],
+            Decimal("2.00001"),  # precision (38, ...) is decimal128
+            Decimal("2.00000000000000000000000000000000000001"),  # precision (>38, ...) is decimal256
+            {"foo": "bar"},
+            {"foo": "baz"},
         ),
         (
             2,
@@ -31,6 +37,10 @@ def test_row_tuples_to_arrow_unknown_types(all_unknown: bool) -> None:
             uuid4(),
             datetime.now(timezone.utc),
             [4, 5, 6],
+            Decimal("3.00001"), # precision (38, ...) is decimal128
+            Decimal("3.00000000000000000000000000000000000001"),  # precision (>38, ...) is decimal256
+            {"foo": "bar"},
+            {"foo": "baz"},
         ),
         (
             3,
@@ -41,6 +51,10 @@ def test_row_tuples_to_arrow_unknown_types(all_unknown: bool) -> None:
             uuid4(),
             datetime.now(timezone.utc),
             [7, 8, 9],
+            Decimal("4.00001"),  # within default precision (38, ...) is decimal128
+            Decimal("4.00000000000000000000000000000000000001"),  # precision (>38, ...) is decimal256
+            {"foo": "bar"},
+            {"foo": "baz"},
         ),
     ]
 
@@ -58,6 +72,10 @@ def test_row_tuples_to_arrow_unknown_types(all_unknown: bool) -> None:
             "nullable": False,
         },
         "array_col": {"name": "array_col", "nullable": False},
+        "decimal_col": {"name": "decimal_col", "nullable": False},
+        "longer_decimal_col": {"name": "longer_decimal_col", "nullable": False},
+        "mapping_col": {"name": "mapping_col", "nullable": False},
+        "json_col": {"name": "json_col", "data_type": "json", "nullable": False},
     }
 
     if all_unknown:
@@ -81,9 +99,94 @@ def test_row_tuples_to_arrow_unknown_types(all_unknown: bool) -> None:
     assert pa.types.is_string(result[5].type)
     assert pa.types.is_timestamp(result[6].type)
     assert pa.types.is_list(result[7].type)
+    assert pa.types.is_decimal128(result[8].type)
+    assert pa.types.is_decimal256(result[9].type)
+    assert pa.types.is_struct(result[10].type)
+    assert pa.types.is_string(result[11].type) is (columns["json_col"].get("data_type") == "json")
 
 
-pytest.importorskip("sqlalchemy", minversion="2.0")
+def test_row_tuples_to_arrow_error_for_decimals() -> None:
+    """Decimals are represented by precision and scale. In pyarrow, decimals are represented as strings.
+
+    precision: the number of significant digits; default=38, which is a 128 bytes decimal
+    scale: the number of decimal digitsl; default=9 
+
+    Currently, dlt has 3 behaviors when converting data to pyarrow:
+    - pyarrow: pyarrow sets the precision, scale, and type (decimal128 vs. decimal256) based on the Python object
+    - destination: dlt applies the destination's settings, default is (38, 9)
+    - user: dlt applies the user specified decimal settings
+    """
+    # the test assumes the following default values
+    DEFAULT_PRECISION, DEFAULT_SCALE = DestinationCapabilitiesContext().generic_capabilities().decimal_precision
+    assert DEFAULT_PRECISION == 38
+    assert DEFAULT_SCALE == 9
+    
+    col_name = "decimal_col"
+    base_column = {col_name: {"name": col_name}}
+    column_with_data_type = {col_name: {"name": col_name, "data_type": "decimal"}}
+    column_with_precision = {col_name: {"name": col_name, "data_type": "decimal", "precision": 20}}
+    column_with_scale = {col_name: {"name": col_name, "data_type": "decimal", "scale": 10}}
+    column_with_precision_and_scale = {col_name: {"name":col_name, "data_type": "decimal", "precision": 22, "scale": 11}}
+
+    # decimal scale 7, within default (38, 9)
+    decimal_scale_7 = Decimal("2.0000001")  
+
+    # if data_type is None, pyarrow infers precision and scale
+    arrow_table = row_tuples_to_arrow([[decimal_scale_7]], columns=base_column)
+    arrow_field_type = arrow_table[col_name].type
+    assert pa.types.is_decimal128(arrow_field_type)
+    assert arrow_field_type.precision == 8
+    assert arrow_field_type.scale == 7
+
+    # data_type="decimal" and destination defaults
+    arrow_table = row_tuples_to_arrow([[decimal_scale_7]], columns=column_with_data_type)
+    arrow_field_type = arrow_table[col_name].type
+    assert pa.types.is_decimal128(arrow_field_type)
+    assert arrow_field_type.precision == 38
+    assert arrow_field_type.scale == DEFAULT_SCALE
+
+    # data_type="decimal" and precision specified
+    arrow_table = row_tuples_to_arrow([[decimal_scale_7]], columns=column_with_precision)
+    arrow_field_type = arrow_table[col_name].type
+    assert pa.types.is_decimal128(arrow_field_type)
+    assert arrow_field_type.precision == column_with_precision[col_name]["precision"]
+    assert arrow_field_type.scale == DEFAULT_SCALE
+
+    # data_type="decimal" and scale specified
+    arrow_table = row_tuples_to_arrow([[decimal_scale_7]], columns=column_with_scale)
+    arrow_field_type = arrow_table[col_name].type
+    assert pa.types.is_decimal128(arrow_field_type)
+    assert arrow_field_type.precision == DEFAULT_PRECISION
+    assert arrow_field_type.scale == column_with_scale[col_name]["scale"]
+
+    # if data_type="decimal" and precision and scale are set, use specified settings
+    arrow_table = row_tuples_to_arrow([[decimal_scale_7]], columns=column_with_precision_and_scale)
+    arrow_field_type = arrow_table[col_name].type
+    assert pa.types.is_decimal128(arrow_field_type)
+    assert arrow_field_type.precision == column_with_precision_and_scale[col_name]["precision"]
+    assert arrow_field_type.scale == column_with_precision_and_scale[col_name]["scale"]
+
+
+    # decimal scale 10, outside default (38, 9)
+    decimal_scale_10 = Decimal("2.0000000001")
+
+    # if data_type is None, pyarrow accommodates precision/scale outside destination values
+    arrow_table = row_tuples_to_arrow([[decimal_scale_10]], columns=base_column)
+    arrow_field_type = arrow_table[col_name].type
+    assert pa.types.is_decimal128(arrow_field_type)
+    assert arrow_field_type.precision == 11
+    assert arrow_field_type.scale == 10
+
+    # if `data_type="decimal"`, but data is outside of destination (38, 9) raise error
+    with pytest.raises(RuntimeError):
+        arrow_table = row_tuples_to_arrow([[decimal_scale_10]], columns=column_with_data_type)
+
+    # setting sufficient precision and scale explicitly prevents the error
+    arrow_table = row_tuples_to_arrow([[decimal_scale_10]], columns=column_with_precision_and_scale)
+    arrow_field_type = arrow_table[col_name].type
+    assert pa.types.is_decimal128(arrow_field_type)
+    assert arrow_field_type.precision == column_with_precision_and_scale[col_name]["precision"]
+    assert arrow_field_type.scale == column_with_precision_and_scale[col_name]["scale"]
 
 
 def test_row_tuples_to_arrow_detects_range_type() -> None:


### PR DESCRIPTION
Better errors for decimal conversion to pyarrow and helpful messages. 

## Related issues
#2224 This might not fix their error, will need more info to repro database-specific issues.

The problem from the original author seems to be solvable with current dlt `precision` and `scale` hints when `data_type="decimal"`([reference](https://dlthub.com/docs/general-usage/schema/#tables-and-columns)). Catching the `pyarrow` exception and adding a helpful message should helpful future users.

Linking #2273 because it touches the same code path. Having pyarrow infer types as default would likely also solve this issue

## Changes
- `dlt.common.libs.pyarrow.row_tuples_to_arrow()` was refactored to flatten conversion logic. 
  - reducing the number of intermediary numpy and arrow references potentially improves memory usage
- `dlt.sources.sql_database.arrow_helpers.row_tuples_to_arrow()` mentions in the docstring that it should pickup the destination's capabilities. Despite the function signature, `caps` was never passed. I added a call to retrieve the current capabilities
- `Decimal` handling has comprehensive warnings, exceptions, and tests

## Design / future work
- `dlt` should more explicitly document if conversion to `pyrrow` will 1) coerce + warn or 2) raise. We could further leverage [pyarrow.compute.CastOptions](https://arrow.apache.org/docs/python/generated/pyarrow.compute.CastOptions.html#pyarrow.compute.CastOptions) to let pyarrow determine behavior
- Currently, setting hints `{"data_type": "decimal"}` without `scale` or `precision` strongly enforces defaults `(38, 9)`. Letting pyarrow handle conversion seems like a better default.
  - It's odd that the destination capabilities set precision and scale. If the data goes **to python**, can't we just infer it? 
- Inspecting `psycopg3` (dlt uses `psycopg2`) [shows that Postgres](https://github.com/psycopg/psycopg/blob/be4e811369e446188e3ffd6c000dd32eec594023/psycopg/psycopg/types/numeric.py#L274) uses binary or bytes representation for `Numeric` type.