### PR TITLE
allow defaults for custom sources v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,10 +139,6 @@ logs/
 # temp
 tmp
 **/tmp
-playground
-repomix-output.xml
-**/*.back
-.dlt/*
 
 # Qdrant embedding models cache
 local_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,10 @@ logs/
 # temp
 tmp
 **/tmp
+playground
+repomix-output.xml
+**/*.back
+.dlt/*
 
 # Qdrant embedding models cache
 local_cache/

--- a/dlt/cli/config_toml_writer.py
+++ b/dlt/cli/config_toml_writer.py
@@ -92,14 +92,12 @@ def write_spec(
         # use default value stored in config
         default_value = getattr(config, name, None)
 
-        if isinstance(config.__config_gen_annotations__, dict) and name in config.__config_gen_annotations__:
-            print("resolving config:", type(config))
-            print("write_spec took default from annotions-dict while writing", name, hint, default_value)
+        # if config is a BaseConfiguration it may have defaults in annotations
+        if (
+            isinstance(config.__config_gen_annotations__, dict)
+            and name in config.__config_gen_annotations__
+        ):
             default_value = config.__config_gen_annotations__.get(name, default_value)
-        else:
-            # print("regular annotated config", type(config))
-            pass
-
 
         # check if field is of particular interest and should be included if it has default
         is_default_of_interest = name in config.__config_gen_annotations__

--- a/dlt/cli/config_toml_writer.py
+++ b/dlt/cli/config_toml_writer.py
@@ -92,6 +92,15 @@ def write_spec(
         # use default value stored in config
         default_value = getattr(config, name, None)
 
+        if isinstance(config.__config_gen_annotations__, dict) and name in config.__config_gen_annotations__:
+            print("resolving config:", type(config))
+            print("write_spec took default from annotions-dict while writing", name, hint, default_value)
+            default_value = config.__config_gen_annotations__.get(name, default_value)
+        else:
+            # print("regular annotated config", type(config))
+            pass
+
+
         # check if field is of particular interest and should be included if it has default
         is_default_of_interest = name in config.__config_gen_annotations__
 

--- a/dlt/cli/source_detection.py
+++ b/dlt/cli/source_detection.py
@@ -114,11 +114,9 @@ def extract_secrets_and_configs_from_source_reference(
         if val_store is not None:
             # we are sure that all sources come from single file so we can put them in single section
             default_value = None
+            # check if defaults are defined in annotations
             if isinstance(source_config.__config_gen_annotations__, dict):
                 default_value = source_config.__config_gen_annotations__.get(field_name, None)
-                print("extract secrets looked up a default from config_annootations", default_value)
-                print('section', section)
-                print('field_name', field_name)
             val_store[source_info.name + ":" + field_name] = WritableConfigValue(
                 field_name, field_type, default_value, section
             )

--- a/dlt/cli/source_detection.py
+++ b/dlt/cli/source_detection.py
@@ -113,6 +113,12 @@ def extract_secrets_and_configs_from_source_reference(
 
         if val_store is not None:
             # we are sure that all sources come from single file so we can put them in single section
+            default_value = None
+            if isinstance(source_config.__config_gen_annotations__, dict):
+                default_value = source_config.__config_gen_annotations__.get(field_name, None)
+                print("extract secrets looked up a default from config_annootations", default_value)
+                print('section', section)
+                print('field_name', field_name)
             val_store[source_info.name + ":" + field_name] = WritableConfigValue(
-                field_name, field_type, None, section
+                field_name, field_type, default_value, section
             )

--- a/dlt/common/configuration/specs/base_configuration.py
+++ b/dlt/common/configuration/specs/base_configuration.py
@@ -290,7 +290,7 @@ class BaseConfiguration(MutableMapping[str, Any]):
     """Holds the exception that prevented the full resolution"""
     __section__: ClassVar[str] = None
     """Obligatory section used by config providers when searching for keys, always present in the search path"""
-    __config_gen_annotations__: ClassVar[List[str]] = []
+    __config_gen_annotations__: ClassVar[Union[List[str], Dict[str, Any]]] = []
     """Additional annotations for config generator, currently holds a list of fields of interest that have defaults"""
     __dataclass_fields__: ClassVar[Dict[str, TDtcField]]
     """Typing for dataclass fields"""

--- a/dlt/common/configuration/specs/connection_string_credentials.py
+++ b/dlt/common/configuration/specs/connection_string_credentials.py
@@ -18,13 +18,14 @@ class ConnectionStringCredentials(CredentialsConfiguration):
     port: Optional[int] = None
     query: Optional[Dict[str, Any]] = None
 
-    __config_gen_annotations__: ClassVar[List[str]] = [
-        "database",
-        "port",
-        "username",
-        "password",
-        "host",
-    ]
+    __config_gen_annotations__: ClassVar[Union[List[str], Dict[str, Any]]] = {
+        "drivername": "mysql+pymysql",
+        "database": "Rfam",
+        "username": "rfamro",
+        "host": "mysql-rfam-public.ebi.ac.uk",
+        "port": "4497",
+    }
+
 
     def __init__(self, connection_string: Union[str, Dict[str, Any]] = None) -> None:
         """Initializes the credentials from SQLAlchemy like connection string or from dict holding connection string elements"""

--- a/dlt/common/configuration/specs/connection_string_credentials.py
+++ b/dlt/common/configuration/specs/connection_string_credentials.py
@@ -26,7 +26,6 @@ class ConnectionStringCredentials(CredentialsConfiguration):
         "port": "4497",
     }
 
-
     def __init__(self, connection_string: Union[str, Dict[str, Any]] = None) -> None:
         """Initializes the credentials from SQLAlchemy like connection string or from dict holding connection string elements"""
         super().__init__()

--- a/dlt/common/reflection/spec.py
+++ b/dlt/common/reflection/spec.py
@@ -36,7 +36,7 @@ def spec_from_signature(
     sig: Signature,
     include_defaults: bool = True,
     base: Type[BaseConfiguration] = BaseConfiguration,
-    config_defaults: Dict[str, Any] = None
+    config_defaults: Dict[str, Any] = None,
 ) -> Tuple[Type[BaseConfiguration], Dict[str, Any]]:
     """Creates a SPEC on base `base1 for a function `f` with signature `sig`.
 

--- a/dlt/common/reflection/spec.py
+++ b/dlt/common/reflection/spec.py
@@ -109,6 +109,13 @@ def spec_from_signature(
                     # set field with default value
                     new_fields[p.name] = p.default
                     # print(f"Param {p.name} is {field_type}: {p.default} due to {include_defaults} or {type_from_literal}")
+                if config_defaults and p.name in config_defaults:
+                    # verify that the type of the value is an instance of the field type
+                    if not isinstance(config_defaults[p.name], field_type):
+                        raise TypeError(
+                            f"Invalid default config: Expected type {field_type} for {p.name} , got"
+                            f" {type(config_defaults[p.name])}"
+                        )
 
     signature_fields = {**sig_base_fields, **new_fields}
 

--- a/dlt/common/reflection/spec.py
+++ b/dlt/common/reflection/spec.py
@@ -36,6 +36,7 @@ def spec_from_signature(
     sig: Signature,
     include_defaults: bool = True,
     base: Type[BaseConfiguration] = BaseConfiguration,
+    config_defaults: Dict[str, Any] = None
 ) -> Tuple[Type[BaseConfiguration], Dict[str, Any]]:
     """Creates a SPEC on base `base1 for a function `f` with signature `sig`.
 
@@ -117,6 +118,8 @@ def spec_from_signature(
     new_fields["__annotations__"] = annotations
     # synthesize type
     T: Type[BaseConfiguration] = type(name, (base,), new_fields)
+    if config_defaults:
+        T.__config_gen_annotations__ = config_defaults
     SPEC = configspec()(T)
     # add to the module
     setattr(module, spec_id, SPEC)

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -464,6 +464,7 @@ def resource(
     incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
+    config_defaults: Dict[str, Any] = None
 ) -> TDltResourceImpl: ...
 
 
@@ -489,6 +490,7 @@ def resource(
     incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
+    config_defaults: Dict[str, Any] = None
 ) -> Callable[[Callable[TResourceFunParams, Any]], TDltResourceImpl]: ...
 
 
@@ -515,6 +517,7 @@ def resource(
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
     standalone: Literal[True] = True,
+    config_defaults: Dict[str, Any] = None
 ) -> Callable[
     [Callable[TResourceFunParams, Any]], Callable[TResourceFunParams, TDltResourceImpl]
 ]: ...
@@ -542,6 +545,7 @@ def resource(
     incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
+    config_defaults: Dict[str, Any] = None
 ) -> TDltResourceImpl: ...
 
 
@@ -568,6 +572,7 @@ def resource(
     section: Optional[str] = None,
     standalone: bool = False,
     data_from: TUnboundDltResource = None,
+    config_defaults: Dict[str, Any] = None
 ) -> Any:
     """When used as a decorator, transforms any generator (yielding) function into a `dlt resource`. When used as a function, it transforms data in `data` argument into a `dlt resource`.
 
@@ -744,7 +749,7 @@ def resource(
         if spec is None:
             # autodetect spec
             SPEC, resolvable_fields = spec_from_signature(
-                f, inspect.signature(f), include_defaults=standalone
+                f, inspect.signature(f), include_defaults=standalone, config_defaults=config_defaults
             )
             if is_inner_resource and not standalone:
                 if len(resolvable_fields) > 0:
@@ -755,6 +760,9 @@ def resource(
                     SPEC = BaseConfiguration
         else:
             SPEC = spec
+            if config_defaults:
+                print('must reconcile with possible given defaults')
+                SPEC.__config_gen_annotations__ = config_defaults
         # assign spec to "f"
         set_fun_spec(f, SPEC)
 

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -464,7 +464,7 @@ def resource(
     incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
-    config_defaults: Dict[str, Any] = None
+    config_defaults: Dict[str, Any] = None,
 ) -> TDltResourceImpl: ...
 
 
@@ -490,7 +490,7 @@ def resource(
     incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
-    config_defaults: Dict[str, Any] = None
+    config_defaults: Dict[str, Any] = None,
 ) -> Callable[[Callable[TResourceFunParams, Any]], TDltResourceImpl]: ...
 
 
@@ -516,8 +516,8 @@ def resource(
     incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
+    config_defaults: Dict[str, Any] = None,
     standalone: Literal[True] = True,
-    config_defaults: Dict[str, Any] = None
 ) -> Callable[
     [Callable[TResourceFunParams, Any]], Callable[TResourceFunParams, TDltResourceImpl]
 ]: ...
@@ -545,7 +545,7 @@ def resource(
     incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
-    config_defaults: Dict[str, Any] = None
+    config_defaults: Dict[str, Any] = None,
 ) -> TDltResourceImpl: ...
 
 
@@ -570,9 +570,9 @@ def resource(
     incremental: Optional[TIncrementalConfig] = None,
     _impl_cls: Type[TDltResourceImpl] = DltResource,  # type: ignore[assignment]
     section: Optional[str] = None,
+    config_defaults: Dict[str, Any] = None,
     standalone: bool = False,
     data_from: TUnboundDltResource = None,
-    config_defaults: Dict[str, Any] = None
 ) -> Any:
     """When used as a decorator, transforms any generator (yielding) function into a `dlt resource`. When used as a function, it transforms data in `data` argument into a `dlt resource`.
 
@@ -649,6 +649,8 @@ def resource(
 
         section (Optional[str], optional): Configuration section that comes right after 'sources` in default layout. If not present, the current python module name will be used.
             Default layout is `sources.<section>.<name>.<key_name>`. Note that resource section is used only when a single resource is passed to the pipeline.
+
+        config_defaults (Dict[str, Any], optional): A dictionary of default values for to be used when writing a `dlt.config.value`s to config.toml
 
         standalone (bool, optional): Returns a wrapped decorated function that creates DltResource instance. Must be called before use. Cannot be part of a source.
 
@@ -749,7 +751,10 @@ def resource(
         if spec is None:
             # autodetect spec
             SPEC, resolvable_fields = spec_from_signature(
-                f, inspect.signature(f), include_defaults=standalone, config_defaults=config_defaults
+                f,
+                inspect.signature(f),
+                include_defaults=standalone,
+                config_defaults=config_defaults,
             )
             if is_inner_resource and not standalone:
                 if len(resolvable_fields) > 0:
@@ -761,7 +766,7 @@ def resource(
         else:
             SPEC = spec
             if config_defaults:
-                print('must reconcile with possible given defaults')
+                # note: should given defaults override spec defaults?
                 SPEC.__config_gen_annotations__ = config_defaults
         # assign spec to "f"
         set_fun_spec(f, SPEC)

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -1674,10 +1674,10 @@ class Pipeline(SupportsPipeline):
     ) -> None:
         """Save given state + schema and extract creating a new load package
 
-        Args:
-            state (TPipelineState): The new pipeline state, replaces the current state
-            schema (Schema): The new source schema, replaces current schema of the same name
-            load_package_state_update (Optional[TLoadPackageState]): Dict which items will be included in the load package state
+        p       Args:
+                   state (TPipelineState): The new pipeline state, replaces the current state
+                   schema (Schema): The new source schema, replaces current schema of the same name
+                   load_package_state_update (Optional[TLoadPackageState]): Dict which items will be included in the load package state
         """
         self.schemas.save_schema(schema)
         with self.managed_state() as old_state:

--- a/dlt/sources/_single_file_templates/arrow_pipeline.py
+++ b/dlt/sources/_single_file_templates/arrow_pipeline.py
@@ -15,6 +15,7 @@ def create_example_arrow_table() -> pa.Table:
     write_disposition="append",
     name="people",
     config_defaults={"sample_config": "if you read this it works!"},
+    # config_defaults={"sample_config": False}, # uncomment this to test importing wrong config
 )
 def resource(sample_config: str = dlt.config.value):
     """One resource function will materialize as a table in the destination, wie yield example data here"""

--- a/dlt/sources/_single_file_templates/arrow_pipeline.py
+++ b/dlt/sources/_single_file_templates/arrow_pipeline.py
@@ -11,8 +11,11 @@ def create_example_arrow_table() -> pa.Table:
     return pa.Table.from_pylist([{"name": "tom", "age": 25}, {"name": "angela", "age": 23}])
 
 
-@dlt.resource(write_disposition="append", name="people")
-def resource():
+@dlt.resource(
+        write_disposition="append", name="people", 
+        config_defaults={"sample_config": "if you read this it works!"}
+)
+def resource(sample_config: str = dlt.config.value):
     """One resource function will materialize as a table in the destination, wie yield example data here"""
     yield create_example_arrow_table()
 

--- a/dlt/sources/_single_file_templates/arrow_pipeline.py
+++ b/dlt/sources/_single_file_templates/arrow_pipeline.py
@@ -12,8 +12,9 @@ def create_example_arrow_table() -> pa.Table:
 
 
 @dlt.resource(
-        write_disposition="append", name="people", 
-        config_defaults={"sample_config": "if you read this it works!"}
+    write_disposition="append",
+    name="people",
+    config_defaults={"sample_config": "if you read this it works!"},
 )
 def resource(sample_config: str = dlt.config.value):
     """One resource function will materialize as a table in the destination, wie yield example data here"""

--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -154,8 +154,10 @@ def sql_database(
 
 
 @decorators.resource(
-    name=lambda args: args["table"], standalone=True, spec=SqlTableResourceConfiguration,
-    config_defaults={"table": "genome2"}
+    name=lambda args: args["table"],
+    standalone=True,
+    spec=SqlTableResourceConfiguration,
+    config_defaults={"table": "genome2"},
 )
 def sql_table(
     credentials: Union[ConnectionStringCredentials, Engine, str] = dlt.secrets.value,

--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -154,7 +154,8 @@ def sql_database(
 
 
 @decorators.resource(
-    name=lambda args: args["table"], standalone=True, spec=SqlTableResourceConfiguration
+    name=lambda args: args["table"], standalone=True, spec=SqlTableResourceConfiguration,
+    config_defaults={"table": "genome2"}
 )
 def sql_table(
     credentials: Union[ConnectionStringCredentials, Engine, str] = dlt.secrets.value,

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -412,3 +412,4 @@ class SqlTableResourceConfiguration(BaseConfiguration):
     write_disposition: Optional[TWriteDispositionDict] = None
     primary_key: Optional[TColumnNames] = None
     merge_key: Optional[TColumnNames] = None
+

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -412,4 +412,3 @@ class SqlTableResourceConfiguration(BaseConfiguration):
     write_disposition: Optional[TWriteDispositionDict] = None
     primary_key: Optional[TColumnNames] = None
     merge_key: Optional[TColumnNames] = None
-

--- a/tests/cli/test_config_toml_writer.py
+++ b/tests/cli/test_config_toml_writer.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import ClassVar, List, Optional, Final
+import dlt
 import pytest
 import tomlkit
 
@@ -292,3 +293,31 @@ aws_secret_access_key = "<configure me>" # fill this in!
 
     # still here because marked specifically as of interest
     assert example_toml["snowflake"]["database"] == "dlt_db"
+
+
+def test_write_spec_from_resource_takes_defaults_from_config_gen_annotations(example_toml) -> None:
+    from tests.common.cases.sources.valid_config_defaults import resource
+
+    # verify that the resource has a dict with example values
+    assert isinstance(resource.SPEC.__config_gen_annotations__, dict)
+    assert resource.SPEC.__config_gen_annotations__["sample_config"] == "some_str"
+
+    # and that they are written to the toml
+    write_value(
+        example_toml,
+        "resource_with_valid_defaults",
+        resource.SPEC,
+        None,
+        is_default_of_interest=False,
+    )
+
+    assert example_toml["resource_with_valid_defaults"]["sample_config"] == "some_str"
+
+
+def test_config_defaults_checks_types(example_toml) -> None:
+    with pytest.raises(TypeError) as exc_info:
+        from tests.common.cases.sources.invalid_config_default import resource
+
+        assert "Expected type <class 'str'> for sample_config , got <class 'bool'>" in str(
+            exc_info.value
+        )

--- a/tests/common/cases/sources/invalid_config_default.py
+++ b/tests/common/cases/sources/invalid_config_default.py
@@ -1,0 +1,9 @@
+import dlt
+from typing import List
+
+
+@dlt.resource(config_defaults={"sample_config": False})
+def resource(
+    sample_config: str = dlt.config.value,
+) -> List[int]:
+    return [1, 2, 3]

--- a/tests/common/cases/sources/valid_config_defaults.py
+++ b/tests/common/cases/sources/valid_config_defaults.py
@@ -1,0 +1,7 @@
+import dlt
+from typing import List
+
+
+@dlt.resource(config_defaults={"sample_config": "some_str"})
+def resource(sample_config: str = dlt.config.value) -> List[int]:
+    return [1, 2, 3]


### PR DESCRIPTION
allow defining defaults for config values via `__config_gen_annotations__`

what's the use:
- a source that gets added (e.g. players in chess) can define defaults that get written to `config.toml` 
- do people define their own sources to be used by others? 


todo: 
- allow this for sources too (I think I need some help to understand how to pass args from sources to resources here)
- ... and transformers?

thoughts:
- there will be no typechecking in the editor or linter, only when the source is imported. that is a bit of a departure from how it is at the moment.
- it's a bit confusing that these defaults are only used to write the config. We could also allow them to be used if no config is provided? (I have the code already, but no tests for it and unsure whether it covers all cases)