### PR TITLE
Psycopg2SqlClient: accept extra options

### DIFF
--- a/dlt/destinations/impl/postgres/sql_client.py
+++ b/dlt/destinations/impl/postgres/sql_client.py
@@ -45,9 +45,13 @@ class Psycopg2SqlClient(SqlClientBase["psycopg2.connection"], DBTransaction):
         self.credentials = credentials
 
     def open_connection(self) -> "psycopg2.connection":
+        options=f"-c search_path={self.fully_qualified_dataset_name()},public"
+        extra_options = self.credentials.query.get("options")
+        if extra_options:
+            options = f"{extra_options} {options}"
         self._conn = psycopg2.connect(
             dsn=self.credentials.to_native_representation(),
-            options=f"-c search_path={self.fully_qualified_dataset_name()},public",
+            options=options,
         )
         # we'll provide explicit transactions see _reset
         self._reset_connection()


### PR DESCRIPTION
### Description

Add ability to add Postgres runtime server config via Psycopg2SqlClient.

Example of PostgresCredentials usage with "my_setting" server setting :
```
from dlt.destinations.impl.postgres.configuration import PostgresCredentials

creds = PostgresCredentials("postgresql://user:password@host:port/db?options=-cmy_setting=value")
```

### Additional Context

I needed to transmit a parameter (such as a session option) to the PostgreSQL server, but the current implementation of Psycopg2SqlClient did not allow me to do this easily.


