### PR TITLE
Fix: insert-from-staging replace strategy incorrectly using staging-optimized pattern

### DIFF
--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -441,7 +441,9 @@ class AthenaClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):
         if self._is_iceberg_table(table_chain[0]):
             return [
                 SqlStagingCopyFollowupJob.from_table_chain(
-                    table_chain, self.sql_client, {"replace": True}
+                    table_chain,
+                    self.sql_client,
+                    {"replace": True, "replace_strategy": self.config.replace_strategy},
                 )
             ]
         return super()._create_replace_followup_jobs(table_chain)

--- a/dlt/destinations/impl/mssql/mssql.py
+++ b/dlt/destinations/impl/mssql/mssql.py
@@ -28,7 +28,7 @@ class MsSqlStagingCopyJob(SqlStagingCopyFollowupJob):
         cls,
         table_chain: Sequence[PreparedTableSchema],
         sql_client: SqlClientBase[Any],
-        params: Optional[SqlJobParams] = None,
+        params: SqlJobParams,
     ) -> List[str]:
         sql: List[str] = []
         for table in table_chain:

--- a/dlt/destinations/impl/postgres/postgres.py
+++ b/dlt/destinations/impl/postgres/postgres.py
@@ -32,7 +32,7 @@ class PostgresStagingCopyJob(SqlStagingCopyFollowupJob):
         cls,
         table_chain: Sequence[PreparedTableSchema],
         sql_client: SqlClientBase[Any],
-        params: Optional[SqlJobParams] = None,
+        params: SqlJobParams,
     ) -> List[str]:
         sql: List[str] = []
         for table in table_chain:

--- a/dlt/destinations/impl/sqlalchemy/load_jobs.py
+++ b/dlt/destinations/impl/sqlalchemy/load_jobs.py
@@ -107,7 +107,7 @@ class SqlalchemyStagingCopyJob(SqlFollowupJob):
         cls,
         table_chain: Sequence[PreparedTableSchema],
         sql_client: SqlalchemyClient,  # type: ignore[override]
-        params: Optional[SqlJobParams] = None,
+        params: SqlJobParams,
     ) -> List[str]:
         statements: List[str] = []
         for table in table_chain:

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -249,7 +249,9 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
         if self.config.replace_strategy in ["insert-from-staging", "staging-optimized"]:
             jobs.append(
                 SqlStagingCopyFollowupJob.from_table_chain(
-                    table_chain, self.sql_client, {"replace": True}
+                    table_chain,
+                    self.sql_client,
+                    params={"replace": True, "replace_strategy": self.config.replace_strategy},
                 )
             )
         return jobs

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -31,6 +31,7 @@ from dlt.common.destination.exceptions import DestinationTransientException
 class SqlJobParams(TypedDict, total=False):
     replace: Optional[bool]
     table_chain_create_table_statements: Dict[str, Sequence[str]]
+    replace_strategy: Optional[str]
 
 
 DEFAULTS: SqlJobParams = {"replace": False}
@@ -145,7 +146,11 @@ class SqlStagingCopyFollowupJob(SqlFollowupJob):
         sql_client: SqlClientBase[Any],
         params: SqlJobParams = None,
     ) -> List[str]:
-        if params["replace"] and sql_client.capabilities.supports_clone_table:
+        if (
+            params["replace"]
+            and params["replace_strategy"] == "staging-optimized"
+            and sql_client.capabilities.supports_clone_table
+        ):
             return cls._generate_clone_sql(table_chain, sql_client)
         return cls._generate_insert_sql(table_chain, sql_client, params)
 

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -147,7 +147,8 @@ class SqlStagingCopyFollowupJob(SqlFollowupJob):
         params: SqlJobParams = None,
     ) -> List[str]:
         if (
-            params["replace"]
+            params
+            and params["replace"]
             and params["replace_strategy"] == "staging-optimized"
             and sql_client.capabilities.supports_clone_table
         ):

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -89,7 +89,7 @@ class SqlFollowupJob(FollowupJobRequestImpl):
         cls,
         table_chain: Sequence[PreparedTableSchema],
         sql_client: SqlClientBase[Any],
-        params: Optional[SqlJobParams] = None,
+        params: SqlJobParams,
     ) -> List[str]:
         pass
 
@@ -119,7 +119,7 @@ class SqlStagingCopyFollowupJob(SqlFollowupJob):
         cls,
         table_chain: Sequence[PreparedTableSchema],
         sql_client: SqlClientBase[Any],
-        params: SqlJobParams = None,
+        params: SqlJobParams,
     ) -> List[str]:
         sql: List[str] = []
         for table in table_chain:
@@ -144,11 +144,10 @@ class SqlStagingCopyFollowupJob(SqlFollowupJob):
         cls,
         table_chain: Sequence[PreparedTableSchema],
         sql_client: SqlClientBase[Any],
-        params: SqlJobParams = None,
+        params: SqlJobParams,
     ) -> List[str]:
         if (
-            params
-            and params["replace"]
+            params["replace"]
             and params["replace_strategy"] == "staging-optimized"
             and sql_client.capabilities.supports_clone_table
         ):
@@ -167,7 +166,7 @@ class SqlMergeFollowupJob(SqlFollowupJob):
         cls,
         table_chain: Sequence[PreparedTableSchema],
         sql_client: SqlClientBase[Any],
