### PR TITLE
Feat/2251-use vectorized scanner

### DIFF
--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -141,6 +141,22 @@ class SnowflakeClientConfiguration(DestinationClientDwhWithStagingConfiguration)
     create_indexes: bool = False
     """Whether UNIQUE or PRIMARY KEY constrains should be created"""
 
+    use_vectorized_scanner: bool = False
+    """Whether to use or not use the vectorized scanner in COPY INTO"""
+
+    on_error_parquet: Optional[str] = None
+    """ON_ERROR behavior for Parquet files. Must be ABORT_STATEMENT or SKIP_FILE if USE_VECTORIZED_SCANNER is enabled"""
+
+    def __post_init__(self):
+        """Enforce conditions for using USE_VECTORIZED_SCANNER"""
+        if self.use_vectorized_scanner:
+            # Ensure on_error_parquet is valid
+            if self.on_error_parquet not in ["ABORT_STATEMENT", "SKIP_FILE"]:
+                raise ValueError(
+                    "USE_VECTORIZED_SCANNER requires on_error_parquet to be 'ABORT_STATEMENT' or 'SKIP_FILE'."
+                )
+
+
     def fingerprint(self) -> str:
         """Returns a fingerprint of host part of a connection string"""
         if self.credentials and self.credentials.host:

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -144,19 +144,6 @@ class SnowflakeClientConfiguration(DestinationClientDwhWithStagingConfiguration)
     use_vectorized_scanner: bool = False
     """Whether to use or not use the vectorized scanner in COPY INTO"""
 
-    on_error_parquet: Optional[str] = None
-    """ON_ERROR behavior for Parquet files. Must be ABORT_STATEMENT or SKIP_FILE if USE_VECTORIZED_SCANNER is enabled"""
-
-    def on_resolved(self) -> None:
-        """Enforce conditions for using USE_VECTORIZED_SCANNER"""
-        if self.use_vectorized_scanner:
-            # Ensure on_error_parquet is valid
-            if self.on_error_parquet not in ["ABORT_STATEMENT", "SKIP_FILE"]:
-                raise ConfigurationValueError(
-                    f"USE_VECTORIZED_SCANNER requires on_error_parquet to be 'ABORT_STATEMENT' or 'SKIP_FILE'. You might want to change '{self.on_error_parquet}'."
-                )
-
-
     def fingerprint(self) -> str:
         """Returns a fingerprint of host part of a connection string"""
         if self.credentials and self.credentials.host:

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -147,13 +147,13 @@ class SnowflakeClientConfiguration(DestinationClientDwhWithStagingConfiguration)
     on_error_parquet: Optional[str] = None
     """ON_ERROR behavior for Parquet files. Must be ABORT_STATEMENT or SKIP_FILE if USE_VECTORIZED_SCANNER is enabled"""
 
-    def __post_init__(self):
+    def on_resolved(self) -> None:
         """Enforce conditions for using USE_VECTORIZED_SCANNER"""
         if self.use_vectorized_scanner:
             # Ensure on_error_parquet is valid
             if self.on_error_parquet not in ["ABORT_STATEMENT", "SKIP_FILE"]:
-                raise ValueError(
-                    "USE_VECTORIZED_SCANNER requires on_error_parquet to be 'ABORT_STATEMENT' or 'SKIP_FILE'."
+                raise ConfigurationValueError(
+                    f"USE_VECTORIZED_SCANNER requires on_error_parquet to be 'ABORT_STATEMENT' or 'SKIP_FILE'. You might want to change '{self.on_error_parquet}'."
                 )
 
 

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -86,9 +86,8 @@ class SnowflakeLoadJob(RunnableLoadJob, HasFollowupJobs):
             self._staging_credentials,
             self._config.csv_format,
             self._config.use_vectorized_scanner,
-            self._config.on_error_parquet,
         )
-        
+
         with self._sql_client.begin_transaction():
             # PUT and COPY in one tx if local file, otherwise only copy
             if is_local_file:
@@ -112,7 +111,6 @@ class SnowflakeLoadJob(RunnableLoadJob, HasFollowupJobs):
         staging_credentials: Optional[CredentialsConfiguration] = None,
         csv_format: Optional[CsvFormatConfiguration] = None,
         use_vectorized_scanner: Optional[bool] = False,
-        on_error_parquet: Optional[str] = None,
     ) -> str:
         parsed_file_url = urlparse(file_url)
         # check if local filesystem (file scheme or just a local file in native form)
@@ -175,14 +173,11 @@ class SnowflakeLoadJob(RunnableLoadJob, HasFollowupJobs):
         if loader_file_format == "jsonl":
             source_format = "( TYPE = 'JSON', BINARY_FORMAT = 'BASE64' )"
         elif loader_file_format == "parquet":
-            source_format = (
-                "(TYPE = 'PARQUET', BINARY_AS_TEXT = FALSE, USE_LOGICAL_TYPE = TRUE"
-            )
+            source_format = "(TYPE = 'PARQUET', BINARY_AS_TEXT = FALSE, USE_LOGICAL_TYPE = TRUE"
             if use_vectorized_scanner:
                 source_format += ", USE_VECTORIZED_SCANNER = TRUE"
