### PR TITLE
rollbacks state migration

### DIFF
--- a/dlt/pipeline/state_sync.py
+++ b/dlt/pipeline/state_sync.py
@@ -24,7 +24,7 @@ from dlt.pipeline.exceptions import (
     PipelineStateEngineNoUpgradePathException,
 )
 
-PIPELINE_STATE_ENGINE_VERSION = 5
+PIPELINE_STATE_ENGINE_VERSION = 4
 LOAD_PACKAGE_STATE_KEY = "pipeline_state"
 
 
@@ -73,7 +73,8 @@ def migrate_pipeline_state(
             state["staging_name"] = Destination.to_name(state["staging"])
             del state["staging"]
         from_engine = 4
-    if from_engine == 4 and to_engine > 4:
+    # change the state but do not bump engine version as long as changes are backward compatible
+    if from_engine == 4:
         # remove destination name if equals to destination type
         if destination_type := state.get("destination_type"):
             if Destination.to_name(destination_type) == state.get("destination_name"):
@@ -81,7 +82,6 @@ def migrate_pipeline_state(
         if staging_type := state.get("staging_type"):
             if Destination.to_name(staging_type) == state.get("staging_name"):
                 state["staging_name"] = None
-        from_engine = 5
 
     # check state engine
     if from_engine != to_engine:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dlt"
-version = "1.6.2a1"
+version = "1.7.0"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 authors = ["dltHub Inc. <services@dlthub.com>"]
 maintainers = [ "Marcin Rudolf <marcin@dlthub.com>", "Adrian Brudaru <adrian@dlthub.com>", "Anton Burnashev <anton@dlthub.com>", "David Scharf <david@dlthub.com>" ]

--- a/tests/pipeline/test_dlt_versions.py
+++ b/tests/pipeline/test_dlt_versions.py
@@ -179,7 +179,7 @@ def test_pipeline_with_dlt_update(test_storage: FileStorage) -> None:
                     test_storage.load(f".dlt/pipelines/{GITHUB_PIPELINE_NAME}/state.json")
                 )
                 assert "_version_hash" in state_dict
-                assert state_dict["_state_engine_version"] == 5
+                assert state_dict["_state_engine_version"] == 4
                 assert state_dict["destination_type"] == "dlt.destinations.duckdb"
                 assert state_dict["destination_name"] is None
 
@@ -306,7 +306,9 @@ def test_load_package_with_dlt_update(test_storage: FileStorage) -> None:
                 {"DESTINATION__DUCKDB__CREDENTIALS": "duckdb:///test_github_3.duckdb"}
             ):
                 # create virtual env with (0.3.0) before the current schema upgrade
-                with Venv.create(tempfile.mkdtemp(), ["dlt[duckdb]==0.3.0"]) as venv:
+                with Venv.create(
+                    tempfile.mkdtemp(), ["dlt[duckdb]==0.3.0", "json-logging==1.4.1rc0"]
+                ) as venv:
                     venv._install_deps(venv.context, ["duckdb" + "==" + pkg_version("duckdb")])
                     # extract and normalize on old version but DO NOT LOAD
                     print(
@@ -381,7 +383,9 @@ def test_normalize_package_with_dlt_update(test_storage: FileStorage) -> None:
                 {"DESTINATION__DUCKDB__CREDENTIALS": "duckdb:///test_github_3.duckdb"}
             ):
                 # create virtual env with (0.3.0) before the current schema upgrade
-                with Venv.create(tempfile.mkdtemp(), ["dlt[duckdb]==0.3.0"]) as venv:
+                with Venv.create(
+                    tempfile.mkdtemp(), ["dlt[duckdb]==0.3.0", "json-logging==1.4.1rc0"]
+                ) as venv:
                     venv._install_deps(venv.context, ["duckdb" + "==" + pkg_version("duckdb")])
                     # extract only
                     print(
@@ -507,7 +511,9 @@ def test_normalize_path_separator_legacy_behavior(test_storage: FileStorage) -> 
             ):
                 venv_dir = tempfile.mkdtemp()
                 # create virtual env with (0.3.0) before the current schema upgrade
-                with Venv.create(venv_dir, ["dlt[duckdb]==0.3.0"]) as venv:
+                with Venv.create(
+                    venv_dir, ["dlt[duckdb]==0.3.0", "json-logging==1.4.1rc0"]
+                ) as venv:
                     venv._install_deps(venv.context, ["duckdb" + "==" + pkg_version("duckdb")])
                     try:
                         print(

--- a/tests/pipeline/test_pipeline_state.py
+++ b/tests/pipeline/test_pipeline_state.py
@@ -639,4 +639,4 @@ def test_migrate_pipeline_state(test_storage: FileStorage) -> None:
     assert state_v4["staging_name"] == "fs_prod"
     assert state_v4["staging_type"] == "dlt.destinations.filesystem"
     # NOTE: we intend it to fail when state engine version is bumped to this test is revised
-    assert state_v4["_state_engine_version"] == 5
+    assert state_v4["_state_engine_version"] == 4


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
* keeps pipeline state engine at 4 so installing old version is easy (state change is backward compat)
* bumps to `1.7.0`
