### PR TITLE
Prevent unecessary preliminary connection in dataset

### DIFF
--- a/dlt/destinations/dataset/dataset.py
+++ b/dlt/destinations/dataset/dataset.py
@@ -136,16 +136,15 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
 
         # here we create the client bound to the resolved schema
         if not self._sql_client:
-            with self._destination_client(self._schema) as destination_client:
-                if isinstance(destination_client, WithSqlClient):
-                    self._sql_client = destination_client.sql_client
-                else:
-                    raise Exception(
-                        f"Destination {destination_client.config.destination_type} does not support"
-                        " SqlClient."
-                    )
-                if isinstance(destination_client, SupportsOpenTables):
-                    self._table_client = destination_client
+            client = self._destination_client(self._schema)
+            if isinstance(client, WithSqlClient):
+                self._sql_client = client.sql_client
+            else:
+                raise Exception(
+                    f"Destination {client.config.destination_type} does not support SqlClient."
+                )
+            if isinstance(client, SupportsOpenTables):
+                self._table_client = client
 
     def __call__(self, query: Any) -> ReadableDBAPIRelation:
         # TODO: accept other query types and return a right relation: sqlglot (DBAPI) and ibis (Expr)

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -28,6 +28,7 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
         """Create a lazy evaluated relation to for the dataset of a destination"""
 
         self._dataset = readable_dataset
+        self._opened_client: SqlClientBase[Any] = None
 
         # wire protocol functions
         self.df = self._wrap_func("df")  # type: ignore
@@ -58,11 +59,24 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
     @contextmanager
     def cursor(self) -> Generator[SupportsReadableRelation, Any, Any]:
         """Gets a DBApiCursor for the current relation"""
-        with self.sql_client as client:
-            with client.execute_query(self.query()) as cursor:
-                if columns_schema := self.columns_schema:
-                    cursor.columns_schema = columns_schema
-                yield cursor
+        try:
+            self._opened_client = self.sql_client
+
+            # case 1: client is already opened and managed from outside
+            if self.sql_client.native_connection:
+                with self.sql_client.execute_query(self.query()) as cursor:
+                    if columns_schema := self.columns_schema:
+                        cursor.columns_schema = columns_schema
+                    yield cursor
+            # case 2: client is not opened, we need to manage it
+            else:
+                with self.sql_client as client:
+                    with client.execute_query(self.query()) as cursor:
+                        if columns_schema := self.columns_schema:
+                            cursor.columns_schema = columns_schema
+                        yield cursor
+        finally:
+            self._opened_client = None
 
     def _wrap_iter(self, func_name: str) -> Any:
         """wrap SupportsReadableRelation generators in cursor context"""

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -28,7 +28,7 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
         """Create a lazy evaluated relation to for the dataset of a destination"""
 
         self._dataset = readable_dataset
-        self._opened_client: SqlClientBase[Any] = None
+        self._opened_sql_client: SqlClientBase[Any] = None
 
         # wire protocol functions
         self.df = self._wrap_func("df")  # type: ignore
@@ -60,7 +60,7 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
     def cursor(self) -> Generator[SupportsReadableRelation, Any, Any]:
         """Gets a DBApiCursor for the current relation"""
         try:
-            self._opened_client = self.sql_client
+            self._opened_sql_client = self.sql_client
 
             # case 1: client is already opened and managed from outside
             if self.sql_client.native_connection:
@@ -76,7 +76,7 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
                             cursor.columns_schema = columns_schema
                         yield cursor
         finally:
-            self._opened_client = None
+            self._opened_sql_client = None
 
     def _wrap_iter(self, func_name: str) -> Any:
         """wrap SupportsReadableRelation generators in cursor context"""

