### PR TITLE
Docs: fix example drop pipeline commands

### DIFF
--- a/docs/website/docs/general-usage/state.md
+++ b/docs/website/docs/general-usage/state.md
@@ -155,7 +155,7 @@ This will display the source and resource state slots for all known sources.
 
 - Drop the destination dataset to fully reset the pipeline.
 - [Set the `dev_mode` flag wh^en creating the pipeline](pipeline.md#do-experiments-with-dev-mode).
-- Use the `dlt pipeline drop --drop-all` command to [drop the state and tables for a given schema name](../reference/command-line-interface.md#dlt-pipeline-drop).
+- Use the `dlt pipeline <pipeline_name> drop --drop-all` command to [drop the state and tables for a given schema name](../reference/command-line-interface.md#dlt-pipeline-drop).
 
 **To partially reset the state:**
 

--- a/docs/website/docs/general-usage/state.md
+++ b/docs/website/docs/general-usage/state.md
@@ -159,6 +159,6 @@ This will display the source and resource state slots for all known sources.
 
 **To partially reset the state:**
 
-- Use the `dlt pipeline drop <resource_name>` command to [drop the state and tables for a given resource](../reference/command-line-interface.md#dlt-pipeline-drop).
-- Use the `dlt pipeline drop --state-paths` command to [reset the state at a given path without touching the tables and data](../reference/command-line-interface.md#dlt-pipeline-drop).
+- Use the `dlt pipeline <pipeline_name> drop <resource_name>` command to [drop the state and tables for a given resource](../reference/command-line-interface.md#dlt-pipeline-drop).
+- Use the `dlt pipeline <pipeline_name> drop --state-paths` command to [reset the state at a given path without touching the tables and data](../reference/command-line-interface.md#dlt-pipeline-drop).
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

The [example commands](https://dlthub.com/docs/general-usage/state#reset-the-pipeline-state-full-or-partial) to drop a pipeline state are wrong. Below is the result of executing one of the commands as per the example.

```
$ uv run dlt pipeline drop ability
Usage: dlt pipeline [-h] [--list-pipelines] [--hot-reload] [--pipelines-dir PIPELINES_DIR] [--verbose]
                    [pipeline_name]
                    {info,show,failed-jobs,drop-pending-packages,sync,trace,schema,drop,load-package} ...
dlt pipeline: error: argument operation: invalid choice: 'ability' (choose from 'info', 'show', 'failed-jobs', 'drop-pending-packages', 'sync', 'trace', 'schema', 'drop', 'load-package')
```

If instead I add the pipeline name to the command, I get the expected result.

```
$ uv run dlt pipeline pokeapi drop ability
Found pipeline pokeapi in /home/michel/.dlt/pipelines
About to drop the following data in dataset poke in destination duckdb:
Selected schema: rest_api
Selected resource(s): ['ability']
Table(s) to drop: ['ability']
        with data in destination: ['ability']
Resource(s) state to reset: []
Source state path(s) to reset: []
Do you want to apply these changes? [y/N]:
```

I've edited the docs to reflect this. This is also in line with [docs elsewhere](https://dlthub.com/docs/reference/command-line-interface#dlt-pipeline-drop).

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

None that I'm aware of.

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