+                on_error_clause = "ON_ERROR = ABORT_STATEMENT"
             source_format += ")"
-            if on_error_parquet:
-                on_error_clause = f"ON_ERROR = {on_error_parquet}"
         elif loader_file_format == "csv":
             # empty strings are NULL, no data is NULL, missing columns (ERROR_ON_COLUMN_COUNT_MISMATCH) are NULL
             csv_format = csv_format or CsvFormatConfiguration()

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -85,6 +85,7 @@ class SnowflakeLoadJob(RunnableLoadJob, HasFollowupJobs):
             stage_file_path,
             self._staging_credentials,
             self._config.csv_format,
+            self._config.use_vectorized_scanner,
         )
 
         with self._sql_client.begin_transaction():
@@ -109,6 +110,7 @@ class SnowflakeLoadJob(RunnableLoadJob, HasFollowupJobs):
         local_stage_file_path: Optional[str] = None,
         staging_credentials: Optional[CredentialsConfiguration] = None,
         csv_format: Optional[CsvFormatConfiguration] = None,
+        use_vectorized_scanner: Optional[bool] = False,
     ) -> str:
         parsed_file_url = urlparse(file_url)
         # check if local filesystem (file scheme or just a local file in native form)
@@ -172,10 +174,11 @@ class SnowflakeLoadJob(RunnableLoadJob, HasFollowupJobs):
             source_format = "( TYPE = 'JSON', BINARY_FORMAT = 'BASE64' )"
         elif loader_file_format == "parquet":
             source_format = (
-                "(TYPE = 'PARQUET', BINARY_AS_TEXT = FALSE, USE_LOGICAL_TYPE = TRUE)"
-                # TODO: USE_VECTORIZED_SCANNER inserts null strings into VARIANT JSON
-                # " USE_VECTORIZED_SCANNER = TRUE)"
+                "(TYPE = 'PARQUET', BINARY_AS_TEXT = FALSE, USE_LOGICAL_TYPE = TRUE"
             )
+            if use_vectorized_scanner:
+                source_format += ", USE_VECTORIZED_SCANNER = TRUE"
+            source_format += ")"
         elif loader_file_format == "csv":
             # empty strings are NULL, no data is NULL, missing columns (ERROR_ON_COLUMN_COUNT_MISMATCH) are NULL
             csv_format = csv_format or CsvFormatConfiguration()

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -190,6 +190,9 @@ To enable the vectorized scanner, add the following to your configuration:
 [destination.snowflake]
 use_vectorized_scanner=true
 ```
+:::note
+The  **vectorized scanner** explicitly displays `NULL` values in the output and has specific characteristics. Please refer to the official Snowflake documentation.
+:::
 
 ### Custom CSV formats
 By default, we support the CSV format [produced by our writers](../file-formats/csv.md#default-settings), which is comma-delimited, with a header, and optionally quoted.

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -183,6 +183,14 @@ When staging is enabled:
 When loading from Parquet, Snowflake will store `json` types (JSON) in `VARIANT` as a string. Use the JSONL format instead or use `PARSE_JSON` to update the `VARIANT` field after loading.
 :::
 
+When using the Parquet format, you can enable the **vectorized scanner** to improve performance. By default, this feature uses the `ON_ERROR=ABORT_STATEMENT` setting in `dlt`, which stops execution if an error occurs.
+To enable the vectorized scanner, add the following to your configuration:
+
+```toml
+[destination.snowflake]
+use_vectorized_scanner=true
+```
+
 ### Custom CSV formats
 By default, we support the CSV format [produced by our writers](../file-formats/csv.md#default-settings), which is comma-delimited, with a header, and optionally quoted.
 
@@ -217,9 +225,9 @@ Names of tables and columns in [schemas](../../general-usage/schema.md) are kept
 
 ## Staging support
 
-Snowflake supports S3 and GCS as file staging destinations. `dlt` will upload files in the parquet format to the bucket provider and will ask Snowflake to copy their data directly into the db.
+Snowflake supports S3 and GCS as file staging destinations. `dlt` will upload files in the Parquet format to the bucket provider and will ask Snowflake to copy their data directly into the db.
 
-Alternatively to parquet files, you can also specify jsonl as the staging file format. For this, set the `loader_file_format` argument of the `run` command of the pipeline to `jsonl`.
+Alternatively to Parquet files, you can also specify jsonl as the staging file format. For this, set the `loader_file_format` argument of the `run` command of the pipeline to `jsonl`.
 
 ### Snowflake and Amazon S3
 
@@ -324,6 +332,8 @@ stage_name="DLT_STAGE"
 keep_staged_files=true
 # Add UNIQUE and PRIMARY KEY hints to tables
 create_indexes=true
+# Enable vectorized scanner when using the Parquet format
+use_vectorized_scanner=true
 ```
 
 ### Setting up CSV format


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR enables the vectorized scanner for Parquet files when loading to Snowflake. the `ON_ERROR` setting defaults to `ABORT_STATEMENT`. 

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Closes #2251 

<!--
Provide any additional context about the PR here.
-->

