### PR TITLE
Feat/2609-clickhouse-precision-integer-mapping

### DIFF
--- a/dlt/destinations/impl/clickhouse/factory.py
+++ b/dlt/destinations/impl/clickhouse/factory.py
@@ -10,6 +10,7 @@ from dlt.common.data_writers.escape import (
 )
 from dlt.common.destination import Destination, DestinationCapabilitiesContext
 
+from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.exceptions import TerminalValueError
 from dlt.common.schema.typing import TColumnSchema, TColumnType
 from dlt.destinations.type_mapping import TypeMapperImpl
@@ -92,7 +93,7 @@ class ClickHouseTypeMapper(TypeMapperImpl):
 
         return super().from_destination_type(db_type, precision, scale)
 
-    def to_db_integer_type(self, column: TColumnSchema, table: Any = None) -> str:
+    def to_db_integer_type(self, column: TColumnSchema, table: PreparedTableSchema = None) -> str:
         """Map integer precision to the appropriate ClickHouse integer type."""
         precision = column.get("precision")
         if precision is None:

--- a/dlt/destinations/impl/clickhouse/factory.py
+++ b/dlt/destinations/impl/clickhouse/factory.py
@@ -10,6 +10,7 @@ from dlt.common.data_writers.escape import (
 )
 from dlt.common.destination import Destination, DestinationCapabilitiesContext
 
