### PR TITLE
Add linter step to prevent large files being merged

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,13 @@ jobs:
           path: .venv
           key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
+      - name: Check filesizes
+        uses: ppremk/lfs-warning@v3.2
+        with:
+          filesizelimit: 50000
+          exclusionPatterns: |
+            **/*.py
+
       - name: Install dependencies
         # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --all-extras --with airflow,providers,pipeline,sentry-sdk,dbt


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR adds a linter step for checking that no files above 50k bytes are committed, python files may be larger.