-        params: Optional[SqlJobParams] = None,
+        params: SqlJobParams,
     ) -> List[str]:
         # resolve only root table
         root_table = table_chain[0]

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -382,7 +382,6 @@ def test_replace_table_clearing(
     destinations_configs(
         default_sql_configs=True,
         default_staging_configs=True,
-        subset=["snowflake"],
     ),
     ids=lambda x: x.name,
 )

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -382,6 +382,7 @@ def test_replace_table_clearing(
     destinations_configs(
         default_sql_configs=True,
         default_staging_configs=True,
+        subset=["snowflake"],
     ),
     ids=lambda x: x.name,
 )
@@ -392,25 +393,46 @@ def test_replace_sql_queries(
     skip_if_unsupported_replace_strategy(destination_config, replace_strategy)
 
     from dlt.destinations.sql_jobs import SqlStagingCopyFollowupJob
+    from dlt.destinations.impl.sqlalchemy.load_jobs import SqlalchemyStagingCopyJob
+    from dlt.destinations.impl.postgres.postgres import PostgresStagingCopyJob
+    from dlt.destinations.impl.mssql.mssql import MsSqlStagingCopyJob
 
     os.environ["DESTINATION__REPLACE_STRATEGY"] = replace_strategy
 
     clone_sql_generator_spy = mocker.spy(SqlStagingCopyFollowupJob, "_generate_clone_sql")
     insert_sql_generator_spy = mocker.spy(SqlStagingCopyFollowupJob, "_generate_insert_sql")
+    sqlalchemy_spy = mocker.spy(SqlalchemyStagingCopyJob, "generate_sql")
+    postgres_spy = mocker.spy(PostgresStagingCopyJob, "generate_sql")
+    mssql_spy = mocker.spy(MsSqlStagingCopyJob, "generate_sql")
 
     pipeline = destination_config.setup_pipeline("insert_from_staging_test", dev_mode=True)
     load_info = pipeline.run([{"id": 1}], table_name="my_table", write_disposition="replace")
 
     assert_load_info(load_info)
 
+    is_sqlalchemy = destination_config.destination_type == "sqlalchemy"
+    is_postgres = destination_config.destination_type == "postgres"
+    is_mssql = destination_config.destination_type == "mssql"
+
     if replace_strategy == "truncate-and-insert":
-        assert clone_sql_generator_spy.call_count == 0
-        assert insert_sql_generator_spy.call_count == 0
+        if is_sqlalchemy:
+            assert sqlalchemy_spy.call_count == 0
+        else:
+            assert clone_sql_generator_spy.call_count == 0
+            assert insert_sql_generator_spy.call_count == 0
 
     elif replace_strategy == "insert-from-staging":
-        assert clone_sql_generator_spy.call_count == 0
-        assert insert_sql_generator_spy.call_count == 1
+        if is_sqlalchemy:
+            assert sqlalchemy_spy.call_count == 1
+        else:
+            assert clone_sql_generator_spy.call_count == 0
+            assert insert_sql_generator_spy.call_count == 1
 
     elif replace_strategy == "staging-optimized":
-        assert clone_sql_generator_spy.call_count == 1
-        assert insert_sql_generator_spy.call_count == 0
+        if is_postgres:
+            assert postgres_spy.call_count == 1
+        elif is_mssql:
+            assert mssql_spy.call_count == 1
+        else:
+            assert clone_sql_generator_spy.call_count == 1
+            assert insert_sql_generator_spy.call_count == 0

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -2,6 +2,7 @@ from typing import Dict
 import yaml
 import dlt, os, pytest
 from dlt.common.utils import uniq_id
+from pytest_mock import MockerFixture
 
 from tests.pipeline.utils import assert_load_info, load_table_counts, load_tables_to_dicts
 from tests.load.utils import (
@@ -374,3 +375,42 @@ def test_replace_table_clearing(
         "other_items": 1,
         "other_items__sub_items": 2,
     }
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_sql_configs=True,
+        default_staging_configs=True,
+    ),
+    ids=lambda x: x.name,
+)
+@pytest.mark.parametrize("replace_strategy", REPLACE_STRATEGIES)
+def test_replace_sql_queries(
+    destination_config: DestinationTestConfiguration, replace_strategy: str, mocker: MockerFixture
+) -> None:
+    skip_if_unsupported_replace_strategy(destination_config, replace_strategy)
+
+    from dlt.destinations.sql_jobs import SqlStagingCopyFollowupJob
+
+    os.environ["DESTINATION__REPLACE_STRATEGY"] = replace_strategy
+
+    clone_sql_generator_spy = mocker.spy(SqlStagingCopyFollowupJob, "_generate_clone_sql")
+    insert_sql_generator_spy = mocker.spy(SqlStagingCopyFollowupJob, "_generate_insert_sql")
+
+    pipeline = destination_config.setup_pipeline("insert_from_staging_test", dev_mode=True)
+    load_info = pipeline.run([{"id": 1}], table_name="my_table", write_disposition="replace")
+
+    assert_load_info(load_info)
+
+    if replace_strategy == "truncate-and-insert":
+        assert clone_sql_generator_spy.call_count == 0
+        assert insert_sql_generator_spy.call_count == 0
+
+    elif replace_strategy == "insert-from-staging":
+        assert clone_sql_generator_spy.call_count == 0
+        assert insert_sql_generator_spy.call_count == 1
+
+    elif replace_strategy == "staging-optimized":
+        assert clone_sql_generator_spy.call_count == 1
+        assert insert_sql_generator_spy.call_count == 0


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Previously, the `SqlStagingCopyFollowupJob` generated a clone sql for both the "staging-optimized" and "insert-from-staging" strategies. Now, its `generate_sql()` method receives the replace strategy from `SqlJobClientBase`'s `_create_replace_followup_jobs()` and correctly generates insert jobs based on that strategy. 
A relevant test has also been added.


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #2422 

