### PR TITLE
Adding sql dialect to destination capabilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ We'll provide you with access to the resources above if you wish to test locally
 
 ## Local Development
 
-Use Python 3.8 for development, as it's the lowest supported version for `dlt`. You'll need `distutils` and `venv`. You may also use `pyenv`, as suggested by [poetry](https://python-poetry.org/docs/managing-environments/).
+Use Python 3.9 for development, as it's the lowest supported version for `dlt`. You'll need `distutils` and `venv`. You may also use `pyenv`, as suggested by [poetry](https://python-poetry.org/docs/managing-environments/).
 
 ## Publishing (Maintainers Only)
 

--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -183,6 +183,9 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
     supports_native_boolean: bool = True
     """The destination supports a native boolean type, otherwise bool columns are usually stored as integers"""
 
+    sqlglot_dialect: Optional[str] = None
+    """The SQL dialect used by sqlglot to transpile a query to match the destination syntax."""
+
     def generates_case_sensitive_identifiers(self) -> bool:
         """Tells if capabilities as currently adjusted, will generate case sensitive identifiers"""
         # must have case sensitive support and folding function must preserve casing

--- a/dlt/destinations/dataset/ibis_relation.py
+++ b/dlt/destinations/dataset/ibis_relation.py
@@ -6,7 +6,6 @@ from dlt.common.exceptions import MissingDependencyException
 from dlt.destinations.dataset.relation import BaseReadableDBAPIRelation
 from dlt.common.schema.typing import TTableSchemaColumns
 
-
 if TYPE_CHECKING:
     from dlt.destinations.dataset.dataset import ReadableDBAPIDataset
 else:
@@ -17,27 +16,9 @@ try:
 except MissingDependencyException:
     Expr = Any
 
-# map dlt destination to sqlglot dialect
-DIALECT_MAP = {
-    "dlt.destinations.duckdb": "duckdb",  # works
-    "dlt.destinations.motherduck": "duckdb",  # works
-    "dlt.destinations.clickhouse": "clickhouse",  # works
-    "dlt.destinations.databricks": "databricks",  # works
-    "dlt.destinations.bigquery": "bigquery",  # works
-    "dlt.destinations.postgres": "postgres",  # works
-    "dlt.destinations.redshift": "redshift",  # works
-    "dlt.destinations.snowflake": "snowflake",  # works
-    "dlt.destinations.mssql": "tsql",  # works
-    "dlt.destinations.synapse": "tsql",  # works
-    "dlt.destinations.athena": "trino",  # works
-    "dlt.destinations.filesystem": "duckdb",  # works
-    "dlt.destinations.dremio": "presto",  # works
-    # NOTE: can we discover the current dialect in sqlalchemy?
-    "dlt.destinations.sqlalchemy": "mysql",  # may work
-}
 
 # NOTE: some dialects are not supported by ibis, but by sqlglot, these need to
-# be transpiled with a intermediary step
+# be transpiled with an intermediary step
 TRANSPILE_VIA_MAP = {
     "tsql": "postgres",
     "databricks": "postgres",
@@ -64,8 +45,7 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
         """build the query"""
         from dlt.helpers.ibis import ibis, sqlglot
 
-        destination_type = self._dataset._destination.destination_type
-        target_dialect = DIALECT_MAP[destination_type]
+        target_dialect = self._dataset._destination.capabilities().sqlglot_dialect
 
         # render sql directly if possible
         if target_dialect not in TRANSPILE_VIA_MAP:

--- a/dlt/destinations/impl/athena/factory.py
+++ b/dlt/destinations/impl/athena/factory.py
@@ -140,6 +140,8 @@ class athena(Destination[AthenaClientConfiguration, "AthenaClient"]):
         caps.supported_merge_strategies = ["delete-insert", "upsert", "scd2"]
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
         caps.merge_strategies_selector = athena_merge_strategies_selector
+        caps.sqlglot_dialect = "athena"
+
         return caps
 
     @property

--- a/dlt/destinations/impl/bigquery/factory.py
+++ b/dlt/destinations/impl/bigquery/factory.py
@@ -123,6 +123,7 @@ class bigquery(Destination[BigQueryClientConfiguration, "BigQueryClient"]):
             "insert-from-staging",
             "staging-optimized",
         ]
+        caps.sqlglot_dialect = "bigquery"
 
         return caps
 

--- a/dlt/destinations/impl/clickhouse/factory.py
+++ b/dlt/destinations/impl/clickhouse/factory.py
@@ -141,6 +141,8 @@ class clickhouse(Destination[ClickHouseClientConfiguration, "ClickHouseClient"])
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
 
+        caps.sqlglot_dialect = "clickhouse"
+
         return caps
 
     @property

--- a/dlt/destinations/impl/databricks/factory.py
+++ b/dlt/destinations/impl/databricks/factory.py
@@ -139,6 +139,8 @@ class databricks(Destination[DatabricksClientConfiguration, "DatabricksClient"])
             "insert-from-staging",
             "staging-optimized",
         ]
+        caps.sqlglot_dialect = "databricks"
+
         return caps
 
     @property

--- a/dlt/destinations/impl/dremio/factory.py
+++ b/dlt/destinations/impl/dremio/factory.py
@@ -110,6 +110,8 @@ class dremio(Destination[DremioClientConfiguration, "DremioClient"]):
         caps.timestamp_precision = 3
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
+        caps.sqlglot_dialect = "presto"
+
         return caps
 
     @property

--- a/dlt/destinations/impl/duckdb/factory.py
+++ b/dlt/destinations/impl/duckdb/factory.py
@@ -150,6 +150,7 @@ class duckdb(Destination[DuckDbClientConfiguration, "DuckDbClient"]):
         caps.supports_truncate_command = False
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
+        caps.sqlglot_dialect = "duckdb"
 
         return caps
 

--- a/dlt/destinations/impl/filesystem/factory.py
+++ b/dlt/destinations/impl/filesystem/factory.py
@@ -52,6 +52,8 @@ class filesystem(Destination[FilesystemDestinationClientConfiguration, "Filesyst
         ]
         caps.has_case_sensitive_identifiers = True
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
+        caps.sqlglot_dialect = "duckdb"
+
         return caps
 
     @property

--- a/dlt/destinations/impl/motherduck/factory.py
+++ b/dlt/destinations/impl/motherduck/factory.py
@@ -41,6 +41,7 @@ class motherduck(Destination[MotherDuckClientConfiguration, "MotherDuckClient"])
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
         caps.max_parallel_load_jobs = 8
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
+        caps.sqlglot_dialect = "duckdb"
 
         return caps
 

--- a/dlt/destinations/impl/mssql/factory.py
+++ b/dlt/destinations/impl/mssql/factory.py
@@ -114,6 +114,7 @@ class mssql(Destination[MsSqlClientConfiguration, "MsSqlJobClient"]):
             "insert-from-staging",
             "staging-optimized",
         ]
+        caps.sqlglot_dialect = "tsql"
 
         return caps
 

--- a/dlt/destinations/impl/postgres/factory.py
+++ b/dlt/destinations/impl/postgres/factory.py
@@ -155,6 +155,7 @@ class postgres(Destination[PostgresClientConfiguration, "PostgresClient"]):
             "insert-from-staging",
             "staging-optimized",
         ]
