### PR TITLE
docs: snowflake_plus: document `iceberg_mode` and `base_location` templating

### DIFF
--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -109,7 +109,7 @@ The `snowflake_plus` destination extends the standard Snowflake configuration wi
 
 | Option | Description | Required | Default |
 |--------|-------------|----------|---------|
-| `iceberg_mode` | Controls which tables are created as Iceberg tables. Possible values: <br> - `"none"`: No tables are created as Iceberg tables <br> - `"data_tables"`: Only data tables (non-dlt system tables) are created as Iceberg tables <br> - `"all"`: All tables including dlt system tables are created as Iceberg tables | No | `"none"` |
+| `iceberg_mode` | Controls which tables are created as Iceberg tables. Possible values: <ul><li>`"all"`: All tables including dlt system tables are created as Iceberg tables</li><li>`"data_tables"`: Only data tables (non-dlt system tables) are created as Iceberg tables</li><li>`"none"`: No tables are created as Iceberg tables</li></ul> | No | `"none"` |
 | `external_volume` | The external volume to store Iceberg metadata | Yes | None |
 | `catalog` | The catalog to use for Iceberg tables | No | `"SNOWFLAKE"` |
 | `base_location` | Template string for the base location where Iceberg data is stored in the external volume. Supports placeholders like `{dataset_name}` and `{table_name}`. | No | `"{dataset_name}/{table_name}"` |

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -153,7 +153,7 @@ When you provide a `base_location`, Snowflake uses it to create the paths where 
 STORAGE_BASE_URL/BASE_LOCATION.<randomId>/[data | metadata]/
 ```
 
-Where `<randomId>` is a random, Snowflake-generated 8-character string appended to create a unique directory.
+Where `<randomId>` is a random Snowflake-generated 8-character string appended to create a unique directory.
 
 For more details on how Snowflake organizes Iceberg table files in external storage, see the [Snowflake documentation on data and metadata directories](https://docs.snowflake.com/en/user-guide/tables-iceberg-storage#data-and-metadata-directories).
 

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -129,7 +129,7 @@ For more flexibility, you can also define custom placeholders using the `extra_p
 
 ### Examples
 
-1. Default pattern (if not specified, `{dataset_name}/{table_name}`) creates paths like `my_dataset/customers` in your external volume.
+1. The default pattern `{dataset_name}/{table_name}` creates paths like `my_dataset/customers` in your external volume.
 
 2. Custom static path:
    ```yaml

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -107,14 +107,39 @@ def my_iceberg_table():
 
 The `snowflake_plus` destination extends the standard Snowflake configuration with additional options:
 
-| Option | Description | Required | Default |
-|--------|-------------|----------|---------|
-| `iceberg_mode` | Controls which tables are created as Iceberg tables. Possible values: <ul><li>`"all"`: All tables including dlt system tables are created as Iceberg tables</li><li>`"data_tables"`: Only data tables (non-dlt system tables) are created as Iceberg tables</li><li>`"none"`: No tables are created as Iceberg tables</li></ul> | No | `"none"` |
-| `external_volume` | The external volume to store Iceberg metadata | Yes | None |
-| `catalog` | The catalog to use for Iceberg tables | No | `"SNOWFLAKE"` |
-| `base_location` | Template string for the base location where Iceberg data is stored in the external volume. Supports placeholders like `{dataset_name}` and `{table_name}`. | No | `"{dataset_name}/{table_name}"` |
-| `extra_placeholders` | Dictionary of additional values that can be used in the `base_location` template. The values can be static strings or functions that accept the dataset name and table name as arguments and return a string. | No | None |
-| `catalog_sync` | The name of a [catalog integration](https://docs.snowflake.com/en/user-guide/tables-iceberg#catalog-integration) for syncing Iceberg tables to an external catalog in [Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/overview) | No | None |
+### `iceberg_mode`
+Controls which tables are created as Iceberg tables.
+- Possible values:
+  - `"all"`: All tables including dlt system tables are created as Iceberg tables
+  - `"data_tables"`: Only data tables (non-dlt system tables) are created as Iceberg tables
+  - `"none"`: No tables are created as Iceberg tables
+- Required: No
+- Default: `"none"`
+
+### `external_volume`
+The external volume to store Iceberg metadata.
+- Required: Yes
+- Default: None
+
+### `catalog`
+The catalog to use for Iceberg tables.
+- Required: No
+- Default: `"SNOWFLAKE"`. This will use [Snowflake as the catalog](https://docs.snowflake.com/en/user-guide/tables-iceberg#label-tables-iceberg-snowflake-as-catalog) for the Iceberg tables.
+
+### `base_location`
+Template string for the base location where Iceberg data is stored in the external volume. Supports placeholders like `{dataset_name}` and `{table_name}`.
+- Required: No
+- Default: `"{dataset_name}/{table_name}"`
+
+### `extra_placeholders`
+Dictionary of additional values that can be used in the `base_location` template. The values can be static strings or functions that accept the dataset name and table name as arguments and return a string.
+- Required: No
+- Default: None
+
+### `catalog_sync`
+The name of a [catalog integration](https://docs.snowflake.com/en/user-guide/tables-iceberg#catalog-integration) for syncing Iceberg tables to an external catalog in [Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/overview).
+- Required: No
+- Default: None
 
 Configure these options in your `config.toml` file under the `[destination.snowflake]` section or in `dlt.yml` file under the `destinations.snowflake_plus` section.
 

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -129,11 +129,7 @@ For more flexibility, you can also define custom placeholders using the `extra_p
 
 ### Examples
 
