### PR TITLE
feat/2502 `sqlglot` lineage

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -96,11 +96,11 @@ jobs:
         run: poetry install --no-interaction --with sentry-sdk
 
       - run: |
-          poetry run pytest tests/common tests/normalize tests/reflection tests/plugins tests/load/test_dummy_client.py tests/extract/test_extract.py tests/extract/test_sources.py tests/pipeline/test_pipeline_state.py
+          poetry run pytest tests/common tests/normalize tests/reflection tests/plugins tests/transformations tests/load/test_dummy_client.py tests/extract/test_extract.py tests/extract/test_sources.py tests/pipeline/test_pipeline_state.py
         if: runner.os != 'Windows'
         name: Run common tests with minimum dependencies Linux/MAC
       - run: |
-          poetry run pytest tests/common tests/normalize tests/reflection tests/plugins tests/load/test_dummy_client.py tests/extract/test_extract.py tests/extract/test_sources.py tests/pipeline/test_pipeline_state.py -m "not forked"
+          poetry run pytest tests/common tests/normalize tests/reflection tests/plugins tests/transformations tests/load/test_dummy_client.py tests/extract/test_extract.py tests/extract/test_sources.py tests/pipeline/test_pipeline_state.py -m "not forked"
         if: runner.os == 'Windows'
         name: Run common tests with minimum dependencies Windows
         shell: cmd

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ lint:
 
 format:
 	poetry run black dlt docs tests --extend-exclude='.*syntax_error.py|_storage/.*'
-	# poetry run isort ./
 
 lint-snippets:
 	cd docs/tools && poetry run python check_embedded_snippets.py full

