### PR TITLE
Add support for creating custom integer-range partition table in BigQuery

### DIFF
--- a/dlt/destinations/adapters.py
+++ b/dlt/destinations/adapters.py
@@ -3,7 +3,7 @@
 from dlt.destinations.impl.weaviate.weaviate_adapter import weaviate_adapter
 from dlt.destinations.impl.qdrant.qdrant_adapter import qdrant_adapter
 from dlt.destinations.impl.lancedb import lancedb_adapter
-from dlt.destinations.impl.bigquery.bigquery_adapter import bigquery_adapter
+from dlt.destinations.impl.bigquery.bigquery_adapter import bigquery_adapter, bigquery_partition
 from dlt.destinations.impl.synapse.synapse_adapter import synapse_adapter
 from dlt.destinations.impl.clickhouse.clickhouse_adapter import clickhouse_adapter
 from dlt.destinations.impl.athena.athena_adapter import athena_adapter, athena_partition
@@ -14,6 +14,7 @@ __all__ = [
     "qdrant_adapter",
     "lancedb_adapter",
     "bigquery_adapter",
+    "bigquery_partition",
     "synapse_adapter",
     "clickhouse_adapter",
     "athena_adapter",

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -251,6 +251,24 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
                     self.config.retry_deadline,
                 )
         return job
+    
+    def _bigquery_partition_clause(self, partition_hint: Optional[Dict[str, str]]) -> str:
+        """Generate partition clause for BigQuery SQL.
+
+        Args:
+            partition_hint (Optional[Dict[str, str]]): Partition hint.
+
+        Returns:
+            str: The partition clause for BigQuery SQL.
+        """
+        if not partition_hint:
+            return ""
+        
+        if len(partition_hint) > 1:
+            raise DestinationSchemaWillNotUpdate("BigQuery only supports partitioning by one column at a time.")
+
+        [(column_name, clause)] = partition_hint.items()
+        return f"PARTITION BY {clause.format(column_name=self.sql_client.escape_column_name(column_name))}"
 
     def _get_table_update_sql(
         self, table_name: str, new_columns: Sequence[TColumnSchema], generate_alter: bool
@@ -264,6 +282,7 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
         sql = super()._get_table_update_sql(table_name, new_columns, generate_alter)
         canonical_name = self.sql_client.make_qualified_table_name(table_name)
 
+        # handle partitioning when user passes a string to the `partition` param in bigquery_adapter
         if partition_list := [
             c for c in new_columns if c.get("partition") or c.get(PARTITION_HINT, False)
         ]:
@@ -288,6 +307,16 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
                     f"\nPARTITION BY RANGE_BUCKET({self.sql_client.escape_column_name(c['name'])},"
                     " GENERATE_ARRAY(-172800000, 691200000, 86400))"
                 )
