### PR TITLE
exp: DltBackend for ibis implemented

### DIFF
--- a/dlt/destinations/dataset/dataset.py
+++ b/dlt/destinations/dataset/dataset.py
@@ -42,12 +42,9 @@ class ReadableDBAPIDataset(SupportsReadableDataset):
 
     def ibis(self) -> IbisBackend:
         """return a connected ibis backend"""
-        from dlt.helpers.ibis import create_ibis_backend
+        from dlt.destinations.dataset.ibis_relation import DltBackend
 
-        return create_ibis_backend(
-            self._destination,
-            self._destination_client(self.schema),
-        )
+        return DltBackend.from_dataset(self)
 
     @property
     def schema(self) -> Schema:

--- a/dlt/destinations/dataset/ibis_relation.py
+++ b/dlt/destinations/dataset/ibis_relation.py
@@ -1,12 +1,37 @@
-from typing import TYPE_CHECKING, Any, Union, Sequence
-
+from __future__ import annotations
+import contextlib
 from functools import partial
+from typing import TYPE_CHECKING, Any, Union
 
+# ibis imports follow the convention used in the library
+import ibis
+import ibis.backends.sql.compilers as sc
+import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
+import ibis.expr.schema as sch
+import ibis.expr.types as ir
+import sqlglot as sg
+from ibis.backends import _get_backend_names, NoUrl, NoExampleLoader
+from ibis.backends.sql import SQLBackend
+from ibis.formats import TypeMapper
+
+import dlt
+import dlt.helpers.ibis
+from dlt.common.schema import Schema as DltSchema
+from dlt.common.destination import TDestinationReferenceArg, Destination
 from dlt.common.exceptions import MissingDependencyException
+from dlt.common.schema.typing import TTableSchemaColumns, TDataType
+from dlt.destinations.dataset import ReadableDBAPIDataset
 from dlt.destinations.dataset.relation import BaseReadableDBAPIRelation
-from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.destinations.dataset.factory import dataset as dataset_factory
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    import pandas as pd
+    import pyarrow as pa
+    import pyarrow_hotfix  # noqa: F401
+
     from dlt.destinations.dataset.dataset import ReadableDBAPIDataset
 else:
     ReadableDBAPIDataset = Any
@@ -23,6 +48,254 @@ TRANSPILE_VIA_DEFAULT = [
     "redshift",
     "presto",
 ]
