### PR TITLE
feat: 2540 - incremental datasets

### DIFF
--- a/dlt/common/libs/sqlglot.py
+++ b/dlt/common/libs/sqlglot.py
@@ -428,7 +428,7 @@ def _filter_dlt_hints(hints: TColumnSchema) -> TColumnSchema:
         # those are directly expressed via the DataType and Column
         if k in DATA_TYPE_HINTS:
             continue
-        
+
         if k in ALLOWED_HINTS:
             final_hints[k] = v
         elif k.startswith(CUSTOM_HINT_PREFIX):

--- a/dlt/destinations/dataset/dataset.py
+++ b/dlt/destinations/dataset/dataset.py
@@ -1,13 +1,18 @@
-from types import TracebackType, MethodType
-from typing import Any, Type, Union, TYPE_CHECKING, List
+from types import TracebackType
+from typing import Any, Type, Union, TYPE_CHECKING, List, Sequence, Set, Optional
 
+from sqlglot import Schema as SQLGlotSchema
 import sqlglot.expressions as sge
 
 from dlt.common.destination.exceptions import OpenTableClientNotAvailable
 from dlt.common.json import json
 from dlt.common.exceptions import MissingDependencyException
 from dlt.common.destination.reference import TDestinationReferenceArg, Destination
-from dlt.common.destination.client import JobClientBase, SupportsOpenTables, WithStateSync
+from dlt.common.destination.client import (
+    JobClientBase,
+    SupportsOpenTables,
+    WithStateSync,
+)
 from dlt.common.destination.dataset import (
     SupportsReadableRelation,
     SupportsReadableDataset,
@@ -15,16 +20,171 @@ from dlt.common.destination.dataset import (
 from dlt.common.destination.typing import TDatasetType
 from dlt.common.schema import Schema
 from dlt.common.typing import Self
+from dlt.common.exceptions import DltException
+from dlt.common.schema.utils import (
+    get_root_table,
+    get_first_column_name_with_prop,
+    is_nested_table,
+)
 
+from dlt.common.schema.typing import C_DLT_LOAD_ID
+from dlt.transformations import lineage
 from dlt.destinations.sql_client import SqlClientBase, WithSqlClient
 from dlt.destinations.dataset.ibis_relation import ReadableIbisRelation
-from dlt.destinations.dataset.relation import ReadableDBAPIRelation, BaseReadableDBAPIRelation
+from dlt.destinations.dataset.relation import (
+    ReadableDBAPIRelation,
+    BaseReadableDBAPIRelation,
+)
 from dlt.destinations.dataset.utils import get_destination_clients
 
 if TYPE_CHECKING:
     from dlt.helpers.ibis import BaseBackend as IbisBackend
 else:
     IbisBackend = Any
+
+
+# TODO this constant should probably live elsewhere
+LOAD_ID_COL_ON_LOADS_TABLE = "load_id"
+
+
+def _filter_by_status(query: sge.Select, *, status: Union[int, Sequence[int], None]) -> sge.Select:
+    """Add `status` filter to a SGLGlot Select expression."""
+    if isinstance(status, int):
+        query = query.where(sge.to_identifier("status").eq(status))
+    elif isinstance(status, Sequence):
+        if len(status) < 1:
+            raise DltException(
+                f"Invalid argument `status`. Reason: `len(status) < 1`. Received `{status}`"
+            )
+        elif not all(isinstance(s, int) for s in status):
+            raise DltException(
+                f"Invalid argument `status`. Reason: not all values are `int`. Received `{status}`"
+            )
+        query = query.where(sge.to_identifier("status").isin(*status))
+    elif status is not None:
+        raise DltException(
+            f"The `status` argument should be `int`, `Sequence[int]` or `None`. Received `{status}`"
+        )
+    return query
+
+
+# TODO use @overload to type hint valid signatures
+def _filter_min_max(
+    query: sge.Select,
+    *,
+    lt: Optional[Any] = None,
+    le: Optional[Any] = None,
+    gt: Optional[Any] = None,
+    ge: Optional[Any] = None,
+) -> sge.Select:
+    # TODO add exception handling to catch invalid user input (e.g., `le < ge`)
+    if ge is not None and gt is not None:
+        raise ValueError()
+
+    if le is not None and lt is not None:
+        raise ValueError()
+
+    load_id_col = sge.to_identifier(LOAD_ID_COL_ON_LOADS_TABLE)
+    conditions = []
+
+    # between is a special condition: (ge, le)
+    if ge is not None and le is not None:
+        cond = load_id_col.between(low=ge, high=le)
+        conditions.append(cond)
+    else:
+        # 8 - 1 combinations: (gt,), (ge,), (lt,), (le,), (gt, lt), (gt, le), (ge, lt); and between() == (ge, le)
+        if ge is not None or gt is not None:
+            cond = load_id_col >= ge if ge is not None else load_id_col > gt
+            conditions.append(cond)
+
+        if le is not None or lt is not None:
+            cond = load_id_col <= le if le is not None else load_id_col < lt
+            conditions.append(cond)
+
+    query = query.where(*conditions)
+    return query
+
+
+def _set_limit(query: sge.Select, *, limit: Optional[int]) -> sge.Select:
+    if isinstance(limit, int):
+        if limit < 1:
+            raise DltException(f"Invalid argument `limit`. Reason: `limit < 1`. Received `{limit}`")
+        query = query.limit(limit)
+    elif limit is not None:
+        raise DltException(f"The `limit` argument should be `int` or `None`. Received `{limit}`")
+    return query
+
+
+# TODO use @overload to document valid signature
+# for example, passing min, max, and limit is ambiguous and shouldn't be possible
+def _list_load_ids_expr(
+    loads_table_name: str = "_dlt_loads",
+    lt: Optional[Any] = None,
+    le: Optional[Any] = None,
+    gt: Optional[Any] = None,
+    ge: Optional[Any] = None,
+    status: Union[int, Sequence[int], None] = None,
+    limit: Optional[int] = None,
+) -> sge.Select:
+    query = (
+        sge.select(sge.to_identifier(LOAD_ID_COL_ON_LOADS_TABLE))
+        .from_(loads_table_name)
+        .order_by(f"{LOAD_ID_COL_ON_LOADS_TABLE} DESC")
+    )
+    query = _filter_by_status(query, status=status)
+    query = _filter_min_max(query, lt=lt, le=le, gt=gt, ge=ge)
+    query = _set_limit(query, limit=limit)
+    return query
+
+
+def _latest_load_id_expr(
+    loads_table_name: str = "_dlt_loads", status: Union[int, Sequence[int], None] = None
+) -> sge.Select:
+    query = sge.select(
+        sge.func("max", sge.to_identifier(LOAD_ID_COL_ON_LOADS_TABLE)).as_(
+            LOAD_ID_COL_ON_LOADS_TABLE
+        )
+    ).from_(loads_table_name)
+    query = _filter_by_status(query, status=status)
+    return query
+
+
+def _filter_root_table_expr(
+    table_name: str,
+    load_ids: Union[Sequence[str], Set[str]],
+) -> sge.Select:
+    query = sge.select("*").from_(sge.to_identifier(table_name))
+
+    # nullable means it's an empty collection; this will match no rows; we return an empty set
+    if not load_ids:
+        query = query.where("1 = 0")
+    else:
+        query = query.where(sge.to_identifier(C_DLT_LOAD_ID).isin(*load_ids))
+
+    return query
+
+
+def _filter_child_table_expr(
+    table_name: str,
+    table_root_key: str,
+    root_table_name: str,
+    root_table_row_key: str,
+    load_ids: Union[Sequence[str], Set[str]],
+) -> sge.Select:
+    root_table_expr = _filter_root_table_expr(table_name=root_table_name, load_ids=load_ids)
+    root_alias = f"{root_table_name}_filtered"
+    join_condition = f"{table_name}.{table_root_key} = {root_alias}.{root_table_row_key}"
+    query = (
+        sge.select(f"{table_name}.*")
+        .from_(sge.to_identifier(table_name))
+        .join(
+            root_table_expr,
+            on=join_condition,
+            join_type="inner",
+            join_alias=root_alias,
+        )
+    )
+    return query
 
 
 class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
@@ -37,12 +197,14 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
         schema: Union[Schema, str, None] = None,
         dataset_type: TDatasetType = "auto",
     ) -> None:
+        self._destination_reference_arg = destination
         self._destination = Destination.from_reference(destination)
         self._provided_schema = schema
         self._dataset_name = dataset_name
         self._sql_client: SqlClientBase[Any] = None
         self._table_client: SupportsOpenTables = None
         self._schema: Schema = None
+        self._load_ids: Optional[set[str]] = None
         # resolve dataset type
         if dataset_type in ("auto", "ibis"):
             try:
@@ -71,6 +233,10 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
         if not self._schema:
             self._ensure_client_and_schema()
         return self._schema
+
+    @property
+    def sqlglot_schema(self) -> SQLGlotSchema:
+        return lineage.create_sqlglot_schema(self.schema)
 
     @property
     def dataset_name(self) -> str:
@@ -111,7 +277,9 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
 
     def _destination_client(self, schema: Schema) -> JobClientBase:
         return get_destination_clients(
-            schema, destination=self._destination, destination_dataset_name=self._dataset_name
+            schema,
+            destination=self._destination,
+            destination_dataset_name=self._dataset_name,
         )[0]
 
     def _ensure_client_and_schema(self) -> None:
@@ -158,7 +326,9 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
 
     def __call__(self, query: Any) -> ReadableDBAPIRelation:
         # TODO: accept other query types and return a right relation: sqlglot (DBAPI) and ibis (Expr)
-        return ReadableDBAPIRelation(readable_dataset=self, provided_query=query)
+        return ReadableDBAPIRelation(
+            readable_dataset=self, provided_query=query, load_ids=self._load_ids
+        )
 
     def table(self, table_name: str) -> ReadableIbisRelation:
         # we can create an ibis powered relation if ibis is available
@@ -172,18 +342,126 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
                 readable_dataset=self,
                 ibis_object=unbound_table,
             )
