### PR TITLE
update dlt and dlt+ installations

### DIFF
--- a/docs/website/docs/plus/getting-started/installation.md
+++ b/docs/website/docs/plus/getting-started/installation.md
@@ -61,6 +61,7 @@ After installing [Python 3.10 (64-bit version) for Windows](https://www.python.o
 
 ```sh
 C:\> pip3 install -U pip
+C:\> pip install uv
 ```
 
   </TabItem>
@@ -90,7 +91,7 @@ source .venv/bin/activate
   </TabItem>
   <TabItem value="macos">
 
-Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create a `./venv` directory where your virtual environment will be stored:
 
 ```sh
 uv venv --python 3.10
@@ -105,7 +106,7 @@ source .venv/bin/activate
   </TabItem>
   <TabItem value="windows">
 
-Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create a `./venv` directory where your virtual environment will be stored:
 
 ```bat
 C:\> uv venv --python 3.10

--- a/docs/website/docs/plus/getting-started/installation.md
+++ b/docs/website/docs/plus/getting-started/installation.md
@@ -40,7 +40,7 @@ You can install Python 3.10 with `apt`.
 ```sh
 sudo apt update
 sudo apt install python3.10
-sudo apt install python3.10-venv
+pip install uv
 ```
 
   </TabItem>
@@ -51,6 +51,7 @@ On macOS, you can use [Homebrew](https://brew.sh) to install Python 3.10.
 ```sh
 brew update
 brew install python@3.10
+brew install uv
 ```
 
   </TabItem>
@@ -74,46 +75,46 @@ This way, all the dependencies for your current project will be isolated from pa
 
   <TabItem value="ubuntu">
 
-Create a new virtual environment in your working folder. This will create an `./env` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
 
 ```sh
-python -m venv ./env
+uv venv --python 3.10
 ```
 
 Activate the virtual environment:
 
 ```sh
-source ./env/bin/activate
+source .venv/bin/activate
 ```
 
   </TabItem>
   <TabItem value="macos">
 
-Create a new virtual environment in your working folder. This will create an `./env` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
 
 ```sh
-python -m venv ./env
+uv venv --python 3.10
 ```
 
 Activate the virtual environment:
 
 ```sh
-source ./env/bin/activate
+source .venv/bin/activate
 ```
 
   </TabItem>
   <TabItem value="windows">
 
-Create a new virtual environment in your working folder. This will create an `./env` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
 
 ```bat
-C:\> python -m venv ./env
+C:\> uv venv --python 3.10
 ```
 
 Activate the virtual environment:
 
 ```bat
-C:\> .\env\Scripts\activate
+C:\> .\venv\Scripts\activate
 ```
 
   </TabItem>
@@ -125,7 +126,7 @@ You can now install dlt+ in your virtual environment by running:
 
 ```sh
 # install the newest dlt version or upgrade the existing version to the newest one
-pip install -U dlt-plus
+uv pip install -U dlt-plus
 ```
 
 Please install a valid license before proceeding, as described under [licensing](#licensing).

--- a/docs/website/docs/plus/getting-started/installation.md
+++ b/docs/website/docs/plus/getting-started/installation.md
@@ -61,7 +61,7 @@ After installing [Python 3.10 (64-bit version) for Windows](https://www.python.o
 
 ```sh
 C:\> pip3 install -U pip
-C:\> pip install uv
+C:\> pip3 install uv
 ```
 
   </TabItem>

--- a/docs/website/docs/plus/getting-started/installation.md
+++ b/docs/website/docs/plus/getting-started/installation.md
@@ -51,7 +51,7 @@ On macOS, you can use [Homebrew](https://brew.sh) to install Python 3.10.
 ```sh
 brew update
 brew install python@3.10
-brew install uv
+pip install uv
 ```
 
   </TabItem>

--- a/docs/website/docs/plus/getting-started/installation.md
+++ b/docs/website/docs/plus/getting-started/installation.md
@@ -75,7 +75,7 @@ This way, all the dependencies for your current project will be isolated from pa
 
   <TabItem value="ubuntu">
 
-Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create a `./venv` directory where your virtual environment will be stored:
 
 ```sh
 uv venv --python 3.10

--- a/docs/website/docs/reference/installation.md
+++ b/docs/website/docs/reference/installation.md
@@ -46,7 +46,7 @@ After installing [Python 3.10 (64-bit version) for Windows](https://www.python.o
 
 ```sh
 C:\> pip3 install -U pip
-C:\> pip install uv
+C:\> pip3 install uv
 ```
 
   </TabItem>

--- a/docs/website/docs/reference/installation.md
+++ b/docs/website/docs/reference/installation.md
@@ -36,7 +36,7 @@ On macOS, you can use [Homebrew](https://brew.sh) to install Python 3.10.
 ```sh
 brew update
 brew install python@3.10
-brew install uv
+pip install uv
 ```
 
   </TabItem>
@@ -46,6 +46,7 @@ After installing [Python 3.10 (64-bit version) for Windows](https://www.python.o
 
 ```sh
 C:\> pip3 install -U pip
+C:\> pip install uv
 ```
 
   </TabItem>
@@ -60,7 +61,7 @@ This way, all the dependencies for your current project will be isolated from pa
 
   <TabItem value="ubuntu">
 
-Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create a `./venv` directory where your virtual environment will be stored:
 
 ```sh
 uv venv --python 3.10
@@ -75,7 +76,7 @@ source .venv/bin/activate
   </TabItem>
   <TabItem value="macos">
 
-Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create a `./venv` directory where your virtual environment will be stored:
 
 ```sh
 uv venv --python 3.10
@@ -90,7 +91,7 @@ source .venv/bin/activate
   </TabItem>
   <TabItem value="windows">
 
-Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create a `./venv` directory where your virtual environment will be stored:
 
 ```bat
 C:\> uv venv --python 3.10

--- a/docs/website/docs/reference/installation.md
+++ b/docs/website/docs/reference/installation.md
@@ -25,7 +25,7 @@ You can install Python 3.10 with `apt`.
 ```sh
 sudo apt update
 sudo apt install python3.10
-sudo apt install python3.10-venv
+pip install uv
 ```
 
   </TabItem>
@@ -36,6 +36,7 @@ On macOS, you can use [Homebrew](https://brew.sh) to install Python 3.10.
 ```sh
 brew update
 brew install python@3.10
+brew install uv
 ```
 
   </TabItem>
@@ -59,46 +60,46 @@ This way, all the dependencies for your current project will be isolated from pa
 
   <TabItem value="ubuntu">
 
-Create a new virtual environment in your working folder. This will create an `./env` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
 
 ```sh
-python -m venv ./env
+uv venv --python 3.10
 ```
 
 Activate the virtual environment:
 
 ```sh
-source ./env/bin/activate
+source .venv/bin/activate
 ```
 
   </TabItem>
   <TabItem value="macos">
 
-Create a new virtual environment in your working folder. This will create an `./env` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
 
 ```sh
-python -m venv ./env
+uv venv --python 3.10
 ```
 
 Activate the virtual environment:
 
 ```sh
-source ./env/bin/activate
+source .venv/bin/activate
 ```
 
   </TabItem>
   <TabItem value="windows">
 
-Create a new virtual environment in your working folder. This will create an `./env` directory where your virtual environment will be stored:
+Create a new virtual environment in your working folder. This will create an `./venv` directory where your virtual environment will be stored:
 
 ```bat
-C:\> python -m venv ./env
+C:\> uv venv --python 3.10
 ```
 
 Activate the virtual environment:
 
 ```bat
-C:\> .\env\Scripts\activate
+C:\> .\venv\Scripts\activate
 ```
 
   </TabItem>
@@ -109,19 +110,19 @@ C:\> .\env\Scripts\activate
 To install or upgrade to the newest version of `dlt` in your virtual environment, run:
 
 ```sh
-pip install -U dlt
+uv pip install -U dlt
 ```
 
 Here are some additional installation examples:
 
 To install dlt with DuckDB support:
 ```sh
-pip install "dlt[duckdb]"
+uv pip install "dlt[duckdb]"
 ```
 
 To install a specific version of dlt (for example, versions before 0.5.0):
 ```sh
-pip install "dlt<0.5.0"
+uv pip install "dlt<0.5.0"
 ```
 
 ### 3.1. Install dlt via Pixi or Conda


### PR DESCRIPTION
Only windows instructions had a line installing pip

Fixes #2299 @akelad 

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context
Updated the python 3.10 installation for ubuntu as well. Previously it gave module not found errors. Didnt end up adding uv as it adds steps to the commands e.g pip install dlt will become uv pip install dlt
<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