+        caps.sqlglot_dialect = "postgres"
 
         return caps
 

--- a/dlt/destinations/impl/redshift/factory.py
+++ b/dlt/destinations/impl/redshift/factory.py
@@ -136,6 +136,7 @@ class redshift(Destination[RedshiftClientConfiguration, "RedshiftClient"]):
         caps.alter_add_multi_column = False
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
+        caps.sqlglot_dialect = "redshift"
 
         return caps
 

--- a/dlt/destinations/impl/snowflake/factory.py
+++ b/dlt/destinations/impl/snowflake/factory.py
@@ -126,6 +126,8 @@ class snowflake(Destination[SnowflakeClientConfiguration, "SnowflakeClient"]):
             "insert-from-staging",
             "staging-optimized",
         ]
+        caps.sqlglot_dialect = "snowflake"
+
         return caps
 
     @property

--- a/dlt/destinations/impl/sqlalchemy/factory.py
+++ b/dlt/destinations/impl/sqlalchemy/factory.py
@@ -83,12 +83,39 @@ class sqlalchemy(Destination[SqlalchemyClientConfiguration, "SqlalchemyJobClient
         caps.max_column_identifier_length = dialect.max_identifier_length
         caps.supports_native_boolean = dialect.supports_native_boolean
 
-        # TODO: define capabilities per dialect, we can also add alchemy_dialect settings to caps
         if dialect.name == "mysql" or backend_name in ("mysql", "mariadb"):
             # correct max identifier length
             # dialect uses 255 (max length for aliases) instead of 64 (max length of identifiers)
             caps.max_identifier_length = 64
             caps.format_datetime_literal = _format_mysql_datetime_literal
+            caps.sqlglot_dialect = "mysql"
+
+        elif backend_name in [
+            "oracle",
+            "redshift",
+            "drill",
+            "druid",
+            "presto",
+            "hive",
+            "trino",
+            "clickhouse",
+            "databricks",
+            "bigquery",
+            "snowflake",
+            "doris",
+            "risingwave",
+            "starrocks",
+        ]:
+            caps.sqlglot_dialect = backend_name
+
+        elif backend_name == "postgresql":
+            caps.sqlglot_dialect = "postgres"
+        elif backend_name == "awsathena":
+            caps.sqlglot_dialect = "athena"
+        elif backend_name == "mssql":
+            caps.sqlglot_dialect = "tsql"
+        elif backend_name == "teradatasql":
+            caps.sqlglot_dialect = "teradata"
 
         return caps
 

--- a/dlt/destinations/impl/sqlalchemy/factory.py
+++ b/dlt/destinations/impl/sqlalchemy/factory.py
@@ -106,7 +106,6 @@ class sqlalchemy(Destination[SqlalchemyClientConfiguration, "SqlalchemyJobClient
             "risingwave",
             "starrocks",
             "sqlite",
-            "mysql",
         ]:
             caps.sqlglot_dialect = backend_name
 

--- a/dlt/destinations/impl/sqlalchemy/factory.py
+++ b/dlt/destinations/impl/sqlalchemy/factory.py
@@ -105,6 +105,8 @@ class sqlalchemy(Destination[SqlalchemyClientConfiguration, "SqlalchemyJobClient
             "doris",
             "risingwave",
             "starrocks",
+            "sqlite",
+            "mysql",
         ]:
             caps.sqlglot_dialect = backend_name
 

--- a/dlt/destinations/impl/synapse/factory.py
+++ b/dlt/destinations/impl/synapse/factory.py
@@ -102,6 +102,8 @@ class synapse(Destination[SynapseClientConfiguration, "SynapseClient"]):
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
 
+        caps.sqlglot_dialect = "tsql"
+
         return caps
 
     @property

--- a/poetry.lock
+++ b/poetry.lock
@@ -7410,6 +7410,7 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
+    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -11085,7 +11086,7 @@ databricks = ["databricks-sdk", "databricks-sql-connector", "databricks-sql-conn
 deltalake = ["deltalake", "pyarrow", "pyarrow"]
 dremio = ["pyarrow", "pyarrow"]
 duckdb = ["duckdb"]
-filesystem = ["botocore", "s3fs", "sqlglot"]
+filesystem = ["botocore", "s3fs"]
 gcp = ["db-dtypes", "gcsfs", "google-cloud-bigquery", "grpcio"]
 gs = ["gcsfs"]
 lancedb = ["lancedb", "pyarrow", "pyarrow", "tantivy"]
@@ -11108,4 +11109,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14"
-content-hash = "3a29dbc91a446856985f855091722787dc020a6fbbfcc77158015babc38ead33"
+content-hash = "60bb2548966bfb6f7c96adb6bcfeb90e2fd1c0cd9762da6ea4aa9c929a4b1144"

--- a/poetry.lock
+++ b/poetry.lock
@@ -11109,4 +11109,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14"
-content-hash = "60bb2548966bfb6f7c96adb6bcfeb90e2fd1c0cd9762da6ea4aa9c929a4b1144"
+content-hash = "ef997f67db2a9054fc17bc474df41da30d3869201137790b10fd8957af1a2e89"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ fsspec = ">=2022.4.0"
 packaging = ">=21.1"
 pluggy = ">=1.3.0"
 win-precise-time = {version = ">=1.4.2", markers="os_name == 'nt'"}
-sqlglot = ">=26.9.0"
+sqlglot = ">=23.0.0"
 
 psycopg2-binary = {version = ">=2.9.1", optional = true}
 # use this dependency as the current version of psycopg2cffi does not have sql module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ fsspec = ">=2022.4.0"
 packaging = ">=21.1"
 pluggy = ">=1.3.0"
 win-precise-time = {version = ">=1.4.2", markers="os_name == 'nt'"}
+sqlglot = ">=26.9.0"
 
 psycopg2-binary = {version = ">=2.9.1", optional = true}
 # use this dependency as the current version of psycopg2cffi does not have sql module
@@ -102,7 +103,6 @@ deltalake = { version = ">=0.21.0", optional = true }
 sqlalchemy = { version = ">=1.4", optional = true }
 alembic = {version = ">1.10.0", optional = true}
 paramiko = {version = ">=3.3.0", optional = true}
-sqlglot = {version = ">=20.0.0", optional = true}
 db-dtypes = { version = ">=1.2.0", optional = true }
 # `sql-sqlite` extra leads to dependency conflict with `apache-airflow` because `apache-airflow`
 # requires `sqlalchemy<2.0.0` while the extra requires `sqlalchemy>=2.0.18`
@@ -122,7 +122,7 @@ postgres = ["psycopg2-binary", "psycopg2cffi"]
 redshift = ["psycopg2-binary", "psycopg2cffi"]
 parquet = ["pyarrow"]
 duckdb = ["duckdb"]
-filesystem = ["s3fs", "botocore", "sqlglot"]
+filesystem = ["s3fs", "botocore"]
 s3 = ["s3fs", "botocore"]
 gs = ["gcsfs"]
 az = ["adlfs"]
@@ -225,7 +225,6 @@ pandas = [
     {version = ">2.1", markers = "python_version >= '3.12'"},
     {version = "<2.1", markers = "python_version < '3.12'"}
 ]
-sqlglot = {version = ">=20.0.0"}
 
 [tool.poetry.group.airflow]
 optional = true

--- a/tests/load/pipeline/test_sqlalchemy_pipeline.py
+++ b/tests/load/pipeline/test_sqlalchemy_pipeline.py
@@ -1,3 +1,4 @@
+from typing import cast
 import pytest
 
 from tests.load.utils import (
@@ -23,9 +24,12 @@ def test_sqlalchemy_create_indexes(
 ) -> None:
     from dlt.destinations import sqlalchemy
     from dlt.common.libs.sql_alchemy import Table, MetaData
+    from dlt.destinations.impl.sqlalchemy.configuration import SqlalchemyCredentials
 
     alchemy_ = sqlalchemy(
-        create_unique_indexes=create_unique_indexes, create_primary_keys=create_primary_keys
+        create_unique_indexes=create_unique_indexes,
+        create_primary_keys=create_primary_keys,
+        credentials=cast(SqlalchemyCredentials, destination_config.credentials),
     )
 
     pipeline = destination_config.setup_pipeline(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
## Description
Adds sqlglot client to destination capabilities where possible. Special treatment for sqlalchemy destination. See the wrap-up below 👇.

Additionally, this PR makes sqlglot a regular dependency. (Added it under `[tool.poetry.dependencies]` and removed everywhere else. `poetry lock --no-update` is ran to update the lock file.)

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
## Related Issues

- Closes #2392 

<!--
Provide any additional context about the PR here.
-->
## Additional Context
### SQLAlchemy
For the sqlalchemy destination, we set the dialect based on the `backend_name` of the connection string. As shown below, most of the time the `backend_name` and the dialect string match, but sometimes they slightly differ (i.e. `postgresql` and `postgres`). 

> `-` means sqlglot doesn't support a dialect that would be compatible with the given destination. (as far as my googling goes). The backend names for such cases are ommitted for simplicity.

#### [External dialects maintained by SQLAlchemy](https://docs.sqlalchemy.org/en/20/dialects/index.html#external-dialects):

| Destination                              | Backend Name       | SQLGlot Dialect       |
|------------------------------------------|--------------------|-----------------------|
| Actian Data Platform, Vector, Actian X, Ingres | -                  | -                     |
| Amazon Athena                            | `awsathena`        | `athena`              |
| Amazon Redshift (via psycopg2)           | `redshift`         | `redshift`            |
| Apache Drill                             | `drill`            | `drill`               |
| Apache Druid                             | `druid`            | `druid`               |
| Apache Hive and Presto                   | `presto, hive, trino` | `presto, hive, trino` |
| Apache Solr                              | -                  | -                     |
| ClickHouse                               | `clickhouse`       | `clickhouse`          |
| CockroachDB                              | -                  | -                     |
| CrateDB                                  | -                  | -                     |
| Databend                                 | -                  | -                     |
| Databricks                               | `databricks`       | `databricks`          |
| EXASolution                              | -                  | -                     |
| Elasticsearch (readonly)                  | -                  | -                     |
| Firebird                                 | -                  | -                     |
| Firebolt                                 | -                  | -                     |
| Google BigQuery                          | `bigquery`         | `bigquery`            |
| Google Sheets                            | -                  | -                     |
| Greenplum                                | -                  | -                     |
| HyperSQL (hsqldb)                        | -                  | -                     |
| IBM DB2 and Informix                     | -                  | -                     |
| IBM Netezza Performance Server           | -                  | -                     |
| Impala                                   | -                  | -                     |
| Kinetica                                 | -                  | -                     |
| Microsoft Access (via pyodbc)            | -                  | -                     |
| Microsoft SQL Server (via python-tds)    | -                  | -                     |
| Microsoft SQL Server (via turbodbc)      | `mssql`            | `tsql`                |
| MonetDB                                  | -                  | -                     |
| OpenGauss                                | -                  | -                     |
| Rockset                                  | -                  | -                     |
| SAP ASE (fork of former Sybase dialect)  | -                  | -                     |
| SAP Hana                                 | -                  | -                     |
| SAP Sybase SQL Anywhere                  | -                  | -                     |
| Snowflake                                | `snowflake`        | `snowflake`           |
| Teradata Vantage                         | `teradatasql`      | `teradata`            |
| TiDB                                     | -                  | -                     |
| YDB                                      | -                  | -                     |
| YugabyteDB                               | -                  | -                     |

#### [Internal dialects:](https://docs.sqlalchemy.org/en/20/dialects/index.html#included-dialects)
| Destination                              | Backend Name       | SQLGlot Dialect       |
|------------------------------------------|--------------------|-----------------------|
| Microsoft SQL Server                         | `mssql`        | `tsql`              |
| MySQL / MariaDB                         | `mysql`        | `mysql`              |
| Oracle Database                         | `oracle`        | `oracle`              |
| PostgreSQL                         | `postgresql`        | `postgres`              |
| SQLite                         | `sqlite`        | `sqlite`              |

### All other destinations

| Destination   | SQLGlot Dialect |
|---------------|----------------|
| athena        | `"athena"`      |
| bigquery      | `"bigquery"`    |
| clickhouse    | `"clickhouse"`  |
| databricks    | `"databricks"`  |
| duckdb        | `"duckdb"`      |
| filesystem    | `"duckdb"`      |
| mssql         | `"tsql"`        |
| postgres      | `"postgres"`    |
| redshift      | `"redshift"`    |
| snowflake     | `"snowflake"`   |
| synapse       | `"tsql"` (previously noted as working)           |
| dremio        | `"presto"` (previously noted as working)            |
| dummy         | `-`            |
| motherduck    | `"duckdb"` (previously noted as working)            |
| weaviate      | `"n/a"`         |
| lancedb       | `"n/a"`         |
| qdrant        | `"n/a"`         |