+
+# TODO move this as a destination capability; the destination should declare if it's compatible
+SUPPORTED_DESTINATIONS = (
+    "postgres",
+    "snowflake",
+    "filesystem",  # uses duckdb
+    "mssql",
+    "bigquery",
+    "redshift",  # uses postgres
+    "motherduck",  # uses duckdb
+    ""
+)
+
+ALL_IBIS_BACKENDS = set(_get_backend_names())
+
+
+# TODO complete implementation and register to singledispatch `sch.infer.register`
+class DltType(TypeMapper):
+    @classmethod
+    def from_ibis(cls):
+        raise NotImplementedError
+
+
+    @classmethod
+    def to_ibis(cls, typ: TDataType, nullable: bool | None = None) -> dt.DataType:
+        nullable = True if nullable is None else bool(nullable)
+        return ibis.dtype(dlt.helpers.ibis.DATA_TYPE_MAP[typ], nullable=nullable)
+    
+
+def _get_sqlalchemy_compiler(destination: Destination):
+    """
+    reference: https://docs.sqlalchemy.org/en/20/dialects/
+    """
+    # Dialects included in SQLAlchemy
+    # SQLite via SQLAlchemy is fully-tested with dlt
+    if ... == "sqlite":
+        compiler = sc.SQLiteCompiler()
+    # MySQL via SQLAlchemy is fully-tested with dlt
+    elif ... == "mysql":
+        compiler = sc.MySQLCompiler()
+
+    elif ... == "oracle":
+        compiler = sc.OracleCompiler()
+
+    elif ... == "mariadb":
+        raise NotImplementedError
+
+    elif ... == "postgres":
+        compiler = sc.PostgresCompiler()
+
+    elif ... == "mssql":
+        compiler = sc.MSSQLCompiler()
+
+    # SQLAlchemy extension dialects
+    elif ... == "druid":
+        compiler = sc.DruidCompiler()
+
+    elif ... == "hive":
+        compiler = sc.TrinoCompiler()
+    
+    elif ... == "clickhouse":
+        compiler = sc.ClickHouseCompiler()
+
+    elif ... == "databricks":
+        compiler = sc.DatabricksCompiler()
+
+    elif ... == "bigquery":
+        compiler = sc.BigQueryCompiler()
+
+    elif ... == "impala":
+        compiler = sc.ImpalaCompiler()
+
+    elif ... == "snowflake":
+        compiler = sc.SnowflakeCompiler()
+
+    else:
+        raise NotImplementedError
+    
+    return compiler
+
+
+
+def get_ibis_to_sqlglot_compiler(destination: TDestinationReferenceArg): 
+    # ensure destination is a Destination instance
+    if not isinstance(destination, Destination):
+        destination = Destination.from_reference(destination)
+    assert isinstance(destination, Destination)
+
+    if destination.destination_name == "duckdb":
+        compiler = sc.DuckDBCompiler()
+
+    elif destination.destination_name == "filesystem":
+        compiler = sc.DuckDBCompiler()
+
+    elif destination.destination_name == "motherduck":
+        compiler = sc.DuckDBCompiler()
+    
+    elif destination.destination_name == "postgres":
+        compiler = sc.PostgresCompiler()
+    
+    elif destination.destination_name == "clickhouse":
+        compiler = sc.ClickHouseCompiler()
+    
+    elif destination.destination_name == "snowflake":
+        compiler = sc.SnowflakeCompiler()
+
+    elif destination.destination_name == "databricks":
+        compiler = sc.DatabricksCompiler()
+
+    elif destination.destination_name == "mssql":
+        compiler = sc.MSSQLCompiler()
+
+    # NOTE synapse might differ from MSSQL
+    elif destination.destination_name == "synapse":
+        compiler = sc.MSSQLCompiler()
+
+    elif destination.destination_name == "bigquery":
+        compiler = sc.BigQueryCompiler()
+
+    elif destination.destination_name == "athena":
+        compiler = sc.AthenaCompiler()
+
+    # NOTE Dremio uses a presto/trino-based language
+    elif destination.destination_name == "dremio":
+        compiler = sc.TrinoCompiler()
+
+    # TODO parse the SQLAlchemy dialect
+    elif destination.destination_name == "sqlalchemy":
+        compiler = _get_sqlalchemy_compiler(destination)
+
+    else:
+        raise NotImplementedError(
+            f"Destination of type {Destination.from_reference(destination).destination_type} not"
+            " supported by ibis."
+        )
+    
+    return compiler
+
+
+# TODO support `database` kwarg (equiv. `dataset_name`) to enable DltBackend to access multiple database
+# NOTE this should support all SQLGlot dialects https://sqlglot.com/sqlglot/dialects.html#Dialect
+
+class DltBackend(SQLBackend, NoUrl, NoExampleLoader):
+    name = "dlt"
+    supports_temporary_tables = False
+    supports_python_udfs = False
+
+    @property
+    def version(self) -> str:
+        import importlib.metadata
+        return importlib.metadata.version("dlt")
+    
+    # NOTE can change signature
+    def do_connect(
+        self,
+        destination: TDestinationReferenceArg,
+        dataset_name: str,
+        schema: Union[DltSchema, str, None] = None,
+        **config: Any,
+    ) -> None:
+        self._dataset = dataset_factory(
+            destination=destination,
+            dataset_name=dataset_name,
+            schema=schema,
+        )
+        self.compiler = get_ibis_to_sqlglot_compiler(self._dataset._destination)
+
+    @classmethod
+    def from_dataset(cls, dataset: ReadableDBAPIDataset) -> DltBackend:
+        new_backend = cls()
+        new_backend._dataset = dataset
+        new_backend.compiler = get_ibis_to_sqlglot_compiler(new_backend._dataset._destination)
+        return new_backend
+
+    @classmethod
+    def from_pipeline(cls, pipeline: dlt.Pipeline) -> DltBackend:
+        new_backend = cls()
+        new_backend._dataset = pipeline.dataset()
+        new_backend.compiler = get_ibis_to_sqlglot_compiler(new_backend._dataset._destination)
+        return new_backend
+
+    @contextlib.contextmanager
+    def _safe_raw_sql(self, *args, **kwargs):
+        yield self.raw_sql(*args, **kwargs)
+
+    def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
+        """Execute SQL string or SQLGlot expression using the dlt destination SQL client"""
+        with contextlib.suppress(AttributeError):
+            query = query.sql(dialect=self.name)
+
+        with self._dataset.sql_client as client:
+            result = client.execute_sql(query)
+
+        return result
+    
+    def _register_udfs(self, *args, **kwargs) -> None:
+        """Override SQLBackend method to avoid round-trip to Ibis SQL compiler"""
+    
+    def list_tables(self, *args, **kwargs) -> list[str]:
+        """Return the list of table names"""
+        return list(self._dataset.schema.tables.keys())
+    
+    def get_schema(self, table_name: str, *args, **kwargs) -> sch.Schema:
+        """Get the Ibis table schema"""
+        return sch.Schema(  
+            {
+                name: DltType.to_ibis(column["data_type"], column.get("nullable"))  # type: ignore
+                for name, column in self._dataset.schema.get_table(table_name)["columns"].items()  # type: ignore
+            }  # type: ignore
+        )
+    
+    def table(self, name: str) -> ir.Table:
+        """Construct a table expression"""
+        # TODO maybe there's a more straighforward way to retrieve catalog and db
+        sql_client = self._dataset.sql_client
+        catalog = sql_client.catalog_name()
+        database =  sql_client.capabilities.casefold_identifier(sql_client.dataset_name)
+
+        table_schema = self.get_schema(name)
+        return ops.DatabaseTable(
+            name,
+            schema=table_schema,
+            source=self,
+            namespace=ops.Namespace(catalog=catalog, database=database)
+        ).to_expr()
+
+    # TODO use the new dlt `model` format with INSERT statement
+    # for non-SQL (e.g., filesystem) use JobClient 
+    def create_table(
+        self,
+        name: str,
+        /,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
+        *,
+        schema: sch.Schema | None = None,
+        database: str | None = None,
+        temp: bool = False,
+        overwrite: bool = False,
+    ) -> ir.Table:
+        raise NotImplementedError
+    
+    def _get_schema_using_query(self, *args, **kwargs):
+        """Required to subclass SQLBackend"""
+        raise NotImplementedError
+
+    def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
+        """Required to subclass SQLBackend"""
+        raise NotImplementedError
 
 
 class ReadableIbisRelation(BaseReadableDBAPIRelation):