+        # handle partitioning when user passes a PartitionTransformation to the `partition` param in bigquery_adapter
+        partition_hint = table.get(PARTITION_HINT)
+        if partition_hint and len(partition_hint) > 1:
+            col_names = [self.sql_client.escape_column_name(col) for col, v in partition_hint.items()]
+            raise DestinationSchemaWillNotUpdate(
+                canonical_name, col_names, "Partition requested for more than one column"
+            )
+
+        sql[0] += self._bigquery_partition_clause(table.get(PARTITION_HINT))
+             
 
         # Collect cluster columns from table-level and per-column hints
         cluster_columns_from_table_hint = list(

--- a/dlt/destinations/impl/bigquery/bigquery_adapter.py
+++ b/dlt/destinations/impl/bigquery/bigquery_adapter.py
@@ -66,7 +66,7 @@ class bigquery_partition:
 
 def bigquery_adapter(
     data: Any,
-    partition: Union[str, PartitionTransformation] = None,
+    partition: Union[TColumnNames, PartitionTransformation] = None,
     cluster: TColumnNames = None,
     round_half_away_from_zero: TColumnNames = None,
     round_half_even: TColumnNames = None,

--- a/dlt/destinations/impl/bigquery/bigquery_adapter.py
+++ b/dlt/destinations/impl/bigquery/bigquery_adapter.py
@@ -60,7 +60,7 @@ class bigquery_partition:
         """
         # Correct BigQuery syntax for integer range partitioning
         template = f"RANGE_BUCKET({{column_name}}, GENERATE_ARRAY({start}, {end}, {interval}))"
-        
+
         return PartitionTransformation(template, column_name)
 
 
@@ -131,15 +131,17 @@ def bigquery_adapter(
 
     if partition:
         if not (isinstance(partition, str) or isinstance(partition, PartitionTransformation)):
-            raise ValueError("`partition` must be a single column name as a string or a PartitionTransformation.")
+            raise ValueError(
+                "`partition` must be a single column name as a string or a PartitionTransformation."
+            )
 
         # Can only have one partition column.
         for column in resource.columns.values():  # type: ignore[union-attr]
             column.pop(PARTITION_HINT, None)  # type: ignore[typeddict-item]
-        
+
         if isinstance(partition, str):
             column_hints[partition] = {"name": partition, PARTITION_HINT: True}  # type: ignore[typeddict-unknown-key]
-        
+
         if isinstance(partition, PartitionTransformation):
             partition_hint: Dict[str, str] = {}
             partition_hint[partition.column_name] = partition.template

--- a/dlt/destinations/impl/bigquery/bigquery_adapter.py
+++ b/dlt/destinations/impl/bigquery/bigquery_adapter.py
@@ -87,7 +87,7 @@ def bigquery_adapter(
         data (Any): The data to be transformed.
             This can be raw data or an instance of DltResource.
             If raw data is provided, the function will wrap it into a `DltResource` object.
-        partition (Union[str, PartitionTransformation], optional): The column to partition the BigQuery table by.
+        partition (Union[TColumnNames, PartitionTransformation], optional): The column to partition the BigQuery table by.
             This can be a string representing a single column name for simple partitioning,
             or a PartitionTransformation object for advanced partitioning.
             Use the bigquery_partition helper class to create transformation objects.

--- a/dlt/destinations/impl/bigquery/bigquery_adapter.py
+++ b/dlt/destinations/impl/bigquery/bigquery_adapter.py
@@ -58,7 +58,7 @@ class bigquery_partition:
         Returns:
             A PartitionTransformation object for integer range partitioning
         """
-        # Correct BigQuery syntax for integer range partitioning
+
         template = f"RANGE_BUCKET({{column_name}}, GENERATE_ARRAY({start}, {end}, {interval}))"
 
         return PartitionTransformation(template, column_name)

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -253,7 +253,6 @@ def test_create_table_with_integer_partition(gcp_client: BigQueryClient) -> None
 
 
 def test_create_table_with_custom_range_bucket_partition() -> None:
-
     @dlt.resource
     def partitioned_table():
         yield {
@@ -290,10 +289,7 @@ def test_create_table_with_custom_range_bucket_partition() -> None:
             False,
         )[0]
 
-
-    expected_clause = (
-        "PARTITION BY RANGE_BUCKET(`user_id`, GENERATE_ARRAY(0, 1000000, 10000))"
-    )
+    expected_clause = "PARTITION BY RANGE_BUCKET(`user_id`, GENERATE_ARRAY(0, 1000000, 10000))"
     assert expected_clause in sql_partitioned
 
 
@@ -570,7 +566,12 @@ def test_adapter_hints_parsing_partitioning_more_than_one_column() -> None:
         "col2": {"data_type": "bigint", "name": "col2"},
     }
 
-    with pytest.raises(ValueError, match="^`partition` must be a single column name as a string or a PartitionTransformation.$"):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "^`partition` must be a single column name as a string or a PartitionTransformation.$"
+        ),
+    ):
         bigquery_adapter(some_data, partition=["col1", "col2"])
 
 

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -267,11 +267,10 @@ def test_create_table_with_custom_integer_range_partition() -> None:
     bigquery_adapter(
         partitioned_table,
         partition=bigquery_partition.integer_range(
-            column="user_id",
+            column_name="user_id",
             start=0,
             end=1000000,
             interval=10000,
-            require_partition_filter=True,
         ),
     )
 

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -571,7 +571,7 @@ def test_adapter_hints_parsing_partitioning_more_than_one_column() -> None:
         "col2": {"data_type": "bigint", "name": "col2"},
     }
 
-    with pytest.raises(ValueError, match="^`partition` must be a single column name as a string.$"):
+    with pytest.raises(ValueError, match="^`partition` must be a single column name as a string or a PartitionTransformation.$"):
         bigquery_adapter(some_data, partition=["col1", "col2"])
 
 

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -292,8 +292,7 @@ def test_create_table_with_custom_range_bucket_partition() -> None:
 
 
     expected_clause = (
-        "PARTITION BY RANGE_BUCKET(`user_id`, GENERATE_ARRAY(0, 1000000, 10000)) OPTIONS("
-        "require_partition_filter=true)"
+        "PARTITION BY RANGE_BUCKET(`user_id`, GENERATE_ARRAY(0, 1000000, 10000))"
     )
     assert expected_clause in sql_partitioned
 

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -283,7 +283,7 @@ def test_create_table_with_custom_range_bucket_partition() -> None:
     pipeline.normalize()
 
     with pipeline.destination_client() as client:
-        sql_partitioned = client._get_table_update_sql(
+        sql_partitioned = client._get_table_update_sql(  # type: ignore[attr-defined]
             "partitioned_table",
             list(pipeline.default_schema.tables["partitioned_table"]["columns"].values()),
             False,

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -253,8 +253,6 @@ def test_create_table_with_integer_partition(gcp_client: BigQueryClient) -> None
 
 
 def test_create_table_with_custom_integer_range_partition() -> None:
-    import dlt
-    from dlt.destinations.adapters import bigquery_adapter, bigquery_partition
 
     @dlt.resource
     def partitioned_table():

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -252,7 +252,7 @@ def test_create_table_with_integer_partition(gcp_client: BigQueryClient) -> None
     assert "PARTITION BY RANGE_BUCKET(`col1`, GENERATE_ARRAY(-172800000, 691200000, 86400))" in sql
 
 
-def test_create_table_with_custom_integer_range_partition() -> None:
+def test_create_table_with_custom_range_bucket_partition() -> None:
 
     @dlt.resource
     def partitioned_table():
@@ -266,7 +266,7 @@ def test_create_table_with_custom_integer_range_partition() -> None:
 
     bigquery_adapter(
         partitioned_table,
-        partition=bigquery_partition.integer_range(
+        partition=bigquery_partition.range_bucket(
             column_name="user_id",
             start=0,
             end=1000000,

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -19,7 +19,7 @@ from dlt.common.schema.exceptions import SchemaIdentifierNormalizationCollision
 from dlt.common.utils import custom_environ
 from dlt.common.utils import uniq_id
 from dlt.destinations import bigquery
-from dlt.destinations.adapters import bigquery_adapter
+from dlt.destinations.adapters import bigquery_adapter, bigquery_partition
 from dlt.destinations.exceptions import DestinationSchemaWillNotUpdate
 from dlt.destinations.impl.bigquery.bigquery import BigQueryClient
 from dlt.destinations.impl.bigquery.bigquery_adapter import (
@@ -250,6 +250,55 @@ def test_create_table_with_integer_partition(gcp_client: BigQueryClient) -> None
     sql = gcp_client._get_table_update_sql("event_test_table", mod_update, False)[0]
     sqlfluff.parse(sql, dialect="bigquery")
     assert "PARTITION BY RANGE_BUCKET(`col1`, GENERATE_ARRAY(-172800000, 691200000, 86400))" in sql
+
+
+def test_create_table_with_custom_integer_range_partition() -> None:
+    import dlt
+    from dlt.destinations.adapters import bigquery_adapter, bigquery_partition
+
+    @dlt.resource
+    def partitioned_table():
+        yield {
+            "user_id": 10000,
+            "name": "user 1",
+            "created_at": "2021-01-01T00:00:00Z",
+            "category": "category 1",
+            "score": 100.0,
+        }
+
+    bigquery_adapter(
+        partitioned_table,
+        partition=bigquery_partition.integer_range(
+            column="user_id",
+            start=0,
+            end=1000000,
+            interval=10000,
+            require_partition_filter=True,
+        ),
+    )
+
+    pipeline = dlt.pipeline(
+        "bigquery_test",
+        destination="bigquery",
+        dev_mode=True,
+    )
+
+    pipeline.extract(partitioned_table)
+    pipeline.normalize()
+
+    with pipeline.destination_client() as client:
+        sql_partitioned = client._get_table_update_sql(
+            "partitioned_table",
+            list(pipeline.default_schema.tables["partitioned_table"]["columns"].values()),
+            False,
+        )[0]
+
+
+    expected_clause = (
+        "PARTITION BY RANGE_BUCKET(`user_id`, GENERATE_ARRAY(0, 1000000, 10000)) OPTIONS("
+        "require_partition_filter=true)"
+    )
+    assert expected_clause in sql_partitioned
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Add full support for the `RANGE_BUCKET` partition expression in BigQuery

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #2516
- Closes #2516
- Resolves #2516

<!--
Provide any additional context about the PR here.
-->
### Additional Context

* [Create an integer-range partitioned table](https://cloud.google.com/bigquery/docs/creating-partitioned-tables#create_an_integer-range_partitioned_table)
* [CREATE TABLE syntax](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_statement)

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
