### PR TITLE
Optional engine_adapter_callback

### DIFF
--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -44,7 +44,7 @@ def sql_database(
     type_adapter_callback: Optional[TTypeAdapter] = None,
     query_adapter_callback: Optional[TQueryAdapter] = None,
     resolve_foreign_keys: bool = False,
-    engine_adapter_callback: Callable[[Engine], Engine] = None,
+    engine_adapter_callback: Optional[Callable[[Engine], Engine]] = None,
 ) -> Iterable[DltResource]:
     """
     A dlt source which loads data from an SQL database using SQLAlchemy.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

The parameter `engine_adapter_callback` on the source `sql_database` wasn't optional, which caused an issue with type checking, as the parameter isn't actually required. This PR makes the parameter optional.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

This is a partial fix for [issue 2415](https://github.com/dlt-hub/dlt/issues/). It adresses the initial finding regarding `engine_adapter_callback`, it doesn't address the more general issue of the mypy setting `strict_optional=false`.

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