--- a/tests/datasets/test_ibis_backend.py
+++ b/tests/datasets/test_ibis_backend.py
@@ -1,0 +1,287 @@
+import pytest
+import dlt
+import os
+from typing import Any, cast
+
+import ibis
+import ibis.expr.types as ir
+import pandas as pd
+from dlt import Pipeline
+from dlt.common import Decimal
+from dlt.common.schema.schema import Schema
+from dlt.common.storages.file_storage import FileStorage
+from tests.load.utils import (
+    destinations_configs,
+    DestinationTestConfiguration,
+    GCS_BUCKET,
+    SFTP_BUCKET,
+    MEMORY_BUCKET,
+)
+from dlt.destinations import filesystem
+from tests.utils import clean_test_storage
+from tests.load.utils import drop_pipeline_data
+
+from dlt.destinations.dataset.ibis_relation import DltBackend
+
+
+def _total_records(p: Pipeline) -> int:
+    """how many records to load for a given pipeline"""
+    if p.destination.destination_type == "dlt.destinations.bigquery":
+        return 80
+    elif p.destination.destination_type == "dlt.destinations.mssql":
+        return 1000
+    return 3000
+
+
+# this also disables autouse_test_storage on function level which destroys some tests here
+@pytest.fixture(scope="session")
+def autouse_test_storage() -> FileStorage:
+    return clean_test_storage()
+
+
+@pytest.fixture(scope="session")
+def populated_pipeline(request, autouse_test_storage) -> Any:
+    """fixture that returns a pipeline object populated with the example data"""
+
+    destination_config = cast(DestinationTestConfiguration, request.param)
+
+    if (
+        destination_config.file_format not in ["parquet", "jsonl"]
+        and destination_config.destination_type == "filesystem"
+    ):
+        pytest.skip(
+            "Test only works for jsonl and parquet on filesystem destination, given:"
+            f" {destination_config.file_format}"
+        )
+
+    pipeline = destination_config.setup_pipeline(
+        "read_pipeline", dataset_name="read_test", dev_mode=True
+    )
+    os.environ["DATA_WRITER__FILE_MAX_ITEMS"] = "700"
+    total_records = _total_records(pipeline)
+
+    @dlt.source()
+    def source():
+        @dlt.resource(
+            table_format=destination_config.table_format,
+            write_disposition="replace",
+            columns={
+                "id": {"data_type": "bigint"},
+                # we add a decimal with precision to see wether the hints are preserved
+                "decimal": {"data_type": "decimal", "precision": 10, "scale": 3},
+                "other_decimal": {"data_type": "decimal", "precision": 12, "scale": 3},
+            },
+        )
+        def items():
+            yield from [
+                {
+                    "id": i,
+                    "children": [{"id": i + 100}, {"id": i + 1000}],
+                    "decimal": Decimal("10.433"),
+                    "other_decimal": Decimal("10.433"),
+                }
+                for i in range(total_records)
+            ]
+
+        @dlt.resource(
+            table_format=destination_config.table_format,
+            write_disposition="replace",
+            columns={
+                "id": {"data_type": "bigint"},
+                "double_id": {"data_type": "bigint"},
+                "di_decimal": {"data_type": "decimal", "precision": 7, "scale": 3},
+            },
+        )
+        def double_items():
+            yield from [
+                {
+                    "id": i,
+                    "double_id": i * 2,
+                    "di_decimal": Decimal("10.433"),
+                }
+                for i in range(total_records)
+            ]
+
+        return [items, double_items]
+
+    # run source
+    s = source()
+    pipeline.run(s, loader_file_format=destination_config.file_format)
+    # create a second schema in the pipeline
+    # NOTE: that generates additional load package and then another one for the state
+    # NOTE: "aleph" schema is now the newest schema in the dataset and we assume that later in the tests
+    # TODO: we need some kind of idea for multi-schema datasets
+    pipeline.run([1, 2, 3], table_name="digits", schema=Schema("aleph"))
+
+    # in case of delta on gcs we use the s3 compat layer for reading
+    # for writing we still need to use the gc authentication, as delta_rs seems to use
+    # methods on the s3 interface that are not implemented by gcs
+    if destination_config.bucket_url == GCS_BUCKET and destination_config.table_format == "delta":
+        gcp_bucket = filesystem(
+            GCS_BUCKET.replace("gs://", "s3://"), destination_name="filesystem_s3_gcs_comp"
+        )
+        access_pipeline = destination_config.setup_pipeline(
+            "read_pipeline", dataset_name="read_test", destination=gcp_bucket
+        )
+
+        pipeline.destination = access_pipeline.destination
+
+    # return pipeline to test
+    yield pipeline
+
+    # NOTE: we need to drop pipeline data here since we are keeping the pipelines around for the whole module
+    drop_pipeline_data(pipeline)
+
+
+# NOTE: we collect all destination configs centrally, this way the session based
+# pipeline population per fixture setup will work and save a lot of time
+configs = destinations_configs(
+    default_sql_configs=True,
+    all_buckets_filesystem_configs=False,
+    table_format_filesystem_configs=False,
+    bucket_exclude=[SFTP_BUCKET, MEMORY_BUCKET],
+)
+duckdb_conf = [c for c in configs if c[0][0].destination_type=="duckdb" and c[0][0].file_format is None]
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+def test_instantiate_backend():
+    DltBackend()
+
+
+# TODO test for all destinations
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_connect_to_backend(populated_pipeline: Pipeline):
+    backend1 = DltBackend.from_dataset(populated_pipeline.dataset())
+    backend2 = DltBackend.from_pipeline(populated_pipeline)
+
+    assert isinstance(backend1, DltBackend)
+    assert isinstance(backend2, DltBackend)
+    assert backend1 is not backend2
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_list_tables(populated_pipeline: Pipeline):
+    backend = DltBackend.from_pipeline(populated_pipeline)
+    expected_table_names = [
+        '_dlt_version', 
+        '_dlt_loads',
+        'items',
+        'double_items',
+        '_dlt_pipeline_state',
+        'items__children'
+    ]
+    
+    assert backend.list_tables() == expected_table_names
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_get_schema(populated_pipeline: Pipeline):
+    backend = DltBackend.from_pipeline(populated_pipeline)
+    expected_schema = ibis.Schema(
+        {
+            "id": ibis.dtype("int64", nullable=True),
+            "decimal": ibis.dtype("decimal", nullable=True),
+            "other_decimal": ibis.dtype("decimal", nullable=True),
+            "_dlt_load_id": ibis.dtype("string", nullable=False),
+            "_dlt_id": ibis.dtype("string", nullable=False),
+        }  # type: ignore
+    )
+
+    ibis_schema = backend.get_schema("items")
+    
+    assert expected_schema.equals(ibis_schema)
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_get_bound_table(populated_pipeline: Pipeline):
+    backend = DltBackend.from_pipeline(populated_pipeline)
+    expected_schema = ibis.Schema(
+        {
+            "id": ibis.dtype("int64", nullable=True),
+            "decimal": ibis.dtype("decimal", nullable=True),
+            "other_decimal": ibis.dtype("decimal", nullable=True),
+            "_dlt_load_id": ibis.dtype("string", nullable=False),
+            "_dlt_id": ibis.dtype("string", nullable=False),
+        }  # type: ignore
+    )
+
+    table = backend.table("items")
+    
+    assert isinstance(table, ir.Table)
+    assert table.schema().equals(expected_schema)
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_execute_expression(populated_pipeline: Pipeline):
+    backend = DltBackend.from_pipeline(populated_pipeline)
+    expected_schema = ibis.Schema(
+        {
+            "_dlt_id": ibis.dtype("string", nullable=False),
+            "id": ibis.dtype("int64", nullable=True),
+        }  # type: ignore
+    )
+
+    table = backend.table("items")
+    expr = table.select("_dlt_id", "id")
+    table2 = backend.execute(expr)
+    
+    assert isinstance(table2, pd.DataFrame)
+    assert expr.schema().equals(expected_schema)
+    assert set(table2.columns) == set(expected_schema.names)
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_user_workflow(populated_pipeline: Pipeline):
+    expected_columns = ["_dlt_id", "id"]
+
+    dataset = populated_pipeline.dataset()
+    con = dataset.ibis()
+    table = con.table("items")
+    result = table.select("_dlt_id", "id").execute()
+    
+    assert isinstance(result, pd.DataFrame)
+    assert set(result.columns) == set(expected_columns)


