### PR TITLE
Speedup CI: Cache google secrets

### DIFF
--- a/tests/helpers/providers/test_google_secrets_provider.py
+++ b/tests/helpers/providers/test_google_secrets_provider.py
@@ -1,4 +1,7 @@
 from dlt import TSecretValue
+
+import pytest
+
 from dlt.common.configuration.specs import GcpServiceAccountCredentials
 from dlt.common.configuration.providers.google_secrets import GoogleSecretsProvider
 from dlt.common.configuration.accessors import secrets
@@ -22,6 +25,7 @@ project_id = "mock-credentials"
 """
 
 
+@pytest.mark.no_google_secrets_patch
 def test_regular_keys() -> None:
     init_test_logging()
     # copy bigquery credentials into providers credentials


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR aims to speed up CI runs by caching google secrets. Previously google secrets was hit about 15 times per test, this patches the secrets provider to cache the first hit during the entire pytest session which works for our specific use case. Exemptions from this patch for the tests for the Provider are included.