+            return relation
 
-        else:
+        # no selection should return all rows
+        if self._load_ids is None:
             # fallback to the standard dbapi relation
-            relation = ReadableDBAPIRelation(
+            return ReadableDBAPIRelation(
                 readable_dataset=self,
                 table_name=table_name,
+            )  # type: ignore[return-value]
+
+        table_schema = self.schema.tables[table_name]
+        # case 1: table is root
+        if not is_nested_table(table_schema):
+            filtered_table = _filter_root_table_expr(table_name=table_name, load_ids=self._load_ids)
+            # TODO modify ReadableDBAPIRelation to take this filtered table as CTE
+            # TODO in the relation, "table_name" refers to the filtered table instead of full table
+        else:
+            root_key = get_first_column_name_with_prop(table_schema, column_prop="root_key")
+            # unsupported case: table is child / not root, but doesn't have `root_key`
+            # could be implemented by traversing parent-row keys to join nested tables
+            # TODO could return the full table if incremental fails instead of raising
+            if root_key is None:
+                raise DltException(
+                    f"No `root_key` found for child table `{table_name}`. To use incremental"
+                    " selection, set `root_key=True` on the source or use"
+                    " `write_disposition='merge'"
+                )
+
+            # case 2: table is child / not root; use `root_key` to join
+            root_table_schema = get_root_table(tables=self.schema.tables, table_name=table_name)
+            root_table_name: str = root_table_schema["name"]
+            root_table_row_key: str = get_first_column_name_with_prop(
+                root_table_schema, column_prop="row_key"
             )
 
-        return relation  # type: ignore[return-value]
+            filtered_table = _filter_child_table_expr(
+                table_name=table_name,
+                table_root_key=root_key,
+                root_table_name=root_table_name,
+                root_table_row_key=root_table_row_key,
+                load_ids=self._load_ids,
+            )
+
+        return ReadableDBAPIRelation(
+            readable_dataset=self, provided_query=filtered_table
+        )  # type: ignore[return-value]
+
+    def incremental(
+        self,
+        *,
+        lt: Optional[Any] = None,
+        le: Optional[Any] = None,
+        gt: Optional[Any] = None,
+        ge: Optional[Any] = None,
+        overwrite: bool = False,
+    ) -> Self:
+        if self._load_ids is not None and overwrite is False:
+            raise DltException(
+                "The method `.incremental()` was previously called and selected `load_ids` for"
+                " dataset. Use `.incremental(overwrite=True)` to update the incremental selection."
+            )
+
+        if all(arg is None for arg in [lt, le, gt, ge]):
+            raise DltException(
+                "The method `.incremental()` was called without arguments. "
+                "Pass at least one argument for `lt`, `le`, `gt`, `ge` with `_dlt_load_id` values."
+            )
+
+        load_id_query = _list_load_ids_expr(
+            loads_table_name=self.schema.loads_table_name,
+            lt=lt,
+            le=le,
+            gt=gt,
+            ge=ge,
+        )
+        # TODO vectorize this operation if we can assume pyarrow
+        self._load_ids = set([row[0] for row in self(load_id_query).fetchall()])
+        return self
+
+    def list_load_ids(
+        self,
+        *,
+        lt: Optional[Any] = None,
+        le: Optional[Any] = None,
+        gt: Optional[Any] = None,
+        ge: Optional[Any] = None,
+        status: Union[int, Sequence[int], None] = None,
+        limit: Optional[int] = None,
+    ) -> "ReadableDBAPIRelation":
+        """Get the list of load id in descending order (from recent to old). This operation is eager"""
+        query_expr = _list_load_ids_expr(
+            loads_table_name=self.schema.loads_table_name,
+            lt=lt,
+            le=le,
+            gt=gt,
+            ge=ge,
+            status=status,
+            limit=limit,
+        )
+        return ReadableDBAPIRelation(readable_dataset=self, provided_query=query_expr.sql())
+
+    def latest_load_id(
+        self, *, status: Union[int, Sequence[int], None] = None
+    ) -> ReadableDBAPIRelation:
+        """Get the latest load id. This operation is eager.
+
+        This is equivalent to `.list_load_ids(limit=1)` but returns a single value instead of
+        a tuple. The implementation also includes performance improvements on larger datasets.
+        """
+        query_expr = _latest_load_id_expr(
+            loads_table_name=self.schema.loads_table_name, status=status
+        )
+        return ReadableDBAPIRelation(readable_dataset=self, provided_query=query_expr.sql())
 
     def row_counts(
-        self, *, data_tables: bool = True, dlt_tables: bool = False, table_names: List[str] = None
+        self,
+        *,
+        data_tables: bool = True,
+        dlt_tables: bool = False,
+        table_names: List[str] = None,
     ) -> SupportsReadableRelation:
         """Returns a dictionary of table names and their row counts, returns counts of all data tables by default"""
         """If table_names is provided, only the tables in the list are returned regardless of the data_tables and dlt_tables flags"""
@@ -247,7 +525,10 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
         return self
 
     def __exit__(
-        self, exc_type: Type[BaseException], exc_val: BaseException, exc_tb: TracebackType
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
     ) -> None:
         self.sql_client.close_connection()
         self._sql_client = None

--- a/tests/datasets/test_incremental.py
+++ b/tests/datasets/test_incremental.py
@@ -1,0 +1,431 @@
+from typing import Union, Generator
+
+import pytest
+import duckdb
+from sqlglot.executor import execute
+
+import dlt
+from dlt.destinations import duckdb as duckdb_dest
+from dlt.common.exceptions import DltException
+from dlt.common.schema.typing import C_DLT_LOAD_ID
+from dlt.destinations.dataset.dataset import (
+    ReadableDBAPIDataset,
+    LOAD_ID_COL_ON_LOADS_TABLE,
+    _list_load_ids_expr,
+    _latest_load_id_expr,
+    _filter_min_max,
+    _filter_root_table_expr,
+    _filter_child_table_expr,
+)
+
+
+DATASET_NAME = "dataset_foo"
+
+DLT_LOAD_TABLE_NAME = "_dlt_loads"
+DLT_LOADS_ROWS = [
+    {LOAD_ID_COL_ON_LOADS_TABLE: "foo", "status": 0},
+    {LOAD_ID_COL_ON_LOADS_TABLE: "bar", "status": 0},
+    {LOAD_ID_COL_ON_LOADS_TABLE: "baz", "status": 1},
+]
+
+ROOT_TABLE_NAME = "orders"
+ROW_KEY = "_dlt_id"
+ROOT_TABLE_ROWS = [
+    {"value": 0, ROW_KEY: "abc", C_DLT_LOAD_ID: "foo"},
+    {"value": 1, ROW_KEY: "def", C_DLT_LOAD_ID: "foo"},
+    {"value": 2, ROW_KEY: "ghi", C_DLT_LOAD_ID: "bar"},
+    {"value": 3, ROW_KEY: "jkl", C_DLT_LOAD_ID: "baz"},
+]
+
+CHILD_TABLE_NAME = "items"
+ROOT_KEY = "_dlt_root_key"
+CHILD_TABLE_ROWS = [
+    {"value": 0.0, ROW_KEY: "ZYX", ROOT_KEY: "abc"},
+    {"value": 1.0, ROW_KEY: "WVU", ROOT_KEY: "abc"},
+    {"value": 2.0, ROW_KEY: "TSR", ROOT_KEY: "ghi"},
+]
+
+# TODO simplify this by efficiently generating that schema
+MOCK_SCHEMA_DICT = {
+    "version": 2,
+    "engine_version": 11,
+    "previous_hashes": [],
+    "version_hash": "abc",
+    "normalizers": {
+        "names": "snake_case",
+        "json": {"module": "dlt.common.normalizers.json.relational"},
+    },
+    "name": DATASET_NAME,
+    "tables": {
+        DLT_LOAD_TABLE_NAME: {
+            "name": DLT_LOAD_TABLE_NAME,
+            "columns": {
+                LOAD_ID_COL_ON_LOADS_TABLE: {
+                    "name": LOAD_ID_COL_ON_LOADS_TABLE,
+                    "data_type": "text",
+                },
+                "status": {"name": "status", "data_type": "bigint"},
+            },
+        },
+        ROOT_TABLE_NAME: {
+            "name": ROOT_TABLE_NAME,
+            "columns": {
+                "value": {"name": "value", "data_type": "bigint"},
+                ROW_KEY: {"name": ROW_KEY, "row_key": True, "data_type": "text"},
+                C_DLT_LOAD_ID: {"name": C_DLT_LOAD_ID, "data_type": "text"},
+            },
+        },
+        CHILD_TABLE_NAME: {
+            "name": CHILD_TABLE_NAME,
+            "columns": {
+                "value": {"name": "value", "data_type": "bigint"},
+                ROW_KEY: {"name": ROW_KEY, "row_key": True, "data_type": "text"},
+                ROOT_KEY: {"name": ROOT_KEY, "root_key": True, "data_type": "text"},
+            },
+            "parent": ROOT_TABLE_NAME,
+        },
+        "_dlt_version": {"columns": {}},
+    },
+}
+
+
+# TODO could improve test speed my reusing connection across stateless tests
+@pytest.fixture(scope="function")
+def dataset() -> Generator[ReadableDBAPIDataset, None, None]:
+    duckdb_con = duckdb.connect(":memory:")
+
+    duckdb_con.execute(f"CREATE SCHEMA IF NOT EXISTS {DATASET_NAME}")
+
+    # loads table
+    duckdb_con.execute(
+        f"CREATE TABLE {DATASET_NAME}.{DLT_LOAD_TABLE_NAME} ({LOAD_ID_COL_ON_LOADS_TABLE} TEXT,"
+        " status INT)"
+    )
+    duckdb_con.executemany(
+        query=(
+            f"INSERT INTO {DATASET_NAME}.{DLT_LOAD_TABLE_NAME} ({LOAD_ID_COL_ON_LOADS_TABLE},"
+            " status) VALUES (?, ?)"
+        ),
+        parameters=[tuple(r.values()) for r in DLT_LOADS_ROWS],
+    )
+
+    # root table
+    duckdb_con.execute(
+        f"CREATE TABLE {DATASET_NAME}.{ROOT_TABLE_NAME} (value INT, {ROW_KEY} TEXT,"
+        f" {C_DLT_LOAD_ID} TEXT)"
+    )
+    duckdb_con.executemany(
+        query=(
+            f"INSERT INTO {DATASET_NAME}.{ROOT_TABLE_NAME} (value, {ROW_KEY}, {C_DLT_LOAD_ID})"
+            " VALUES (?, ?, ?)"
+        ),
+        parameters=[tuple(r.values()) for r in ROOT_TABLE_ROWS],
+    )
+
+    # child table
+    duckdb_con.execute(
+        f"CREATE TABLE {DATASET_NAME}.{CHILD_TABLE_NAME} (value INT, {ROW_KEY} TEXT,"
+        f" {ROOT_KEY} TEXT)"
+    )
+    duckdb_con.executemany(
+        query=(
+            f"INSERT INTO {DATASET_NAME}.{CHILD_TABLE_NAME} (value, {ROW_KEY}, {ROOT_KEY}) VALUES"
+            " (?, ?, ?)"
+        ),
+        parameters=[tuple(r.values()) for r in CHILD_TABLE_ROWS],
+    )
+
+    duckdb_con.commit()
+
+    # NOTE must set `dataset_type="default"` to avoid using Ibis dataset and relation
+    yield ReadableDBAPIDataset(
+        destination=duckdb_dest(duckdb_con),
+        dataset_name=DATASET_NAME,
+        schema=dlt.Schema.from_dict(MOCK_SCHEMA_DICT),
+        dataset_type="default",
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_query",
+    [
+        (
+            {},
+            (
+                f"SELECT {LOAD_ID_COL_ON_LOADS_TABLE} FROM _dlt_loads ORDER BY"
+                f" {LOAD_ID_COL_ON_LOADS_TABLE} DESC"
+            ),
+        ),
+        (
+            {"status": None},
+            (
+                f"SELECT {LOAD_ID_COL_ON_LOADS_TABLE} FROM _dlt_loads ORDER BY"
+                f" {LOAD_ID_COL_ON_LOADS_TABLE} DESC"
+            ),
+        ),
+        (
+            {"status": 0},
+            (
+                f"SELECT {LOAD_ID_COL_ON_LOADS_TABLE} FROM _dlt_loads WHERE status = 0 ORDER BY"
+                f" {LOAD_ID_COL_ON_LOADS_TABLE} DESC"
+            ),
+        ),
+        (
+            {"status": [0]},
+            (
+                f"SELECT {LOAD_ID_COL_ON_LOADS_TABLE} FROM _dlt_loads WHERE status IN (0) ORDER BY"
+                f" {LOAD_ID_COL_ON_LOADS_TABLE} DESC"
+            ),
+        ),
+        (
+            {"status": [0, 1]},
+            (
+                f"SELECT {LOAD_ID_COL_ON_LOADS_TABLE} FROM _dlt_loads WHERE status IN (0, 1) ORDER"
+                f" BY {LOAD_ID_COL_ON_LOADS_TABLE} DESC"
+            ),
+        ),
+        (
+            {"limit": 2},
+            (
+                f"SELECT {LOAD_ID_COL_ON_LOADS_TABLE} FROM _dlt_loads ORDER BY"
+                f" {LOAD_ID_COL_ON_LOADS_TABLE} DESC LIMIT 2"
+            ),
+        ),
+        (
+            {"status": [0, 1], "limit": 2},
+            (
+                f"SELECT {LOAD_ID_COL_ON_LOADS_TABLE} FROM _dlt_loads WHERE status IN (0, 1) ORDER"
+                f" BY {LOAD_ID_COL_ON_LOADS_TABLE} DESC LIMIT 2"
+            ),
+        ),
+        ({"status": []}, DltException()),
+        ({"status": [0, "1"]}, DltException()),
+        ({"status": "1"}, DltException()),
+        ({"limit": 0}, DltException()),
+        ({"limit": "1"}, DltException()),
+    ],
+)
+def test_list_load_ids_expr(dataset, kwargs: dict, expected_query: Union[str, Exception]) -> None:
+    """Test query generation"""
+    if isinstance(expected_query, Exception):
+        with pytest.raises(DltException):
+            _list_load_ids_expr(**kwargs)
+        with pytest.raises(DltException):
+            dataset.list_load_ids(**kwargs)
+    else:
+        query = _list_load_ids_expr(**kwargs)
+        relation = dataset.list_load_ids(**kwargs)
+        assert query.sql() == relation.query() == expected_query
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_load_ids",
+    [
+        ({}, ["foo", "baz", "bar"]),  # NOTE results are ORDER BY DESC
+        ({"status": None}, ["foo", "baz", "bar"]),
+        ({"status": 0}, ["foo", "bar"]),
+        ({"status": [0]}, ["foo", "bar"]),
+        ({"status": [0, 1]}, ["foo", "baz", "bar"]),
+    ],
+)
+def test_list_load_ids_execution(
+    dataset, kwargs: dict, expected_load_ids: Union[str, Exception]
+) -> None:
+    """Test query generation"""
+    # mock execution
+    query = _list_load_ids_expr(**kwargs)
+    rows = execute(query.sql(), tables={DLT_LOAD_TABLE_NAME: DLT_LOADS_ROWS})
+    assert [r[LOAD_ID_COL_ON_LOADS_TABLE] for r in rows] == expected_load_ids
+
+    # duckdb execution
+    relation = dataset.list_load_ids(**kwargs)
+    results = relation.fetchall()
+    assert [r[0] for r in results] == expected_load_ids
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_query",
+    [
+        (
+            {},
+            f"SELECT MAX({LOAD_ID_COL_ON_LOADS_TABLE}) AS load_id FROM _dlt_loads",
+        ),
+        (
+            {"status": None},
+            f"SELECT MAX({LOAD_ID_COL_ON_LOADS_TABLE}) AS load_id FROM _dlt_loads",
+        ),
+        (
+            {"status": 0},
+            f"SELECT MAX({LOAD_ID_COL_ON_LOADS_TABLE}) AS load_id FROM _dlt_loads WHERE status = 0",
+        ),
+        (
+            {"status": [0]},
+            (
+                f"SELECT MAX({LOAD_ID_COL_ON_LOADS_TABLE}) AS load_id FROM _dlt_loads WHERE status"
+                " IN (0)"
+            ),
+        ),
+        (
+            {"status": [0, 1]},
+            (
+                f"SELECT MAX({LOAD_ID_COL_ON_LOADS_TABLE}) AS load_id FROM _dlt_loads WHERE status"
+                " IN (0, 1)"
+            ),
+        ),
+        ({"status": []}, DltException()),
+        ({"status": [0, "1"]}, DltException()),
+        ({"status": "1"}, DltException()),
+    ],
+)
+def test_latest_load_ids_expr(dataset, kwargs: dict, expected_query: Union[str, Exception]) -> None:
+    """Test query generation"""
+    if isinstance(expected_query, Exception):
+        with pytest.raises(DltException):
+            _latest_load_id_expr(**kwargs)
+        with pytest.raises(DltException):
+            dataset.latest_load_id(**kwargs)
+    else:
+        query = _latest_load_id_expr(**kwargs)
+        relation = dataset.latest_load_id(**kwargs)
+        assert query.sql() == expected_query
+        assert query.sql() == relation.query() == expected_query
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_load_id",
+    [
+        ({}, "foo"),
+        ({"status": None}, "foo"),
+        ({"status": 1}, "baz"),
+        ({"status": [1]}, "baz"),
+        ({"status": [0, 1]}, "foo"),
+    ],
+)
+def test_latest_load_ids_execution(
+    dataset, kwargs: dict, expected_load_id: Union[str, Exception]
+) -> None:
+    """Test query generation"""
+    # mock execution
+    query = _latest_load_id_expr(**kwargs)
+    rows = execute(query.sql(), tables={DLT_LOAD_TABLE_NAME: DLT_LOADS_ROWS})
+    assert [r[LOAD_ID_COL_ON_LOADS_TABLE] for r in rows] == [expected_load_id]
+
+    # duckdb execution
+    relation = dataset.latest_load_id(**kwargs)
+    results = relation.fetchall()
+    assert [r[0] for r in results] == [expected_load_id]
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_load_ids",
+    [
+        ({"lt": "foo"}, ["bar", "baz"]),
+        ({"le": "foo"}, ["bar", "baz", "foo"]),
+        ({"gt": "baz"}, ["foo"]),
+        ({"ge": "baz"}, ["baz", "foo"]),
+        ({"gt": "bar", "lt": "foo"}, ["baz"]),
+        ({"gt": "bar", "le": "foo"}, ["baz", "foo"]),
+        ({"ge": "baz", "lt": "foo"}, ["baz"]),
+        ({"ge": "baz", "le": "foo"}, ["baz", "foo"]),
+        # TODO add cases where we expect an exception to raise; i.e., `gt < lt`
+    ],
+)
+def test_filter_min_max_execution(
+    dataset, kwargs, expected_load_ids: Union[set[str], Exception]
+) -> None:
+    query = _list_load_ids_expr()
+
+    query = _filter_min_max(query, **kwargs)
+    if "ge" in kwargs and "le" in kwargs:
+        assert "BETWEEN" in query.sql()
+
+    # mock execution
+    rows = execute(query.sql(), tables={DLT_LOAD_TABLE_NAME: DLT_LOADS_ROWS})
+    assert set([r[LOAD_ID_COL_ON_LOADS_TABLE] for r in rows]) == set(expected_load_ids)
+
+    # duckdb execution
+    relation = dataset.list_load_ids(**kwargs)
+    results = relation.fetchall()
+    assert set([r[0] for r in results]) == set(expected_load_ids)
+
+
+def test_incremental_sets_load_ids(dataset) -> None:
+    dataset_pre = dataset
+
+    dataset_post = dataset_pre.incremental(gt="boz")
+
+    assert isinstance(dataset_post, ReadableDBAPIDataset)
+    # .incremental() sets an attribute and returns Self, not a copy
+    assert dataset_pre is dataset_post
+    assert dataset_post._load_ids == set(["foo"])
+
+
+@pytest.mark.parametrize(
+    "load_ids, expected_dlt_ids",
+    [
+        (set(["bar", "baz"]), ["ghi", "jkl"]),
+        (set(["foo", "bar"]), ["abc", "def", "ghi"]),
+        (set(["foo"]), ["abc", "def"]),
+        (set(), []),  # TODO should this raise? currently returns empty set
+        # TODO add case where load_id exists, but no row found
+    ],
+)
+def test_incremental_on_root_table(
+    dataset, load_ids: set[str], expected_dlt_ids: Union[list[str], Exception]
+) -> None:
+    query = _filter_root_table_expr(ROOT_TABLE_NAME, load_ids=load_ids)
+    assert all(load_id in query.sql() for load_id in load_ids)
+
+    # mock execution
+    rows = execute(
+        query.sql(), tables={ROOT_TABLE_NAME: ROOT_TABLE_ROWS, DLT_LOAD_TABLE_NAME: DLT_LOADS_ROWS}
+    )
+    assert set([r[ROW_KEY] for r in rows]) == set(expected_dlt_ids)
+
+    # duckdb execution
+    dataset._load_ids = load_ids
+    relation = dataset.table(ROOT_TABLE_NAME)
+    results = relation.fetchall()
+    assert set([r[1] for r in results]) == set(expected_dlt_ids)
+
+
+@pytest.mark.parametrize(
+    "load_ids, expected_dlt_ids",
+    [
+        (set(["bar", "baz"]), ["TSR"]),
+        (set(["foo", "bar"]), ["ZYX", "WVU", "TSR"]),
+        (set(["foo"]), ["ZYX", "WVU"]),
+        (set(["baz"]), []),
+        (set(), []),  # TODO should this raise? currently returns empty set
+    ],
+)
+def test_incremental_on_child_table(
+    dataset, load_ids: set[str], expected_dlt_ids: Union[list[str], Exception]
+) -> None:
+    query = _filter_child_table_expr(
+        table_name=CHILD_TABLE_NAME,
+        table_root_key=ROOT_KEY,
+        root_table_name=ROOT_TABLE_NAME,
+        root_table_row_key=ROW_KEY,
+        load_ids=load_ids,
+    )
+    assert all(load_id in query.sql() for load_id in load_ids)
+
+    # NOTE for some reason, mock execution fails because it can't resolve joins
+    
+    # mock execution
+    # rows = execute(
+    #     query.sql(),
+    #     tables={
+    #         CHILD_TABLE_NAME: CHILD_TABLE_ROWS,
+    #         ROOT_TABLE_NAME: ROOT_TABLE_ROWS,
+    #         DLT_LOAD_TABLE_NAME: DLT_LOADS_ROWS,
+    #     }
+    # )
+    # assert set([r[ROW_KEY] for r in rows]) == set(expected_dlt_ids)
+
+    # duckdb execution
+    dataset._load_ids = load_ids
+    relation = dataset.table(CHILD_TABLE_NAME)
+    results = relation.fetchall()
+    assert set([r[1] for r in results]) == set(expected_dlt_ids)

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -594,8 +594,6 @@ def test_column_selection(populated_pipeline: Pipeline) -> None:
     assert arrow_table.schema.field("decimal").type.precision == expected_decimal_precision
     assert arrow_table.schema.field("other_decimal").type.precision == expected_decimal_precision_2
 
