### PR TITLE
Update docs for transaction handling - snowflake.md

### DIFF
--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -132,6 +132,10 @@ This will set the timezone and session keep alive. Mind that if you use TOML, yo
 `"snowflake://loader/dlt_data?authenticator=oauth&timezone=UTC&client_session_keep_alive=true"`
 will pass `client_session_keep_alive` as a string to the connect method (which we didn't verify if it works).
 
+:::note
+Be aware that dlt is expecting the transaction behavior to `ALTER SESSION SET AUTOCOMMIT = TRUE;`. Meaning all DMLs are automatically committed or set to `ALTER SESSION SET AUTOCOMMIT = FALSE;` where needed by dlt. BUT, dlt will not set it explicitly to `TRUE` when needed; therefore, if you have set the transaction mode to `FALSE` on Snowflake, dlt will have opened COMMITs that will not be committed anymore. Please use the default behaviour of Snowflake to avoid running into issues.
+:::
+
 ### Write disposition
 
 All write dispositions are supported.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
If you use Snowflake and have transaction settings not set to default, e.g., have set `ALTER SESSION SET AUTOCOMMIT = FALSE;`, dlt will not work properly and end up having an open session with uncommitted Inserts/merge statements.

I added a note to the docs with this PR to make that clear and not run into errors I did.

### Additional Context
Even better would be to explicitly set `ALTER SESSION SET AUTOCOMMIT = TRUE;` on the insert to destination schema as well as you do for inserting into Staging, where you added `ALTER SESSION SET AUTOCOMMIT = TRUE;` explicitly.


PS: I added the note to `Additional connection options`, not sure if that is the best place. Feel free to reorder or let me know where it would make more sense.