### PR TITLE
adds condition to check XDG_DATA_HOME to set global_dir value

### DIFF
--- a/tests/common/runtime/test_run_context.py
+++ b/tests/common/runtime/test_run_context.py
@@ -157,3 +157,17 @@ def test_tmp_folder_writable() -> None:
     import tempfile
 
     assert is_folder_writable(tempfile.gettempdir()) is True
+
+
+def test_context_with_xdg_dir() -> None:
+    import tempfile
+
+    temp_data_home = os.path.join(tempfile.gettempdir(), "test")
+
+    os.environ["XDG_DATA_HOME"] = temp_data_home
+
+    ctx = PluggableRunContext()
+    run_context = ctx.context
+    assert run_context.global_dir == os.path.join(temp_data_home, "dlt")
+
+    os.environ.pop("XDG_DATA_HOME")


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Check for XDG_DATA_HOME env var when setting the global directory for storing pipeline data.

If the variable if set but `~/.dlt` exists, then it is used with a warning raised to move it manually and not break backwards compatibility.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Closes #2319 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
