### PR TITLE
use pendulum.parse instead of fromisoformat when deserializing pua json

### DIFF
--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -96,7 +96,8 @@ def _datetime_decoder(obj: str) -> datetime:
         # Backwards compatibility for data encoded with previous dlt version
         # fromisoformat does not support Z suffix (until py3.11)
         obj = obj[:-1] + "+00:00"
-    return pendulum.DateTime.fromisoformat(obj)
+    # TODO: should we check that this is in fact a datetime?
+    return pendulum.parse(obj)
 
 
 # define decoder for each prefix

--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -91,13 +91,16 @@ _TIME = chr(PUA_START + 7)
 PUA_START_UTF8_MAGIC = _DECIMAL.encode("utf-8")[:2]
 
 
-def _datetime_decoder(obj: str) -> datetime:
+def _datetime_decoder(obj: str) -> pendulum.DateTime:
     if obj.endswith("Z"):
         # Backwards compatibility for data encoded with previous dlt version
         # fromisoformat does not support Z suffix (until py3.11)
         obj = obj[:-1] + "+00:00"
-    # TODO: should we check that this is in fact a datetime?
-    return pendulum.parse(obj)
+    # tz=None sets no timezone if if it not specified on string
+    dt = pendulum.parse(obj, tz=None)
+    if not isinstance(dt, pendulum.DateTime):
+        raise ValueError(f"Expected pendulum.DateTime, got {type(dt)}")
+    return dt
 
 
 # define decoder for each prefix

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -1852,7 +1852,7 @@ def test_timezone_naive_datetime(item_type: TestDataItemFormat) -> None:
     # last value has timezone added
     last_value = resource.state["incremental"]["updated_at"]["last_value"]
     assert isinstance(last_value, pendulum.DateTime)
-    assert last_value.tzname() == "UTC"
+    assert last_value.tzname() == "+00:00"
     # try again with more records
     extract_info = pipeline.extract(some_data(max_hours=3))
     assert (


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

We have a bug, where the pua_decoder creates a `datetime` object from a json string which looses timezone information on `deepcopy` (repro script attached). This means every time we modify the pipeline state, all timezone informations of all datetime entries are dropped which leads to problems in incrementals. This PR fixes this at least for when pendulum is installed, there is a new test that verifies this too.

pendulum.DateTime.fromisoformat was used before, pendulum.parse is used now. You can see that during a deepcopy the isoformat parsed datetime object will loose its timezone.

```
some_vals = {
    "nested": {
        "parse": pendulum.parse('2024-01-01T00:00:00+00:00'),
        "isoformat": pendulum.DateTime.fromisoformat('2024-01-01T00:00:00+00:00')
    }
}

print(type(some_vals["nested"]["parse"]))
print(type(some_vals["nested"]["isoformat"]))

print(some_vals)
print(deepcopy(some_vals))
```
