### PR TITLE
fix/2677: remove recursive filewatching

### DIFF
--- a/docs/website/tools/preprocess_docs.js
+++ b/docs/website/tools/preprocess_docs.js
@@ -420,7 +420,7 @@ processDocs()
 if (process.argv.includes("--watch")) {
   console.log(`Watching...`)
   let lastUpdate = Date.now();
-  watch("../", { recursive: true, filter: /\.(py|toml|md)$/  }, function(evt, name) {
+  watch("./docs", { recursive: true, filter: /\.(py|toml|md)$/  }, function(evt, name) {
       // break update loop
       if (Date.now() - lastUpdate < 500) {
           return;


### PR DESCRIPTION
Partially fixes #2677. 

Nonetheless, docs updates are slow because `tools/preprocess_docs.js` updates all files in `docs_processed/`. Then, Docusaurus thinks it needs to recompile everything.  