-1. Default pattern (if not specified):
-   ```
-   {dataset_name}/{table_name}
-   ```
-   This creates paths like `my_dataset/customers` in your external volume.
+1. Default pattern (if not specified, `{dataset_name}/{table_name}`) creates paths like `my_dataset/customers` in your external volume.
 
 2. Custom static path:
    ```yaml
@@ -153,7 +149,7 @@ For more flexibility, you can also define custom placeholders using the `extra_p
 
 When you provide a `base_location`, Snowflake uses it to create the paths where data and metadata are stored in your external cloud storage. The actual directory structure Snowflake creates follows this pattern:
 
-```
+```text
 STORAGE_BASE_URL/BASE_LOCATION.<randomId>/[data | metadata]/
 ```
 

--- a/docs/website/docs/plus/ecosystem/snowflake_plus.md
+++ b/docs/website/docs/plus/ecosystem/snowflake_plus.md
@@ -9,11 +9,12 @@ keywords: [Snowflake, Iceberg, destination]
 Snowflake Plus is an **experimental** extension of the [Snowflake destination](../../dlt-ecosystem/destinations/snowflake.md) that adds [Apache Iceberg tables](https://docs.snowflake.com/en/user-guide/tables-iceberg) creation and related features.
 This destination is available starting from dlt+ version 0.9.0. It fully supports all the functionality of the standard Snowflake destination, plus:
 
-1. The ability to create Iceberg tables in Snowflake by setting `force_iceberg` to `true` in your `config.toml` file or `dlt.yml` file.
+1. The ability to create Iceberg tables in Snowflake by configuring `iceberg_mode` in your `config.toml` file or `dlt.yml` file.
 2. Additional configuration for Iceberg tables in Snowflake via:
    - `external_volume`: The external volume name where Iceberg data is stored.
    - `catalog`: The catalog name in which Iceberg tables are created. Defaults to `"SNOWFLAKE"`.
-   - `base_location`: The base path that Snowflake uses for storing the table. If omitted, the table name is used.
+   - `base_location`: A template string for the base path that Snowflake uses for storing the table data in external storage, supporting placeholders.
+   - `extra_placeholders`: Additional values that can be used in the `base_location` template.
    - `catalog_sync`: The name of a [catalog integration](https://docs.snowflake.com/en/user-guide/tables-iceberg#catalog-integration) configured for [Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/overview). If specified, Snowflake syncs Snowflake-managed Iceberg tables in the database with an external catalog in your Snowflake Open Catalog account.
 
 ## Installation
@@ -62,14 +63,14 @@ destinations:
     type: snowflake_plus
 ```
 
-To enable Iceberg table creation, set the `force_iceberg` option to `true` and `external_volume` to the name of the external volume you created in step 3.
+To enable Iceberg table creation, set the `iceberg_mode` option and `external_volume` to the name of the external volume you created in step 3.
 
 ```yaml
 destinations:
   snowflake:
     type: snowflake_plus
     external_volume: "<external_volume_name>"
-    force_iceberg: true
+    iceberg_mode: "all"
 ```
 
   </TabItem>