-    import sqlglot
-
     with pytest.raises(LineageFailedException):
         arrow_table = table_relationship.select("unknown_column").head().arrow()
 
@@ -824,7 +822,6 @@ def test_ibis_expression_relation(populated_pipeline: Pipeline) -> None:
         ),
         ALL_COLUMNS,
     )
-
     # topk
     assert sql_from_expr(items_table.decimal.topk(10)) == (
         (

--- a/tests/transformations/test_lineage.py
+++ b/tests/transformations/test_lineage.py
@@ -171,7 +171,7 @@ QUERY_KNOWN_AND_UNKNOWN_JOIN_STAR_ON_KNOW_TABLE_SELECT = """\
                 "col_varchar": {"name": "col_varchar", "data_type": "text"},
                 "col_bool": {"name": "col_bool", "data_type": "bool"},
                 "col_unknown_1": {"name": "col_unknown_1"},
-            }
+            },
         ),
     ],
 )


### PR DESCRIPTION
This PR leverages adds incremental filters to `ReadableDBAPIDataset` and `ReadableDBAPIRelation`. 

Filters are SQL queries that filter a `target` table based on the `_dlt_load` table (`_dlt_load_id`, load date, load status). It leverages SQLGlot to write queries that are portable across destination backends. 

## Potential API
Here are some potential user-facing API. One or more could be implemented. The real convenience is that it hides the table joins

### 1. Dataset instantiation
  ```python
  latest_dataset = ReadableDBAPIDataset(dataset_name="foo", load_id=[...])
  
  @dlt.transformations()
  def customer_transactions(dataset):
    latest_customers = latest_dataset.customers
    latest_transactions = latest_dataset.transactions
    ...
    return ...
  ```
  
### 2. Dataset-level generic filter
  ```python
  dataset = ReadableDBAPIDataset(dataset_name="foo")
  
  @dlt.transformations()
  def customer_transactions(dataset):
    all_customers = dataset.customers
    latest_transactions = dataset.filter_loads(load_ids=[...], status=..., ).transactions
    ...
    return ...
    
  # also
  latest_dataset = dataset.filter_loads(...)
  latest_customers = latest_dataset.customers
  latest_transactions = latest_dataset.transactions
  ```
  
### 3. Dataset-level named filters
  ```python
  dataset = ReadableDBAPIDataset(dataset_name="foo")
  
  @dlt.transformations()
  def customer_transactions(dataset):
    all_customers = dataset.customers
    latest_transactions = dataset.latest_load.transactions   # dataset property
    ...
    return ...
  ```

### 4. Relation-level named filters
  ```python
  dataset = ReadableDBAPIDataset(dataset_name="foo")
  
  @dlt.transformations()
  def customer_transactions(dataset):
    all_customers = dataset.customers
    all_transactions = dataset.transactions
    latest_transactions = all_transactions.latest_load   # relation property
    ...
    return ...
  ```
  
### 5. Relation-level generic filters
  ```python
  dataset = ReadableDBAPIDataset(dataset_name="foo")
  
  @dlt.transformations()
  def customer_transactions(dataset):
    all_customers = dataset.customers
    all_transactions = dataset.transactions
    latest_transactions = all_transactions.filter_loads(...)
    ...
    return ...
  ```
  
## Implementation
The filter expression can be stored as a SQLGlot expression. This can be composed as a Common Table Expression (CTE) when querying the `ReadableRelation`. Here's some pseudo code

```python
dataset = ReadableDBAPIDataset()

dataset = dataset.filter(status=...)
# internally
load_id_expr = dataset._list_load_ids(status=...)
dataset._filter = load_id_expr

latest_customers = dataset.table("customers")
df = latest_customer.select("id", "name").df()
#  internally
customers_relation = dataset.table("customers", cte=dataset._filter)
select_query = sge.select("id", "name")
# ...
full_query = select_query.with(customers_relation.cte)
df = execute(full_query.sql())
```
  
## Thoughts
I have a general preference for dataset levels filters. This forces the user to do the filtering / selection at the beginning of the query. There's no performance hit if using SQLGlot or Ibis because the full expression can be later optimized