### PR TITLE
Add clickhouse distributed (ON CLUSTER) support

### DIFF
--- a/dlt/destinations/impl/clickhouse/configuration.py
+++ b/dlt/destinations/impl/clickhouse/configuration.py
@@ -85,11 +85,23 @@ class ClickHouseClientConfiguration(DestinationClientDwhWithStagingConfiguration
     """Special table to mark dataset as existing"""
     staging_use_https: bool = True
     """Connect to the staging buckets via https"""
+    distributed_tables: bool = False
+    """Set to True if ClickHouse tables are distributed/shareded across multiple nodes, this will enable creating base and distributed tables."""
+    cluster: Optional[str] = None
+    """Cluster name for sharded tables. This is used in ON CLUSTER clause for sharded distributed tables"""
+    base_table_database_prefix: Optional[str] = None
+    """Prefix for the database name of the base table. This is used for sharded distributed tables."""
+    base_table_name_postfix: Optional[str] = None
+    """Postfix for the base table name. This is used for sharded distributed tables."""
 
     __config_gen_annotations__: ClassVar[List[str]] = [
         "dataset_table_separator",
         "dataset_sentinel_table_name",
         "table_engine_type",
+        "distributed_tables",
+        "cluster",
+        "base_table_name_postfix",
+        "base_table_database_prefix",
     ]
 
     def fingerprint(self) -> str:

--- a/dlt/destinations/impl/clickhouse/sql_client.py
+++ b/dlt/destinations/impl/clickhouse/sql_client.py
@@ -410,7 +410,7 @@ class ClickHouseSqlClient(
 
     def _get_information_schema_components(self, *tables: str) -> Tuple[str, str, List[str]]:
         components = super()._get_information_schema_components(*tables)
-        # clickhouse has a catalogue and no schema but uses catalogue as a schema to query the information schema ­Ъци
+        # clickhouse has a catalogue and no schema but uses catalogue as a schema to query the information schema ­🤷
         # so we must disable catalogue search. also note that table name is prefixed with logical "dataset_name"
         return (None, components[0], components[2])
 


### PR DESCRIPTION

### Description
When Clickhouse is setup with replicas and distributed tables, DDL & DML statements need to be modified:
* ON CLUSTER needs to added after the table name
* A pair of base table and a distributed table needs to be created
* ALTER and DROP need to be executed for both tables, base and distributed
* Deletes need to be done on the base table
* Add GLOBAL to all joins as we can't know which do not needed

This was achieved by adding additional configuration parameters for Clickhouse and modifying queries in the execute_query function in the sql_client file.
This way we didn't change any core dlt functionality and all changes are restricted only to clickhouse destination and only in a single function.
And for Clickhouse changes will be applied only if the configuration is set for the distributed Clickhouse setup

To test the changes Clickhouse with a few replicated nodes is needed.

### Related Issues

- Resolves [2200 Cluster support for Clickhouse](https://github.com/dlt-hub/dlt/issues/2200)

### Additional Context