@@ -80,7 +81,7 @@ Add the configuration to your `config.toml` file:
 ```toml
 [destination.snowflake]
 external_volume = "<external_volume_name>"
-force_iceberg = true
+iceberg_mode = "all"
 ```
 
 Use the `snowflake_plus` destination in your pipeline:
@@ -102,20 +103,63 @@ def my_iceberg_table():
   </TabItem>
 </Tabs>
 
-
 ## Configuration
 
 The `snowflake_plus` destination extends the standard Snowflake configuration with additional options:
 
 | Option | Description | Required | Default |
 |--------|-------------|----------|---------|
-| `force_iceberg` | Whether to force the creation of Iceberg tables | No | `False` |
+| `iceberg_mode` | Controls which tables are created as Iceberg tables. Possible values: <br> - `"none"`: No tables are created as Iceberg tables <br> - `"data_tables"`: Only data tables (non-dlt system tables) are created as Iceberg tables <br> - `"all"`: All tables including dlt system tables are created as Iceberg tables | No | `"none"` |
 | `external_volume` | The external volume to store Iceberg metadata | Yes | None |
 | `catalog` | The catalog to use for Iceberg tables | No | `"SNOWFLAKE"` |
-| `base_location` | Custom base location for Iceberg data in the external volume | No | `<dataset_name>/<table_name>` |
+| `base_location` | Template string for the base location where Iceberg data is stored in the external volume. Supports placeholders like `{dataset_name}` and `{table_name}`. | No | `"{dataset_name}/{table_name}"` |
+| `extra_placeholders` | Dictionary of additional values that can be used in the `base_location` template. The values can be static strings or functions that accept the dataset name and table name as arguments and return a string. | No | None |
 | `catalog_sync` | The name of a [catalog integration](https://docs.snowflake.com/en/user-guide/tables-iceberg#catalog-integration) for syncing Iceberg tables to an external catalog in [Snowflake Open Catalog](https://other-docs.snowflake.com/en/opencatalog/overview) | No | None |
 
 Configure these options in your `config.toml` file under the `[destination.snowflake]` section or in `dlt.yml` file under the `destinations.snowflake_plus` section.
+
+## Base location templating
+
+The `base_location` parameter controls where Snowflake stores your Iceberg table data and metadata in the external volume. It's a template string that supports the following built-in placeholders:
+
+- `{dataset_name}`: The name of your dataset
+- `{table_name}`: The name of the table
+
+For more flexibility, you can also define custom placeholders using the `extra_placeholders` option.
+
+### Examples
+
+1. Default pattern (if not specified):
+   ```
+   {dataset_name}/{table_name}
+   ```
+   This creates paths like `my_dataset/customers` in your external volume.
+
+2. Custom static path:
+   ```yaml
+   base_location: "custom/static/path"
+   ```
+   This creates all tables in the same directory `custom/static/path`.
+
+3. Using custom placeholders:
+   ```yaml
+   base_location: "{env}/{dataset_name}/{table_name}"
+   extra_placeholders:
+     env: "prod"
+   ```
+   This creates paths like `prod/my_dataset/customers`.
+
+### How Snowflake uses the base location
+
+When you provide a `base_location`, Snowflake uses it to create the paths where data and metadata are stored in your external cloud storage. The actual directory structure Snowflake creates follows this pattern:
+
+```
+STORAGE_BASE_URL/BASE_LOCATION.<randomId>/[data | metadata]/
+```
+
+Where `<randomId>` is a random, Snowflake-generated 8-character string appended to create a unique directory.
+
+For more details on how Snowflake organizes Iceberg table files in external storage, see the [Snowflake documentation on data and metadata directories](https://docs.snowflake.com/en/user-guide/tables-iceberg-storage#data-and-metadata-directories).
 
 ## Write dispositions
 
@@ -137,7 +181,6 @@ The Snowflake Plus destination supports all standard Snowflake destination data 
 | `decimal` | `decimal` |
 | `binary` | `binary` |
 | `json` | `string` |
-
 
 ## Syncing Snowflake-managed Iceberg tables to Snowflake Open Catalog
 


### PR DESCRIPTION
### Description

- changed `force_iceberg` option to `iceberg_mode` (with `all`, `data_tables` and `none` values).
- document `base_location` templating and usage of `extra_placeholders` with some examples.
