### PR TITLE
Fixes bigquery, ibis tests

### DIFF
--- a/dlt/helpers/ibis.py
+++ b/dlt/helpers/ibis.py
@@ -64,20 +64,11 @@ def create_ibis_backend(
         con = ibis.duckdb.from_connection(duck)
     elif issubclass(destination.spec, PostgresClientConfiguration):
         if destination.spec is RedshiftClientConfiguration:
-            # patch psycopg
-            try:
-                import psycopg  # type: ignore[import-not-found, unused-ignore]
-
-                old_fetch = psycopg.types.TypeInfo.fetch
-
-                def _ignore_hstore(conn: Any, name: Any) -> Any:
-                    if name == "hstore":
-                        raise TypeError("HSTORE")
-                    return old_fetch(conn, name)
-
-                psycopg.types.TypeInfo.fetch = _ignore_hstore  # type: ignore[method-assign, unused-ignore]
-            except Exception:
-                pass
+            raise NotImplementedError(
+                "Destination of type"
+                f" {Destination.from_reference(destination).destination_type} not supported by"
+                " ibis."
+            )
         credentials = client.config.credentials.to_native_representation()
         con = ibis.connect(credentials)
     elif issubclass(destination.spec, SnowflakeClientConfiguration):

--- a/docs/website/docs/general-usage/dataset-access/ibis-backend.md
+++ b/docs/website/docs/general-usage/dataset-access/ibis-backend.md
@@ -11,7 +11,7 @@ Ibis is a powerful portable Python dataframe library. Learn more about what it i
 `dlt` provides an easy way to hand over your loaded dataset to an Ibis backend connection.
 
 :::tip
-Not all destinations supported by `dlt` have an equivalent Ibis backend. Natively supported destinations include DuckDB (including Motherduck), Postgres, Redshift, Snowflake, Clickhouse, MSSQL (including Synapse), and BigQuery. The filesystem destination is supported via the [Filesystem SQL client](./sql-client#the-filesystem-sql-client); please install the DuckDB backend for Ibis to use it. Mutating data with Ibis on the filesystem will not result in any actual changes to the persisted files.
+Not all destinations supported by `dlt` have an equivalent Ibis backend. Natively supported destinations include DuckDB (including Motherduck), Postgres, Snowflake, Clickhouse, MSSQL (including Synapse), and BigQuery. The filesystem destination is supported via the [Filesystem SQL client](./sql-client#the-filesystem-sql-client); please install the DuckDB backend for Ibis to use it. Mutating data with Ibis on the filesystem will not result in any actual changes to the persisted files.
 :::
 
 ## Prerequisites

--- a/docs/website/docs/general-usage/dataset-access/ibis-backend.md
+++ b/docs/website/docs/general-usage/dataset-access/ibis-backend.md
@@ -11,7 +11,7 @@ Ibis is a powerful portable Python dataframe library. Learn more about what it i
 `dlt` provides an easy way to hand over your loaded dataset to an Ibis backend connection.
 
 :::tip
-Not all destinations supported by `dlt` have an equivalent Ibis backend. Natively supported destinations include DuckDB (including Motherduck), Postgres, Snowflake, Clickhouse, MSSQL (including Synapse), and BigQuery. The filesystem destination is supported via the [Filesystem SQL client](./sql-client#the-filesystem-sql-client); please install the DuckDB backend for Ibis to use it. Mutating data with Ibis on the filesystem will not result in any actual changes to the persisted files.
+Not all destinations supported by `dlt` have an equivalent Ibis backend. Natively supported destinations include DuckDB (including Motherduck), Postgres (Redshift is supported via the Postgres backend for Ibis versions lower than 10.4.0), Snowflake, Clickhouse, MSSQL (including Synapse), and BigQuery. The filesystem destination is supported via the [Filesystem SQL client](./sql-client#the-filesystem-sql-client); please install the DuckDB backend for Ibis to use it. Mutating data with Ibis on the filesystem will not result in any actual changes to the persisted files.
 :::
 
 ## Prerequisites

--- a/tests/load/bigquery/test_bigquery_client.py
+++ b/tests/load/bigquery/test_bigquery_client.py
@@ -393,7 +393,7 @@ def test_loading_errors(client: BigQueryClient, file_storage: FileStorage) -> No
     job = expect_load_file(
         client, file_storage, json.dumps(insert_json), user_table_name, status="failed"
     )
-    assert "Couldn't convert value to timestamp:" in job.exception()
+    assert "Could not parse 'AA' as a timestamp" in job.exception()
 
     # numeric overflow on bigint
     insert_json = copy(load_json)

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -726,8 +726,8 @@ def test_ibis_expression_relation(populated_pipeline: Pipeline) -> None:
     # topk
     assert sql_from_expr(items_table.decimal.topk(10)) == (
         (
-            'SELECT * FROM ( SELECT "t0"."decimal", COUNT(*) AS "CountStar(items)" FROM'
-            ' "dataset"."items" AS "t0" GROUP BY 1 ) AS "t1" ORDER BY "t1"."CountStar(items)" DESC'
+            'SELECT * FROM ( SELECT "t0"."decimal", COUNT(*) AS "decimal_count" FROM'
+            ' "dataset"."items" AS "t0" GROUP BY 1 ) AS "t1" ORDER BY "t1"."decimal_count" DESC'
             " LIMIT 10"
         ),
         None,
@@ -796,8 +796,16 @@ def test_ibis_dataset_access(populated_pipeline: Pipeline) -> None:
         )
     }
 
-    items_table = ibis_connection.table(add_table_prefix(map_i("items")), database=dataset_name)
-    assert items_table.count().to_pandas() == total_records
+    if populated_pipeline.destination.destination_type == "dlt.destinations.redshift":
+        # Redshift does not support pg_enum (used in the latest ibis get_schema update)
+        # so we bypass ibis expressions and use raw sql + fetchall() to count rows
+        qualified_table_name = f"{dataset_name}.{add_table_prefix(map_i('items'))}"
+        cursor = ibis_connection.raw_sql(f"SELECT * FROM {qualified_table_name}")
+        total_in_db = len(cursor.fetchall())
+        assert total_in_db == total_records
+    else:
+        items_table = ibis_connection.table(add_table_prefix(map_i("items")), database=dataset_name)
+        assert items_table.count().to_pandas() == total_records
     ibis_connection.disconnect()
 
 

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -796,16 +796,8 @@ def test_ibis_dataset_access(populated_pipeline: Pipeline) -> None:
         )
     }
 
-    if populated_pipeline.destination.destination_type == "dlt.destinations.redshift":
-        # Redshift does not support pg_enum (used in the latest ibis get_schema update)
-        # so we bypass ibis expressions and use raw sql + fetchall() to count rows
-        qualified_table_name = f"{dataset_name}.{add_table_prefix(map_i('items'))}"
-        cursor = ibis_connection.raw_sql(f"SELECT * FROM {qualified_table_name}")
-        total_in_db = len(cursor.fetchall())
-        assert total_in_db == total_records
-    else:
-        items_table = ibis_connection.table(add_table_prefix(map_i("items")), database=dataset_name)
-        assert items_table.count().to_pandas() == total_records
+    items_table = ibis_connection.table(add_table_prefix(map_i("items")), database=dataset_name)
+    assert items_table.count().to_pandas() == total_records
     ibis_connection.disconnect()
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR tries to fix ci tests that are failing. 

1. `test_read_interfaces.py::test_ibis_dataset_access`

   - Root of cause: [This commit](https://github.com/ibis-project/ibis/commit/9b25ab1be5b43d8b1933a093500547710e122729) in the latest 10.4.0 ibis release, which refactored `get_schema` to use raw sql and introduced a dependency on the pg_enum system table, a table that doesn't exist in redshift, causing schema introspection to fail during `ibis.table(...)` calls.
  
2. `test_read_interfaces.py::test_ibis_expression_relation`

   - Root of cause: [This commit](https://github.com/ibis-project/ibis/commit/329ad7c1a1500b21c02b70dd06973fe1c89aa6a3) in the latest 10.4.0 ibis release, which basically replaces the CountStar syntax with `<table_name>_count`.

3. Bigquery error text change
   - Root of cause: A change in the error message. The fix is pretty straightforward.
