### PR TITLE
Added `dlt init --list-destinations`

### DIFF
--- a/dlt/cli/command_wrappers.py
+++ b/dlt/cli/command_wrappers.py
@@ -16,6 +16,7 @@ from dlt.cli.exceptions import CliCommandException
 from dlt.cli.init_command import (
     init_command,
     list_sources_command,
+    list_destinations_command,
     DLT_INIT_DOCS_URL,
 )
 from dlt.cli.pipeline_command import pipeline_command, DLT_PIPELINE_COMMAND_DOCS_URL
@@ -57,6 +58,11 @@ def init_command_wrapper(
 @utils.track_command("list_sources", False)
 def list_sources_command_wrapper(repo_location: str, branch: str) -> None:
     list_sources_command(repo_location, branch)
+
+
+@utils.track_command("list_destinations", False)
+def list_destinations_command_wrapper() -> None:
+    list_destinations_command()
 
 
 @utils.track_command("pipeline", True, "operation")

--- a/dlt/cli/init_command.py
+++ b/dlt/cli/init_command.py
@@ -5,6 +5,7 @@ import tomlkit
 from typing import Dict, Sequence, Tuple
 from pathlib import Path
 
+import dlt.destinations
 from dlt.common import git
 from dlt.common.configuration.specs import known_sections
 from dlt.common.configuration.providers import (
@@ -181,6 +182,10 @@ def _list_verified_sources(
     return sources
 
 
+def _list_core_destinations() -> list[str]:
+    return dlt.destinations.__all__
+
+
 def _welcome_message(
     source_name: str,
     destination_type: str,
@@ -287,6 +292,16 @@ def list_sources_command(repo_location: str, branch: str = None) -> None:
         if not reqs.is_installed_dlt_compatible():
             msg += fmt.warning_style(" [needs update: %s]" % (dlt_req_string))
 
+        fmt.echo(msg)
+
+
+def list_destinations_command() -> None:
+    fmt.echo("---")
+    fmt.echo("Available dlt core destinations:")
+    fmt.echo("---")
+    core_destinations = _list_core_destinations()
+    for destination_name in core_destinations:
+        msg = "%s" % fmt.bold(destination_name)
         fmt.echo(msg)
 
 

--- a/dlt/cli/plugins.py
+++ b/dlt/cli/plugins.py
@@ -13,6 +13,7 @@ from dlt.cli.exceptions import CliCommandException
 from dlt.cli.command_wrappers import (
     init_command_wrapper,
     list_sources_command_wrapper,
+    list_destinations_command_wrapper,
     pipeline_command_wrapper,
     schema_command_wrapper,
     telemetry_status_command_wrapper,
@@ -82,6 +83,12 @@ version if run again with an existing `source` name. You will be warned if files
             ),
         )
         parser.add_argument(
+            "--list-destinations",
+            default=False,
+            action="store_true",
+            help="Shows the name of all core dlt destinations.",
+        )
+        parser.add_argument(
             "source",
             nargs="?",
             help=(
@@ -120,6 +127,8 @@ version if run again with an existing `source` name. You will be warned if files
     def execute(self, args: argparse.Namespace) -> None:
         if args.list_sources:
             list_sources_command_wrapper(args.location, args.branch)
+        elif args.list_destinations:
+            list_destinations_command_wrapper()
         else:
             if not args.source or not args.destination:
                 self.parser.print_usage()

--- a/dlt/common/reflection/ref.py
+++ b/dlt/common/reflection/ref.py
@@ -111,8 +111,11 @@ def object_from_ref(
     Returns: a tuple (typechecked attr, trace if error)
 
     """
+    # TODO consider using `module.submodule:object_in_module` notation
+    # There's no official PEP, but it's used in pyproject.toml, setuptools, pytest, uvicorn
+    # This would allow `module_path, _, attr_name = ref.partition(":")`
     if "." not in ref:
-        raise ValueError("ref format is module.attr and must contain at leas one dot")
+        raise ValueError("ref format is module.attr and must contain at least one dot")
     module_path, attr_name = ref.rsplit(".", 1)
     try:
         spec = importlib.util.find_spec(module_path)
@@ -142,6 +145,7 @@ def object_from_ref(
             raise
         return None, ImportTrace(ref, module_path, attr_name, "ImportError", mod_ex)
 
+    dest_module = importlib.reload(dest_module)
     try:
         factory = getattr(dest_module, attr_name)
     except AttributeError as attr_ex:

--- a/docs/website/docs/reference/command-line-interface.md
+++ b/docs/website/docs/reference/command-line-interface.md
@@ -491,8 +491,8 @@ Creates a pipeline project in the current folder by adding existing verified sou
 
 **Usage**
 ```sh
-dlt init [-h] [--list-sources] [--location LOCATION] [--branch BRANCH] [--eject]
-    [source] [destination]
+dlt init [-h] [--list-sources] [--list-destinations] [--location LOCATION]
+    [--branch BRANCH] [--eject] [source] [destination]
 ```
 
 **Description**
@@ -522,6 +522,7 @@ Inherits arguments from [`dlt`](#dlt).
 **Options**
 * `-h, --help` - Show this help message and exit
 * `--list-sources, -l` - Shows all available verified sources and their short descriptions. for each source, it checks if your local `dlt` version requires an update and prints the relevant warning.
+* `--list-destinations` - Shows the name of all core dlt destinations.
 * `--location LOCATION` - Advanced. uses a specific url or local path to verified sources repository.
 * `--branch BRANCH` - Advanced. uses specific branch of the verified sources repository to fetch the template.
 * `--eject` - Ejects the source code of the core source like sql_database or rest_api so they will be editable by you.

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -172,6 +172,15 @@ def test_init_list_sources(repo_dir: str) -> None:
         assert source in _out
 
 
+def test_init_list_destinations() -> None:
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        init_command.list_destinations_command()
+        _out = buf.getvalue()
+
+    for destination in IMPLEMENTED_DESTINATIONS:
+        assert destination in _out
+
+
 @pytest.mark.parametrize(
     "source_name",
     [name for name in CORE_SOURCES_CONFIG if CORE_SOURCES_CONFIG[name]["requires_extra"]],


### PR DESCRIPTION
The command `dlt init <source>  <destination>` has a `--list-sources` that pulls from `dlt-hub/verified-sources`, but didn't have a `--list-destinations` flag. This addition improves the CLI experience and helps agents properly use this command.

The values for `--list-destinations` are taken from `dlt.destinations.__all__` which aims to match the logic used by the `dlt init` command.