### PR TITLE
docs: fix invalid bigquery reference in athena destination

### DIFF
--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -201,7 +201,7 @@ class AthenaSQLClient(SqlClientBase[Connection]):
         if not v:
             return v
         v = self.capabilities.casefold_identifier(v)
-        # bigquery uses hive escaping
+        # athena uses hive escaping
         return escape_hive_identifier(v)
 
     def fully_qualified_ddl_dataset_name(self) -> str:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Fixes a tiny comment where `bigquery` was referenced instead of `athena`

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
