### PR TITLE
Feat: Add configuration propagation to deltalake.write_deltalake (#2629)

### DIFF
--- a/dlt/common/libs/deltalake.py
+++ b/dlt/common/libs/deltalake.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Optional, Dict, Union, List
 from pathlib import Path
 
@@ -95,6 +96,7 @@ def write_delta_table(
     write_disposition: TWriteDisposition,
     partition_by: Optional[Union[List[str], str]] = None,
     storage_options: Optional[Dict[str, str]] = None,
+    configuration: Optional[Mapping[str, Optional[str]]] = None,
 ) -> None:
     """Writes in-memory Arrow data to on-disk Delta table.
 
@@ -108,6 +110,7 @@ def write_delta_table(
         schema_mode="merge",  # enable schema evolution (adding new columns)
         storage_options=storage_options,
         engine="rust",  # `merge` schema mode requires `rust` engine
+        configuration=configuration,
     )
 
 

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -16,7 +16,7 @@ from dlt.common.configuration.specs import (
     SFTPCredentials,
 )
 from dlt.common.exceptions import TerminalValueError
-from dlt.common.typing import DictStrAny, get_args
+from dlt.common.typing import DictStrAny, DictStrOptionalStr, get_args
 from dlt.common.utils import digest128
 
 
@@ -184,6 +184,7 @@ class FilesystemConfiguration(BaseConfiguration):
     kwargs: Optional[DictStrAny] = None
     client_kwargs: Optional[DictStrAny] = None
     deltalake_storage_options: Optional[DictStrAny] = None
+    deltalake_configuration: Optional[DictStrOptionalStr] = None
 
     @property
     def protocol(self) -> str:

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -88,6 +88,7 @@ CallableAny = NewType("CallableAny", Any)  # type: ignore[valid-newtype]
 NoneType = type(None)
 DictStrAny: TypeAlias = Dict[str, Any]
 DictStrStr: TypeAlias = Dict[str, str]
+DictStrOptionalStr: TypeAlias = Dict[str, Optional[str]]
 StrAny: TypeAlias = Mapping[str, Any]  # immutable, covariant entity
 StrStr: TypeAlias = Mapping[str, str]  # immutable, covariant entity
 StrStrStr: TypeAlias = Mapping[str, Mapping[str, str]]  # immutable, covariant entity

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -199,6 +199,7 @@ class DeltaLoadFilesystemJob(TableFormatLoadFilesystemJob):
                     write_disposition=self._load_table["write_disposition"],
                     partition_by=self._partition_columns,
                     storage_options=storage_options,
+                    configuration=self._job_client.config.deltalake_configuration,
                 )
         # release memory ASAP by deleting objects explicitly
         del source_ds

--- a/docs/website/docs/dlt-ecosystem/destinations/delta-iceberg.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/delta-iceberg.md
@@ -110,15 +110,17 @@ def my_upsert_resource():
 - Deleting records from nested tables not supported
   - This means updates to JSON columns that involve element removals are not propagated. For example, if you first load `{"key": 1, "nested": [1, 2]}` and then load `{"key": 1, "nested": [1]}`, then the record for element `2` will not be deleted from the nested table.
 
-## Delta table format storage options
-You can pass storage options by configuring `destination.filesystem.deltalake_storage_options`:
+## Delta table format storage options and configuration
+You can pass storage options and configuration by configuring both `destination.filesystem.deltalake_storage_options` and
+`destination.filesystem.deltalake_configuration`:
 
 ```toml
 [destination.filesystem]
+deltalake_configuration = '{"delta.enableChangeDataFeed": "true", "delta.minWriterVersion": "7"}'
 deltalake_storage_options = '{"AWS_S3_LOCKING_PROVIDER": "dynamodb", "DELTA_DYNAMO_TABLE_NAME": "custom_table_name"}'
 ```
 
-dlt passes these options to the `storage_options` argument of the `write_deltalake` method in the `deltalake` library. Look at their [documentation](https://delta-io.github.io/delta-rs/api/delta_writer/#deltalake.write_deltalake) to see which options can be used.
+dlt passes these as arguments to the `write_deltalake` method in the `deltalake` library (`deltalake_configuration` maps to `configuration` and `deltalake_storage_options` maps to `storage_options`). Look at their [documentation](https://delta-io.github.io/delta-rs/api/delta_writer/#deltalake.write_deltalake) to see which options can be used.
 
 You don't need to specify credentials here. dlt merges the required credentials with the options you provided before passing it as `storage_options`.
 

--- a/docs/website/docs/plus/ecosystem/delta.md
+++ b/docs/website/docs/plus/ecosystem/delta.md
@@ -226,17 +226,19 @@ The Delta destination automatically assigns the `delta` table format to all reso
   pipeline = dlt.pipeline("loads_delta", destination="delta")
   ```
 
-### Storage options
-You can pass storage options by configuring `destination.delta.deltalake_storage_options`:
+## Storage options and configuration
+You can pass storage options and configuration by configuring both `destination.filesystem.deltalake_storage_options` and
+`destination.filesystem.deltalake_configuration`:
 
 ```toml
-[destination.delta]
+[destination.filesystem]
+deltalake_configuration = '{"delta.enableChangeDataFeed": "true", "delta.minWriterVersion": "7"}'
 deltalake_storage_options = '{"AWS_S3_LOCKING_PROVIDER": "dynamodb", "DELTA_DYNAMO_TABLE_NAME": "custom_table_name"}'
 ```
 
-dlt passes these options to the `storage_options` argument of the `write_deltalake` method in the `deltalake` library. See the [Delta Lake `write_deltalake` API documentation](https://delta-io.github.io/delta-rs/api/delta_writer/#deltalake.write_deltalake) for available storage options.
+dlt passes these as arguments to the `write_deltalake` method in the `deltalake` library (`deltalake_configuration` maps to `configuration` and `deltalake_storage_options` maps to `storage_options`). Look at their [documentation](https://delta-io.github.io/delta-rs/api/delta_writer/#deltalake.write_deltalake) to see which options can be used.
 
-You don't need to specify credentials here. dlt merges the required credentials with the options you provided before passing them as `storage_options`.
+You don't need to specify credentials here. dlt merges the required credentials with the options you provided before passing it as `storage_options`.
 
 :::warning
 When using `s3`, you need to specify storage options to [configure](https://delta-io.github.io/delta-rs/usage/writing/writing-to-s3-with-locking-provider/) locking behavior.

--- a/tests/libs/test_deltalake.py
+++ b/tests/libs/test_deltalake.py
@@ -107,9 +107,15 @@ def test_write_delta_table(
         arrow_data(arrow_table, arrow_data_type),
         write_disposition="append",
         storage_options=storage_options,
+        configuration={"delta.logRetentionDuration": "interval 1 day"},  # default is 30 days
     )
     dt = DeltaTable(remote_dir, storage_options=storage_options)
+
     assert dt.version() == 0
+
+    # Check that the configuration is passed to the Delta table correctly
+    assert dt.metadata().configuration == {"delta.logRetentionDuration": "interval 1 day"}
+
     dt_arrow_table = dt.to_pyarrow_table()
     assert dt_arrow_table.shape == (arrow_table.num_rows, arrow_table.num_columns)
 

--- a/tests/load/filesystem/test_filesystem_common.py
+++ b/tests/load/filesystem/test_filesystem_common.py
@@ -52,6 +52,7 @@ def test_filesystem_configuration() -> None:
         "client_kwargs": None,
         "kwargs": None,
         "deltalake_storage_options": None,
+        "deltalake_configuration": None,
     }
 
 
@@ -212,6 +213,10 @@ def test_filesystem_configuration_with_additional_arguments() -> None:
         kwargs={"use_ssl": True},
         client_kwargs={"verify": "public.crt"},
         deltalake_storage_options={"AWS_S3_LOCKING_PROVIDER": "dynamodb"},
+        deltalake_configuration={
+            "delta.minWriterVersion": "7",
+            "delta.enableChangeDataFeed": "true",
+        },
     )
     assert dict(config) == {
         "read_only": False,
@@ -220,6 +225,10 @@ def test_filesystem_configuration_with_additional_arguments() -> None:
         "kwargs": {"use_ssl": True},
         "client_kwargs": {"verify": "public.crt"},
         "deltalake_storage_options": {"AWS_S3_LOCKING_PROVIDER": "dynamodb"},
+        "deltalake_configuration": {
+            "delta.minWriterVersion": "7",
+            "delta.enableChangeDataFeed": "true",
+        },
     }
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Currently there is no way to configure the `delta` table destination. DLT uses a thin wrapper (`write_delta_table`) around the `deltalake.write_deltalake` function, but uses the default `configuration=None`. So currently there is no direct way of configuring the resulting delta table. This PR changes that by exposing a new config field `deltalake_configuration` that is passed through.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #2629 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
As described in the issue, there is an alternative approach of simply allowing a `kwargs` parameter that can be constructed that will be passed to the `write_deltalake` call, but that scope is slightly bigger, and the current approach is more consistent with `storage_options`.

In my previous PR I had unrelated failing tests, and I do so again, but the stuff that I've touched seems to work, so I think it's all good from my side, but I don't have had enough exposure to the project to really assess that correctly.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
