### PR TITLE
Fix clickhouse sql syntax for sentinel table creation

### DIFF
--- a/dlt/destinations/impl/clickhouse/sql_client.py
+++ b/dlt/destinations/impl/clickhouse/sql_client.py
@@ -136,8 +136,9 @@ class ClickHouseSqlClient(
         sentinel_table_type = cast(TTableEngineType, self.config.table_engine_type)
         self.execute_sql(f"""
             CREATE TABLE {sentinel_table_name}
-            (_dlt_id String NOT NULL PRIMARY KEY)
+            (_dlt_id String NOT NULL)
             ENGINE={TABLE_ENGINE_TYPE_TO_CLICKHOUSE_ATTR.get(sentinel_table_type)}
+            PRIMARY KEY _dlt_id
             COMMENT 'internal dlt sentinel table'""")
 
     def drop_dataset(self) -> None:


### PR DESCRIPTION
### Description
This small PR aligns the sql syntax for creating the sentinel table on clickhouse with what is specified in the official docs (also chatgpt agrees...). For our clickhouse instance, both syntax works, I checked that on the console and verified that in both cases the correct column has the primary key constraint. We have a use reporting that the old syntax does not work, I'm assuming they are on a different clickhouse version, I can't find any mention of this changing in the clickhouse changelogs for the last 18 months though.