### PR TITLE
make it easier to customize range paginator, and support sending via JSON body

### DIFF
--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -140,10 +140,7 @@ class RangePaginator(BasePaginator):
     def init_request(self, request: Request) -> None:
         self._has_next_page = True
         self.current_value = self.initial_value
-        if request.params is None:
-            request.params = {}
-
-        request.params[self.param_name] = self.current_value
+        self.update_request(request)
 
     def update_state(self, response: Response, data: Optional[List[Any]] = None) -> None:
         if self._stop_after_this_page(data):
@@ -389,10 +386,6 @@ class OffsetPaginator(RangePaginator):
         )
         self.limit_param = limit_param
         self.limit = limit
-
-    def init_request(self, request: Request) -> None:
-        super().init_request(request)
-        request.params[self.limit_param] = self.limit
 
     def update_request(self, request: Request) -> None:
         super().update_request(request)

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -98,7 +98,7 @@ class RangePaginator(BasePaginator):
         total_path: Optional[jsonpath.TJsonPath] = None,
         error_message_items: str = "items",
         stop_after_empty_page: Optional[bool] = True,
-        via_json_body: bool = False,
+        via_json_body: Optional[bool] = False,
     ):
         """
         Args:
@@ -253,7 +253,7 @@ class PageNumberPaginator(RangePaginator):
         total_path: Optional[jsonpath.TJsonPath] = "total",
         maximum_page: Optional[int] = None,
         stop_after_empty_page: Optional[bool] = True,
-        via_json_body: bool = False,
+        via_json_body: Optional[bool] = False,
     ):
         """
         Args:
@@ -364,7 +364,7 @@ class OffsetPaginator(RangePaginator):
         total_path: Optional[jsonpath.TJsonPath] = "total",
         maximum_offset: Optional[int] = None,
         stop_after_empty_page: Optional[bool] = True,
-        via_json_body: bool = False,
+        via_json_body: Optional[bool] = False,
     ) -> None:
         """
         Args:


### PR DESCRIPTION
I have an endpoint that uses `PagePaginator` but it's a `POST` API and I need to inject the value `{ 'page': page_num }` into the JSON payload.

The way I implement this is make a `CustomPageNumberPaginator` and override a single `update_request()`:
```py
def update_request(self, request: Request):
  super().update_request(request)
  request.json[self.param_name] = self.current_value
```

This works fine if I fix some of the redundant code in DLT's `RangePaginator` to get rid of duplications in `init_request` and `update_request`


For some endpoints that need POST, I also need the ability to send data via the JSON payload instead of query params, similar to this: https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/basic#via-json-body

I have a `POST .../search` endpoint that wants the page number to be in the payload, with something that looks like:
```
{
  query: ...,
  page: ...,
}
```
