### PR TITLE
fix: better import exception for numpy

### DIFF
--- a/dlt/common/libs/numpy.py
+++ b/dlt/common/libs/numpy.py
@@ -1,6 +1,6 @@
 from dlt.common.exceptions import MissingDependencyException
 
 try:
-    import numpy
+    import numpy  # noqa: I251
 except ModuleNotFoundError:
-    raise MissingDependencyException("dlt Numpy Helpers", ["numpy"])
+    raise MissingDependencyException("dlt numpy Helpers", ["numpy"])

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -731,6 +731,13 @@ def transpose_rows_to_columns(
     Uses pandas if available. Otherwise, use numpy, which is slower
     """
     try:
+        from dlt.common.libs.numpy import numpy as np
+    except MissingDependencyException:
+        raise MissingDependencyException(
+            "dlt pyarrow helpers", ["numpy"], "Numpy is required for this pyarrow operation"
+        )
+
+    try:
         from pandas._libs import lib
 
         pivoted_rows = lib.to_object_array_tuples(rows).T
@@ -738,14 +745,6 @@ def transpose_rows_to_columns(
         logger.info(
             "Pandas not installed, reverting to numpy.asarray to create a table which is slower"
         )
-
-        try:
-            from dlt.common.libs.numpy import numpy as np
-        except MissingDependencyException:
-            raise MissingDependencyException(
-                "dlt pyarrow helpers", ["numpy"], "Numpy is required for this pyarrow operation"
-            )
-
         pivoted_rows = np.asarray(rows, dtype="object", order="k").T  # type: ignore[call-overload]
 
     return {

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -730,16 +730,18 @@ def transpose_rows_to_columns(
 
     Uses pandas if available. Otherwise, use numpy, which is slower
     """
-    import numpy as np
-
     try:
         from pandas._libs import lib
 
         pivoted_rows = lib.to_object_array_tuples(rows).T
     except ImportError:
-        logger.info(
-            "Pandas not installed, reverting to numpy.asarray to create a table which is slower"
-        )
+        logger.info("Pandas not installed, reverting to numpy.asarray to create a table which is slower")
+
+        try:
+            from dlt.common.libs.numpy import numpy as np
+        except MissingDependencyException:
+            raise MissingDependencyException("dlt pyarrow helpers", ["numpy"], "Numpy is required for this pyarrow operation")
+        
         pivoted_rows = np.asarray(rows, dtype="object", order="k").T  # type: ignore[call-overload]
 
     return {

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -735,13 +735,17 @@ def transpose_rows_to_columns(
 
         pivoted_rows = lib.to_object_array_tuples(rows).T
     except ImportError:
-        logger.info("Pandas not installed, reverting to numpy.asarray to create a table which is slower")
+        logger.info(
+            "Pandas not installed, reverting to numpy.asarray to create a table which is slower"
+        )
 
         try:
             from dlt.common.libs.numpy import numpy as np
         except MissingDependencyException:
-            raise MissingDependencyException("dlt pyarrow helpers", ["numpy"], "Numpy is required for this pyarrow operation")
-        
+            raise MissingDependencyException(
+                "dlt pyarrow helpers", ["numpy"], "Numpy is required for this pyarrow operation"
+            )
+
         pivoted_rows = np.asarray(rows, dtype="object", order="k").T  # type: ignore[call-overload]
 
     return {

--- a/dlt/destinations/impl/lancedb/lancedb_client.py
+++ b/dlt/destinations/impl/lancedb/lancedb_client.py
@@ -22,10 +22,10 @@ from lancedb import DBConnection
 from lancedb.common import DATA  # type: ignore
 from lancedb.embeddings import EmbeddingFunctionRegistry, TextEmbeddingFunction  # type: ignore
 from lancedb.query import LanceQueryBuilder  # type: ignore
-from numpy import ndarray
 from pyarrow import Array, ChunkedArray, ArrowInvalid
 
 from dlt.common import json, pendulum, logger
+from dlt.common.libs.numpy import numpy
 from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.destination.exceptions import (
     DestinationUndefinedEntity,
@@ -85,9 +85,9 @@ from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.type_mapping import TypeMapperImpl
 
 if TYPE_CHECKING:
-    NDArray = ndarray[Any, Any]
+    NDArray = numpy.ndarray[Any, Any]
 else:
-    NDArray = ndarray
+    NDArray = numpy.ndarray
 
 TIMESTAMP_PRECISION_TO_UNIT: Dict[int, str] = {0: "s", 3: "ms", 6: "us", 9: "ns"}
 UNIT_TO_TIMESTAMP_PRECISION: Dict[str, int] = {v: k for k, v in TIMESTAMP_PRECISION_TO_UNIT.items()}

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/configuration.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/configuration.md
@@ -280,7 +280,14 @@ The `SQLAlchemy` backend (the default) yields table data as a list of Python dic
 
 The `PyArrow` backend yields data as `Arrow` tables. It uses `SQLAlchemy` to read rows in batches but then immediately converts them into `ndarray`, transposes it, and sets it as columns in an `Arrow` table. This backend always fully reflects the database table and preserves original types (i.e., **decimal** / **numeric** data will be extracted without loss of precision). If the destination loads parquet files, this backend will skip the `dlt` normalizer, and you can gain two orders of magnitude (20x - 30x) speed increase.
 
-Note that if `pandas` is installed, we'll use it to convert `SQLAlchemy` tuples into `ndarray` as it seems to be 20-30% faster than using `numpy` directly.
+:::note
+To use the `backend="arrow"` configuration, you will need `numpy` installed. You can get another 20-30% speed increase by having `pandas` installed.
+The library `numpy` is a required dependency of `pandas` and `pyarrow<18.0.0`. To have all required dependencies, we suggest using this command:
+
+```sh
+pip install dlt[sql_database] pyarrow numpy pandas
+```
+:::
 
 ```py
 import dlt

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/setup.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/setup.md
@@ -55,6 +55,14 @@ If you'd like to use a different destination, simply replace `duckdb` with the n
     pip install -r requirements.txt
     ```
 
+    :::note
+    To [load data more efficiently using pyarrow](./configuration#pyarrow), you'll also need to install `pyarrow`, `numpy`, and `pandas`. 
+
+    ```sh
+    pip install pyarrow numpy pandas
+    ```
+    :::
+
 5. Run the pipeline  
 
     ```sh

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/troubleshooting.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/troubleshooting.md
@@ -98,3 +98,8 @@ In the `SQLAlchemy` backend, the JSON data type is represented as a Python objec
 #### UUID  
 UUIDs are represented as strings by default. You can switch this behavior by using `table_adapter_callback` to modify properties of the UUID type for a particular column. (See the code example [here](./configuration#pyarrow) for how to modify the data type properties of a particular column.)
 
+### Notes on data loading
+
+#### Arrow loading
+
+Using the configuration `sql_database(backend="pyarrow")` improves performance by pivoting all records (row-major) into a arrow table (column-major). The library `pyarrow` doesn't have a utility for this pivot operation, which is why `numpy` or `pandas` is necessary. Either library is required for this pivot operation only, then `pyarrow` handles the rest of type conversion and applying dlt constraints. 

--- a/tests/sources/sql_database/test_arrow_helpers.py
+++ b/tests/sources/sql_database/test_arrow_helpers.py
@@ -207,7 +207,7 @@ def test_convert_to_arrow_cast_string_to_decimal():
     columns_schema: TTableSchemaColumns = {
         column_name: {"name": column_name, "data_type": "decimal"}
     }
-    rows = ["2.00001", "3.00001"]
+    rows = [("2.00001",), ("3.00001",)]
 
     columns = transpose_rows_to_columns(rows, columns_schema)
     arrow_array = convert_numpy_to_arrow(

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ banned-modules = datetime = use dlt.common.pendulum
                  decimal = use dlt.common.decimal
                  decimal.Decimal = use dlt.common.Decimal
                  open = use dlt.common.open
+                 numpy = use dlt.common.libs.numpy
                  pendulum = use dlt.common.pendulum
                  typing.TypedDict = use dlt.common.typing.TypedDict
                  typing-extensions.TypedDict = use dlt.common.typing.TypedDict

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ banned-modules = datetime = use dlt.common.pendulum
                  typing.TypedDict = use dlt.common.typing.TypedDict
                  typing-extensions.TypedDict = use dlt.common.typing.TypedDict
 extend-immutable-calls = dlt.sources.incremental
+# allow banned-imports (I251) in tests and docs e.g., direct numpy import
 per-file-ignores =
-    tests/*: T20
-    docs/*: T20
+    tests/*: T20, I251 
+    docs/*: T20, I251


### PR DESCRIPTION
### Related Issues
Fixes #2380

### Context
When converting arbitrary row data to `pyarrow`, we try to use `pandas` to transpose row-wise data to column-wise data. If unavailable, we fallback to `numpy`

Since `pyarrow >= 18`, [numpy is no longer a dependency](https://github.com/apache/arrow/issues/25118). Our pyarrow code assumed that numpy was available. There's no error / change from related to our recent refactoring. 

### Problem
User reported (#2380) that a pipeline with SQL source fails with an import error when using `pyarrow >= 18` because of missing numpy dependency.

Note. the reported config `pyarrow==18, python==3.12` doesn't match the `pyproject.toml` constraints `pyarrow < 18` for `python < 3.13`. I would expect the package manager to enforce contraints and prevent this error. 

### Solution
Pyarrow is not a dependency of `dlt[sql_database]`, so numpy probably shouldn't be either. Also, except this code, only some LanceDB-related function seems to assume numpy to be available.

Exception handling now raises a message similar to when pyarrow is missing.
```
E               dlt.common.exceptions.MissingDependencyException: 
E               You must install additional dependencies to run dlt pyarrow helpers. If you use pip you may do the following:
E               
E               pip install "numpy"
E               
E               Numpy is required for this pyarrow operation
```

Unfortunately, it's hard to raise earlier than `DBApiCursor`'s arrow related methods