--- a/docs/website/docs/general-usage/dataset-access/dataset.md
+++ b/docs/website/docs/general-usage/dataset-access/dataset.md
@@ -75,6 +75,12 @@ To handle large datasets efficiently, you can process data in smaller chunks.
 
 The methods available on the ReadableRelation correspond to the methods available on the cursor returned by the SQL client. Please refer to the [SQL client](./sql-client.md#supported-methods-on-the-cursor) guide for more information.
 
+## Connection Handling
+
+For every call that actually fetches data from the destination, such as `df()`, `arrow()`, `fetchall()` etc., the dataset will open a connection and close it after it has been retrieved or the iterator is completed. You can keep the connection open for multiple requests with the dataset context manager:
+
+<!--@@@DLT_SNIPPET ./dataset_snippets/dataset_snippets.py::context_manager-->
+
 ## Special queries
 
 You can use the `row_counts` method to get the row counts of all tables in the destination as a DataFrame.

--- a/docs/website/docs/general-usage/dataset-access/dataset_snippets/dataset_snippets.py
+++ b/docs/website/docs/general-usage/dataset-access/dataset_snippets/dataset_snippets.py
@@ -116,6 +116,18 @@ def row_counts_snippet(dataset: ReadableDBAPIDataset) -> None:
     # @@@DLT_SNIPPET_END row_counts
 
 
+def context_manager_snippet(dataset: ReadableDBAPIDataset) -> None:
+    # @@@DLT_SNIPPET_START context_manager
+
+    # the dataset context manager will keep the connection open
+    # and close it after the with block is exited
+    with dataset as dataset_:
+        print(dataset.customers.limit(50).arrow())
+        print(dataset.purchases.arrow())
+
+    # @@@DLT_SNIPPET_END context_manager
+
+
 def limiting_records_snippet(dataset: ReadableDBAPIDataset) -> None:
     customers_relation = dataset.customers
     # @@@DLT_SNIPPET_START limiting_records

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -465,7 +465,7 @@ def test_limit_and_head(populated_pipeline: Pipeline) -> None:
     dataset_ = populated_pipeline.dataset()
 
     # test sql_client lifecycle
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     table_relationship = dataset_.items
     # ibis relation creates client, default not
@@ -473,54 +473,54 @@ def test_limit_and_head(populated_pipeline: Pipeline) -> None:
 
     assert len(table_relationship.head().fetchall()) == 5
     # no client remains
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     assert len(table_relationship.limit(24).fetchall()) == 24
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     assert len(table_relationship.head().df().index) == 5
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     assert len(table_relationship.limit(24).df().index) == 24
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     assert table_relationship.head().arrow().num_rows == 5
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     assert table_relationship.limit(24).arrow().num_rows == 24
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     limit_relationship = table_relationship.limit(24)
     for data_ in limit_relationship.iter_fetch(6):
         assert len(data_) == 6
         # client stays open
-        assert limit_relationship._opened_client is not None
+        assert limit_relationship._opened_sql_client is not None
 
     # run multiple requests on one connection
     with dataset_ as d_:
         limit_relationship = table_relationship.limit(24)
         for data_ in limit_relationship.iter_fetch(6):
             # client stays open
-            assert limit_relationship._opened_client is not None
+            assert limit_relationship._opened_sql_client is not None
             assert (
-                limit_relationship._opened_client.native_connection
-                == d_._opened_client.native_connection
+                limit_relationship._opened_sql_client.native_connection
+                == d_._opened_sql_client.native_connection
             )
 
         other_relationship = table_relationship.limit(10)
         for data_ in other_relationship.iter_fetch(6):
-            assert other_relationship._opened_client is not None
+            assert other_relationship._opened_sql_client is not None
             assert (
-                other_relationship._opened_client.native_connection
-                == d_._opened_client.native_connection
+                other_relationship._opened_sql_client.native_connection
+                == d_._opened_sql_client.native_connection
             )
 
     # connection closed
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     chunk_size = _chunk_size(populated_pipeline.destination.destination_type)
     list(table_relationship.iter_fetch(chunk_size=chunk_size))
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
 
 @pytest.mark.no_load
@@ -531,44 +531,68 @@ def test_limit_and_head(populated_pipeline: Pipeline) -> None:
     indirect=True,
     ids=lambda x: x.name,
 )
-def test_dataset_context_manager_keeps_connection(populated_pipeline: Pipeline) -> None:
-    with populated_pipeline.dataset() as dataset_:
-        # test sql_client lifecycle
-        assert dataset_._opened_client is not None
+def test_dataset_client_caching_and_connection_handling(populated_pipeline: Pipeline) -> None:
+    # no clients exist yet
+    dataset = populated_pipeline.dataset()
+    assert dataset._opened_sql_client is None
+    assert dataset._sql_client is None
 
