### PR TITLE
docs: Fix incorrect nesting in secrets.toml

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/setup.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/setup.md
@@ -39,7 +39,7 @@ If you'd like to use a different destination, simply replace `duckdb` with the n
 
     Alternatively, you can also authenticate using connection strings:
     ```toml
-    [sources.sql_database.credentials]
+    [sources.sql_database]
     credentials="mysql+pymysql://rfamro@mysql-rfam-public.ebi.ac.uk:4497/Rfam"
     ```
 


### PR DESCRIPTION
There is one `credentials` too many.