### PR DESCRIPTION
Continuous work to improve the transformation engine.

## Requirements
- instantiate lazy tables from the dlt table schema; we don't want to query the destination for table information
- enable `ibis -> SQL string` conversion to use the dlt engine for execution
- try to support the full Ibis user-facing API / avoid proxying

## Intended user workflow
```python
pipeline = dlt.pipeline(...)
dataset = pipeline.dataset()
con = dataset.ibis()

customers = con.table("customers")
orders = con.table("orders")

query = (
  customers
  .join(
    orders.filter(orders.date > "2025-02-01"),
    customers.id == orders.customer_id,
    how="left",
  )
  .select("name", "address", "category", "cost")
  .group_by("category")
  .cost.sum()
)

# .execute() returns a pandas dataframe by default
result = query.execute()
# we can override for this to use dlt's implementation (not yet in the PR)
result.to_pyarrow()
```

## Technical implementation
- the `DltBackend` class is an Ibis backend. It's responsible for translating and executing Ibis expressions.
- the `DltBackend` subclasses the `SQLBackend` which implements almost all required methods through SQLGlot. The Ibis expression is compiled to an SQLGlot expression, and then compiled to an SQL string.
- no custom compiler is implemented, we just need to map dlt destinations to the right compiler. For example, `filesystem` destination has an SQLClient that uses Duckdb, so we compile `ibis -> sqlglot duckdb -> string`
- the SQL clients of the dlt destinations are used for execution

## Future work / Limitations
- I currently disabled UDF and extension support, but it should work
- Ibis has a hook system that we can use for logging, store things on the backend object, or even write to destination
- Ibis has a caching system using temporary tables that is useful for executing transformation DAGs