### PR TITLE
skips schema validation when loading from internal storage

### DIFF
--- a/.github/workflows/test_dbt_cloud.yml
+++ b/.github/workflows/test_dbt_cloud.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_dbt_runner.yml
+++ b/.github/workflows/test_dbt_runner.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_athena.yml
+++ b/.github/workflows/test_destination_athena.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_athena_iceberg.yml
+++ b/.github/workflows/test_destination_athena_iceberg.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_bigquery.yml
+++ b/.github/workflows/test_destination_bigquery.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_clickhouse.yml
+++ b/.github/workflows/test_destination_clickhouse.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_databricks.yml
+++ b/.github/workflows/test_destination_databricks.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_dremio.yml
+++ b/.github/workflows/test_destination_dremio.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Start dremio
         run: docker compose -f "tests/load/dremio/docker-compose.yml" up -d

--- a/.github/workflows/test_destination_lancedb.yml
+++ b/.github/workflows/test_destination_lancedb.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_motherduck.yml
+++ b/.github/workflows/test_destination_motherduck.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_mssql.yml
+++ b/.github/workflows/test_destination_mssql.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install ODBC driver for SQL Server
         run: |

--- a/.github/workflows/test_destination_qdrant.yml
+++ b/.github/workflows/test_destination_qdrant.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_snowflake.yml
+++ b/.github/workflows/test_destination_snowflake.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_destination_synapse.yml
+++ b/.github/workflows/test_destination_synapse.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install ODBC driver for SQL Server
         run: |

--- a/.github/workflows/test_destinations.yml
+++ b/.github/workflows/test_destinations.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test_doc_snippets.yml
+++ b/.github/workflows/test_doc_snippets.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Check out
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Start weaviate
         run:  docker compose -f "tests/load/weaviate/docker-compose.yml" up -d

--- a/dlt/common/configuration/specs/base_configuration.py
+++ b/dlt/common/configuration/specs/base_configuration.py
@@ -20,7 +20,7 @@ from typing import (
     TypeVar,
     Literal,
 )
-from typing_extensions import get_args, get_origin, dataclass_transform
+from typing_extensions import dataclass_transform
 from functools import wraps
 
 if TYPE_CHECKING:
@@ -41,6 +41,8 @@ from dlt.common.typing import (
     is_optional_type,
     is_subclass,
     is_union_type,
+    get_args,
+    get_origin,
 )
 from dlt.common.data_types import py_type_to_sc_type
 from dlt.common.configuration.exceptions import (

--- a/dlt/common/configuration/utils.py
+++ b/dlt/common/configuration/utils.py
@@ -11,16 +11,14 @@ from typing import (
     Tuple,
     Type,
     Sequence,
-    get_args,
     Literal,
-    get_origin,
 )
 from collections.abc import Mapping as C_Mapping
 
 import yaml
 
 from dlt.common.json import json
-from dlt.common.typing import AnyType, DictStrAny, TAny, is_any_type
+from dlt.common.typing import AnyType, DictStrAny, TAny, is_any_type, get_args, get_origin
 from dlt.common.data_types import coerce_value, py_type_to_sc_type
 from dlt.common.configuration.providers import EnvironProvider
 from dlt.common.configuration.exceptions import ConfigValueCannotBeCoercedException, LookupTrace

--- a/dlt/common/data_types/typing.py
+++ b/dlt/common/data_types/typing.py
@@ -1,4 +1,6 @@
-from typing import Literal, Set, get_args
+from typing import Literal, Set
+
+from dlt.common.typing import get_args
 
 
 TDataType = Literal[

--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -11,12 +11,11 @@ from typing import (
     Set,
     Protocol,
     Type,
-    get_args,
 )
 from dlt.common.data_types import TDataType
 from dlt.common.exceptions import TerminalValueError
 from dlt.common.normalizers.typing import TNamingConventionReferenceArg
-from dlt.common.typing import TLoaderFileFormat
+from dlt.common.typing import TLoaderFileFormat, get_args
 from dlt.common.configuration.utils import serialize_value
 from dlt.common.configuration import configspec
 from dlt.common.configuration.specs import ContainerInjectableContext

--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -1,5 +1,4 @@
 from __future__ import annotations as _annotations
-import inspect
 from copy import copy
 from typing import (
     Dict,
@@ -9,18 +8,20 @@ from typing import (
     List,
     Type,
     Union,
-    TypeVar,
     Any,
 )
-from typing_extensions import Annotated, get_args, get_origin
 
-from dlt.common.typing import TypedDict
 from dlt.common.data_types import py_type_to_sc_type
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.schema import DataValidationError
 from dlt.common.schema.typing import TSchemaEvolutionMode, TTableSchemaColumns
 from dlt.common.normalizers.naming.snake_case import NamingConvention as SnakeCaseNamingConvention
 from dlt.common.typing import (
+    TypedDict,
+    Annotated,
+    get_args,
+    get_origin,
+    TypeVar,
     TDataItem,
     TDataItems,
     extract_union_types,

--- a/dlt/common/normalizers/json/helpers.py
+++ b/dlt/common/normalizers/json/helpers.py
@@ -20,12 +20,10 @@ from dlt.common.schema.utils import (
 from dlt.common.utils import digest128, digest128b
 
 
-@lru_cache(maxsize=None)
 def shorten_fragments(naming: NamingConvention, *idents: str) -> str:
     return naming.shorten_fragments(*idents)
 
 
-@lru_cache(maxsize=None)
 def normalize_table_identifier(schema: Schema, naming: NamingConvention, table_name: str) -> str:
     if schema._normalizers_config.get("use_break_path_on_normalize", True):
         return naming.normalize_tables_path(table_name)
@@ -33,7 +31,6 @@ def normalize_table_identifier(schema: Schema, naming: NamingConvention, table_n
         return naming.normalize_table_identifier(table_name)
 
 
-@lru_cache(maxsize=None)
 def normalize_identifier(schema: Schema, naming: NamingConvention, identifier: str) -> str:
     if schema._normalizers_config.get("use_break_path_on_normalize", True):
         return naming.normalize_path(identifier)
@@ -41,7 +38,6 @@ def normalize_identifier(schema: Schema, naming: NamingConvention, identifier: s
         return naming.normalize_identifier(identifier)
 
 
-@lru_cache(maxsize=None)
 def get_table_nesting_level(
     schema: Schema, table_name: str, default_nesting: int = 1000
 ) -> Optional[int]:
@@ -56,7 +52,6 @@ def get_table_nesting_level(
     return default_nesting
 
 
-@lru_cache(maxsize=None)
 def get_primary_key(schema: Schema, table_name: str) -> List[str]:
     if table_name not in schema.tables:
         return []
@@ -65,7 +60,6 @@ def get_primary_key(schema: Schema, table_name: str) -> List[str]:
     return pk
 
 
-@lru_cache(maxsize=None)
 def is_nested_type(
     schema: Schema,
     table_name: str,
@@ -93,7 +87,6 @@ def is_nested_type(
     return data_type == "json"
 
 
-@lru_cache(maxsize=None)
 def should_be_nested(schema: Schema, table_name: str) -> bool:
     """Tells if table should be nested or should be a root table. All tables created by the normalizer
     are nested, defined tables are checked.
@@ -103,7 +96,6 @@ def should_be_nested(schema: Schema, table_name: str) -> bool:
     return True
 
 
-@lru_cache(maxsize=None)
 def get_root_row_id_type(schema: Schema, table_name: str) -> TRowIdType:
     if table := schema.tables.get(table_name):
         merge_strategy = resolve_merge_strategy(schema.tables, table)

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -1244,5 +1244,11 @@ class Schema:
         # look for auto-detections in settings and then normalizer
         self._type_detections = self._settings.get("detections") or self._normalizers_config.get("detections") or []  # type: ignore
 
+    def __getstate__(self) -> Any:
+        state = self.__dict__.copy()
+        del state["naming"]
+        del state["data_item_normalizer"]
+        return state
+
     def __repr__(self) -> str:
         return f"Schema {self.name} at {id(self)}"

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -115,12 +115,17 @@ class Schema:
 
     @classmethod
     def from_dict(
-        cls, d: DictStrAny, remove_processing_hints: bool = False, bump_version: bool = True
+        cls,
+        d: DictStrAny,
+        remove_processing_hints: bool = False,
+        bump_version: bool = True,
+        validate_schema: bool = True,
     ) -> "Schema":
         # upgrade engine if needed
         stored_schema = migrate_schema(d, d["engine_version"], cls.ENGINE_VERSION)
         # verify schema
-        utils.validate_stored_schema(stored_schema)
+        if validate_schema:
+            utils.validate_stored_schema(stored_schema)
         # add defaults
         stored_schema = utils.apply_defaults(stored_schema)
         # remove processing hints that could be created by normalize and load steps
@@ -964,8 +969,8 @@ class Schema:
         Returns:
             Tuple[int, str]: Current (``stored_version``, ``stored_version_hash``) tuple
         """
-        self._stored_version, self._stored_version_hash, _, _ = utils.bump_version_if_modified(
-            self.to_dict(bump_version=False)
+        self._stored_version, self._stored_version_hash, _, self._stored_previous_hashes = (
+            utils.bump_version_if_modified(self.to_dict(bump_version=False))
         )
         return self._stored_version, self._stored_version_hash
 

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -12,14 +12,19 @@ from typing import (
     Type,
     NewType,
     Union,
-    get_args,
 )
 from typing_extensions import Never
 
-from dlt.common.typing import TypedDict
 from dlt.common.data_types import TDataType
 from dlt.common.normalizers.typing import TNormalizersConfig
-from dlt.common.typing import TSortOrder, TAnyDateTime, TLoaderFileFormat, TColumnNames
+from dlt.common.typing import (
+    TSortOrder,
+    TAnyDateTime,
+    TLoaderFileFormat,
+    TColumnNames,
+    TypedDict,
+    get_args,
+)
 
 try:
     from pydantic import BaseModel as _PydanticBaseModel

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -148,7 +148,7 @@ def remove_column_defaults(column_schema: TColumnSchema) -> TColumnSchema:
     return column_schema
 
 
-def bump_version_if_modified(stored_schema: TStoredSchema) -> Tuple[int, str, str, Sequence[str]]:
+def bump_version_if_modified(stored_schema: TStoredSchema) -> Tuple[int, str, str, List[str]]:
     """Bumps the `stored_schema` version and version hash if content modified, returns (new version, new hash, old hash, 10 last hashes) tuple"""
     hash_ = generate_version_hash(stored_schema)
     previous_hash = stored_schema.get("version_hash")
@@ -169,9 +169,12 @@ def store_prev_hash(
     stored_schema: TStoredSchema, previous_hash: str, max_history_len: int = 10
 ) -> None:
     # unshift previous hash to previous_hashes and limit array to 10 entries
-    if previous_hash not in stored_schema["previous_hashes"]:
-        stored_schema["previous_hashes"].insert(0, previous_hash)
-        stored_schema["previous_hashes"] = stored_schema["previous_hashes"][:max_history_len]
+    previous_hashes = stored_schema["previous_hashes"]
+    if previous_hash not in previous_hashes:
+        previous_hashes.insert(0, previous_hash)
+        if (sur := len(previous_hashes) - max_history_len) > 0:
+            del previous_hashes[-sur:]
+        # stored_schema["previous_hashes"] = stored_schema["previous_hashes"][:max_history_len]
 
 
 def generate_version_hash(stored_schema: TStoredSchema) -> str:

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-from typing import Any, Literal, Optional, Type, get_args, ClassVar, Dict, Union
+from typing import Any, Literal, Optional, Type, ClassVar, Dict, Union
 from urllib.parse import urlparse, unquote, urlunparse
 
 from dlt.common.configuration import configspec, resolve_type
@@ -15,7 +15,7 @@ from dlt.common.configuration.specs import (
     SFTPCredentials,
 )
 from dlt.common.exceptions import TerminalValueError
-from dlt.common.typing import DictStrAny
+from dlt.common.typing import DictStrAny, get_args
 from dlt.common.utils import digest128
 
 

--- a/dlt/common/storages/load_package.py
+++ b/dlt/common/storages/load_package.py
@@ -17,14 +17,13 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    get_args,
     cast,
     Any,
     Tuple,
 )
 from typing_extensions import NotRequired
 
-from dlt.common.typing import TypedDict
+from dlt.common.typing import TypedDict, get_args, DictStrAny, SupportsHumanize
 from dlt.common.pendulum import pendulum
 from dlt.common.json import json
 from dlt.common.configuration import configspec
@@ -43,7 +42,6 @@ from dlt.common.storages.exceptions import (
     LoadPackageNotFound,
     CurrentLoadPackageStateNotAvailable,
 )
-from dlt.common.typing import DictStrAny, SupportsHumanize
 from dlt.common.utils import flatten_list_or_items
 from dlt.common.versioned_state import (
     generate_state_version_hash,

--- a/dlt/common/storages/load_package.py
+++ b/dlt/common/storages/load_package.py
@@ -517,7 +517,7 @@ class PackageStorage:
         self.storage.delete_folder(package_path, recursively=True)
 
     def load_schema(self, load_id: str) -> Schema:
-        return Schema.from_dict(self._load_schema(load_id))
+        return Schema.from_dict(self._load_schema(load_id), validate_schema=False)
 
     def schema_name(self, load_id: str) -> str:
         """Gets schema name associated with the package"""
@@ -616,7 +616,7 @@ class PackageStorage:
         )
         if self.storage.has_file(applied_schema_update_file):
             applied_update = json.loads(self.storage.load(applied_schema_update_file))
-        schema = Schema.from_dict(self._load_schema(load_id))
+        schema = Schema.from_dict(self._load_schema(load_id), validate_schema=False)
 
         # read jobs with all statuses
         all_job_infos: Dict[TPackageJobState, List[LoadJobInfo]] = {}

--- a/dlt/common/storages/schema_storage.py
+++ b/dlt/common/storages/schema_storage.py
@@ -54,7 +54,7 @@ class SchemaStorage(Mapping[str, Schema]):
             return self._maybe_import_schema(name, storage_schema)
         if storage_schema is None:
             raise SchemaNotFoundError(name, self.config.schema_volume_path)
-        return Schema.from_dict(storage_schema)
+        return Schema.from_dict(storage_schema, validate_schema=False)
 
     def save_schema(self, schema: Schema) -> str:
         """Saves schema to the storage and returns the path relative to storage.
@@ -141,7 +141,7 @@ class SchemaStorage(Mapping[str, Schema]):
                 self._save_and_export_schema(rv_schema, check_processing_hints=True)
             else:
                 # import schema when imported schema was modified from the last import
-                rv_schema = Schema.from_dict(storage_schema)
+                rv_schema = Schema.from_dict(storage_schema, validate_schema=False)
                 i_s = Schema.from_dict(imported_schema)
                 if i_s.version_hash != rv_schema._imported_version_hash:
                     logger.warning(
@@ -173,7 +173,7 @@ class SchemaStorage(Mapping[str, Schema]):
                     self.config.import_schema_path,
                     self.config.external_schema_format,
                 )
-            rv_schema = Schema.from_dict(storage_schema)
+            rv_schema = Schema.from_dict(storage_schema, validate_schema=False)
 
         assert rv_schema is not None
         return rv_schema

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -3,10 +3,8 @@ from datetime import datetime, date  # noqa: I251
 import inspect
 import os
 from re import Pattern as _REPattern
-import sys
 from types import FunctionType
 from typing import (
-    ForwardRef,
     Callable,
     ClassVar,
     Dict,
@@ -19,8 +17,6 @@ from typing import (
     Optional,
     Tuple,
     Type,
-    TypeVar,
-    Generic,
     Protocol,
     TYPE_CHECKING,
     Union,
@@ -33,6 +29,7 @@ from typing import (
 )
 
 from typing_extensions import (
+    ForwardRef,
     Annotated,
     Never,
     ParamSpec,
@@ -40,7 +37,11 @@ from typing_extensions import (
     Concatenate,
     Unpack,
     Self,
+    Generic,
     get_args,
+    TypeVar,
+    get_origin,
+    get_type_hints,
     get_origin,
     get_original_bases,
 )

--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -1,6 +1,6 @@
 import functools
 import inspect
-from typing import Callable, Any, List, Type
+from typing import Callable, Any, List, Type, get_type_hints
 from typing_extensions import get_args
 
 from dlt.common.exceptions import DictValidationException
@@ -57,7 +57,10 @@ def validate_dict(
     # can't validate anything
     validator_f = validator_f or (lambda p, pk, pv, t: False)
 
-    allowed_props = spec.__annotations__
+    # TODO: get_type_hints is very slow and we possibly should cache the result
+    # even better option is to rewrite "verify_prop" so we can cache annotations mapper to validators
+    # so we do not check the types of typeddict keys all the time
+    allowed_props = get_type_hints(spec)
     required_props = {k: v for k, v in allowed_props.items() if not is_optional_type(v)}
     # remove optional props
     props = {k: v for k, v in doc.items() if filter_f(k)}

--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -1,7 +1,6 @@
 import functools
 import inspect
-from typing import Callable, Any, List, Type, get_type_hints
-from typing_extensions import get_args
+from typing import Callable, Any, List, Type
 
 from dlt.common.exceptions import DictValidationException
 from dlt.common.typing import (
@@ -16,6 +15,8 @@ from dlt.common.typing import (
     is_typeddict,
     is_list_generic_type,
     is_dict_generic_type,
+    get_args,
+    get_type_hints,
     _TypedDict,
 )
 

--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -1,8 +1,7 @@
-import contextlib
 import functools
 import inspect
 from typing import Callable, Any, List, Type
-from typing_extensions import get_type_hints, get_args
+from typing_extensions import get_args
 
 from dlt.common.exceptions import DictValidationException
 from dlt.common.typing import (
@@ -58,7 +57,7 @@ def validate_dict(
     # can't validate anything
     validator_f = validator_f or (lambda p, pk, pv, t: False)
 
-    allowed_props = get_type_hints(spec)
+    allowed_props = spec.__annotations__
     required_props = {k: v for k, v in allowed_props.items() if not is_optional_type(v)}
     # remove optional props
     props = {k: v for k, v in doc.items() if filter_f(k)}
@@ -73,7 +72,7 @@ def validate_dict(
 
     def verify_prop(pk: str, pv: Any, t: Any) -> None:
         # covers none in optional and union types
-        if is_optional_type(t) and pv is None:
+        if pv is None and is_optional_type(t):
             return
         if is_union_type(t):
             # pass if value is none

--- a/dlt/destinations/impl/clickhouse/typing.py
+++ b/dlt/destinations/impl/clickhouse/typing.py
@@ -1,6 +1,8 @@
-from typing import Literal, Dict, get_args, Set
+from typing import Literal, Dict, Set
 
 from dlt.common.schema import TColumnHint
+from dlt.common.typing import get_args
+
 
 TSecureConnection = Literal[0, 1]
 TTableEngineType = Literal[

--- a/dlt/destinations/impl/synapse/synapse_adapter.py
+++ b/dlt/destinations/impl/synapse/synapse_adapter.py
@@ -1,5 +1,6 @@
-from typing import Any, Literal, Set, get_args, Final, Dict
+from typing import Any, Literal, Set, Final, Dict
 
+from dlt.common.typing import get_args
 from dlt.extract import DltResource, resource as make_resource
 from dlt.extract.items import TTableHintTemplate
 from dlt.extract.hints import TResourceHints

--- a/dlt/destinations/impl/weaviate/weaviate_adapter.py
+++ b/dlt/destinations/impl/weaviate/weaviate_adapter.py
@@ -1,7 +1,7 @@
-from typing import Dict, Any, Literal, Set, get_args
+from typing import Dict, Any, Literal, Set
 
 from dlt.common.schema.typing import TTableSchemaColumns
-from dlt.common.typing import TColumnNames
+from dlt.common.typing import TColumnNames, get_args
 from dlt.extract import DltResource, resource as make_resource
 from dlt.destinations.utils import get_resource_for_adapter
 

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -2,8 +2,6 @@ import os
 from datetime import datetime  # noqa: I251
 from typing import Generic, ClassVar, Any, Optional, Type, Dict, Union, Literal, Tuple
 
-from typing_extensions import get_args
-
 import inspect
 from functools import wraps
 
@@ -16,6 +14,7 @@ from dlt.common.typing import (
     TDataItems,
     TFun,
     TSortOrder,
+    get_args,
     extract_inner_type,
     get_generic_type_argument_from_instance,
     is_optional_type,

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -13,7 +13,6 @@ from typing import (
     Sequence,
     Tuple,
     cast,
-    get_type_hints,
     ContextManager,
     Union,
 )
@@ -45,7 +44,7 @@ from dlt.common.schema.typing import (
 )
 from dlt.common.schema.utils import normalize_schema_name
 from dlt.common.storages.exceptions import LoadPackageNotFound
-from dlt.common.typing import ConfigValue, TFun, TSecretStrValue, TColumnNames
+from dlt.common.typing import ConfigValue, TFun, TSecretStrValue, TColumnNames, get_type_hints
 from dlt.common.runners import pool_runner as runner
 from dlt.common.storages import (
     LiveSchemaStorage,

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -1745,7 +1745,12 @@ class Pipeline(SupportsPipeline):
 
     def __getstate__(self) -> Any:
         # pickle only the SupportsPipeline protocol fields
-        return {"pipeline_name": self.pipeline_name}
+        return {
+            "pipeline_name": self.pipeline_name,
+            "default_schema_name": self.default_schema_name,
+            "dataset_name": self.dataset_name,
+            "working_dir": self.working_dir,
+        }
 
     def dataset(
         self, schema: Union[Schema, str, None] = None, dataset_type: TDatasetType = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dlt"
-version = "1.8.0a0"
+version = "1.8.0"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 authors = ["dltHub Inc. <services@dlthub.com>"]
 maintainers = [ "Marcin Rudolf <marcin@dlthub.com>", "Adrian Brudaru <adrian@dlthub.com>", "Anton Burnashev <anton@dlthub.com>", "David Scharf <david@dlthub.com>" ]

--- a/tests/common/normalizers/test_json_relational.py
+++ b/tests/common/normalizers/test_json_relational.py
@@ -422,7 +422,6 @@ def test_list_in_list() -> None:
 
     rows = list(schema.normalize_data_item(chats, "1762162.1212", "zen"))
     # both lists are json types now
-    print(rows)
     assert len(rows) == 3
     zen__webpath = [row for row in rows if row[0][0] == "zen__webpath"]
     assert all("list" in row[1] for row in zen__webpath)

--- a/tests/common/normalizers/test_json_relational.py
+++ b/tests/common/normalizers/test_json_relational.py
@@ -416,12 +416,13 @@ def test_list_in_list() -> None:
         "zen__webpath", parent_table_name="zen", columns=[{"name": "list", "data_type": "json"}]
     )
     schema.update_table(path_table)
+    # NOTE: we could reset normalizer in update_table so schema caches are removed. skip for now
+    schema.data_item_normalizer._reset()  # type: ignore[attr-defined]
     assert "zen__webpath" in schema.tables
-    # clear cache with json paths
-    normalize_helpers.is_nested_type.cache_clear()
 
     rows = list(schema.normalize_data_item(chats, "1762162.1212", "zen"))
     # both lists are json types now
+    print(rows)
     assert len(rows) == 3
     zen__webpath = [row for row in rows if row[0][0] == "zen__webpath"]
     assert all("list" in row[1] for row in zen__webpath)

--- a/tests/common/test_validation.py
+++ b/tests/common/test_validation.py
@@ -308,6 +308,14 @@ class EndpointResource(TypedDict, total=False):
     write_disposition: Optional[TTableHintTemplate[TWriteDispositionConfig]]
 
 
+def test_inherited_typeddict() -> None:
+    valid_dict = {
+        "cursor_path": "$",  # from IncrementalArgs
+        "start_param": "par1",  # from IncrementalConfig
+    }
+    validate_dict(IncrementalConfig, valid_dict, ".")
+
+
 def test_typeddict_friendly_exceptions() -> None:
     valid_dict = {
         "endpoint": {

--- a/tests/helpers/dbt_tests/test_runner_dbt_versions.py
+++ b/tests/helpers/dbt_tests/test_runner_dbt_versions.py
@@ -81,10 +81,10 @@ def test_infer_venv_deps() -> None:
     # provide version ranges
     requirements = _create_dbt_deps(["duckdb"], dbt_version=">3")
     # special duckdb dependency
-    assert requirements[:-1] == ["dbt-core>3", "dbt-duckdb", "duckdb==1.1.3"]
+    assert requirements[:-1] == ["dbt-core>3", "dbt-duckdb", "duckdb==1.2.0"]
     # we do not validate version ranges, pip will do it and fail when creating venv
     requirements = _create_dbt_deps(["motherduck"], dbt_version="y")
-    assert requirements[:-1] == ["dbt-corey", "dbt-duckdb", "duckdb==1.1.3"]
+    assert requirements[:-1] == ["dbt-corey", "dbt-duckdb", "duckdb==1.2.0"]
 
 
 def test_default_profile_name() -> None:

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -952,7 +952,10 @@ def test_adapter_additional_table_hints_parsing_table_description() -> None:
     table_description = "Once upon a time a small table got hinted."
     bigquery_adapter(some_data, table_description=table_description)
 
-    assert some_data._hints["x-bigquery-table-description"] == table_description  # type: ignore
+    assert (
+        some_data._hints["additional_table_hints"]["x-bigquery-table-description"]
+        == table_description
+    )
 
 
 @pytest.mark.parametrize(
@@ -1052,4 +1055,6 @@ def test_adapter_additional_table_hints_parsing_table_expiration() -> None:
 
     bigquery_adapter(some_data, table_expiration_datetime="2030-01-01")
 
-    assert some_data._hints["x-bigquery-table-expiration"] == pendulum.datetime(2030, 1, 1)  # type: ignore
+    assert some_data._hints["additional_table_hints"][
+        "x-bigquery-table-expiration"
+    ] == pendulum.datetime(2030, 1, 1)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. fixes #2356 
2. makes schema caches private so they are discarded when relational normalizer is discarded
3. ~get_type_hints are super slow and were replaced with ___annotations__~ (not that easy)
4. schema validation is skipped on loading from pipeline schema storage (and kept for external sources)
5. also bumps `dlt` version
