### PR TITLE
un-deprecates force_iceberg on athena via new destination cap settings

### DIFF
--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -457,9 +457,7 @@ class AthenaClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):
         table_format = table.get("table_format")
         # all dlt tables that are not loaded via files are iceberg tables, no matter if they are on staging or regular dataset
         # all other iceberg tables are HIVE (external) tables on staging dataset
-        table_format_iceberg = table_format == "iceberg" or (
-            self.config.force_iceberg and table_format is None
-        )
+        table_format_iceberg = table_format == "iceberg"
         return (table_format_iceberg and not is_staging_dataset) or table[
             "write_disposition"
         ] == "skip"

--- a/dlt/destinations/impl/athena/configuration.py
+++ b/dlt/destinations/impl/athena/configuration.py
@@ -19,17 +19,6 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
 
     __config_gen_annotations__: ClassVar[List[str]] = ["athena_work_group"]
 
-    def on_resolved(self) -> None:
-        if self.force_iceberg is not None:
-            warnings.warn(
-                "The `force_iceberg` is deprecated.If you upgraded dlt on existing pipeline and you"
-                " have data already loaded, please keep this flag to make sure your data is"
-                " consistent.If you are creating a new dataset and no data was loaded, please set"
-                " `table_format='iceberg`` on your resources explicitly.",
-                Dlt100DeprecationWarning,
-                stacklevel=1,
-            )
-
     def __str__(self) -> str:
         """Return displayable destination location"""
         if self.staging_config:

--- a/dlt/destinations/impl/athena/factory.py
+++ b/dlt/destinations/impl/athena/factory.py
@@ -7,6 +7,7 @@ from dlt.common.data_writers.escape import (
     escape_athena_identifier,
     format_bigquery_datetime_literal,
 )
+from dlt.common.normalizers.naming import NamingConvention
 from dlt.common.arithmetics import DEFAULT_NUMERIC_PRECISION, DEFAULT_NUMERIC_SCALE
 from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.exceptions import TerminalValueError
@@ -149,6 +150,18 @@ class athena(Destination[AthenaClientConfiguration, "AthenaClient"]):
         from dlt.destinations.impl.athena.athena import AthenaClient
 
         return AthenaClient
+
+    @classmethod
+    def adjust_capabilities(
+        cls,
+        caps: DestinationCapabilitiesContext,
+        config: AthenaClientConfiguration,
+        naming: t.Optional[NamingConvention],
+    ) -> DestinationCapabilitiesContext:
+        if config.force_iceberg:
+            caps.preferred_table_format = "iceberg"
+
+        return super().adjust_capabilities(caps, config, naming)
 
     def __init__(
         self,

--- a/docs/website/docs/dlt-ecosystem/destinations/athena.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/athena.md
@@ -85,7 +85,7 @@ athena_work_group="my_workgroup"
 You can force all tables to be in iceberg format:
 ```toml
 [destination.athena]
-force_iceberg=True
+force_iceberg = true
 ```
 
 
@@ -147,7 +147,7 @@ See [athena adapter](#athena-adapter) for partitioning and other options.
 You can also force all tables to be in iceberg format:
 ```toml
 [destination.athena]
-force_iceberg=True
+force_iceberg = true
 ```
 
 

--- a/docs/website/docs/dlt-ecosystem/destinations/athena.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/athena.md
@@ -82,6 +82,13 @@ You can provide an Athena workgroup like so:
 athena_work_group="my_workgroup"
 ```
 
+You can force all tables to be in iceberg format:
+```toml
+[destination.athena]
+force_iceberg=True
+```
+
+
 ## Write disposition
 
 The `athena` destination handles the write dispositions as follows:
@@ -134,6 +141,15 @@ def data() -> Iterable[TDataItem]:
 ```
 
 For every table created as an Iceberg table, the Athena destination will create a regular Athena table in the staging dataset of both the filesystem and the Athena glue catalog, and then copy all data into the final Iceberg table that lives with the non-Iceberg tables in the same dataset on both the filesystem and the glue catalog. Switching from Iceberg to regular table or vice versa is not supported.
+
+See [athena adapter](#athena-adapter) for partitioning and other options.
+
+You can also force all tables to be in iceberg format:
+```toml
+[destination.athena]
+force_iceberg=True
+```
+
 
 #### `merge` support
 

--- a/tests/load/athena_iceberg/test_athena_iceberg.py
+++ b/tests/load/athena_iceberg/test_athena_iceberg.py
@@ -81,7 +81,7 @@ def test_iceberg(destination_config: DestinationTestConfiguration) -> None:
     ),
     ids=lambda x: x.name,
 )
-def test_force_iceberg_deprecation(destination_config: DestinationTestConfiguration) -> None:
+def test_force_iceberg(destination_config: DestinationTestConfiguration) -> None:
     """Fails on deprecated force_iceberg option"""
     destination_config.force_iceberg = True
     pipeline = destination_config.setup_pipeline("test_force_iceberg_deprecation", dev_mode=True)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
we can have `force_iceberg` again: this time correctly implemented
