### PR TITLE
feat: Expand sql table resource config

### DIFF
--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -236,6 +236,9 @@ def sql_table(
     Returns:
         DltResource: The dlt resource for loading data from the SQL database table.
     """
+    # In case we get None from the config, we want to default to "append"
+    write_disposition = write_disposition if write_disposition else "append"
+
     _detect_precision_hints_deprecated(detect_precision_hints)
 
     if detect_precision_hints:

--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -174,6 +174,8 @@ def sql_table(
     resolve_foreign_keys: bool = False,
     engine_adapter_callback: Callable[[Engine], Engine] = None,
     write_disposition: TWriteDispositionConfig = "append",
+    primary_key: List[str] = None,
+    merge_key: List[str] = None,
 ) -> DltResource:
     """
     A dlt resource which loads data from an SQL database table using SQLAlchemy.
@@ -227,6 +229,9 @@ def sql_table(
             set transaction isolation level.
 
         write_disposition (TWriteDispositionConfig): write disposition of the table resource, defaults to `append`.
+        primary_key (List[str]): A list of column names that comprise a private key. Typically used with "merge" write disposition to deduplicate loaded data.
+        merge_key (List[str]): A list of column names that define a merge key. Typically used with "merge" write disposition to remove overlapping data ranges ie. to
+            keep a single record for a given day.
 
     Returns:
         DltResource: The dlt resource for loading data from the SQL database table.
@@ -264,8 +269,15 @@ def sql_table(
     else:
         hints = {}
 
+    if primary_key:
+        hints["primary_key"] = primary_key
+
     return decorators.resource(
-        table_rows, name=str(table), write_disposition=write_disposition, **hints
+        table_rows,
+        name=str(table),
+        write_disposition=write_disposition,
+        merge_key=merge_key,
+        **hints
     )(
         engine,
         table_obj if table_obj is not None else table,  # Pass table name if reflection deferred

--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -7,6 +7,7 @@ from dlt.common.configuration.specs import ConnectionStringCredentials
 from dlt.common.schema.typing import TWriteDispositionConfig
 from dlt.common.libs.sql_alchemy import MetaData, Table, Engine
 
+from dlt.common.typing import TColumnNames
 from dlt.extract import DltResource, Incremental, decorators
 
 from .helpers import (
@@ -174,8 +175,8 @@ def sql_table(
     resolve_foreign_keys: bool = False,
     engine_adapter_callback: Callable[[Engine], Engine] = None,
     write_disposition: TWriteDispositionConfig = "append",
-    primary_key: List[str] = None,
-    merge_key: List[str] = None,
+    primary_key: TColumnNames = None,
+    merge_key: TColumnNames = None,
 ) -> DltResource:
     """
     A dlt resource which loads data from an SQL database table using SQLAlchemy.
@@ -229,8 +230,8 @@ def sql_table(
             set transaction isolation level.
 
         write_disposition (TWriteDispositionConfig): write disposition of the table resource, defaults to `append`.
-        primary_key (List[str]): A list of column names that comprise a private key. Typically used with "merge" write disposition to deduplicate loaded data.
-        merge_key (List[str]): A list of column names that define a merge key. Typically used with "merge" write disposition to remove overlapping data ranges ie. to
+        primary_key (TColumnNames): A list of column names that comprise a private key. Typically used with "merge" write disposition to deduplicate loaded data.
+        merge_key (TColumnNames): A list of column names that define a merge key. Typically used with "merge" write disposition to remove overlapping data ranges ie. to
             keep a single record for a given day.
 
     Returns:
@@ -273,7 +274,8 @@ def sql_table(
         hints = {}
 
     if primary_key:
-        hints["primary_key"] = primary_key
+        # may be from what is found in the reflection, so it is set explicitly
+        hints["primary_key"] = [primary_key] if isinstance(primary_key, str) else list(primary_key)
 
     return decorators.resource(
         table_rows,

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -23,7 +23,7 @@ from dlt.common.configuration.specs import (
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.schema import TTableSchemaColumns
 from dlt.common.schema.typing import TWriteDispositionDict
-from dlt.common.typing import TDataItem, TSortOrder
+from dlt.common.typing import TColumnNames, TDataItem, TSortOrder
 from dlt.common.jsonpath import extract_simple_field_name
 
 from dlt.common.utils import is_typeerror_due_to_wrong_call
@@ -410,5 +410,5 @@ class SqlTableResourceConfiguration(BaseConfiguration):
     reflection_level: Optional[ReflectionLevel] = "full"
     included_columns: Optional[List[str]] = None
     write_disposition: Optional[TWriteDispositionDict] = None
-    primary_key: Optional[List[str]] = None
-    merge_key: Optional[List[str]] = None
+    primary_key: Optional[TColumnNames] = None
+    merge_key: Optional[TColumnNames] = None

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -22,6 +22,7 @@ from dlt.common.configuration.specs import (
 )
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.schema import TTableSchemaColumns
+from dlt.common.schema.typing import TWriteDispositionConfig
 from dlt.common.typing import TDataItem, TSortOrder
 from dlt.common.jsonpath import extract_simple_field_name
 
@@ -408,3 +409,4 @@ class SqlTableResourceConfiguration(BaseConfiguration):
     defer_table_reflect: Optional[bool] = False
     reflection_level: Optional[ReflectionLevel] = "full"
     included_columns: Optional[List[str]] = None
+    write_disposition: TWriteDispositionConfig = {"disposition": "append"}

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -410,5 +410,5 @@ class SqlTableResourceConfiguration(BaseConfiguration):
     reflection_level: Optional[ReflectionLevel] = "full"
     included_columns: Optional[List[str]] = None
     write_disposition: Optional[TWriteDispositionDict] = None
-    primary_key: List[str] = None
-    merge_key: List[str] = None
+    primary_key: Optional[List[str]] = None
+    merge_key: Optional[List[str]] = None

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -22,7 +22,7 @@ from dlt.common.configuration.specs import (
 )
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.schema import TTableSchemaColumns
-from dlt.common.schema.typing import TWriteDispositionConfig
+from dlt.common.schema.typing import TWriteDispositionDict
 from dlt.common.typing import TDataItem, TSortOrder
 from dlt.common.jsonpath import extract_simple_field_name
 
@@ -409,6 +409,6 @@ class SqlTableResourceConfiguration(BaseConfiguration):
     defer_table_reflect: Optional[bool] = False
     reflection_level: Optional[ReflectionLevel] = "full"
     included_columns: Optional[List[str]] = None
-    write_disposition: TWriteDispositionConfig = {"disposition": "append"}
+    write_disposition: Optional[TWriteDispositionDict] = None
     primary_key: List[str] = None
     merge_key: List[str] = None

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -410,3 +410,5 @@ class SqlTableResourceConfiguration(BaseConfiguration):
     reflection_level: Optional[ReflectionLevel] = "full"
     included_columns: Optional[List[str]] = None
     write_disposition: TWriteDispositionConfig = {"disposition": "append"}
+    primary_key: List[str] = None
+    merge_key: List[str] = None

--- a/tests/load/sources/sql_database/test_sql_database_source.py
+++ b/tests/load/sources/sql_database/test_sql_database_source.py
@@ -271,6 +271,26 @@ def test_general_sql_database_config(sql_source_db: SQLAlchemySourceDB) -> None:
     assert len(list(sql_database(schema=sql_source_db.schema).with_resources("app_user"))) > 0
 
 
+def test_sql_table_accepts_merge_and_primary_key_in_decorator(
+    sql_source_db: SQLAlchemySourceDB,
+) -> None:
+    # setup
+    os.environ["SOURCES__SQL_DATABASE__CREDENTIALS"] = sql_source_db.engine.url.render_as_string(
+        False
+    )
+    table = sql_table(
+        table="chat_message",
+        schema=sql_source_db.schema,
+        write_disposition="merge",
+        primary_key=["id"],
+        merge_key=["merge_id"],
+    )
+    # verify
+    assert table.write_disposition == "merge"
+    assert table._hints["primary_key"] == ["id"]
+    assert table._hints["merge_key"] == ["merge_id"]
+
+
 @pytest.mark.parametrize("backend", ["sqlalchemy", "pandas", "pyarrow"])
 @pytest.mark.parametrize("add_new_columns", [True, False])
 def test_text_query_adapter(


### PR DESCRIPTION
### Description
It's possible to specify sql table using `config.toml` file ([see docs](https://dlthub.com/docs/dlt-ecosystem/verified-sources/sql_database/advanced#configuring-with-toml-or-environment-variables)).
```
[sources.sql_database.chat_message]
backend="pandas"
chunk_size=1000

[sources.sql_database.chat_message.incremental]
cursor_path="updated_at"
```
The problem is this setting-based approach allows only `append` strategy and doesn't allow to specify custom `primary` or `merge` keys.
While `primary` keys are reflected from source table it's not possible for views.
So this PR allows to specify `write_disposition`, `primary_key` and `merge_key` in `config.toml` file with some restrictions (see Additional Context):

```
[sources.sql_database.chat_message]
chunk_size=1000

[sources.sql_database.chat_message.incremental]
write_disposition.disposition = "merge"
primary_key = ["id", "updated_at"]
cursor_path="updated_at"
```
<!--
Provide any additional context about the PR here.
-->
### Additional Context
There is a problem with not total alignment between `def resource(...)` method's arguments and fields in config classes.
Current config system doesn't support `Union` types (and probably it's not possible and there is no point) but this leads to the situation that we can't use plain string values:
```
[sources.sql_database.chat_message.incremental]
write_disposition= "merge"
primary_key = "id"
```
but we have to use more complex dict or lists values:

```
[sources.sql_database.chat_message.incremental]
write_disposition.disposition= "merge"
primary_key = ["id"]
```
If you have any better ideas how to realize this opportunity I'm open to adjust my PR or implement it different way.