### PR TITLE
Fix/2527-transformations: snowflake case sensitivity workaround

### DIFF
--- a/dlt/normalize/items_normalizers.py
+++ b/dlt/normalize/items_normalizers.py
@@ -286,7 +286,13 @@ class ModelItemsNormalizer(ItemsNormalizer):
 
             norm_casefolded = self._normalize_casefold(name)
             selected_columns.append(norm_casefolded)
-            outer_selects.append(sqlglot.column(name, table=DLT_SUBQUERY_NAME).as_(norm_casefolded))
+
+            column_ref = sqlglot.exp.Dot(
+                this=sqlglot.exp.to_identifier(DLT_SUBQUERY_NAME),
+                expression=sqlglot.exp.to_identifier(name, quoted=True),
+            )
+
+            outer_selects.append(column_ref.as_(norm_casefolded))
 
         needs_reordering = selected_columns != list(columns.keys())
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR adjusts the building of the outer select in the model normalizer. As a result, the normalizer now explicitly quotes all columns in the outer select. For comparison, previously the resulting query looked like:
```sql
SELECT
   _dlt_subquery.ID AS ID, 
   '1748422702.911065' AS _DLT_LOAD_ID, 
   _dlt_subquery._DLT_ID AS _DLT_ID, 
   _dlt_subquery.double_items AS DOUBLE_ITEMS 
FROM (
   SELECT
      "t0"."ID" AS "ID", 
      "t0"."_DLT_LOAD_ID" AS "_DLT_LOAD_ID",
      "t0"."_DLT_ID" AS "_DLT_ID", "t0"."ID" * 2 AS "double_items" 
   FROM
      "SOURCE_202505280858122110"."ITEMS" AS "t0" 
   WHERE
      "t0"."_DLT_LOAD_ID" > '0' AND "t0"."_DLT_LOAD_ID" <= '1748422692.6911948'
)  AS _dlt_subquery
```
Now it looks like:
```sql
SELECT
   _dlt_subquery."ID " AS ID,
   '1748436815.547415' AS _DLT_LOAD_ID,
   _dlt_subquery."_DLT_ID" AS _DLT_ID,
   _dlt_subquery."double_items" AS DOUBLE_ITEMS
FROM (
   SELECT
      "t0"."ID"  AS "ID",
      "t0"."_DLT_LOAD_ID" AS "_DLT_LOAD_ID",
      "t0"."_DLT_ID" AS "_DLT_ID",
      "t0"."ID" * 2 AS "double_items"
   FROM
      "SOURCE_20250528"."ITEMS" AS "t0"
   WHERE
      "t0"."_DLT_LOAD_ID" > '0' AND "t0"."_DLT_LOAD_ID" <= '1748436805.877721'
)  AS _dlt_subquery
```