### PR TITLE
Experiment: Test disable dropping of datasets in tests

### DIFF
--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -753,19 +753,18 @@ def drop_pipeline(request, preserve_environ) -> Iterator[None]:
 
 def drop_pipeline_data(p: dlt.Pipeline) -> None:
     """Drops all the datasets for a given pipeline"""
+    return
 
     def _drop_dataset(schema_name: str) -> None:
         with p.destination_client(schema_name) as client:
             try:
                 client.drop_storage()
-                print("dropped")
             except Exception as exc:
                 print(exc)
             if isinstance(client, WithStagingDataset):
                 with client.with_staging_dataset():
                     try:
                         client.drop_storage()
-                        print("staging dropped")
                     except Exception as exc:
                         print(exc)
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This is an experiment to see if we can save CI time by not dropping datasets in a pytest fixtures but maybe in a nightly workflow run. These nightly runs would not be concurrent but only run once, so they could also be executed from some github runner on a small DO droplet to note waste CI minutes.

Things to check:

* Execution time (Athena w/o iceberg is at around 70-80 minutes for essential tests, with iceberg around 170 minutes)
* Test collissions. It is conceivable that some tests use the same dataset name without dev mode and we see collissions, so if tests fail, investigate!