### PR TITLE
fixes custom destination to go line by line in typed jsonl

### DIFF
--- a/dlt/destinations/job_impl.py
+++ b/dlt/destinations/job_impl.py
@@ -179,20 +179,21 @@ class DestinationJsonlLoadJob(DestinationLoadJob):
 
         # stream items
         with FileStorage.open_zipsafe_ro(self._file_path) as f:
-            encoded_json = json.typed_loads(f.read())
-            if isinstance(encoded_json, dict):
-                encoded_json = [encoded_json]
+            for line in f:
+                encoded_json = json.typed_loads(line)
+                if isinstance(encoded_json, dict):
+                    encoded_json = [encoded_json]
 
-            for item in encoded_json:
-                # find correct start position
-                if start_index > 0:
-                    start_index -= 1
-                    continue
-                # skip internal columns
-                for column in self._skipped_columns:
-                    item.pop(column, None)
-                current_batch.append(item)
-                if len(current_batch) == self._config.batch_size:
-                    yield current_batch
-                    current_batch = []
-            yield current_batch
+                for item in encoded_json:
+                    # find correct start position
+                    if start_index > 0:
+                        start_index -= 1
+                        continue
+                    # skip internal columns
+                    for column in self._skipped_columns:
+                        item.pop(column, None)
+                    current_batch.append(item)
+                    if len(current_batch) == self._config.batch_size:
+                        yield current_batch
+                        current_batch = []
+                yield current_batch


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
The custom destination would fail on multiline typed jsonl files. This was previously undetected, because orjsons typed_dump wraps after a large amount of items only.