--- a/dlt/cli/pipeline_files.py
+++ b/dlt/cli/pipeline_files.py
@@ -322,12 +322,6 @@ def gen_index_diff(
         if name not in remote_index["files"]:
             deleted[name] = entry
 
-    # print("NEW")
-    # print(new)
-    # print("MOD")
-    # print(modified)
-    # print("DEL")
-    # print(deleted)
     return new, modified, deleted
 
 

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -36,6 +36,11 @@ class SupportsReadableRelation(Protocol):
 
     def query(self) -> Any:
         """Represents relation as a query, currently always SQL"""
+        ...
+
+    def compute_column_schema(self, **kwargs) -> TTableSchemaColumns:
+        """Return the expected dlt schema of the execution result of self.query()"""
+        ...
 
     def df(self, chunk_size: int = None) -> Optional[DataFrame]:
         """Fetches the results as data frame. For large queries the results may be chunked

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -38,7 +38,9 @@ class SupportsReadableRelation(Protocol):
         """Represents relation as a query, currently always SQL"""
         ...
 
-    def compute_column_schema(self, **kwargs) -> TTableSchemaColumns:
+    # TODO think for a better name that matches the type `TTableSchemaColumns`
+    # `compute_table_columns_schema()` ?
+    def compute_columns_schema(self, **kwargs: Any) -> TTableSchemaColumns:
         """Return the expected dlt schema of the execution result of self.query()"""
         ...
 

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -34,9 +34,8 @@ class SupportsReadableRelation(Protocol):
     columns_schema: TTableSchemaColumns
     """Known dlt table columns for this relation"""
 
-    def query(self) -> Any: ...
-
-    """Represents relation as an query, currently always SQL"""
+    def query(self) -> Any:
+        """Represents relation as a query, currently always SQL"""
 
     def df(self, chunk_size: int = None) -> Optional[DataFrame]:
         """Fetches the results as data frame. For large queries the results may be chunked

--- a/dlt/destinations/dataset/ibis_relation.py
+++ b/dlt/destinations/dataset/ibis_relation.py
@@ -64,7 +64,7 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
     def columns_schema(self, new_value: TTableSchemaColumns) -> None:
         raise NotImplementedError("columns schema in ReadableDBAPIRelation can only be computed")
 
-    def compute_columns_schema(self) -> TTableSchemaColumns:
+    def compute_columns_schema(self, **kwargs: Any) -> TTableSchemaColumns:
         """provide schema columns for the cursor, may be filtered by selected columns"""
         # TODO: provide column lineage tracing with sqlglot lineage
         return self._columns_schema

--- a/dlt/destinations/dataset/ibis_relation.py
+++ b/dlt/destinations/dataset/ibis_relation.py
@@ -56,19 +56,6 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
         sql = sqlglot.transpile(sql, write=target_dialect)[0]
         return sql
 
-    @property
-    def columns_schema(self) -> TTableSchemaColumns:
-        return self.compute_columns_schema()
-
-    @columns_schema.setter
-    def columns_schema(self, new_value: TTableSchemaColumns) -> None:
-        raise NotImplementedError("columns schema in ReadableDBAPIRelation can only be computed")
-
-    def compute_columns_schema(self, **kwargs: Any) -> TTableSchemaColumns:
-        """provide schema columns for the cursor, may be filtered by selected columns"""
-        # TODO: provide column lineage tracing with sqlglot lineage
-        return self._columns_schema
-
     def _proxy_expression_method(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
         """Proxy method calls to the underlying ibis expression, allowing to wrap the resulting expression in a new relation"""
 

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -92,7 +92,10 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
 
         dialect: str = self._dataset._destination.capabilities().sqlglot_dialect
         # TODO store the SQLGlot schema on the dataset
-        sqlglot_schema = lineage.create_sqlglot_schema(self._dataset, dialect)
+        d = self._dataset
+        sqlglot_schema = lineage.create_sqlglot_schema(
+            d.dataset_name, d.schema, dialect, d._destination.capabilities().get_type_mapper()
+        )
         return lineage.compute_columns_schema(self.query(), sqlglot_schema, dialect)
 
     @property

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -148,8 +148,16 @@ class ReadableDBAPIRelation(BaseReadableDBAPIRelation):
     def columns_schema(self, new_value: TTableSchemaColumns) -> None:
         raise NotImplementedError("columns schema in ReadableDBAPIRelation can only be computed")
 
-    def compute_columns_schema(self) -> TTableSchemaColumns:
+    def compute_columns_schema(self, **kwargs: Any) -> TTableSchemaColumns:
         """provide schema columns for the cursor, may be filtered by selected columns"""
+
+        # NOTE: if we do not have a schema, we cannot compute the columns schema
+        if (
+            self._dataset.schema is None
+            or self._dataset.schema.tables.get(self._table_name) is None
+        ):
+            return {}
+
         dialect: str = self._dataset._destination.capabilities().sqlglot_dialect
         # TODO store the SQLGlot schema on the dataset
         sqlglot_schema = lineage.create_sqlglot_schema(self._dataset, dialect)

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -128,7 +128,7 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
         # TODO: maybe store the SQLGlot schema on the dataset
         # TODO: support joins between datasets
         d = self._dataset
-        sqlglot_schema = lineage.create_sqlglot_schema(d.dataset_name, d.schema, dialect, caps)
+        sqlglot_schema = lineage.create_sqlglot_schema(d.sql_client, d.schema, dialect, caps)
         return lineage.compute_columns_schema(
             query,
             sqlglot_schema,

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -90,6 +90,10 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
         if self._dataset.schema is None:
             return {}
 
+        # TODO: sqlalchemy is not supported at this point
+        if self._dataset._destination.destination_type == "dlt.destinations.sqlalchemy":
+            return {}
+
         dialect: str = self._dataset._destination.capabilities().sqlglot_dialect
         # TODO store the SQLGlot schema on the dataset
         d = self._dataset

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -152,10 +152,7 @@ class ReadableDBAPIRelation(BaseReadableDBAPIRelation):
         """provide schema columns for the cursor, may be filtered by selected columns"""
 
         # NOTE: if we do not have a schema, we cannot compute the columns schema
-        if (
-            self._dataset.schema is None
-            or self._dataset.schema.tables.get(self._table_name) is None
-        ):
+        if self._dataset.schema is None:
             return {}
 
         dialect: str = self._dataset._destination.capabilities().sqlglot_dialect

--- a/dlt/destinations/impl/clickhouse/sql_client.py
+++ b/dlt/destinations/impl/clickhouse/sql_client.py
@@ -291,6 +291,9 @@ class ClickHouseSqlClient(
                 table_name = self.capabilities.escape_identifier(table_name)
             # we have only two path components
             path[1] = table_name
+        else:
+            # we have only one path component, dataset name is included in the table name
+            path.pop()
         return path
 
     def _get_information_schema_components(self, *tables: str) -> Tuple[str, str, List[str]]:

--- a/dlt/destinations/impl/dummy/factory.py
+++ b/dlt/destinations/impl/dummy/factory.py
@@ -8,6 +8,7 @@ from dlt.destinations.impl.dummy.configuration import (
     DummyClientConfiguration,
     DummyClientCredentials,
 )
+from dlt.common.arithmetics import DEFAULT_NUMERIC_PRECISION, DEFAULT_NUMERIC_SCALE
 
 if t.TYPE_CHECKING:
     from dlt.destinations.impl.dummy.dummy import DummyClient
@@ -67,6 +68,11 @@ class dummy(Destination[DummyClientConfiguration, "DummyClient"]):
         caps.preferred_loader_file_format = config.loader_file_format
         caps.supported_loader_file_formats = additional_formats + [config.loader_file_format]
         caps.supported_staging_file_formats = additional_formats + [config.loader_file_format]
+        caps.decimal_precision = (DEFAULT_NUMERIC_PRECISION, DEFAULT_NUMERIC_SCALE)
+        caps.wei_precision = (DEFAULT_NUMERIC_PRECISION, 0)
+        from dlt.destinations.impl.duckdb.factory import DuckDbTypeMapper
+
+        caps.type_mapper = DuckDbTypeMapper
         return caps
 
 

--- a/dlt/destinations/impl/filesystem/factory.py
+++ b/dlt/destinations/impl/filesystem/factory.py
@@ -71,6 +71,10 @@ class filesystem(Destination[FilesystemDestinationClientConfiguration, "Filesyst
         caps.sqlglot_dialect = "duckdb"
         caps.supports_nested_types = True
 
+        from dlt.destinations.impl.duckdb.factory import DuckDbTypeMapper
+
+        caps.type_mapper = DuckDbTypeMapper
+
         return caps
 
     @property

--- a/dlt/helpers/ibis.py
+++ b/dlt/helpers/ibis.py
@@ -18,7 +18,7 @@ from dlt.destinations.impl.snowflake.configuration import SnowflakeClientConfigu
 from dlt.destinations.impl.mssql.configuration import MsSqlClientConfiguration
 from dlt.destinations.impl.bigquery.configuration import BigQueryClientConfiguration
 from dlt.destinations.impl.clickhouse.configuration import ClickHouseClientConfiguration
-
+from dlt.destinations.impl.synapse.configuration import SynapseClientConfiguration
 
 try:
     import ibis  # type: ignore
@@ -109,11 +109,14 @@ def create_ibis_backend(
         con = ibis.snowflake.connect(
             schema=dataset_name, **sn_credentials, create_object_udfs=False
         )
-    elif issubclass(destination.spec, MsSqlClientConfiguration):
+    elif issubclass(destination.spec, MsSqlClientConfiguration) and not issubclass(
+        destination.spec, SynapseClientConfiguration
+    ):
         from dlt.destinations.impl.mssql.mssql import MsSqlJobClient
 
         assert isinstance(client, MsSqlJobClient)
         ms_credentials = client.config.credentials.to_native_representation()
+        ms_credentials = ms_credentials.replace("synapse://", "mssql://")
         con = ibis.connect(ms_credentials, driver=client.config.credentials.driver)
     elif issubclass(destination.spec, BigQueryClientConfiguration):
         from dlt.destinations.impl.bigquery.bigquery import BigQueryClient
@@ -139,14 +142,14 @@ def create_ibis_backend(
             secure=bool(ch_client.config.credentials.secure),
             # compression=True,
         )
-    elif issubclass(destination.spec, DatabricksClientConfiguration):
-        from dlt.destinations.impl.databricks.databricks import DatabricksClient
+    # elif issubclass(destination.spec, DatabricksClientConfiguration):
+    #     from dlt.destinations.impl.databricks.databricks import DatabricksClient
 
-        bricks_client = cast(DatabricksClient, client)
-        con = ibis.databricks.connect(
-            **bricks_client.config.credentials.to_connector_params(),
-            schema=bricks_client.sql_client.dataset_name,
-        )
+    #     bricks_client = cast(DatabricksClient, client)
+    #     con = ibis.databricks.connect(
+    #         **bricks_client.config.credentials.to_connector_params(),
+    #         schema=bricks_client.sql_client.dataset_name,
+    #     )
     elif issubclass(destination.spec, AthenaClientConfiguration):
         from dlt.destinations.impl.athena.athena import AthenaClient
 

--- a/dlt/transformations/lineage.py
+++ b/dlt/transformations/lineage.py
@@ -100,6 +100,7 @@ def to_sqlglot_type(
         return None
 
     destination_type = type_mapper.to_destination_type(column, cast(PreparedTableSchema, table))
+
     # TODO modify nullable arg_types on destination_type
     sqlglot_type = DataType.build(destination_type, dialect=dialect)
     # TODO verify how nullable is used exactly in sqlglot

--- a/dlt/transformations/lineage.py
+++ b/dlt/transformations/lineage.py
@@ -1,0 +1,138 @@
+from typing import Optional
+
+import sqlglot
+import sqlglot.expressions as sge
+from sqlglot.expressions import DataType as dt, DATA_TYPE
+from sqlglot.schema import Schema as SQLGlotSchema, ensure_schema
+from sqlglot.optimizer.annotate_types import annotate_types
+from sqlglot.optimizer.qualify import qualify
+
+from dlt.common.schema.typing import TTableSchemaColumns, TColumnType
+from dlt.destinations.type_mapping import TypeMapperImpl
+from dlt.destinations.dataset import ReadableDBAPIDataset
+
+
+# TODO maybe we don't need a full on type mapper
+class SQLGlotTypeMapper(TypeMapperImpl):
+    sct_to_unbound_dbt = {
+        "json": "JSON",
+        "text": "TEXT",
+        "double": "DOUBLE",
+        "bool": "BOOLEAN",
+        "date": "DATE",
+        "timestamp": "TIMESTAMPTZ",
+        "bigint": "BIGINT",
+        "binary": "BINARY",
+        "time": "TIME",  # should we use TIMETZ ?
+    }
+
+    # what is that for?
+    sct_to_dbt = {}
+
+    dbt_to_sct = {
+        dt.Type.BINARY: "binary",
+        dt.Type.BOOLEAN: "bool",
+        **{typ: "json" for typ in dt.NESTED_TYPES},  # array and struct
+        **{typ: "text" for typ in dt.TEXT_TYPES},
+        **{typ: "decimal" for typ in dt.REAL_TYPES},
+        **{typ: "double" for typ in dt.FLOAT_TYPES},
+        **{typ: "bigint" for typ in dt.INTEGER_TYPES},  # signed and unsigned
+        **{
+            typ: "date" for typ in dt.TEMPORAL_TYPES
+            if typ in [
+                dt.Type.DATE,
+                dt.Type.DATE32,
+                dt.Type.DATETIME,
+                dt.Type.DATETIME2,
+                dt.Type.DATETIME64,
+                dt.Type.SMALLDATETIME,
+            ]
+        },
+        **{
+            typ: "timestamp" for typ in dt.TEMPORAL_TYPES
+            if typ in [
+                dt.Type.TIMESTAMP,
+                dt.Type.TIMESTAMPNTZ,
+                dt.Type.TIMESTAMPLTZ,
+                dt.Type.TIMESTAMPTZ,
+                dt.Type.TIMESTAMP_MS,
+                dt.Type.TIMESTAMP_NS,
+                dt.Type.TIMESTAMP_S,
+            ]
+        },
+        **{typ: "time" for typ in [dt.Type.TIME, dt.Type.TIMETZ]},
+    }  # type: ignore
+    # NOTE not rquired at the moment
+    # def to_db_integer_type(self, column: TColumnSchema, table: PreparedTableSchema = None) -> str:
+
+    # def to_db_datetime_type(self, column: TColumnSchema, table: PreparedTableSchema = None) -> str:
+
+    def from_destination_type(
+        self, db_type: DATA_TYPE, precision: Optional[int], scale: Optional[int]
+    ) -> TColumnType:
+        db_type = dt.build(db_type)
+        # NOTE can retrieve nullable from `db_type.arg_types["nullable"]`
+        return super().from_destination_type(db_type.this, precision, scale)
+
+    
+def create_sqlglot_schema(dataset: ReadableDBAPIDataset) -> SQLGlotSchema:
+    type_mapper = dataset._destination.capabilities().get_type_mapper()
+
+    mapping_schema = {}
+    for table_name, table in dataset.schema.tables.items():
+        if mapping_schema.get(table_name) is None:
+            mapping_schema[table_name] = {}
+
+        for column_name, column in table["columns"].items():  # type: ignore
+            mapping_schema[table_name][column_name] = type_mapper.to_destination_type(column, table)
+
+    # NOTE we can use either: {table: {col: type}} or {db: ...} or {catalog: {db: ...}}
+    # catalog_name = dataset.sql_client.catalog_name
+    # dataset_name = dataset.dataset_name
+    return ensure_schema(mapping_schema)
+
+
+def get_sqlglot_dialect(dataset: ReadableDBAPIDataset) -> str:
+    return dataset._destination.capabilities().sqlglot_dialect
+
+
+def compute_columns_schema(
+    sql_query: str,
+    sqlglot_schema: SQLGlotSchema,
+    dialect: str,
+    type_mapper: TypeMapperImpl,
+) -> TTableSchemaColumns:
+    expression = sqlglot.maybe_parse(sql_query, dialect=dialect)
+    assert isinstance(expression, sge.Select)
+
+    expression = qualify(expression, schema=sqlglot_schema, dialect=dialect)
+    expression = annotate_types(expression, schema=sqlglot_schema, dialect=dialect)
+
+    dlt_columns_schema: TTableSchemaColumns = {
+        str(column.output_name): type_mapper.from_destination_type(column.type, None, None)
+        for column in expression.selects
+    } # type: ignore
+
+    return dlt_columns_schema
+
+if __name__ == "__main__":
+    import dlt
+    from dlt.sources._single_file_templates.fruitshop_pipeline import fruitshop as fruitshop_source
+
+    # typical user code
+    pipeline = dlt.pipeline(pipeline_name="test_fruitshop", destination="duckdb", dev_mode=True)
+    pipeline.run(fruitshop_source())
+    dataset = pipeline.dataset(dataset_type="default")
+    # sql_query = dataset.customers.select("name", "city").query()
+    sql_query = "SELECT AVG(id) as mean_id, name, CAST(LEN(name) as DOUBLE) FROM customers"
+
+
+    dialect = get_sqlglot_dialect(dataset)
+    sqlglot_schema = create_sqlglot_schema(dataset)
+    dlt_types = compute_columns_schema(
+        sql_query,
+        sqlglot_schema,
+        dialect,
+        SQLGlotTypeMapper(dataset._destination.capabilities())
+    )
+    print()

--- a/dlt/transformations/lineage.py
+++ b/dlt/transformations/lineage.py
@@ -88,6 +88,8 @@ SQLGLOT_TO_DLT_TYPE_MAP: dict[DataType.Type, str] = {
     DataType.Type.TIMESTAMP_S: "timestamp",
     DataType.Type.TIME: "time",
     DataType.Type.TIMETZ: "time",
+    # binary
+    DataType.Type.VARBINARY: "binary",
     # BOOLEAN
     DataType.Type.BOOLEAN: "bool",
     # UKNOWN

--- a/dlt/transformations/lineage.py
+++ b/dlt/transformations/lineage.py
@@ -87,6 +87,8 @@ SQLGLOT_TO_DLT_TYPE_MAP: dict[DataType.Type, str] = {
     DataType.Type.TIMETZ: "time",
     # BOOLEAN
     DataType.Type.BOOLEAN: "bool",
+    # UKNOWN
+    DataType.Type.UNKNOWN: None,
 }
 
 
@@ -109,11 +111,13 @@ def to_sqlglot_type(
 
 
 def from_sqlglot_type(column: sge.Column) -> TColumnSchema:
-    return {
+    col = {
         "name": column.output_name,
-        "data_type": SQLGLOT_TO_DLT_TYPE_MAP[column.type.this],
-        **column.type.meta,  # type: ignore
+        **column.type.meta,
     }
+    if data_type := SQLGLOT_TO_DLT_TYPE_MAP[column.type.this]:
+        col["data_type"] = data_type
+    return cast(TColumnSchema, col)
 
 
 def create_sqlglot_schema(

--- a/dlt/transformations/lineage.py
+++ b/dlt/transformations/lineage.py
@@ -85,12 +85,17 @@ SQLGLOT_TO_DLT_TYPE_MAP: dict[DataType.Type, str] = {
     DataType.Type.TIMESTAMP_S: "timestamp",
     DataType.Type.TIME: "time",
     DataType.Type.TIMETZ: "time",
+    # BOOLEAN
+    DataType.Type.BOOLEAN: "bool",
 }
 
 
 def to_sqlglot_type(
     column: TColumnSchema, table: TTableSchema, type_mapper: DataTypeMapper, dialect: str
 ) -> DATA_TYPE:
+    if not column.get("data_type"):
+        return None
+
     destination_type = type_mapper.to_destination_type(column, cast(PreparedTableSchema, table))
     # TODO modify nullable arg_types on destination_type
     sqlglot_type = DataType.build(destination_type, dialect=dialect)
@@ -123,9 +128,8 @@ def create_sqlglot_schema(
             mapping_schema[table_name] = {}
 
         for column_name, column in table["columns"].items():
-            mapping_schema[table_name][column_name] = to_sqlglot_type(
-                column, table, type_mapper, dialect
-            )
+            if sqlglot_type := to_sqlglot_type(column, table, type_mapper, dialect):
+                mapping_schema[table_name][column_name] = sqlglot_type
 
     return ensure_schema(mapping_schema)
 

--- a/tests/destinations/test_readable_dbapi_dataset.py
+++ b/tests/destinations/test_readable_dbapi_dataset.py
@@ -100,7 +100,7 @@ def test_computed_schema_columns(dataset_type: TDatasetType) -> None:
     relation = dataset.items
 
     # no schema present
-    assert relation.columns_schema is None
+    assert relation.columns_schema == {}
 
     # we can select any columns because it can't be verified
     relation["one", "two"]
@@ -108,17 +108,27 @@ def test_computed_schema_columns(dataset_type: TDatasetType) -> None:
     # now add columns
     relation = dataset.items
     dataset.schema.tables["items"] = {
-        "columns": {"one": {"data_type": "text"}, "two": {"data_type": "json"}}
+        "columns": {
+            "one": {"data_type": "text", "name": "one"},
+            "two": {"data_type": "json", "name": "two"},
+        }
     }
 
     # computed columns are same as above
-    assert relation.columns_schema == {"one": {"data_type": "text"}, "two": {"data_type": "json"}}
+    assert relation.columns_schema == {
+        "one": {"data_type": "text", "name": "one"},
+        "two": {"data_type": "json", "name": "two"},
+    }
 
     # when selecting only one column, computing schema columns will only show that one
-    assert relation.select("one").columns_schema == {"one": {"data_type": "text"}}
+    assert relation.select("one").columns_schema == {"one": {"data_type": "text", "name": "one"}}
 
     # selecting unknown column fails
-    with pytest.raises(ReadableRelationUnknownColumnException):
+
+    # TODO: add correct exception
+    import sqlglot
+
+    with pytest.raises(sqlglot.errors.OptimizeError):
         relation["unknown_columns"]
 
 

--- a/tests/destinations/test_readable_dbapi_dataset.py
+++ b/tests/destinations/test_readable_dbapi_dataset.py
@@ -129,7 +129,7 @@ def test_computed_schema_columns(dataset_type: TDatasetType) -> None:
     import sqlglot
 
     with pytest.raises(sqlglot.errors.OptimizeError):
-        relation["unknown_columns"]
+        relation["unknown_columns"].compute_columns_schema()
 
 
 @pytest.mark.parametrize("dataset_type", ("default",))

--- a/tests/load/pipeline/test_snowflake_pipeline.py
+++ b/tests/load/pipeline/test_snowflake_pipeline.py
@@ -207,7 +207,8 @@ def test_char_replacement_cs_naming_convention(
     rel_ = pipeline.dataset()["AMLPerFornyelseoe"]
     results = rel_.fetchall()
     assert len(results) == 1
-    assert "AmlSistUtfoertDato" in rel_.columns_schema
+    # TODO: this is a bug in sqlglot, it should be retain casing
+    assert "amlsistutfoertdato" in rel_.columns_schema
 
 
 @pytest.mark.parametrize(

--- a/tests/load/test_lineage.py
+++ b/tests/load/test_lineage.py
@@ -56,11 +56,10 @@ def example_schema(autouse_test_storage) -> Schema:
 )
 def test_various_queries(destination_config: DestinationTestConfiguration, example_schema: Schema):
     # setup
-    destination = destination_config.destination_factory()
+    destination = destination_config.destination_factory(dataset_name="d1")
     dialect = destination.capabilities().sqlglot_dialect
-    DATASET_NAME = "d1"
     sqlglot_schema = lineage.create_sqlglot_schema(
-        DATASET_NAME,
+        destination.client(example_schema).sql_client,
         example_schema,
         dialect,
         destination.capabilities(),

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -577,7 +577,9 @@ def test_column_selection(populated_pipeline: Pipeline) -> None:
     assert arrow_table.schema.field("decimal").type.precision == expected_decimal_precision
     assert arrow_table.schema.field("other_decimal").type.precision == expected_decimal_precision_2
 
-    with pytest.raises(ReadableRelationUnknownColumnException):
+    import sqlglot
+
+    with pytest.raises(sqlglot.errors.OptimizeError):
         arrow_table = table_relationship.select("unknown_column").head().arrow()
 
 

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -702,7 +702,7 @@ def test_ibis_expression_relation(populated_pipeline: Pipeline) -> None:
             'SELECT "t0"."id", "t0"."decimal", "t0"."id" * 2 AS "new_col" FROM'
             ' "dataset"."items" AS "t0"'
         ),
-        None,
+        ["id", "decimal", "new_col"],
     )
 
     # mutating table (add a new column computed from existing columns)
@@ -710,13 +710,16 @@ def test_ibis_expression_relation(populated_pipeline: Pipeline) -> None:
         items_table.mutate(double_id=items_table.id * 2).select("id", "double_id")
     ) == (
         'SELECT "t0"."id", "t0"."id" * 2 AS "double_id" FROM "dataset"."items" AS "t0"',
-        None,
+        ["id", "double_id"],
     )
 
     # mutating table add new static column
     assert sql_from_expr(
         items_table.mutate(new_col=ibis.literal("static_value")).select("id", "new_col")
-    ) == ('SELECT "t0"."id", \'static_value\' AS "new_col" FROM "dataset"."items" AS "t0"', None)
+    ) == (
+        'SELECT "t0"."id", \'static_value\' AS "new_col" FROM "dataset"."items" AS "t0"',
+        ["id", "new_col"],
+    )
 
     # check filtering (preserves all columns)
     assert sql_from_expr(items_table.filter(items_table.id < 10)) == (
@@ -753,7 +756,7 @@ def test_ibis_expression_relation(populated_pipeline: Pipeline) -> None:
             ' COUNT(*) AS "CountStar(items)" FROM "dataset"."items" AS "t0" GROUP BY 1 ) AS "t1"'
             ' WHERE "t1"."CountStar(items)" >= 1000'
         ),
-        None,
+        ["id", "sum_id"],
     )
 
     # sorting and ordering
@@ -790,7 +793,7 @@ def test_ibis_expression_relation(populated_pipeline: Pipeline) -> None:
             'SELECT "t2"."id", "t3"."double_id" FROM "dataset"."items" AS "t2" INNER JOIN'
             ' "dataset"."double_items" AS "t3" ON "t2"."id" = "t3"."id"'
         ),
-        None,
+        ["id", "double_id"],
     )
 
     # subqueries
@@ -811,7 +814,7 @@ def test_ibis_expression_relation(populated_pipeline: Pipeline) -> None:
             ' "dataset"."items" AS "t0" GROUP BY 1 ) AS "t1" ORDER BY "t1"."decimal_count" DESC'
             " LIMIT 10"
         ),
-        None,
+        ["decimal", "decimal_count"],
     )
 
 

--- a/tests/pipeline/test_dlt_versions.py
+++ b/tests/pipeline/test_dlt_versions.py
@@ -548,6 +548,3 @@ def test_normalize_path_separator_legacy_behavior(test_storage: FileStorage) -> 
                     "_dlt_id",
                     "_dlt_load_id",
                 }
-                # datasets must be the same
-                data_ = pipeline.dataset().issues_2.select("issue_id", "id").fetchall()
-                print(data_)

--- a/tests/transformations/test_lineage.py
+++ b/tests/transformations/test_lineage.py
@@ -1,0 +1,32 @@
+import pytest
+
+import dlt
+from dlt.sources._single_file_templates.fruitshop_pipeline import (
+    fruitshop as fruitshop_source,
+)
+from dlt.transformations import lineage
+from tests.utils import autouse_test_storage
+
+
+@pytest.fixture
+def dataset(autouse_test_storage):
+    pipeline = dlt.pipeline(pipeline_name="test_fruitshop", destination="duckdb", dev_mode=True)
+    pipeline.run(fruitshop_source())
+    yield pipeline.dataset(dataset_type="default")
+
+
+def test_build_scope(dataset):
+    sql_query = "SELECT AVG(id) as mean_id, name, CAST(LEN(name) as DOUBLE) FROM customers"
+    expected_schema = {
+        "mean_id": {"name": "mean_id", "data_type": "double"},
+        "name": {"name": "name", "data_type": "text", "nullable": True},
+        "_col_2": {"name": "_col_2", "data_type": "double"},  # anonymous columns
+    }
+
+    dialect: str = dataset._destination.capabilities().sqlglot_dialect
+    sqlglot_schema = lineage.create_sqlglot_schema(dataset, dialect)
+    manual_schema = lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect)
+
+    relation_schema = dataset(sql_query).compute_columns_schema()
+
+    assert expected_schema == manual_schema == relation_schema

--- a/tests/transformations/test_lineage.py
+++ b/tests/transformations/test_lineage.py
@@ -1,32 +1,113 @@
 import pytest
 
-import dlt
+import sqlglot
+
+from dlt import Schema
 from dlt.sources._single_file_templates.fruitshop_pipeline import (
     fruitshop as fruitshop_source,
 )
 from dlt.transformations import lineage
 from tests.utils import autouse_test_storage
 
+from dlt.destinations import duckdb
+
 
 @pytest.fixture
-def dataset(autouse_test_storage):
-    pipeline = dlt.pipeline(pipeline_name="test_fruitshop", destination="duckdb", dev_mode=True)
-    pipeline.run(fruitshop_source())
-    yield pipeline.dataset(dataset_type="default")
+def example_schema(autouse_test_storage) -> Schema:
+    s = Schema("d1")
+    s.update_table(
+        {
+            "name": "customers",
+            "columns": {
+                "id": {"data_type": "bigint", "name": "id"},
+                "name": {  #  type: ignore[typeddict-unknown-key]
+                    "data_type": "text",
+                    "name": "name",
+                    "x-pii": True,
+                },
+                "email": {"data_type": "text", "name": "email", "nullable": True},
+            },
+        }
+    )
+    s.update_table(
+        {
+            "name": "orders",
+            "columns": {
+                "id": {"data_type": "bigint", "name": "id"},
+                "customer_id": {"data_type": "bigint", "name": "customer_id"},
+                "amount": {"data_type": "double", "name": "amount"},
+            },
+        }
+    )
+    return s
 
 
-def test_build_scope(dataset):
-    sql_query = "SELECT AVG(id) as mean_id, name, CAST(LEN(name) as DOUBLE) FROM customers"
-    expected_schema = {
-        "mean_id": {"name": "mean_id", "data_type": "double"},
-        "name": {"name": "name", "data_type": "text", "nullable": True},
-        "_col_2": {"name": "_col_2", "data_type": "double"},  # anonymous columns
+def test_various_queries(example_schema: Schema):
+    # setup
+    # TODO: run for all supported destinations
+    destination = duckdb(credentials=":memory:")
+    dialect = destination.capabilities().sqlglot_dialect
+    DATASET_NAME = "d1"
+    sqlglot_schema = lineage.create_sqlglot_schema(
+        DATASET_NAME,
+        example_schema,
+        dialect,
+        destination.capabilities().get_type_mapper(),
+    )
+
+    # test star select
+    sql_query = "SELECT * FROM customers"
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
+        "id": {"name": "id", "data_type": "bigint"},
+        "name": {"name": "name", "data_type": "text", "x-pii": True},
+        "email": {"name": "email", "data_type": "text", "nullable": True},
     }
 
-    dialect: str = dataset._destination.capabilities().sqlglot_dialect
-    sqlglot_schema = lineage.create_sqlglot_schema(dataset, dialect)
-    manual_schema = lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect)
+    # test select with fully qualified table and column names
+    sql_query = "SELECT d1.customers.id, d1.customers.name, d1.customers.email FROM d1.customers"
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
+        "id": {"name": "id", "data_type": "bigint"},
+        "name": {"name": "name", "data_type": "text", "x-pii": True},
+        "email": {"name": "email", "data_type": "text", "nullable": True},
+    }
 
-    relation_schema = dataset(sql_query).compute_columns_schema()
+    # test select with casting and avg
+    sql_query = "SELECT AVG(id) as mean_id, name, email, CAST(LEN(name) as DOUBLE) FROM customers"
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
+        "mean_id": {"name": "mean_id", "data_type": "double"},
+        "name": {"name": "name", "data_type": "text", "x-pii": True},
+        "email": {"name": "email", "data_type": "text", "nullable": True},
+        "_col_3": {"name": "_col_3", "data_type": "double"},  # anonymous columns
+    }
 
-    assert expected_schema == manual_schema == relation_schema
+    # test concat
+    sql_query = "SELECT CONCAT(name, email) as concat FROM customers"
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
+        "concat": {"name": "concat", "data_type": "text"},
+    }
+
+    # test join
+    sql_query = (
+        "SELECT customers.name, orders.amount FROM customers JOIN orders ON customers.id ="
+        " orders.customer_id"
+    )
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
+        "name": {"name": "name", "data_type": "text", "x-pii": True},
+        "amount": {"name": "amount", "data_type": "double"},
+    }
+
+    # test topk
+    sql_query = """
+        SELECT * FROM ( SELECT amount, COUNT(*) AS "count" FROM
+        orders GROUP BY 1 ) AS "t1" ORDER BY t1.count DESC
+        LIMIT 10
+    """
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
+        "count": {"name": "count", "data_type": "bigint"},
+        "amount": {"name": "amount", "data_type": "double"},
+    }
+
+    # test select unknown column
+    sql_query = "SELECT unknown_column FROM customers"
+    with pytest.raises(sqlglot.errors.OptimizeError):
+        lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb")