+    with dataset as dataset_:
+        # test sql_client lifecycle
+        assert dataset_._opened_sql_client is not None
+
+        first_encountered_opened_sql_client = dataset_._opened_sql_client
+
+        # "regular" clients are not created yet as never used
+        assert dataset_._sql_client is None
+
+        # cached sql client is used
         table_relationship = dataset_.items
-        assert dataset_._opened_client is not None
+        assert dataset_._opened_sql_client is not None
+        assert dataset_._opened_sql_client == first_encountered_opened_sql_client
 
         assert len(table_relationship.head().fetchall()) == 5
-        assert dataset_._opened_client is not None
+        assert dataset_._opened_sql_client is not None
+        assert dataset_._opened_sql_client == first_encountered_opened_sql_client
+
         # connection is kept
-        assert dataset_._opened_client.native_connection is not None
+        assert dataset_._opened_sql_client.native_connection is not None
 
         for data_ in table_relationship.limit(24).iter_fetch(6):
             assert len(data_) == 6
             # connection kept open
-            assert dataset_._opened_client.native_connection is not None
+            assert dataset_._opened_sql_client.native_connection is not None
 
     # connection closed
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
+
+    # we do something that activates the "regular" caching
+    dataset_.items.fetchall()
+    assert dataset_._sql_client is not None
+    assert dataset_._opened_sql_client is None
 
     # open again
     with dataset_:
-        assert dataset_._opened_client is not None
+        assert dataset_._opened_sql_client is not None
         assert len(table_relationship.head().fetchall()) == 5
-        assert dataset_._opened_client is not None
+        assert dataset_._opened_sql_client is not None
         # connection is kept
-        assert dataset_._opened_client.native_connection is not None
+        assert dataset_._opened_sql_client.native_connection is not None
+
+        # the opened client is different from the "regular" one
+        assert dataset_._sql_client != dataset_._opened_sql_client
+        # and different from the last one
+        assert dataset_._opened_sql_client != first_encountered_opened_sql_client
 
         with pytest.raises(AssertionError):
             with dataset_:
                 pass
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
     # check that if the schema needs to be fetched, no opened client is left
     dataset_._schema = None
     assert dataset_.schema
-    assert dataset_._opened_client is None
+    assert dataset_._opened_sql_client is None
 
 
 @pytest.mark.no_load
@@ -937,7 +961,7 @@ def test_standalone_dataset(populated_pipeline: Pipeline) -> None:
     )
     # verify that sql client and schema are lazy loaded
     assert not dataset._schema
-    assert not dataset._opened_client
+    assert not dataset._opened_sql_client
     table_relationship = dataset.items
     table = table_relationship.fetchall()
     assert len(table) == total_records

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -499,7 +499,7 @@ def test_limit_and_head(populated_pipeline: Pipeline) -> None:
     # run multiple requests on one connection
     with dataset_ as d_:
         limit_relationship = table_relationship.limit(24)
-        for data_ in limit_relationship.iter_fetch(6):
+        for _data in limit_relationship.iter_fetch(6):
             # client stays open
             assert limit_relationship._opened_sql_client is not None
             assert (
@@ -508,7 +508,7 @@ def test_limit_and_head(populated_pipeline: Pipeline) -> None:
             )
 
         other_relationship = table_relationship.limit(10)
