### PR TITLE
Docs: tip on explicitly disablint merg_key hint

### DIFF
--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -349,8 +349,9 @@ pipeline.run(dim_customer())  # second run — 2024-04-09 22:13:07.943703
 | **2024-04-09 22:13:07.943703** | **NULL** | **1** | **foo_updated** | **1** |
 
 :::tip
-To disable the prevention of retiring absent records,
-the `merge_key` must be explicitly unset:
+If you decide to undo the previous configuration that prevented retiring absent records for an existing pipeline,
+and want to start retiring them again,
+you must explicitly unset the `merge_key`:
 ```py
 @dlt.resource(
     columns={"customer_key": {"merge_key": False}},

--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -357,7 +357,7 @@ the `merge_key` must be explicitly unset:
     write_disposition={"disposition": "merge", "strategy": "scd2"}
 )
 def dim_customer():
-...
+    ...
 ```
 Simply omitting `merge_key` from the decorator will not disable the behavior. Aternatively, you can disable the `merge_key` hint for the affected column in the import schema.
 :::

--- a/docs/website/docs/general-usage/incremental-loading.md
+++ b/docs/website/docs/general-usage/incremental-loading.md
@@ -348,6 +348,20 @@ pipeline.run(dim_customer())  # second run — 2024-04-09 22:13:07.943703
 | 2024-04-09 18:27:53.734235 | NULL | 2 | bar | 2 |
 | **2024-04-09 22:13:07.943703** | **NULL** | **1** | **foo_updated** | **1** |
 
+:::tip
+To disable the prevention of retiring absent records,
+the `merge_key` must be explicitly unset:
+```py
+@dlt.resource(
+    columns={"customer_key": {"merge_key": False}},
+    write_disposition={"disposition": "merge", "strategy": "scd2"}
+)
+def dim_customer():
+...
+```
+Simply omitting `merge_key` from the decorator will not disable the behavior. Aternatively, you can disable the `merge_key` hint for the affected column in the import schema.
+:::
+
 *Case 2: only retire records for given partitions*
 
 :::note


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This is a small PR adding a tip on disabling the `merge_key` hint when using `scd2`.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Closes #2440 