--- a/tests/transformations/test_lineage.py
+++ b/tests/transformations/test_lineage.py
@@ -56,7 +56,6 @@ def example_schema(autouse_test_storage) -> Schema:
 )
 def test_various_queries(destination_config: DestinationTestConfiguration, example_schema: Schema):
     # setup
-    # TODO: run for all supported destinations
     destination = destination_config.destination_factory()
     dialect = destination.capabilities().sqlglot_dialect
     DATASET_NAME = "d1"


### PR DESCRIPTION
This follows #2502 [WIP]

This uses SQLGlot's [built-in type annotation and propagation](https://github.com/tobymao/sqlglot/blob/17f7eaff564790b1fe7faa414143accf362f550e/sqlglot/optimizer/annotate_types.py#L135). Essentially it does:
1. Get the dlt schema associated with the dataset
2. Map dlt types to destination types
3. Create a SQLGlot schema using the destination types
4. Parse the query to SQL AST
5. Quality and type-annotate the AST
6. Collect the columns specified in the final SELECT clause
7. Convert the SELECT columns SQLGlot types back to dlt types 

## TODOs
- support joins between two separate datasets, this will probably require catching incoming tables in the args in the proxy and checking wether they are from another dataset, if so, extend the sqlglot schema.
- Ensure case sensitive columns keep their case in lineage, it seems this is not the case at the moment. check  NormalizationStrategy in sqlglot
- Snowflake lineage does not work properly, right now we use duckdb instead, because for example on star selects, snowflake lineage does not seem to know what to do