-        for data_ in other_relationship.iter_fetch(6):
+        for _data in other_relationship.iter_fetch(6):
             assert other_relationship._opened_sql_client is not None
             assert (
                 other_relationship._opened_sql_client.native_connection

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -465,43 +465,62 @@ def test_limit_and_head(populated_pipeline: Pipeline) -> None:
     dataset_ = populated_pipeline.dataset()
 
     # test sql_client lifecycle
-    assert dataset_._sql_client is None
+    assert dataset_._opened_client is None
 
     table_relationship = dataset_.items
     # ibis relation creates client, default not
     # assert dataset_._sql_client is None
 
     assert len(table_relationship.head().fetchall()) == 5
-    assert dataset_._sql_client is not None
-    # we close the connection after each use
-    assert dataset_._sql_client.native_connection is None
+    # no client remains
+    assert dataset_._opened_client is None
 
     assert len(table_relationship.limit(24).fetchall()) == 24
-    assert dataset_._sql_client.native_connection is None
+    assert dataset_._opened_client is None
 
     assert len(table_relationship.head().df().index) == 5
-    assert dataset_._sql_client.native_connection is None
+    assert dataset_._opened_client is None
 
     assert len(table_relationship.limit(24).df().index) == 24
-    assert dataset_._sql_client.native_connection is None
+    assert dataset_._opened_client is None
 
     assert table_relationship.head().arrow().num_rows == 5
-    assert dataset_._sql_client.native_connection is None
+    assert dataset_._opened_client is None
 
     assert table_relationship.limit(24).arrow().num_rows == 24
-    assert dataset_._sql_client.native_connection is None
+    assert dataset_._opened_client is None
 
-    for data_ in table_relationship.limit(24).iter_fetch(6):
+    limit_relationship = table_relationship.limit(24)
+    for data_ in limit_relationship.iter_fetch(6):
         assert len(data_) == 6
-        # connection kept open
-        assert dataset_._sql_client.native_connection is not None
+        # client stays open
+        assert limit_relationship._opened_client is not None
+
+    # run multiple requests on one connection
+    with dataset_ as d_:
+        limit_relationship = table_relationship.limit(24)
+        for data_ in limit_relationship.iter_fetch(6):
+            # client stays open
+            assert limit_relationship._opened_client is not None
+            assert (
+                limit_relationship._opened_client.native_connection
+                == d_._opened_client.native_connection
+            )
+
+        other_relationship = table_relationship.limit(10)
+        for data_ in other_relationship.iter_fetch(6):
+            assert other_relationship._opened_client is not None
+            assert (
+                other_relationship._opened_client.native_connection
+                == d_._opened_client.native_connection
+            )
 
     # connection closed
-    assert dataset_._sql_client.native_connection is None
+    assert dataset_._opened_client is None
 
     chunk_size = _chunk_size(populated_pipeline.destination.destination_type)
     list(table_relationship.iter_fetch(chunk_size=chunk_size))
-    assert dataset_._sql_client.native_connection is None
+    assert dataset_._opened_client is None
 
 
 @pytest.mark.no_load
@@ -515,36 +534,41 @@ def test_limit_and_head(populated_pipeline: Pipeline) -> None:
 def test_dataset_context_manager_keeps_connection(populated_pipeline: Pipeline) -> None:
     with populated_pipeline.dataset() as dataset_:
         # test sql_client lifecycle
-        assert dataset_._sql_client is not None
+        assert dataset_._opened_client is not None
 
         table_relationship = dataset_.items
-        assert dataset_._sql_client is not None
+        assert dataset_._opened_client is not None
 
         assert len(table_relationship.head().fetchall()) == 5
-        assert dataset_._sql_client is not None
+        assert dataset_._opened_client is not None
         # connection is kept
-        assert dataset_._sql_client.native_connection is not None
+        assert dataset_._opened_client.native_connection is not None
 
         for data_ in table_relationship.limit(24).iter_fetch(6):
             assert len(data_) == 6
             # connection kept open
-            assert dataset_._sql_client.native_connection is not None
+            assert dataset_._opened_client.native_connection is not None
 
     # connection closed
-    assert dataset_._sql_client is None
+    assert dataset_._opened_client is None
 
     # open again
     with dataset_:
-        assert dataset_._sql_client is not None
+        assert dataset_._opened_client is not None
         assert len(table_relationship.head().fetchall()) == 5
-        assert dataset_._sql_client is not None
+        assert dataset_._opened_client is not None
         # connection is kept
-        assert dataset_._sql_client.native_connection is not None
+        assert dataset_._opened_client.native_connection is not None
 
         with pytest.raises(AssertionError):
             with dataset_:
                 pass
-    assert dataset_._sql_client is None
+    assert dataset_._opened_client is None
+
+    # check that if the schema needs to be fetched, no opened client is left
+    dataset_._schema = None
+    assert dataset_.schema
+    assert dataset_._opened_client is None
 
 
 @pytest.mark.no_load
@@ -913,7 +937,7 @@ def test_standalone_dataset(populated_pipeline: Pipeline) -> None:
     )
     # verify that sql client and schema are lazy loaded
     assert not dataset._schema
-    assert not dataset._sql_client
+    assert not dataset._opened_client
     table_relationship = dataset.items
     table = table_relationship.fetchall()
     assert len(table) == total_records


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
The dataset opened the connection in some cases when it was not needed, which slows down operations in certain cases (discovered during development on dlt app)