### PR TITLE
feat: add dbt seed and snapshot methods to runner.py

### DIFF
--- a/dlt/helpers/dbt/runner.py
+++ b/dlt/helpers/dbt/runner.py
@@ -215,6 +215,57 @@ with exec_to_stdout(f):
             "test", cmd_params, self._get_package_vars(additional_vars, destination_dataset_name)
         )
 
+    def seed(
+        self,
+        cmd_params: Sequence[str] = None,
+        additional_vars: StrAny = None,
+        destination_dataset_name: str = None,
+    ) -> Sequence[DBTNodeResult]:
+        """Seeds `dbt` package
+
+        Executes `dbt seed` on previously cloned package.
+
+        Args:
+            run_params (Sequence[str], optional): Additional parameters to `seed` command ie. seed selectors`.
+            additional_vars (StrAny, optional): Additional jinja variables to be passed to the package. Defaults to None.
+            destination_dataset_name (str, optional): Overwrites the dbt schema where seeds will be created. Defaults to None.
+
+        Returns:
+            Sequence[DBTNodeResult]: A list of executed seeds with names, statuses, execution messages and execution times
+
+        Exceptions:
+            DBTProcessingError: `seed` command failed. Contains a list of models with their execution statuses and error messages
+        """
+        return self._run_dbt_command(
+            "seed", cmd_params, self._get_package_vars(additional_vars, destination_dataset_name)
+        )
+
+    def snapshot(
+        self,
+        cmd_params: Sequence[str] = None,
+        additional_vars: StrAny = None,
+        destination_dataset_name: str = None,
+    ) -> Sequence[DBTNodeResult]:
+        """Snapshots `dbt` package
+
+        Executes `dbt snapshot` on previously cloned package.
+
+        Args:
+            run_params (Sequence[str], optional): Additional parameters to `snapshot` command ie. snapshot selectors`.
+            additional_vars (StrAny, optional): Additional jinja variables to be passed to the package. Defaults to None.
+            destination_dataset_name (str, optional): Overwrites the dbt schema where snapshots will be created. Defaults to None.
+
+        Returns:
+            Sequence[DBTNodeResult]: A list of executed snapshots with names, statuses, execution messages and execution times
+
+        Exceptions:
+            DBTProcessingError: `snapshot` command failed. Contains a list of models with their execution statuses and error messages
+        """
+        return self._run_dbt_command(
+            "snapshot", cmd_params, self._get_package_vars(additional_vars, destination_dataset_name)
+        )
+
+
     def _run_db_steps(
         self, run_params: Sequence[str], package_vars: StrAny, source_tests_selector: str
     ) -> Sequence[DBTNodeResult]:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This pull request adds two new methods, `seed` and `snapshot`, to the `DBTRunner` class in `dlt/helpers/dbt/runner.py`. These methods provide functionality for executing `dbt seed` and `dbt snapshot` commands, respectively, on previously cloned `dbt` packages.


#### New `dbt` Command Methods:

* **`seed` Method**:
  - Executes the `dbt seed` command to populate the database with seed data.
  - Accepts parameters for additional command options, Jinja variables, and an optional schema override for seed creation.
  - Returns a list of executed seeds with details such as names, statuses, execution messages, and times.
  - Raises a `DBTProcessingError` if the `seed` command fails.

* **`snapshot` Method**:
  - Executes the `dbt snapshot` command to create snapshots of data models.
  - Accepts parameters for additional command options, Jinja variables, and an optional schema override for snapshot creation.
  - Returns a list of executed snapshots with details such as names, statuses, execution messages, and times.
  - Raises a `DBTProcessingError` if the `snapshot` command fails.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues


<!--
Provide any additional context about the PR here.
-->
### Additional Context

- Implemented `seed` method to execute `dbt seed` command with appropriate parameters and error handling.
- Implemented `snapshot` method to execute `dbt snapshot` command with appropriate parameters and error handling.
- Enhanced documentation for both methods, detailing arguments, return types, and exceptions.