+from dlt.common.exceptions import TerminalValueError
 from dlt.common.schema.typing import TColumnSchema, TColumnType
 from dlt.destinations.type_mapping import TypeMapperImpl
 from dlt.destinations.impl.clickhouse.configuration import (
@@ -104,8 +105,8 @@ class ClickHouseTypeMapper(TypeMapperImpl):
             return "Int32"
         if precision <= 64:
             return "Int64"
-        raise ValueError(
-            f"Integer with {precision} bits precision cannot be mapped into ClickHouse integer type"
+        raise TerminalValueError(
+            f"bigint with {precision} bits precision cannot be mapped into ClickHouse integer type"
         )
 
 

--- a/dlt/destinations/impl/clickhouse/factory.py
+++ b/dlt/destinations/impl/clickhouse/factory.py
@@ -91,6 +91,23 @@ class ClickHouseTypeMapper(TypeMapperImpl):
 
         return super().from_destination_type(db_type, precision, scale)
 
+    def to_db_integer_type(self, column: Dict[str, Any], table: Any = None) -> str:
+        """Map integer precision to the appropriate ClickHouse integer type."""
+        precision = column.get("precision")
+        if precision is None:
+            return "Int64"
+        if precision <= 8:
+            return "Int8"
+        if precision <= 16:
+            return "Int16"
+        if precision <= 32:
+            return "Int32"
+        if precision <= 64:
+            return "Int64"
+        raise ValueError(
+            f"Integer with {precision} bits precision cannot be mapped into ClickHouse integer type"
+        )
+
 
 class clickhouse(Destination[ClickHouseClientConfiguration, "ClickHouseClient"]):
     spec = ClickHouseClientConfiguration

--- a/dlt/destinations/impl/clickhouse/factory.py
+++ b/dlt/destinations/impl/clickhouse/factory.py
@@ -10,7 +10,7 @@ from dlt.common.data_writers.escape import (
 )
 from dlt.common.destination import Destination, DestinationCapabilitiesContext
 
-from dlt.common.schema.typing import TColumnType
+from dlt.common.schema.typing import TColumnSchema, TColumnType
 from dlt.destinations.type_mapping import TypeMapperImpl
 from dlt.destinations.impl.clickhouse.configuration import (
     ClickHouseClientConfiguration,
@@ -91,7 +91,7 @@ class ClickHouseTypeMapper(TypeMapperImpl):
 
         return super().from_destination_type(db_type, precision, scale)
 
-    def to_db_integer_type(self, column: Dict[str, Any], table: Any = None) -> str:
+    def to_db_integer_type(self, column: TColumnSchema, table: Any = None) -> str:
         """Map integer precision to the appropriate ClickHouse integer type."""
         precision = column.get("precision")
         if precision is None:

--- a/tests/load/clickhouse/test_type_mapper.py
+++ b/tests/load/clickhouse/test_type_mapper.py
@@ -1,6 +1,8 @@
 import pytest
 from dlt.destinations.impl.clickhouse.factory import ClickHouseTypeMapper
 from dlt.common.schema.typing import TColumnSchema
+
+
 @pytest.mark.parametrize(
     "column,expected_type",
     [
@@ -10,11 +12,12 @@ from dlt.common.schema.typing import TColumnSchema
         (TColumnSchema(precision=32), "Int32"),
         (TColumnSchema(precision=64), "Int64"),
         (TColumnSchema(), "Int64"),  # No precision key at all
-    ]
+    ],
 )
 def test_to_db_integer_type_valid(column, expected_type):
     mapper = ClickHouseTypeMapper(capabilities=None)
     assert mapper.to_db_integer_type(column) == expected_type
+
 
 def test_to_db_integer_type_invalid():
     mapper = ClickHouseTypeMapper(capabilities=None)

--- a/tests/load/clickhouse/test_type_mapper.py
+++ b/tests/load/clickhouse/test_type_mapper.py
@@ -1,22 +1,22 @@
 import pytest
 from dlt.destinations.impl.clickhouse.factory import ClickHouseTypeMapper
-
+from dlt.common.schema.typing import TColumnSchema
 @pytest.mark.parametrize(
-    "precision,expected_type",
+    "column,expected_type",
     [
-        (None, "Int64"),
-        (8, "Int8"),
-        (16, "Int16"),
-        (32, "Int32"),
-        (64, "Int64"),
+        (TColumnSchema(precision=None), "Int64"),
+        (TColumnSchema(precision=8), "Int8"),
+        (TColumnSchema(precision=16), "Int16"),
+        (TColumnSchema(precision=32), "Int32"),
+        (TColumnSchema(precision=64), "Int64"),
+        (TColumnSchema(), "Int64"),  # No precision key at all
     ]
 )
-def test_to_db_integer_type_valid(precision, expected_type):
+def test_to_db_integer_type_valid(column, expected_type):
     mapper = ClickHouseTypeMapper(capabilities=None)
-    column = {"precision": precision} if precision is not None else {}
     assert mapper.to_db_integer_type(column) == expected_type
 
 def test_to_db_integer_type_invalid():
     mapper = ClickHouseTypeMapper(capabilities=None)
     with pytest.raises(ValueError):
-        mapper.to_db_integer_type({"precision": 128})
+        mapper.to_db_integer_type(TColumnSchema(precision=128))

--- a/tests/load/clickhouse/test_type_mapper.py
+++ b/tests/load/clickhouse/test_type_mapper.py
@@ -1,0 +1,22 @@
+import pytest
+from dlt.destinations.impl.clickhouse.factory import ClickHouseTypeMapper
+
+@pytest.mark.parametrize(
+    "precision,expected_type",
+    [
+        (None, "Int64"),
+        (8, "Int8"),
+        (16, "Int16"),
+        (32, "Int32"),
+        (64, "Int64"),
+    ]
+)
+def test_to_db_integer_type_valid(precision, expected_type):
+    mapper = ClickHouseTypeMapper(capabilities=None)
+    column = {"precision": precision} if precision is not None else {}
+    assert mapper.to_db_integer_type(column) == expected_type
+
+def test_to_db_integer_type_invalid():
+    mapper = ClickHouseTypeMapper(capabilities=None)
+    with pytest.raises(ValueError):
+        mapper.to_db_integer_type({"precision": 128})


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Add support for all of [Clickhouse's integer precision](https://clickhouse.com/docs/sql-reference/data-types/int-uint#integer-ranges).

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #2609
- Closes #2609
- Resolves #2609

<!--
Provide any additional context about the PR here.
-->
### Additional Context
This PR gives users the option to map `bigint` to Int8, Int16, etc using the `precision` hint to optimise storage.

Currently, `bigint` only maps to Int64.


<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
