### PR TITLE
do not write config.toml for dlt init

### DIFF
--- a/dlt/cli/init_command.py
+++ b/dlt/cli/init_command.py
@@ -738,12 +738,14 @@ def init_pipeline_at_destination(
         ):
             dest_storage.save(pipeline_script_target_path, dest_script_source)
 
-        # generate tomls with comments
+        # generate secret toml with comments
         secrets_prov = SecretsTomlProvider(settings_dir)
         write_values(secrets_prov._config_toml, required_secrets.values(), overwrite_existing=False)
 
+        # generate config.toml with runtime settings (log_level and dlthub_telemetry)
         config_prov = ConfigTomlProvider(settings_dir)
-        write_values(config_prov._config_toml, required_config.values(), overwrite_existing=False)
+        runtime_configs = {k: v for k, v in required_config.items() if k.startswith("runtime")}
+        write_values(config_prov._config_toml, runtime_configs.values(), overwrite_existing=False)
 
         # write toml files
         secrets_prov.write_toml()

--- a/tests/cli/test_init_command.py
+++ b/tests/cli/test_init_command.py
@@ -1,6 +1,7 @@
 import io
 from copy import deepcopy
 import hashlib
+import pathlib
 import os
 import contextlib
 from subprocess import CalledProcessError
@@ -248,6 +249,16 @@ def test_init_all_sources_together(repo_dir: str, project_files: FileStorage) ->
         assert secrets.get_value(source_name, type, None, "sources") is not None
         # must have index for this source
         assert files_ops.load_verified_sources_local_index(source_name) is not None
+    # no settings should be written to config.toml
+    config_content = pathlib.Path(
+        os.path.join(project_files.storage_path, ".dlt", CONFIG_TOML)
+    ).read_text(encoding="utf-8")
+    for source_name in source_candidates:
+        assert f"sources.{source_name}" not in config_content
+    assert "please set me up!" not in config_content
+    # but the default content is there
+    assert "dlthub_telemetry = true" in config_content
+
     # credentials for all destinations
     for destination_name in ["bigquery", "postgres", "redshift"]:
         assert secrets.get_value(destination_name, type, None, "destination") is not None


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
all example pipeline scripts added by `dlt init`  demonstrate how the imported sources are completely configured in the code, so there is no need to also write some values into the config.


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
- mentioned: https://github.com/dlt-hub/dlt/issues/2531#issuecomment-2825361442
