### PR TITLE
Testing sqlglot's insert

### DIFF
--- a/tests/load/test_insert_copy.py
+++ b/tests/load/test_insert_copy.py
@@ -9,20 +9,20 @@ from tests.load.utils import (
 
 
 DESTINATIONS: List[str] = [
-    #    "duckdb",
-    #    "athena",
-    #    "bigquery",
-    #    "clickhouse",
-    #    "databricks",
-    #    "motherduck",
-    #    "redshift",
-    #    "snowflake",
-    #    "sqlalchemy",
-    # NOTE: the following haven't been tested yet
-    #    "postgres"
-    #    "mssql",
-    #    "filesystem",
-    #    "dremio"
+    # NOTE: The following destinations
+    # support simple INSERT INTO FROM expressions
+    "duckdb",
+    "athena",
+    "bigquery",
+    "clickhouse",
+    "databricks",
+    "motherduck",
+    "redshift",
+    "snowflake",
+    "sqlalchemy",
+    "mssql",
+    "postgres",
+    "dremio",
 ]
 
 
@@ -30,7 +30,6 @@ DESTINATIONS: List[str] = [
     "destination_config",
     destinations_configs(
         default_sql_configs=True,
-        # subset=DESTINATIONS,
     ),
     ids=lambda x: x.name,
 )

--- a/tests/load/test_insert_copy.py
+++ b/tests/load/test_insert_copy.py
@@ -1,0 +1,89 @@
+import pytest
+import dlt
+from typing import List
+
+from tests.load.utils import (
+    destinations_configs,
+    DestinationTestConfiguration,
+)
+
+
+DESTINATIONS: List[str] = [
+    #    "duckdb",
+    #    "athena",
+    #    "bigquery",
+    #    "clickhouse",
+    #    "databricks",
+    #    "motherduck",
+    #    "redshift",
+    #    "snowflake",
+    #    "sqlalchemy",
+    # NOTE: the following haven't been tested yet
+    #    "postgres"
+    #    "mssql",
+    #    "filesystem",
+    #    "dremio"
+]
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_sql_configs=True,
+        # subset=DESTINATIONS,
+    ),
+    ids=lambda x: x.name,
+)
+def test_execute_insert_query(destination_config: DestinationTestConfiguration) -> None:
+    import sqlglot.expressions as sge
+
+    # we will later insert everything from this table to the next one
+    @dlt.resource(table_name="select_from_table")
+    def select_from_table():
+        yield from [{"id": i} for i in range(10, 20)]
+
+    @dlt.resource(table_name="insert_into_table")
+    def insert_into_table():
+        yield from [{"id": i} for i in range(10)]
+
+    pipeline = destination_config.setup_pipeline(
+        "read_pipeline",
+        dataset_name="read_test",
+        dev_mode=True,
+    )
+
+    pipeline.run(select_from_table, loader_file_format=destination_config.file_format)
+    pipeline.run(insert_into_table, loader_file_format=destination_config.file_format)
+
+    dataset = pipeline.dataset()
+    select_relation_query = dataset.table("select_from_table").query()  # type: ignore
+    dialect = dataset._destination.capabilities().sqlglot_dialect
+
+    # NOTE: The resulting insert into sql queries for these destinations
+    # are being double-parsed (presumably by ibis and sqlglot)
+    # so we just define cases for special handling.
+    # The reason - they don't recognize double quotes ("") for identifiers
+    specical_handling = [
+        "bigquery",
+        "databricks",
+        "sqlalchemy",
+    ]
+
+    with pipeline.sql_client() as client:
+        if destination_config.destination_type in specical_handling:
+            target_table = client.make_qualified_table_name("insert_into_table", escape=False)
+            select_relation_query = str(select_relation_query).replace("`", "")
+        else:
+            target_table = client.make_qualified_table_name("insert_into_table")
+
+        query = sge.insert(
+            expression=select_relation_query,
+            into=target_table,
+            dialect=dialect,
+        ).sql()
+
+        client.execute_sql(query)
+
+        with client.execute_query(f"SELECT * FROM {target_table}") as curr:
+            df = curr.df()
+            assert df.shape[0] == 20


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

> Please check out #2399 where the motivation behind this PR is explained.

Here, we're just testing if an INSERT INTO statement created with the following steps works for different destinations:
- Assume two tables have the same schema
- Create a `SELECT * FROM` statement using an IbisRelation with something like:
     ```python
     dataset = pipeline.dataset()
     select_relation_query = dataset.table("select_from_table").query()  
     ```
- Make the `target_table` with:
     ```python
     target_table = client.make_qualified_table_name("insert_into_table")
     ```
- Make sqlglot create an `INSERT INTO ... SELECT * FROM ...` statement with something like:
     ```python
     import sqlglot.expressions as sge
     query = sge.insert(
        expression=select_relation_query,
        into=target_table  
        dialect=dialect,
    ).sql()
     ```
   > [The source code of insert](https://github.com/tobymao/sqlglot/blob/1d6218e386b3b1a5081272e179b8e48ec57153b4/sqlglot/expressions.py#L7494). Thanks to @zilto for pointing into this direction 🙏


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Relates to #2399 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

Some destination don't really recognize double quotes ("") for identifiers, so there's a special handling in the test.