### PR TITLE
feat: adds iceberg table properties configuration for athena (#2546)

### DIFF
--- a/dlt/destinations/impl/athena/configuration.py
+++ b/dlt/destinations/impl/athena/configuration.py
@@ -17,6 +17,7 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
     force_iceberg: Optional[bool] = None
     # possible placeholders: {dataset_name}, {table_name}, {location_tag}
     table_location_layout: Optional[str] = "{dataset_name}/{table_name}"
+    table_properties: Optional[Dict[str, str]] = None
 
     __config_gen_annotations__: ClassVar[List[str]] = ["athena_work_group", "aws_data_catalog"]
 

--- a/docs/website/docs/dlt-ecosystem/destinations/athena.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/athena.md
@@ -177,6 +177,11 @@ You can also force all tables to be in iceberg format:
 force_iceberg = true
 ```
 
+You can also adjust iceberg table properties:
+```toml
+[destination.athena.table_properties]
+vacuum_max_snapshot_age_seconds = 86400
+```
 
 #### `merge` support
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
* implemented custom table properties for AWS Athena destination
* updated documentation
* tested manually against my aws setup


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #2546 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
Allows to configure iceberg table properties for athena destination
```toml
[destination.athena.table_properties]
vacuum_max_snapshot_age_seconds = 86400
```

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
