### PR TITLE
fix: index invariant add_row_hash_to_table 

### DIFF
--- a/dlt/sources/helpers/transform.py
+++ b/dlt/sources/helpers/transform.py
@@ -129,7 +129,7 @@ def add_row_hash_to_table(row_hash_column_name: str) -> TDataItem:
         else:
             df = table
 
-        hash_ = pd.util.hash_pandas_object(df)
+        hash_ = pd.util.hash_pandas_object(df, index=False)
 
         if is_arrow:
             table = pyarrow.append_column(

--- a/tests/sources/helpers/transform/test_row_hash.py
+++ b/tests/sources/helpers/transform/test_row_hash.py
@@ -1,0 +1,14 @@
+import pyarrow as pa
+from dlt.sources.helpers.transform import add_row_hash_to_table
+
+
+def test_add_row_hash_to_table():
+    names = ["n_legs", "animals"]
+    n_legs = [2, 2, 2]
+    animals = ["duck", "duck", "duck"]
+
+    table = pa.Table.from_arrays([n_legs, animals], names=names)
+
+    add_row_hash = add_row_hash_to_table("row_hash")
+    table_with_rowhash = add_row_hash(table)
+    assert len(table_with_rowhash["row_hash"].unique()) == 1, "Expected identical row hashes"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

add_row_hash_to_table was not index invariant and caused different row hashes for identical rows of data.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #2489 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
