### PR TITLE
docs: plus: snowflake_plus: added details on `catalog_sync`

### DIFF
--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -109,7 +109,7 @@ All standard write dispositions (`append`, `replace`, and `merge`) are supported
 
 ## Data types
 
-Snowflake Plus destination supports all standard Snowflake destination data types, with additional type mappings for Iceberg tables:
+The Snowflake Plus destination supports all standard Snowflake destination data types, with additional type mappings for Iceberg tables:
 
 | dlt Type | Iceberg Type |
 |----------|--------------|

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -7,13 +7,14 @@ keywords: [Snowflake, Iceberg, destination]
 # Snowflake Plus
 
 Snowflake Plus is an **experimental** extension of the [Snowflake destination](../../dlt-ecosystem/destinations/snowflake.md) that adds [Apache Iceberg tables](https://docs.snowflake.com/en/user-guide/tables-iceberg) creation and related features.
-This destination is available starting from `dlt-plus==0.9.0`. It fully supports all the functionality of the standard Snowflake destination, plus:
+This destination is available starting from `dlt-plus` version `0.9.0`. It fully supports all the functionality of the standard Snowflake destination, plus:
 
 1. The ability to create Iceberg tables in Snowflake by setting `force_iceberg` to `true` in your `config.toml` file or `dlt.yml` file.
 2. Additional configuration for Iceberg tables in Snowflake via:
    - `external_volume`: The external volume name where Iceberg data is stored.
    - `catalog`: The catalog name in which Iceberg tables are created. Defaults to `"SNOWFLAKE"`.
    - `base_location`: The base path that Snowflake uses for storing the table. If omitted, the table name is used.
+   - `catalog_sync`: The name of a [catalog integration](https://docs.snowflake.com/en/user-guide/tables-iceberg#catalog-integration) configured for [Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/overview). If specified, Snowflake syncs Snowflake-managed Iceberg tables in the database with an external catalog in your Snowflake Open Catalog account.
 
 ## Installation
 
@@ -29,8 +30,8 @@ Once the `snowflake` extra is installed, you can configure a pipeline to use `sn
 
 ### Use as a drop-in replacement for the `snowflake` destination
 
-1. Make sure you have configured [Snowflake credentials](../../dlt-ecosystem/destinations/snowflake.md#setup-guide)
-2. Make sure you [set up database user and permissions](../../dlt-ecosystem/destinations/snowflake.md#set-up-the-database-user-and-permissions)
+1. [Configure Snowflake credentials](../../dlt-ecosystem/destinations/snowflake.md#setup-guide)
+2. [Set up database user and permissions](../../dlt-ecosystem/destinations/snowflake.md#set-up-the-database-user-and-permissions)
 3. [Configure an external volume in Snowflake](https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume)
 4. Grant usage on the external volume to the role you are using to load data:
 
@@ -98,18 +99,17 @@ The `snowflake_plus` destination extends the standard Snowflake configuration wi
 | `external_volume` | The external volume to store Iceberg metadata | Yes | None |
 | `catalog` | The catalog to use for Iceberg tables | No | `"SNOWFLAKE"` |
 | `base_location` | Custom base location for Iceberg data in the external volume | No | `<dataset_name>/<table_name>` |
+| `catalog_sync` | The name of a [catalog integration](https://docs.snowflake.com/en/user-guide/tables-iceberg#catalog-integration) for syncing Iceberg tables to an external catalog in [Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/overview) | No | None |
 
-You can configure these options in your `config.toml` file under the `[destination.snowflake]` section or in `dlt.yml` file under the `destinations.snowflake_plus` section.
+Configure these options in your `config.toml` file under the `[destination.snowflake]` section or in `dlt.yml` file under the `destinations.snowflake_plus` section.
 
 ## Write dispositions
 
 All standard write dispositions (`append`, `replace`, and `merge`) are supported for both regular Snowflake tables and Iceberg tables.
 
-## Data Types
+## Data types
 
-The `snowflake_plus` destination extends the standard Snowflake data types with additional types:
-
-Snowflake Plus supports all the data types from the standard Snowflake destination, with additional type mappings for Iceberg tables:
+Snowflake Plus destination supports all standard Snowflake destination data types, with additional type mappings for Iceberg tables:
 
 | dlt Type | Iceberg Type |
 |----------|--------------|
@@ -123,6 +123,56 @@ Snowflake Plus supports all the data types from the standard Snowflake destinati
 | `decimal` | `decimal` |
 | `binary` | `binary` |
 | `json` | `string` |
+
+
+## Syncing Snowflake-managed Iceberg tables to Snowflake Open Catalog
+
+To enable querying of Snowflake-managed Iceberg tables by third-party engines (e.g., Apache Spark) via an external catalog (Snowflake Open Catalog), use the `catalog_sync` configuration option. This setting specifies a [catalog integration](https://docs.snowflake.com/en/user-guide/tables-iceberg#catalog-integration) that syncs Iceberg tables to the external catalog.
+
+### Setup
+
+1. [Create an external catalog in Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/create-catalog).
+
+2. Create a catalog integration in Snowflake. Example:
+
+```sql
+  CREATE OR REPLACE CATALOG INTEGRATION my_open_catalog_int
+    CATALOG_SOURCE = POLARIS
+    TABLE_FORMAT = ICEBERG
+    REST_CONFIG = (
+      CATALOG_URI = 'https://<orgname>-<my-snowflake-open-catalog-account-name>.snowflakecomputing.com/polaris/api/catalog'
+      CATALOG_NAME = 'myOpenCatalogExternalCatalogName'
+    )
+    REST_AUTHENTICATION = (
+      TYPE = OAUTH
+      OAUTH_CLIENT_ID = 'myClientId'
+      OAUTH_CLIENT_SECRET = 'myClientSecret'
+      OAUTH_ALLOWED_SCOPES = ('PRINCIPAL_ROLE:ALL')
+    )
+    ENABLED = TRUE;
+```
+
+Refer to the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/tables-iceberg-open-catalog-sync#step-4-create-a-catalog-integration-for-open-catalog) for detailed setup instructions.
+
+3. Configure the `catalog_sync` option in your `config.toml` or `dlt.yml` file:
+
+- In `config.toml`:
+
+```toml
+[destination.snowflake]
+# ... other configuration
+catalog_sync = "my_open_catalog_int"
+```
+
+- In `dlt.yml`:
+
+```yaml
+destinations:
+  snowflake_plus:
+    type: snowflake_plus
+    # ... other configuration
+    catalog_sync: "my_open_catalog_int"
+```
 
 ## Additional Resources
 

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -7,7 +7,7 @@ keywords: [Snowflake, Iceberg, destination]
 # Snowflake Plus
 
 Snowflake Plus is an **experimental** extension of the [Snowflake destination](../../dlt-ecosystem/destinations/snowflake.md) that adds [Apache Iceberg tables](https://docs.snowflake.com/en/user-guide/tables-iceberg) creation and related features.
-This destination is available starting from `dlt-plus` version `0.9.0`. It fully supports all the functionality of the standard Snowflake destination, plus:
+This destination is available starting from dlt+ version 0.9.0. It fully supports all the functionality of the standard Snowflake destination, plus:
 
 1. The ability to create Iceberg tables in Snowflake by setting `force_iceberg` to `true` in your `config.toml` file or `dlt.yml` file.
 2. Additional configuration for Iceberg tables in Snowflake via:
@@ -39,13 +39,36 @@ Once the `snowflake` extra is installed, you can configure a pipeline to use `sn
 GRANT USAGE ON EXTERNAL VOLUME <external_volume_name> TO ROLE <role_name>;
 ```
 
-5. Configure the `snowflake_plus` destination in your `config.toml`:
+5. Configure the `snowflake_plus` destination:
+
+<Tabs
+  groupId="config-format"
+  defaultValue="config-toml"
+  values={[
+    {"label": "dlt.yml", "value": "dlt-yml"},
+    {"label": "config.toml", "value": "config-toml"},
+]}>
+  <TabItem value="dlt-yml">
+
+```yaml
+destinations:
+  snowflake:
+    type: snowflake_plus
+    external_volume: "<external_volume_name>"
+    force_iceberg: true
+```
+
+  </TabItem>
+  <TabItem value="config-toml">
 
 ```toml
 [destination.snowflake]
 external_volume = "<external_volume_name>"
 force_iceberg = true
 ```
+
+  </TabItem>
+</Tabs>
 
 6. Use the `snowflake_plus` destination in your pipeline:
 
@@ -73,21 +96,34 @@ dlt project init sql_database snowflake_plus
 
 This will create a Snowflake Plus destination in your `dlt.yml` file.
 
+<Tabs
+  groupId="config-format"
+  defaultValue="config-toml"
+  values={[
+    {"label": "dlt.yml", "value": "dlt-yml"},
+    {"label": "config.toml", "value": "config-toml"},
+]}>
+  <TabItem value="dlt-yml">
+
 ```yaml
 destinations:
-  snowflake_plus:
-    type: snowflake_plus
-```
-
-To enable Iceberg table creation, set the `force_iceberg` option to `true` and `external_volume` to the name of the external volume you created in step 3.
-
-```yaml
-destinations:
-  snowflake_plus:
+  snowflake:
     type: snowflake_plus
     force_iceberg: true
     external_volume: "<external_volume_name>"
 ```
+
+  </TabItem>
+  <TabItem value="config-toml">
+
+```toml
+[destination.snowflake]
+force_iceberg = true
+external_volume = "<external_volume_name>"
+```
+
+  </TabItem>
+</Tabs>
 
 ## Configuration
 
@@ -154,9 +190,27 @@ To enable querying of Snowflake-managed Iceberg tables by third-party engines (e
 
 Refer to the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/tables-iceberg-open-catalog-sync#step-4-create-a-catalog-integration-for-open-catalog) for detailed setup instructions.
 
-3. Configure the `catalog_sync` option in your `config.toml` or `dlt.yml` file:
+3. Configure the `catalog_sync` option:
 
-- In `config.toml`:
+<Tabs
+  groupId="config-format"
+  defaultValue="config-toml"
+  values={[
+    {"label": "dlt.yml", "value": "dlt-yml"},
+    {"label": "config.toml", "value": "config-toml"},
+]}>
+  <TabItem value="dlt-yml">
+
+```yaml
+destinations:
+  snowflake:
+    type: snowflake_plus
+    # ... other configuration
+    catalog_sync: "my_open_catalog_int"
+```
+
+  </TabItem>
+  <TabItem value="config-toml">
 
 ```toml
 [destination.snowflake]
@@ -164,15 +218,8 @@ Refer to the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/
 catalog_sync = "my_open_catalog_int"
 ```
 
-- In `dlt.yml`:
-
-```yaml
-destinations:
-  snowflake_plus:
-    type: snowflake_plus
-    # ... other configuration
-    catalog_sync: "my_open_catalog_int"
-```
+  </TabItem>
+</Tabs>
 
 ## Additional Resources
 

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -30,8 +30,8 @@ Once the `snowflake` extra is installed, you can configure a pipeline to use `sn
 
 ### Use as a drop-in replacement for the `snowflake` destination
 
-1. [Configure Snowflake credentials](../../dlt-ecosystem/destinations/snowflake.md#setup-guide)
-2. [Set up database user and permissions](../../dlt-ecosystem/destinations/snowflake.md#set-up-the-database-user-and-permissions)
+1. [Configure your Snowflake credentials](../../dlt-ecosystem/destinations/snowflake.md#setup-guide)
+2. [Set up a database user and permissions](../../dlt-ecosystem/destinations/snowflake.md#set-up-the-database-user-and-permissions)
 3. [Configure an external volume in Snowflake](https://docs.snowflake.com/en/user-guide/tables-iceberg-configure-external-volume)
 4. Grant usage on the external volume to the role you are using to load data:
 

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -145,7 +145,7 @@ To enable querying of Snowflake-managed Iceberg tables by third-party engines (e
 
 ### Setup
 
-1. [Create an external catalog in Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/create-catalog).
+1. Create an [external catalog in Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/create-catalog).
 
 2. Create a catalog integration in Snowflake. Example:
 

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -1,5 +1,5 @@
 ---
-title: Snowflake Plus
+title: "Destination: Snowflake Plus"
 description: Snowflake destination with Iceberg table support
 keywords: [Snowflake, Iceberg, destination]
 ---
@@ -24,7 +24,7 @@ Install the `dlt-plus` package with the `snowflake` extra:
 pip install "dlt-plus[snowflake]"
 ```
 
-Once the `snowflake` extra is installed, you can configure a pipeline to use `snowflake_plus` exactly the same way you would use `snowflake` or initialize a dlt+ project with the `snowflake_plus` source and use it as a drop-in replacement for the `snowflake` destination.
+Once the `snowflake` extra is installed, you can configure a pipeline to use `snowflake_plus` exactly the same way you would use the `snowflake` destination.
 
 ## Setup
 
@@ -37,14 +37,14 @@ Once the `snowflake` extra is installed, you can configure a pipeline to use `sn
 GRANT USAGE ON EXTERNAL VOLUME <external_volume_name> TO ROLE <role_name>;
 ```
 
-5. Configure the `snowflake_plus` destination in in dlt+ project (in `dlt.yml`) or in a Python script (in `config.toml`):
+5. Configure the `snowflake_plus` destination. For a dlt+ project (in `dlt.yml`) or for a Python script (in `config.toml`):
 
 <Tabs
   groupId="config-format"
   defaultValue="dlt-yml"
   values={[
-    {"label": "dlt+ project", "value": "dlt-yml"},
-    {"label": "Python script", "value": "config-toml"},
+    {"label": "dlt.yml", "value": "dlt-yml"},
+    {"label": "config.toml", "value": "config-toml"},
 ]}>
   <TabItem value="dlt-yml">
 

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -24,11 +24,9 @@ Install the `dlt-plus` package with the `snowflake` extra:
 pip install "dlt-plus[snowflake]"
 ```
 
+Once the `snowflake` extra is installed, you can configure a pipeline to use `snowflake_plus` exactly the same way you would use `snowflake` or initialize a dlt+ project with the `snowflake_plus` source and use it as a drop-in replacement for the `snowflake` destination.
+
 ## Setup
-
-Once the `snowflake` extra is installed, you can configure a pipeline to use `snowflake_plus` exactly the same way you would use `snowflake` or initialize a dlt+ project with the `snowflake_plus` source.
-
-### Use as a drop-in replacement for the `snowflake` destination
 
 1. [Configure your Snowflake credentials](../../dlt-ecosystem/destinations/snowflake.md#setup-guide)
 2. [Set up a database user and permissions](../../dlt-ecosystem/destinations/snowflake.md#set-up-the-database-user-and-permissions)
@@ -39,16 +37,32 @@ Once the `snowflake` extra is installed, you can configure a pipeline to use `sn
 GRANT USAGE ON EXTERNAL VOLUME <external_volume_name> TO ROLE <role_name>;
 ```
 
-5. Configure the `snowflake_plus` destination:
+5. Configure the `snowflake_plus` destination in in dlt+ project (in `dlt.yml`) or in a Python script (in `config.toml`):
 
 <Tabs
   groupId="config-format"
-  defaultValue="config-toml"
+  defaultValue="dlt-yml"
   values={[
-    {"label": "dlt.yml", "value": "dlt-yml"},
-    {"label": "config.toml", "value": "config-toml"},
+    {"label": "dlt+ project", "value": "dlt-yml"},
+    {"label": "Python script", "value": "config-toml"},
 ]}>
   <TabItem value="dlt-yml">
+
+If you don't have a dlt+ project yet, initialize one in the current working directory. Replace `sql_database` with the source of your choice:
+
+```sh
+dlt project init sql_database snowflake_plus
+```
+
+This will create a Snowflake Plus destination in your `dlt.yml` file:
+
+```yaml
+destinations:
+  snowflake:
+    type: snowflake_plus
+```
+
+To enable Iceberg table creation, set the `force_iceberg` option to `true` and `external_volume` to the name of the external volume you created in step 3.
 
 ```yaml
 destinations:
@@ -61,16 +75,15 @@ destinations:
   </TabItem>
   <TabItem value="config-toml">
 
+Add the configuration to your `config.toml` file:
+
 ```toml
 [destination.snowflake]
 external_volume = "<external_volume_name>"
 force_iceberg = true
 ```
 
-  </TabItem>
-</Tabs>
-
-6. Use the `snowflake_plus` destination in your pipeline:
+Use the `snowflake_plus` destination in your pipeline:
 
 ```py
 import dlt
@@ -86,44 +99,9 @@ def my_iceberg_table():
     ...
 ```
 
-### Use with `dlt+` project
-
-Initialize a dlt+ project in the current working directory. Replace `sql_database` with the source of your choice:
-
-```sh
-dlt project init sql_database snowflake_plus
-```
-
-This will create a Snowflake Plus destination in your `dlt.yml` file.
-
-<Tabs
-  groupId="config-format"
-  defaultValue="config-toml"
-  values={[
-    {"label": "dlt.yml", "value": "dlt-yml"},
-    {"label": "config.toml", "value": "config-toml"},
-]}>
-  <TabItem value="dlt-yml">
-
-```yaml
-destinations:
-  snowflake:
-    type: snowflake_plus
-    force_iceberg: true
-    external_volume: "<external_volume_name>"
-```
-
-  </TabItem>
-  <TabItem value="config-toml">
-
-```toml
-[destination.snowflake]
-force_iceberg = true
-external_volume = "<external_volume_name>"
-```
-
   </TabItem>
 </Tabs>
+
 
 ## Configuration
 


### PR DESCRIPTION
Added docs for [syncing Snowflake-managed tables with Snowflake Open Catalog](https://docs.snowflake.com/en/user-guide/tables-iceberg-open-catalog-sync) in the `snowflake_plus` destination.