### PR TITLE
Fix: drop corresponding staging table when original table is dropped

### DIFF
--- a/dlt/load/utils.py
+++ b/dlt/load/utils.py
@@ -131,15 +131,17 @@ def init_client(
             )
         )
 
-        with job_client.with_staging_dataset():
-            _init_dataset_and_update_schema(
-                job_client,
-                expected_update,
-                staging_tables | {schema.version_table_name},  # keep only schema version
-                staging_tables,  # all eligible tables must be also truncated
-                staging_info=True,
-                drop_tables=drop_table_names,  # try to drop all the same tables on staging
-            )
+        # if there are tables to drop, we should also drop them in the staging dataset
+        if staging_tables or drop_table_names:
+            with job_client.with_staging_dataset():
+                _init_dataset_and_update_schema(
+                    job_client,
+                    expected_update,
+                    staging_tables | {schema.version_table_name},  # keep only schema version
+                    staging_tables,  # all eligible tables must be also truncated
+                    staging_info=True,
+                    drop_tables=drop_table_names,  # try to drop all the same tables on staging
+                )
 
     return applied_update
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR simply drops staging tables when the `drop_tables` function is called. Previously, the drop command didn't drop the staging tables, which was causing issues when the resource was being loaded with an updated schema.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #2534 

