### PR TITLE
cli: fix 404 in the "ai" command output

### DIFF
--- a/dlt/cli/ai_command.py
+++ b/dlt/cli/ai_command.py
@@ -20,7 +20,9 @@ TSupportedIde = Literal[
 SUPPORTED_IDES: Set[TSupportedIde] = list(get_args(TSupportedIde))  # type: ignore
 VERIFIED_SOURCES_AI_BASE_DIR = "ai"
 AI_CONTRIBUTE_URL = (
-    os.path.splitext(DEFAULT_VERIFIED_SOURCES_REPO)[0] + "/" + VERIFIED_SOURCES_AI_BASE_DIR
+    os.path.splitext(DEFAULT_VERIFIED_SOURCES_REPO)[0]
+    + "/tree/master/"
+    + VERIFIED_SOURCES_AI_BASE_DIR
 )
 
 # TODO Claude Desktop: rules need to be named `CLAUDE.md`, allow command to append to it


### PR DESCRIPTION
The output of:
```
dlt ai setup cursor
```

Produces a 404 link: https://github.com/dlt-hub/verified-sources/ai 

```
...
NOTE: Help us to build better support for cursor by contributing better rules, prompts or configs in https://github.com/dlt-hub/verified-sources/ai
```