### PR TITLE
Fix: sqlalchemy table names of type sqlalchemy.sql.elements.quoted_name causing deserialization error

### DIFF
--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -233,7 +233,7 @@ def sql_table(
         hints = {}
 
     return decorators.resource(
-        table_rows, name=table, write_disposition=write_disposition, **hints
+        table_rows, name=str(table), write_disposition=write_disposition, **hints
     )(
         engine,
         table_obj if table_obj is not None else table,  # Pass table name if reflection deferred


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR simply force-casts sqlalchemy table names of type `sqlalchemy.sql.elements.quoted_name` to string. As a result, the following utility function in `dlt/common/schema/utils.py` stops serializing them as Python objects. 
```python
def to_pretty_yaml(stored_schema: TStoredSchema) -> str:
    return yaml.dump(stored_schema, allow_unicode=True, default_flow_style=False, sort_keys=False)
```
<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #2452 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
We could alternatively handle it in the utility function with something like:
```python
import yaml

def generic_str_subclass_representer(dumper, data):
    return dumper.represent_str(str(data))

# This will match all subclasses of str (including quoted_name)
yaml.add_multi_representer(str, generic_str_subclass_representer)
```
so that we handle all string subclasses, not just `sqlalchemy.sql.elements.quoted_name`.