### PR TITLE
Fix read parquet chunk size

### DIFF
--- a/dlt/sources/filesystem/readers.py
+++ b/dlt/sources/filesystem/readers.py
@@ -55,12 +55,12 @@ def _read_jsonl(items: Iterator[FileItemDict], chunksize: int = 1000) -> Iterato
 
 def _read_parquet(
     items: Iterator[FileItemDict],
-    chunksize: int = 10,
+    chunksize: int = 1000,
 ) -> Iterator[TDataItems]:
     """Reads parquet file content and extract the data.
 
     Args:
-        chunksize (int, optional): The number of files to process at once, defaults to 10.
+        chunksize (int, optional): The number of records to process at once, defaults to 1000.
 
     Returns:
         TDataItem: The file content


### PR DESCRIPTION
### Description
Look at the actual documentation for `iter_batches` https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetFile.html#pyarrow.parquet.ParquetFile.iter_batches

The old code was incorrectly using a tiny 10 batch size thinking it was batches of parquet files to read, but the actual code was reading parquet files one by one, and iterating 10 records at a time from each file.

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->



<!--
Provide any additional context about the PR here.
-->
### Additional Context
Was seeing bad parquet performance, turns out the default chunk size was horribly inefficient.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
