### PR TITLE
Fix/rest api handle expressions in graphql payload

### DIFF
--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -322,8 +322,12 @@ def build_resource_dependency_graph(
         params_expressions = _find_expressions(endpoint_resource["endpoint"].get("params", {}))
         _raise_if_any_not_in(params_expressions, available_contexts, message="params")
 
-        json_expressions = _find_expressions(endpoint_resource["endpoint"].get("json", {}))
-        _raise_if_any_not_in(json_expressions, available_contexts, message="json")
+        # In case of graphql endpoint, the json will contain the key "query" and the associated
+        # value will contain elements that looks like expressions, we will ignore those. 
+        json_request = endpoint_resource["endpoint"].get("json", {})
+        json_expressions = _find_expressions(json_request)
+        if not json_request.get("query"):
+            _raise_if_any_not_in(json_expressions, available_contexts, message="json")
 
         resolved_params += _expressions_to_resolved_params(
             _filter_resource_expressions(path_expressions | params_expressions | json_expressions)

--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -16,6 +16,7 @@ from typing import (
 )
 import graphlib
 import string
+import re
 from requests import Response
 
 from dlt.common import logger
@@ -682,9 +683,12 @@ def _find_expressions(
             for item in value:
                 recursive_search(item)
         elif isinstance(value, str):
+
+            pattern = r'\{\s*([A-Za-z0-9._]+)\s*\}'
+ 
             e = [
                 field_name
-                for _, field_name, _, _ in string.Formatter().parse(value)
+                for  field_name in re.findall(pattern, value)
                 if field_name
                 and (prefixes is None or any(field_name.startswith(prefix) for prefix in prefixes))
             ]


### PR DESCRIPTION
### Description
This is a fix to handle REST API POST requests to GraphQL endpoing

### Related Issues

- Fixes https://github.com/dlt-hub/dlt/issues/2398 

### Additional Context
Unfortunately to patch the current error, we had to use a workaround.

The current solution has two drawbacks:
- GraphQL queries can contain elements who look like placeholders (e.g. in the string `"query { shop { name } }", `{name}` is the name of a field returned by GraphQL endpoint, but it could also be the name of a params). For this reason we had to disable the method `_raise_if_any_not_in` is the call is to GraphQL endpoint.

- Not introduced in this PR, but GraphQL endpoints return valid JSON objects with an error message, in this case the REST API doesn't raise any error and insert the error message in the destination table. This is quite annoying. 

We need to have a better way to deal with GraphQL than just handle them as POST calls, we need to have an additional method or configuration to correctly handle placeholders and errors.