### PR TITLE
[transformations] decouples sqlglot lineage and schema generation from destination identifiers

### DIFF
--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -199,6 +199,9 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
     supports_nested_types: bool = False
     """Tells if destination can write nested types, currently only destinations storing parquet are supported"""
 
+    enforces_nulls_on_alter: bool = True
+    """Tells if destination enforces null constraints when adding NOT NULL columns to existing tables"""
+
     sqlglot_dialect: Optional[str] = None
     """The SQL dialect used by sqlglot to transpile a query to match the destination syntax."""
 

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -39,14 +39,12 @@ class SupportsReadableRelation:
     sql glot query analysis and lineage. dlt hints for columns are kept in some cases. Refere to <docs-page> for more details.
     """
 
-    def query(self, qualified: bool = False) -> Any:
-        """Returns the sql query that represents the relation
-
-        Args:
-            qualified (bool, optional): Whether to return the qualified query. Defaults to False.
+    def query(self) -> Any:
+        """Returns the sql query that represents the relation. The query will be qualified, quoted and escaped
+           according to a SQL dialect that the destination uses.
 
         Returns:
-            Any: The sql query that represents the relation
+            Any: The qualified sql query that represents the relation
         """
         raise NotImplementedError("Query is not supported for this relation")
 

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -306,7 +306,7 @@ class SupportsReadableDataset(Generic[TReadableRelation], Protocol):
         data_tables: bool = True,
         dlt_tables: bool = False,
         table_names: List[str] = None,
-        load_id: str = None
+        load_id: str = None,
     ) -> SupportsReadableRelation:
         """Returns the row counts of the dataset
 

--- a/dlt/common/libs/sqlglot.py
+++ b/dlt/common/libs/sqlglot.py
@@ -471,9 +471,12 @@ def get_metadata(sqlglot_type: sge.DataType) -> TColumnSchema:
 
 def _filter_dlt_hints(hints: TColumnSchema) -> TColumnSchema:
     """Filter the metadata dictionary to only include dlt hints."""
-    DATA_TYPE_HINTS = ("name", "data_type", "nullable", "precision", "scale", "timezone")
-    ALLOWED_HINTS = ("hard_delete", "incremental")
-    CUSTOM_HINT_PREFIX = "x-"
+    DATA_TYPE_HINTS = ("data_type", "nullable", "precision", "scale", "timezone")
+    # allow original name to be propagated, so we can track it if aliases were used
+    ALLOWED_HINTS = ("name", "hard_delete", "incremental")
+    # only propagate specially designated hints
+    # TODO review all x- hints we use and decide which to propagate
+    CUSTOM_HINT_PREFIX = "x-annotation"
 
     final_hints = {}
     for k, v in hints.items():

--- a/dlt/destinations/dataset/ibis_relation.py
+++ b/dlt/destinations/dataset/ibis_relation.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING, Any, Union, Sequence
 from functools import partial
 import sqlglot
 
-from dlt.common.schema.typing import TTableSchemaColumns
-
 from dlt.destinations.dataset.relation import BaseReadableDBAPIRelation
 
 
@@ -35,22 +33,27 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
         self._ibis_object = ibis_object
 
     def _query(self) -> Any:
-        """build the query"""
         from dlt.helpers.ibis import ibis
 
-        target_dialect = self._dataset.sql_client.capabilities.sqlglot_dialect
+        ibis_expr = self._ibis_object
+        caps = self._dataset.sql_client.capabilities
+        target_dialect = caps.sqlglot_dialect
 
         # render sql directly if possible
+        # NOTE: ibis is optimized for reading a real schema from db and pushing back optimized sql
+        #  - it quotes all identifiers, there's no option to get unqoted query
+        #  - it converts full lists of column names back into star
+        #  - it optimizes the query inside, adds meaningless aliases to all tables etc.
         if target_dialect not in TRANSPILE_VIA_DEFAULT:
             if target_dialect == "tsql":
                 # NOTE: Ibis uses the product name "mssql" as the dialect instead of the official "tsql".
-                return ibis.to_sql(self._ibis_object, dialect="mssql")
+                return ibis.to_sql(ibis_expr, dialect="mssql")
             else:
-                return ibis.to_sql(self._ibis_object, dialect=target_dialect)
+                return ibis.to_sql(ibis_expr, dialect=target_dialect)
 
         # here we need to transpile to ibis default and transpile back to target with sqlglot
         # NOTE: ibis defaults to the duckdb dialect, if a dialect is not passed
-        sql = ibis.to_sql(self._ibis_object)
+        sql = ibis.to_sql(ibis_expr)
         sql = sqlglot.transpile(sql, write=target_dialect)[0]
         return sql
 
@@ -69,16 +72,6 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
             for k, v in kwargs.items()
         }
 
-        # casefold string params, we assume these are column names
-        args = tuple(
-            self.sql_client.capabilities.casefold_identifier(arg) if isinstance(arg, str) else arg
-            for arg in args
-        )
-        kwargs = {
-            k: self.sql_client.capabilities.casefold_identifier(v) if isinstance(v, str) else v
-            for k, v in kwargs.items()
-        }
-
         # Call it with provided args
         result = method(*args, **kwargs)
 
@@ -89,11 +82,6 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
         """Wrap all callable attributes of the expression"""
 
         attr = getattr(self._ibis_object, name, None)
-
-        # try casefolded name for ibis columns access
-        if attr is None:
-            name = self._dataset._sql_client.capabilities.casefold_identifier(name)
-            attr = getattr(self._ibis_object, name, None)
 
         if attr is None:
             raise AttributeError(
@@ -107,12 +95,7 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
         return partial(self._proxy_expression_method, name)
 
     def __getitem__(self, columns: Union[str, Sequence[str]]) -> "ReadableIbisRelation":
-        # casefold column-names
-        if isinstance(columns, str):
-            columns = self.sql_client.capabilities.casefold_identifier(columns)
-        elif isinstance(columns, Sequence):
-            columns = [self.sql_client.capabilities.casefold_identifier(col) for col in columns]
-        else:
+        if not isinstance(columns, (str, Sequence)):
             raise TypeError(
                 f"Invalid argument type: {type(columns).__name__}, requires a sequence of column"
                 " names Sequence[str] or a single column name str"

--- a/dlt/destinations/impl/athena/factory.py
+++ b/dlt/destinations/impl/athena/factory.py
@@ -162,6 +162,7 @@ class athena(Destination[AthenaClientConfiguration, "AthenaClient"]):
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
         caps.merge_strategies_selector = athena_merge_strategies_selector
         caps.replace_strategies_selector = athena_replace_strategies_selector
+        caps.enforces_nulls_on_alter = False
         caps.sqlglot_dialect = "athena"
 
         return caps

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -341,9 +341,7 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
         )
 
         if cluster_columns_final:
-            cluster_list = [
-                self.sql_client.escape_column_name(col) for col in cluster_columns_final
-            ]
+            cluster_list = [self.sql_client.escape_column_name(col) for col in cluster_columns_final]
             sql[0] += "\nCLUSTER BY " + ", ".join(cluster_list)
 
         # Table options.
@@ -415,7 +413,7 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
             try:
                 schema_table: TTableSchemaColumns = {}
                 table = self.sql_client.native_connection.get_table(
-                    self.sql_client.make_qualified_table_name(table_name, escape=False),
+                    self.sql_client.make_qualified_table_name(table_name, quote=False),
                     retry=self.sql_client._default_retry,
                     timeout=self.config.http_timeout,
                 )
@@ -496,7 +494,7 @@ SELECT {",".join(self._get_storage_table_query_columns())}
         if bucket_path:
             return self.sql_client.native_connection.load_table_from_uri(
                 bucket_path,
-                self.sql_client.make_qualified_table_name(table_name, escape=False),
+                self.sql_client.make_qualified_table_name(table_name, quote=False),
                 job_id=job_id,
                 job_config=job_config,
                 timeout=self.config.file_upload_timeout,
@@ -505,7 +503,7 @@ SELECT {",".join(self._get_storage_table_query_columns())}
         with open(file_path, "rb") as f:
             return self.sql_client.native_connection.load_table_from_file(
                 f,
-                self.sql_client.make_qualified_table_name(table_name, escape=False),
+                self.sql_client.make_qualified_table_name(table_name, quote=False),
                 job_id=job_id,
                 job_config=job_config,
                 timeout=self.config.file_upload_timeout,
@@ -586,7 +584,7 @@ def _streaming_load(
 
     sql_client = job_client.sql_client
 
-    full_name = sql_client.make_qualified_table_name(table["name"], escape=False)
+    full_name = sql_client.make_qualified_table_name(table["name"], quote=False)
 
     bq_client = sql_client._client
     bq_client.insert_rows_json(

--- a/dlt/destinations/impl/clickhouse/factory.py
+++ b/dlt/destinations/impl/clickhouse/factory.py
@@ -164,6 +164,7 @@ class clickhouse(Destination[ClickHouseClientConfiguration, "ClickHouseClient"])
 
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
+        caps.enforces_nulls_on_alter = False
 
         caps.sqlglot_dialect = "clickhouse"
 

--- a/dlt/destinations/impl/clickhouse/sql_client.py
+++ b/dlt/destinations/impl/clickhouse/sql_client.py
@@ -171,7 +171,7 @@ class ClickHouseSqlClient(
             )
         else:
             sentinel_table_name = self.make_qualified_table_name_path(
-                self.config.dataset_sentinel_table_name, escape=False
+                self.config.dataset_sentinel_table_name, quote=False
             )[-1]
             if sentinel_table_name not in all_ds_tables:
                 # no sentinel table, dataset does not exist
@@ -220,7 +220,7 @@ class ClickHouseSqlClient(
             )
 
     def _list_tables(self) -> List[str]:
-        catalog_name, table_name = self.make_qualified_table_name_path("%", escape=False)
+        catalog_name, table_name = self.make_qualified_table_name_path("%", quote=False)
         rows = self.execute_sql(
             """
             SELECT name
@@ -267,27 +267,30 @@ class ClickHouseSqlClient(
 
             yield ClickHouseDBApiCursorImpl(cursor)
 
-    def catalog_name(self, escape: bool = True) -> Optional[str]:
-        database_name = self.capabilities.casefold_identifier(self.database_name)
-        if escape:
+    def catalog_name(self, quote: bool = True, casefold: bool = True) -> Optional[str]:
+        if casefold:
+            database_name = self.capabilities.casefold_identifier(self.database_name)
+        else:
+            database_name = self.database_name
+        if quote:
             database_name = self.capabilities.escape_identifier(database_name)
         return database_name
 
     def make_qualified_table_name_path(
-        self, table_name: Optional[str], escape: bool = True
+        self, table_name: Optional[str], quote: bool = True, casefold: bool = True
     ) -> List[str]:
         # get catalog and dataset
-        path = super().make_qualified_table_name_path(None, escape=escape)
+        path = super().make_qualified_table_name_path(None, quote=quote, casefold=casefold)
         if table_name:
             # table name combines dataset name and table name
             if self.dataset_name:
-                table_name = self.capabilities.casefold_identifier(
-                    f"{self.dataset_name}{self.config.dataset_table_separator}{table_name}"
-                )
+                table_name = f"{self.dataset_name}{self.config.dataset_table_separator}{table_name}"
             else:
                 # without dataset just use the table name
+                pass
+            if casefold:
                 table_name = self.capabilities.casefold_identifier(table_name)
-            if escape:
+            if quote:
                 table_name = self.capabilities.escape_identifier(table_name)
             # we have only two path components
             path[1] = table_name

--- a/dlt/destinations/impl/databricks/sql_client.py
+++ b/dlt/destinations/impl/databricks/sql_client.py
@@ -143,9 +143,12 @@ class DatabricksSqlClient(SqlClientBase[DatabricksSqlConnection], DBTransaction)
             curr.execute(query, db_args)
             yield DatabricksCursorImpl(curr)  # type: ignore[arg-type, abstract, unused-ignore]
 
-    def catalog_name(self, escape: bool = True) -> Optional[str]:
-        catalog = self.capabilities.casefold_identifier(self.credentials.catalog)
-        if escape:
+    def catalog_name(self, quote: bool = True, casefold: bool = True) -> Optional[str]:
+        if casefold:
+            catalog = self.capabilities.casefold_identifier(self.credentials.catalog)
+        else:
+            catalog = self.credentials.catalog
+        if quote:
             catalog = self.capabilities.escape_identifier(catalog)
         return catalog
 

--- a/dlt/destinations/impl/dremio/factory.py
+++ b/dlt/destinations/impl/dremio/factory.py
@@ -110,6 +110,7 @@ class dremio(Destination[DremioClientConfiguration, "DremioClient"]):
         caps.timestamp_precision = 3
         caps.supported_merge_strategies = ["delete-insert", "scd2"]
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
+        caps.enforces_nulls_on_alter = False
         caps.sqlglot_dialect = "presto"
 
         return caps

--- a/dlt/destinations/impl/dremio/sql_client.py
+++ b/dlt/destinations/impl/dremio/sql_client.py
@@ -111,16 +111,19 @@ class DremioSqlClient(SqlClientBase[pydremio.DremioConnection]):
                 raise DatabaseTransientException(ex)
             yield DremioCursorImpl(curr)  # type: ignore
 
-    def catalog_name(self, escape: bool = True) -> Optional[str]:
-        database_name = self.capabilities.casefold_identifier(self.database_name)
-        if escape:
+    def catalog_name(self, quote: bool = True, casefold: bool = True) -> Optional[str]:
+        if casefold:
+            database_name = self.capabilities.casefold_identifier(self.database_name)
+        else:
+            database_name = self.database_name
+        if quote:
             database_name = self.capabilities.escape_identifier(database_name)
         return database_name
 
     def _get_information_schema_components(self, *tables: str) -> Tuple[str, str, List[str]]:
         components = super()._get_information_schema_components(*tables)
         # catalog is always DREMIO but schema contains "database" prefix 🤷
-        return ("DREMIO", self.fully_qualified_dataset_name(escape=False), components[2])
+        return ("DREMIO", self.fully_qualified_dataset_name(quote=False), components[2])
 
     @classmethod
     def _make_database_exception(cls, ex: Exception) -> Exception:

--- a/dlt/destinations/impl/filesystem/factory.py
+++ b/dlt/destinations/impl/filesystem/factory.py
@@ -68,6 +68,7 @@ class filesystem(Destination[FilesystemDestinationClientConfiguration, "Filesyst
         # for delta and iceberg this is copy from staging, use replace strategy selector
         caps.supported_replace_strategies = ["truncate-and-insert", "insert-from-staging"]
         caps.replace_strategies_selector = filesystem_replace_strategies_selector
+        caps.enforces_nulls_on_alter = False
         caps.sqlglot_dialect = "duckdb"
         caps.supports_nested_types = True
 

--- a/dlt/destinations/impl/filesystem/sql_client.py
+++ b/dlt/destinations/impl/filesystem/sql_client.py
@@ -92,7 +92,7 @@ class FilesystemSqlClient(WithTableScanners):
         if first_connection:
             # TODO: we need to frontload the httpfs extension for abfss for some reason
             if self.is_abfss:
-                self._conn.sql("LOAD httpfs;")
+                self._conn.sql("INSTALL https; LOAD httpfs;")
 
             # create single authentication for the whole client
             self.create_secret(

--- a/dlt/destinations/impl/motherduck/configuration.py
+++ b/dlt/destinations/impl/motherduck/configuration.py
@@ -14,7 +14,7 @@ from dlt.destinations.impl.duckdb.configuration import DuckDbBaseCredentials
 
 MOTHERDUCK_DRIVERNAME = "md"
 MOTHERDUCK_USER_AGENT = f"dlt/{__version__}({sys.platform})"
-MOTHERDUCK_DEFAULT_TOKEN_ENV = "motherduck_token"
+MOTHERDUCK_DEFAULT_TOKEN_ENV = "MOTHERDUCK_TOKEN"
 
 
 @configspec(init=False)

--- a/dlt/destinations/impl/motherduck/sql_client.py
+++ b/dlt/destinations/impl/motherduck/sql_client.py
@@ -16,8 +16,11 @@ class MotherDuckSqlClient(DuckDbSqlClient):
         super().__init__(dataset_name, staging_dataset_name, credentials, capabilities)
         self.database_name = credentials.database
 
-    def catalog_name(self, escape: bool = True) -> Optional[str]:
-        database_name = self.database_name
-        if escape:
+    def catalog_name(self, quote: bool = True, casefold: bool = True) -> Optional[str]:
+        if casefold:
+            database_name = self.capabilities.casefold_identifier(self.database_name)
+        else:
+            database_name = self.database_name
+        if quote:
             database_name = self.capabilities.escape_identifier(database_name)
         return database_name

--- a/dlt/destinations/impl/postgres/postgres.py
+++ b/dlt/destinations/impl/postgres/postgres.py
@@ -96,14 +96,14 @@ class PostgresCsvCopyJob(RunnableLoadJob, HasFollowupJobs):
 
             # normalized and quoted headers
             split_headers = [
-                sql_client.escape_column_name(h.strip('"'), escape=True) for h in split_headers
+                sql_client.escape_column_name(h.strip('"'), quote=True) for h in split_headers
             ]
             split_null_headers = []
             split_columns = []
             # detect columns with NULL to use in FORCE NULL
             # detect headers that are not in columns
             for col in self._job_client.schema.get_table_columns(table_name).values():
-                norm_col = sql_client.escape_column_name(col["name"], escape=True)
+                norm_col = sql_client.escape_column_name(col["name"], quote=True)
                 split_columns.append(norm_col)
                 if norm_col in split_headers and is_nullable_column(col):
                     split_null_headers.append(norm_col)

--- a/dlt/destinations/impl/snowflake/sql_client.py
+++ b/dlt/destinations/impl/snowflake/sql_client.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager, suppress
-from typing import Any, AnyStr, ClassVar, Iterator, Optional, Sequence
+from typing import Any, AnyStr, ClassVar, Generator, Iterator, Optional, Sequence
 
 import snowflake.connector as snowflake_lib
 
@@ -16,7 +16,7 @@ from dlt.destinations.sql_client import (
     raise_database_error,
     raise_open_connection_error,
 )
-from dlt.destinations.typing import DBApi, DBTransaction, DataFrame
+from dlt.destinations.typing import DBApi, DBTransaction, DataFrame, ArrowTable
 from dlt.destinations.impl.snowflake.configuration import SnowflakeCredentials
 from dlt.common.destination.dataset import DBApiCursor
 
@@ -24,10 +24,23 @@ from dlt.common.destination.dataset import DBApiCursor
 class SnowflakeCursorImpl(DBApiCursorImpl):
     native_cursor: snowflake_lib.cursor.SnowflakeCursor  # type: ignore[assignment]
 
-    def df(self, chunk_size: int = None, **kwargs: Any) -> Optional[DataFrame]:
-        if chunk_size is None:
-            return self.native_cursor.fetch_pandas_all(**kwargs)
-        return super().df(chunk_size=chunk_size, **kwargs)
+    def iter_df(self, chunk_size: int) -> Generator[DataFrame, None, None]:
+        # full frame
+        if not chunk_size:
+            yield self.native_cursor.fetch_pandas_all()
+            return
+        # iterate
+        # NOTE: no way to impact chunk size
+        yield from self.native_cursor.fetch_pandas_batches()
+
+    def iter_arrow(self, chunk_size: int) -> Generator[ArrowTable, None, None]:
+        # TODO: figure out if empty table should be returned (there's a test for that)
+        if not chunk_size:
+            yield self.native_cursor.fetch_arrow_all(force_return_table=False)
+            return
+        # iterate
+        # NOTE: no way to impact chunk size
+        yield from self.native_cursor.fetch_arrow_batches()
 
 
 class SnowflakeSqlClient(SqlClientBase[snowflake_lib.SnowflakeConnection], DBTransaction):
@@ -52,6 +65,8 @@ class SnowflakeSqlClient(SqlClientBase[snowflake_lib.SnowflakeConnection], DBTra
         # we get dlt expected UTC
         if "timezone" not in conn_params:
             conn_params["timezone"] = "UTC"
+        if "arrow_number_to_decimal" not in conn_params:
+            conn_params["arrow_number_to_decimal"] = True
         # set autocommit when opening connection to override account and user level setting
         conn_params["autocommit"] = True
         self._conn = snowflake_lib.connect(

--- a/dlt/destinations/impl/sqlalchemy/db_api_client.py
+++ b/dlt/destinations/impl/sqlalchemy/db_api_client.py
@@ -280,7 +280,12 @@ class SqlalchemyClient(SqlClientBase[Connection]):
     ) -> Iterator[SqlClientBase[Connection]]:
         with super().with_alternative_dataset_name(dataset_name):
             if self.dialect_name == "sqlite" and dataset_name not in self._sqlite_attached_datasets:
-                self._sqlite_reattach_dataset_if_exists(dataset_name)
+                if not self.native_connection:
+                    # opening connection attaches dataset
+                    with self:
+                        pass
+                else:
+                    self._sqlite_reattach_dataset_if_exists(dataset_name)
             yield self
 
     def create_dataset(self) -> None:
@@ -346,24 +351,29 @@ class SqlalchemyClient(SqlClientBase[Connection]):
         with self._ensure_transaction():
             table_obj.create(self._current_connection)
 
-    def _make_qualified_table_name(self, table: sa.Table, escape: bool = True) -> str:
-        if escape:
-            return self.dialect.identifier_preparer.format_table(table)  # type: ignore[attr-defined,no-any-return]
-        return table.fullname  # type: ignore[no-any-return]
+    def make_qualified_table_name_path(
+        self, table_name: Optional[str], quote: bool = True, casefold: bool = True
+    ) -> List[str]:
+        from sqlalchemy.sql import quoted_name
 
-    def make_qualified_table_name(self, table_name: str, escape: bool = True) -> str:
-        tbl = self.get_existing_table(table_name)
-        if tbl is None:
-            tmp_metadata = sa.MetaData()
-            tbl = sa.Table(table_name, tmp_metadata, schema=self.dataset_name)
-        return self._make_qualified_table_name(tbl, escape)
+        path: List[str] = []
+        # no catalog for sqlalchemy
+        if catalog_name := self.catalog_name(quote=quote, casefold=casefold):
+            path.append(catalog_name)
 
-    def fully_qualified_dataset_name(self, escape: bool = True, staging: bool = False) -> str:
-        if staging:
-            dataset_name = self.staging_dataset_name
-        else:
-            dataset_name = self.dataset_name
-        return self.dialect.identifier_preparer.format_schema(dataset_name)  # type: ignore[attr-defined, no-any-return]
+        dataset_name = self.dataset_name
+        if self.dialect.requires_name_normalize and casefold:  # type: ignore[attr-defined]
+            dataset_name = str(self.dialect.normalize_name(dataset_name))  # type: ignore[func-returns-value]
+        if quote:
+            dataset_name = self.dialect.identifier_preparer.quote_identifier(dataset_name)  # type: ignore[attr-defined]
+        path.append(dataset_name)
+        if table_name:
+            if self.dialect.requires_name_normalize and casefold:  # type: ignore[attr-defined]
+                table_name = str(self.dialect.normalize_name(table_name))  # type: ignore[func-returns-value]
+            if quote:
+                table_name = self.dialect.identifier_preparer.quote_identifier(table_name)  # type: ignore[attr-defined]
+            path.append(table_name)
+        return path
 
     def alter_table_add_columns(self, columns: Sequence[sa.Column]) -> None:
         if not columns:
@@ -376,11 +386,11 @@ class SqlalchemyClient(SqlClientBase[Connection]):
         for statement in statements:
             self.execute_sql(statement)
 
-    def escape_column_name(self, column_name: str, escape: bool = True) -> str:
-        if self.dialect.requires_name_normalize:  # type: ignore[attr-defined]
-            column_name = self.dialect.normalize_name(column_name)  # type: ignore[func-returns-value]
-        if escape:
-            return self.dialect.identifier_preparer.format_column(sa.Column(column_name))  # type: ignore[attr-defined,no-any-return]
+    def escape_column_name(self, column_name: str, quote: bool = True, casefold: bool = True) -> str:
+        if self.dialect.requires_name_normalize and casefold:  # type: ignore[attr-defined]
+            column_name = str(self.dialect.normalize_name(column_name))  # type: ignore[func-returns-value]
+        if quote:
+            return self.dialect.identifier_preparer.quote_identifier(column_name)  # type: ignore[attr-defined,no-any-return]
         return column_name
 
     def reflect_table(

--- a/dlt/destinations/impl/sqlalchemy/factory.py
+++ b/dlt/destinations/impl/sqlalchemy/factory.py
@@ -89,6 +89,7 @@ class sqlalchemy(Destination[SqlalchemyClientConfiguration, "SqlalchemyJobClient
                 caps.max_identifier_length = 64
                 caps.max_column_identifier_length = 64
                 caps.format_datetime_literal = _format_mysql_datetime_literal
+                caps.enforces_nulls_on_alter = False
                 caps.sqlglot_dialect = "mysql"
 
             elif backend_name in [

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -168,7 +168,7 @@ class ModelLoadJob(RunnableLoadJob, HasFollowupJobs):
         """
         sql_client = self._job_client.sql_client
         target_table = sql_client.make_qualified_table_name(self._load_table["name"])
-        target_catalog = sql_client.catalog_name(escape=False)
+        target_catalog = sql_client.catalog_name(quote=False)
         destination_dialect = self._job_client.capabilities.sqlglot_dialect
 
         # Parse SELECT

--- a/dlt/destinations/sql_client.py
+++ b/dlt/destinations/sql_client.py
@@ -195,51 +195,68 @@ SELECT 1
                     ret.append(result)
         return ret
 
-    def catalog_name(self, escape: bool = True) -> Optional[str]:
+    def catalog_name(self, quote: bool = True, casefold: bool = True) -> Optional[str]:
         # default is no catalogue component of the name, which typically means that
         # connection is scoped to a current database
         return None
 
-    def fully_qualified_dataset_name(self, escape: bool = True, staging: bool = False) -> str:
+    def fully_qualified_dataset_name(
+        self, quote: bool = True, staging: bool = False, casefold: bool = True
+    ) -> str:
         if staging:
             with self.with_staging_dataset():
-                path = self.make_qualified_table_name_path(None, escape=escape)
+                path = self.make_qualified_table_name_path(None, quote=quote, casefold=casefold)
         else:
-            path = self.make_qualified_table_name_path(None, escape=escape)
+            path = self.make_qualified_table_name_path(None, quote=quote, casefold=casefold)
         return ".".join(path)
 
-    def make_qualified_table_name(self, table_name: str, escape: bool = True) -> str:
-        return ".".join(self.make_qualified_table_name_path(table_name, escape=escape))
+    def make_qualified_table_name(
+        self, table_name: str, quote: bool = True, casefold: bool = True
+    ) -> str:
+        return ".".join(
+            self.make_qualified_table_name_path(table_name, quote=quote, casefold=casefold)
+        )
 
     def make_qualified_table_name_path(
-        self, table_name: Optional[str], escape: bool = True
+        self, table_name: Optional[str], quote: bool = True, casefold: bool = True
     ) -> List[str]:
         """Returns a list with path components leading from catalog to table_name.
         Used to construct fully qualified names. `table_name` is optional.
         """
         path: List[str] = []
-        if catalog_name := self.catalog_name(escape=escape):
+        if catalog_name := self.catalog_name(quote=quote, casefold=casefold):
             path.append(catalog_name)
-        dataset_name = self.capabilities.casefold_identifier(self.dataset_name)
-        if escape:
+        dataset_name = self.dataset_name
+        if casefold:
+            dataset_name = self.capabilities.casefold_identifier(self.dataset_name)
+        if quote:
             dataset_name = self.capabilities.escape_identifier(dataset_name)
         path.append(dataset_name)
         if table_name:
-            table_name = self.capabilities.casefold_identifier(table_name)
-            if escape:
+            if casefold:
+                table_name = self.capabilities.casefold_identifier(table_name)
+            if quote:
                 table_name = self.capabilities.escape_identifier(table_name)
             path.append(table_name)
         return path
 
-    def get_qualified_table_names(self, table_name: str, escape: bool = True) -> Tuple[str, str]:
+    def get_qualified_table_names(
+        self, table_name: str, quote: bool = True, casefold: bool = True
+    ) -> Tuple[str, str]:
         """Returns qualified names for table and corresponding staging table as tuple."""
         with self.with_staging_dataset():
-            staging_table_name = self.make_qualified_table_name(table_name, escape)
-        return self.make_qualified_table_name(table_name, escape), staging_table_name
+            staging_table_name = self.make_qualified_table_name(
+                table_name, quote=quote, casefold=casefold
+            )
+        return (
+            self.make_qualified_table_name(table_name, quote=quote, casefold=casefold),
+            staging_table_name,
+        )
 
-    def escape_column_name(self, column_name: str, escape: bool = True) -> str:
-        column_name = self.capabilities.casefold_identifier(column_name)
-        if escape:
+    def escape_column_name(self, column_name: str, quote: bool = True, casefold: bool = True) -> str:
+        if casefold:
+            column_name = self.capabilities.casefold_identifier(column_name)
+        if quote:
             return self.capabilities.escape_identifier(column_name)
         return column_name
 
@@ -289,11 +306,11 @@ SELECT 1
         used to query INFORMATION_SCHEMA. catalog name is optional: in that case None is
         returned in the first element of the tuple.
         """
-        schema_path = self.make_qualified_table_name_path(None, escape=False)
+        schema_path = self.make_qualified_table_name_path(None, quote=False)
         return (
-            self.catalog_name(escape=False),
+            self.catalog_name(quote=False),
             schema_path[-1],
-            [self.make_qualified_table_name_path(table, escape=False)[-1] for table in tables],
+            [self.make_qualified_table_name_path(table, quote=False)[-1] for table in tables],
         )
 
     #

--- a/dlt/helpers/studio/app.py
+++ b/dlt/helpers/studio/app.py
@@ -200,8 +200,8 @@ def section_schema(
             ),
         )
 
-        for table in dlt_schema_table_list.value:  # type: ignore[union-attr]
-            _table_name = table["name"]  # type: ignore[index]
+        for table in dlt_schema_table_list.value:  # type: ignore[union-attr,unused-ignore]
+            _table_name = table["name"]  # type: ignore[index,unused-ignore]
             _result.append(mo.md(strings.schema_table_columns_title.format(_table_name)))
             _result.append(
                 mo.ui.table(
@@ -278,7 +278,7 @@ def section_browse_data_table_list(
 
             _sql_query = ""
             if dlt_data_table_list.value:
-                _table_name = dlt_data_table_list.value[0]["name"]  # type: ignore[index]
+                _table_name = dlt_data_table_list.value[0]["name"]  # type: ignore[index,unused-ignore]
                 _sql_query = (
                     dlt_pipeline.dataset()
                     .table(_table_name)
@@ -411,8 +411,8 @@ def section_browse_data_query_history(
         )
         _result.append(dlt_query_history_table)
 
-        for _r in dlt_query_history_table.value:  # type: ignore
-            _query = _r["query"]  # type: ignore
+        for _r in dlt_query_history_table.value:  # type: ignore[unused-ignore]
+            _query = _r["query"]  # type: ignore[unused-ignore]
             _q_result = utils.get_query_result(dlt_pipeline, _query)
             _result.append(mo.md(f"<small>```{_query}```</small>"))
             _result.append(mo.ui.table(_q_result, selection=None))
@@ -504,8 +504,8 @@ def section_trace(
                 )
             )
             _result.append(dlt_trace_steps_table)
-            for item in dlt_trace_steps_table.value:  # type: ignore
-                step_id = item["step"]  # type: ignore
+            for item in dlt_trace_steps_table.value:  # type: ignore[unused-ignore]
+                step_id = item["step"]  # type: ignore[unused-ignore]
                 _result.append(
                     ui.build_title_and_subtitle(
                         strings.trace_step_details_title.format(step_id.capitalize()),
@@ -605,13 +605,13 @@ def section_loads_results(
         and dlt_loads_table is not None
         and dlt_loads_table.value
     ):
-        _load_id = dlt_loads_table.value[0]["load_id"]  # type: ignore
+        _load_id = dlt_loads_table.value[0]["load_id"]  # type: ignore[unused-ignore]
         _result.append(mo.md(strings.loads_details_title.format(_load_id)))
 
         try:
             with mo.status.spinner(title=strings.loads_details_loading_spinner_text):
                 _schema = utils.get_schema_by_version(
-                    dlt_pipeline, dlt_loads_table.value[0]["schema_version_hash"]  # type: ignore
+                    dlt_pipeline, dlt_loads_table.value[0]["schema_version_hash"]  # type: ignore[unused-ignore]
                 )
 
                 # prepare and sort row counts
@@ -842,7 +842,7 @@ def ui_primary_controls(
             show_child_tables=dlt_schema_show_child_tables.value,
         )
         dlt_schema_table_list = mo.ui.table(
-            _table_list,  # type: ignore[arg-type]
+            _table_list,  # type: ignore[arg-type,unused-ignore]
             style_cell=utils.style_cell,
             initial_selection=[0],
             freeze_columns_left=["name"],
@@ -854,7 +854,7 @@ def ui_primary_controls(
     dlt_data_table_list: mo.ui.table = None
     if dlt_section_browse_data_switch.value and dlt_pipeline and dlt_pipeline.default_schema_name:
         dlt_data_table_list = mo.ui.table(
-            utils.create_table_list(  # type: ignore[arg-type]
+            utils.create_table_list(  # type: ignore[arg-type,unused-ignore]
                 dlt_config,
                 dlt_pipeline,
                 show_internals=dlt_schema_show_dlt_tables.value,

--- a/docs/website/docs/dlt-ecosystem/destinations/motherduck.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/motherduck.md
@@ -54,7 +54,7 @@ Motherduck now supports configurable **access tokens**. Please refer to the [doc
 
 You can pass token in a native Motherduck environment variable:
 ```sh
-export motherduck_token='<token>'
+export MOTHERDUCK_TOKEN='<token>'
 ```
 in that case you can skip **password** / **motherduck_token** secret.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -157,3 +157,6 @@ ignore_missing_imports = True
 
 [mypy-ibis.*]
 ignore_missing_imports = True
+
+[mypy-playwright.*]
+ignore_missing_imports = True

--- a/tests/e2e/helpers/studio/test_e2e.py
+++ b/tests/e2e/helpers/studio/test_e2e.py
@@ -193,7 +193,7 @@ def test_page_loads(page: Page):
     _go_home(page)
     page.get_by_role("link", name="never_run_pipeline").click()
 
-    expect(page.get_by_text(app_strings.sync_status_error_text)).to_be_visible()
+    expect(page.get_by_text(app_strings.sync_status_success_text.split("from")[0])).to_be_visible()
     expect(page.get_by_text("_storage/.dlt/pipelines/never_run_pipeline")).to_be_visible()
 
     # check schema info (this is the yaml part)

--- a/tests/helpers/studio/test_welcome_page.py
+++ b/tests/helpers/studio/test_welcome_page.py
@@ -4,7 +4,7 @@ from dlt.helpers.studio.app import home
 
 
 def test_welcome_cell():
-    output, defs = home.run(  # type: ignore
+    output, defs = home.run(  # type: ignore[unused-ignore]
         dlt_pipeline_select=mo.ui.multiselect([1, 2, 3]),
         dlt_all_pipelines=[
             {"name": "pipeline1", "link": "link1", "timestamp": 0},

--- a/tests/load/bigquery/test_bigquery_client.py
+++ b/tests/load/bigquery/test_bigquery_client.py
@@ -359,7 +359,7 @@ def test_bigquery_location(location: str, file_storage: FileStorage, client) -> 
             file_storage.make_full_path(job.file_name()),
             uniq_id(),
         )
-        canonical_name = client.sql_client.make_qualified_table_name(user_table_name, escape=False)
+        canonical_name = client.sql_client.make_qualified_table_name(user_table_name, quote=False)
         t = client.sql_client.native_connection.get_table(canonical_name)
         assert t.location == location
 

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -635,9 +635,9 @@ def test_adapter_hints_partitioning(
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
 
-        fqtn_no_hints = c.make_qualified_table_name("no_hints", escape=False)
-        fqtn_hints = c.make_qualified_table_name("hints", escape=False)
-        fqtn_date_hints = c.make_qualified_table_name("date_hints", escape=False)
+        fqtn_no_hints = c.make_qualified_table_name("no_hints", quote=False)
+        fqtn_hints = c.make_qualified_table_name("hints", quote=False)
+        fqtn_date_hints = c.make_qualified_table_name("date_hints", quote=False)
 
         no_hints_table = nc.get_table(fqtn_no_hints)
         hints_table = nc.get_table(fqtn_hints)
@@ -892,8 +892,8 @@ def test_adapter_hints_multiple_clustering(
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
 
-        fqtn_no_hints = c.make_qualified_table_name("no_hints", escape=False)
-        fqtn_hints = c.make_qualified_table_name("hints", escape=False)
+        fqtn_no_hints = c.make_qualified_table_name("no_hints", quote=False)
+        fqtn_hints = c.make_qualified_table_name("hints", quote=False)
 
         no_hints_table = nc.get_table(fqtn_no_hints)
         hints_table = nc.get_table(fqtn_hints)
@@ -955,7 +955,7 @@ def test_adapter_hints_custom_clustering_order(
 
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
-        fqtn = c.make_qualified_table_name("cluster_order", escape=False)
+        fqtn = c.make_qualified_table_name("cluster_order", quote=False)
         table = nc.get_table(fqtn)
         cluster_fields = [] if table.clustering_fields is None else table.clustering_fields
         # The cluster fields must match the user-specified order
@@ -993,8 +993,8 @@ def test_adapter_hints_clustering(
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
 
-        fqtn_no_hints = c.make_qualified_table_name("no_hints", escape=False)
-        fqtn_hints = c.make_qualified_table_name("hints", escape=False)
+        fqtn_no_hints = c.make_qualified_table_name("no_hints", quote=False)
+        fqtn_hints = c.make_qualified_table_name("hints", quote=False)
 
         no_hints_table = nc.get_table(fqtn_no_hints)
         hints_table = nc.get_table(fqtn_hints)
@@ -1086,8 +1086,8 @@ def test_adapter_additional_table_hints_table_description(
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
 
-        fqtn_no_hints = c.make_qualified_table_name("no_hints", escape=False)
-        fqtn_hints = c.make_qualified_table_name("hints", escape=False)
+        fqtn_no_hints = c.make_qualified_table_name("no_hints", quote=False)
+        fqtn_hints = c.make_qualified_table_name("hints", quote=False)
 
         no_hints_table = nc.get_table(fqtn_no_hints)
         hints_table = nc.get_table(fqtn_hints)
@@ -1135,8 +1135,8 @@ def test_adapter_additional_table_hints_table_description_with_alter_table(
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
 
-        fqtn_no_hints = c.make_qualified_table_name("no_hints", escape=False)
-        fqtn_hints = c.make_qualified_table_name("hints", escape=False)
+        fqtn_no_hints = c.make_qualified_table_name("no_hints", quote=False)
+        fqtn_hints = c.make_qualified_table_name("hints", quote=False)
 
         no_hints_table = nc.get_table(fqtn_no_hints)
         hints_table = nc.get_table(fqtn_hints)

--- a/tests/load/clickhouse/test_clickhouse_configuration.py
+++ b/tests/load/clickhouse/test_clickhouse_configuration.py
@@ -99,16 +99,16 @@ def test_client_table_name_and_paths(client: ClickHouseClient) -> None:
     dataset_name = client.sql_client.dataset_name
     separator = client.config.dataset_table_separator
 
-    assert client.sql_client.make_qualified_table_name_path(None, escape=False) == ["dlt_data"]
-    assert client.sql_client.make_qualified_table_name_path("test_table", escape=False) == [
+    assert client.sql_client.make_qualified_table_name_path(None, quote=False) == ["dlt_data"]
+    assert client.sql_client.make_qualified_table_name_path("test_table", quote=False) == [
         "dlt_data",
         f"{dataset_name}{separator}test_table",
     ]
 
     client.config.dataset_table_separator = separator = "###"
 
-    assert client.sql_client.make_qualified_table_name_path(None, escape=False) == ["dlt_data"]
-    assert client.sql_client.make_qualified_table_name_path("test_table", escape=False) == [
+    assert client.sql_client.make_qualified_table_name_path(None, quote=False) == ["dlt_data"]
+    assert client.sql_client.make_qualified_table_name_path("test_table", quote=False) == [
         "dlt_data",
         f"{dataset_name}{separator}test_table",
     ]

--- a/tests/load/pipeline/test_bigquery.py
+++ b/tests/load/pipeline/test_bigquery.py
@@ -87,7 +87,7 @@ def test_bigquery_autodetect_schema(
     client: BigQuerySqlClient
     with pipeline.sql_client() as client:  # type: ignore[assignment]
         table = client.native_connection.get_table(
-            client.make_qualified_table_name("cve", escape=False)
+            client.make_qualified_table_name("cve", quote=False)
         )
     field = next(field for field in table.schema if field.name == "source")
     # not repeatable
@@ -110,7 +110,7 @@ def test_bigquery_autodetect_schema(
     assert_load_info(info)
     with pipeline.sql_client() as client:  # type: ignore[assignment]
         table = client.native_connection.get_table(
-            client.make_qualified_table_name("cve", escape=False)
+            client.make_qualified_table_name("cve", quote=False)
         )
     field = next(field for field in table.schema if field.name == "references")
     field = field.fields[0]
@@ -137,7 +137,7 @@ def test_bigquery_autodetect_schema(
     assert_load_info(info)
     with pipeline.sql_client() as client:  # type: ignore[assignment]
         table = client.native_connection.get_table(
-            client.make_qualified_table_name("cve", escape=False)
+            client.make_qualified_table_name("cve", quote=False)
         )
     field = next(field for field in table.schema if field.name == "references")
     field = field.fields[0]
@@ -184,8 +184,8 @@ def test_adapter_additional_table_hints_table_expiration(
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
 
-        fqtn_no_hints = c.make_qualified_table_name("no_hints", escape=False)
-        fqtn_hints = c.make_qualified_table_name("hints", escape=False)
+        fqtn_no_hints = c.make_qualified_table_name("no_hints", quote=False)
+        fqtn_hints = c.make_qualified_table_name("hints", quote=False)
 
         no_hints_table = nc.get_table(fqtn_no_hints)
         hints_table = nc.get_table(fqtn_hints)
@@ -232,7 +232,7 @@ def test_adapter_merge_behaviour(
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
 
-        table_fqtn = c.make_qualified_table_name("hints", escape=False)
+        table_fqtn = c.make_qualified_table_name("hints", quote=False)
 
         table: Table = nc.get_table(table_fqtn)
 
@@ -338,7 +338,7 @@ def test_adapter_autodetect_schema_with_hints(
     with pipeline.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection
 
-        table_fqtn = c.make_qualified_table_name("general_types", escape=False)
+        table_fqtn = c.make_qualified_table_name("general_types", quote=False)
 
         table: Table = nc.get_table(table_fqtn)
 
@@ -350,13 +350,13 @@ def test_adapter_autodetect_schema_with_hints(
 
     with pipeline_time.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection  # type: ignore[no-redef]
-        table_fqtn = c.make_qualified_table_name("partition_time", escape=False)
+        table_fqtn = c.make_qualified_table_name("partition_time", quote=False)
         table: Table = nc.get_table(table_fqtn)  # type: ignore[no-redef]
         assert table.time_partitioning.field == "my_time_column"
 
     with pipeline_date.sql_client() as c:
         nc: google.cloud.bigquery.client.Client = c.native_connection  # type: ignore[no-redef]
-        table_fqtn = c.make_qualified_table_name("partition_date", escape=False)
+        table_fqtn = c.make_qualified_table_name("partition_date", quote=False)
         table: Table = nc.get_table(table_fqtn)  # type: ignore[no-redef]
         assert table.time_partitioning.field == "my_date_column"
         assert table.time_partitioning.type_ == "DAY"

--- a/tests/load/pipeline/test_write_disposition_changes.py
+++ b/tests/load/pipeline/test_write_disposition_changes.py
@@ -129,13 +129,7 @@ def test_switch_to_merge(destination_config: DestinationTestConfiguration, with_
     # they do not mind adding NOT NULL columns to tables with existing data (id NOT NULL is supported at all)
     # doing this will result in somewhat useless behavior
     destination_allows_adding_root_key = (
-        destination_config.destination_type
-        in [
-            "dremio",
-            "clickhouse",
-            "athena",
-        ]
-        or destination_config.destination_name == "sqlalchemy_mysql"
+        not pipeline.destination_client().capabilities.enforces_nulls_on_alter
     )
 
     if destination_allows_adding_root_key and not with_root_key:

--- a/tests/load/postgres/test_postgres_table_builder.py
+++ b/tests/load/postgres/test_postgres_table_builder.py
@@ -181,7 +181,7 @@ def test_create_table_case_sensitive(cs_client: PostgresClient) -> None:
     )[0]
     sqlfluff.parse(sql, dialect="postgres")
     # everything capitalized
-    assert cs_client.sql_client.fully_qualified_dataset_name(escape=False)[0] == "T"  # Test
+    assert cs_client.sql_client.fully_qualified_dataset_name(quote=False)[0] == "T"  # Test
     # every line starts with "Col"
     for line in sql.split("\n")[1:]:
         assert line.startswith('"Col')
@@ -339,7 +339,7 @@ WHERE f_table_name in
        'geodata_default_csv_wkt', 'geodata_3857_csv_wkt', 'geodata_2163_csv_wkt', 'geodata_default_csv_wkb_hex',
        'geodata_3857_csv_wkb_hex', 'geodata_2163_csv_wkb_hex'
           )
-  AND f_table_schema = '{c.fully_qualified_dataset_name(escape=False)}'""") as cur:
+  AND f_table_schema = '{c.fully_qualified_dataset_name(quote=False)}'""") as cur:
             records = cur.fetchall()
             assert records
             assert {record[0] for record in records} == {"geom"}

--- a/tests/load/redshift/test_redshift_table_builder.py
+++ b/tests/load/redshift/test_redshift_table_builder.py
@@ -136,7 +136,7 @@ def test_create_table_case_sensitive(cs_client: RedshiftClient) -> None:
     )[0]
     sqlfluff.parse(sql, dialect="redshift")
     # everything capitalized
-    assert cs_client.sql_client.fully_qualified_dataset_name(escape=False)[0] == "T"  # Test
+    assert cs_client.sql_client.fully_qualified_dataset_name(quote=False)[0] == "T"  # Test
     # every line starts with "Col"
     for line in sql.split("\n")[1:]:
         assert line.startswith('"Col')

--- a/tests/load/snowflake/test_snowflake_table_builder.py
+++ b/tests/load/snowflake/test_snowflake_table_builder.py
@@ -52,12 +52,12 @@ def test_create_table(snowflake_client: SnowflakeClient) -> None:
     assert snowflake_client.capabilities.generates_case_sensitive_identifiers() is False
     # check if dataset name is properly folded
     assert (
-        snowflake_client.sql_client.fully_qualified_dataset_name(escape=False)
+        snowflake_client.sql_client.fully_qualified_dataset_name(quote=False)
         == snowflake_client.config.dataset_name.upper()
     )
     with snowflake_client.sql_client.with_staging_dataset():
         assert (
-            snowflake_client.sql_client.fully_qualified_dataset_name(escape=False)
+            snowflake_client.sql_client.fully_qualified_dataset_name(quote=False)
             == (
                 snowflake_client.config.staging_dataset_name_layout
                 % snowflake_client.config.dataset_name
@@ -180,7 +180,7 @@ def test_create_table_case_sensitive(cs_client: SnowflakeClient) -> None:
     )[0]
     sqlfluff.parse(sql, dialect="snowflake")
     # everything capitalized
-    assert cs_client.sql_client.fully_qualified_dataset_name(escape=False)[0] == "T"  # Test
+    assert cs_client.sql_client.fully_qualified_dataset_name(quote=False)[0] == "T"  # Test
     # every line starts with "Col"
     for line in sql.split("\n")[1:]:
         assert line.startswith('"Col')

--- a/tests/load/sqlalchemy/docker-compose.yml
+++ b/tests/load/sqlalchemy/docker-compose.yml
@@ -6,6 +6,7 @@ services:
   db:
     image: mysql:8
     restart: always
+    command: --sql-mode="STRICT_ALL_TABLES,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION" --innodb-strict-mode
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: dlt_data

--- a/tests/load/synapse/utils.py
+++ b/tests/load/synapse/utils.py
@@ -8,7 +8,7 @@ from dlt.destinations.impl.synapse.synapse_adapter import TTableIndexType
 def get_storage_table_index_type(sql_client: SynapseSqlClient, table_name: str) -> TTableIndexType:
     """Returns table index type of table in storage destination."""
     with sql_client:
-        schema_name = sql_client.fully_qualified_dataset_name(escape=False)
+        schema_name = sql_client.fully_qualified_dataset_name(quote=False)
         sql = dedent(f"""
             SELECT
                 CASE i.type_desc

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -231,7 +231,7 @@ def test_complete_load(naming: str, client: SqlJobClientBase) -> None:
     assert load_rows[0][4] == client.schema.version_hash
     # make sure that hash in loads exists in schema versions table
     versions_table = client.sql_client.make_qualified_table_name(version_table_name)
-    version_hash_column = client.sql_client.escape_column_name(
+    version_hash_column = client.sql_client.quote_column_name(
         client.schema.naming.normalize_identifier("version_hash")
     )
     version_rows = list(
@@ -507,7 +507,7 @@ def test_preserve_sql_column_order(client: SqlJobClientBase) -> None:
             if hasattr(client.sql_client, "escape_ddl_identifier"):
                 col_name = client.sql_client.escape_ddl_identifier(c["name"])
             else:
-                col_name = client.sql_client.escape_column_name(c["name"])
+                col_name = client.sql_client.quote_column_name(c["name"])
             # find column names
             idx = sql_.find(col_name, idx)
             assert idx > 0, f"column {col_name} not found in script"
@@ -557,7 +557,7 @@ def test_data_writer_load(naming: str, client: SqlJobClientBase, file_storage: F
         client, file_storage, query, table_name, file_format=client.destination_config.file_format  # type: ignore[attr-defined]
     )
     f_int_name = client.schema.naming.normalize_identifier("f_int")
-    f_int_name_quoted = client.sql_client.escape_column_name(f_int_name)
+    f_int_name_quoted = client.sql_client.quote_column_name(f_int_name)
     db_row = client.sql_client.execute_sql(
         f"SELECT * FROM {canonical_name} WHERE {f_int_name_quoted} = {rows[1][f_int_name]}"
     )[0]
@@ -1084,11 +1084,7 @@ def test_many_schemas_single_dataset(
         )
         client.schema._bump_version()
         # open tables on filesystem update schema on write and this write will fail
-        if destination_config.destination_type in ("clickhouse", "filesystem") or (
-            # mysql allows adding not-null columns (they have an implicit default)
-            destination_config.destination_type == "sqlalchemy"
-            and client.sql_client.dialect_name == "mysql"
-        ):
+        if not client.capabilities.enforces_nulls_on_alter:
             client.update_stored_schema()
         else:
             with pytest.raises(DestinationException) as py_ex:

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -231,7 +231,7 @@ def test_complete_load(naming: str, client: SqlJobClientBase) -> None:
     assert load_rows[0][4] == client.schema.version_hash
     # make sure that hash in loads exists in schema versions table
     versions_table = client.sql_client.make_qualified_table_name(version_table_name)
-    version_hash_column = client.sql_client.quote_column_name(
+    version_hash_column = client.sql_client.escape_column_name(
         client.schema.naming.normalize_identifier("version_hash")
     )
     version_rows = list(
@@ -507,7 +507,7 @@ def test_preserve_sql_column_order(client: SqlJobClientBase) -> None:
             if hasattr(client.sql_client, "escape_ddl_identifier"):
                 col_name = client.sql_client.escape_ddl_identifier(c["name"])
             else:
-                col_name = client.sql_client.quote_column_name(c["name"])
+                col_name = client.sql_client.escape_column_name(c["name"])
             # find column names
             idx = sql_.find(col_name, idx)
             assert idx > 0, f"column {col_name} not found in script"
@@ -557,7 +557,7 @@ def test_data_writer_load(naming: str, client: SqlJobClientBase, file_storage: F
         client, file_storage, query, table_name, file_format=client.destination_config.file_format  # type: ignore[attr-defined]
     )
     f_int_name = client.schema.naming.normalize_identifier("f_int")
-    f_int_name_quoted = client.sql_client.quote_column_name(f_int_name)
+    f_int_name_quoted = client.sql_client.escape_column_name(f_int_name)
     db_row = client.sql_client.execute_sql(
         f"SELECT * FROM {canonical_name} WHERE {f_int_name_quoted} = {rows[1][f_int_name]}"
     )[0]

--- a/tests/load/test_lineage.py
+++ b/tests/load/test_lineage.py
@@ -1,15 +1,9 @@
 import pytest
 
-import sqlglot
-
 from dlt import Schema
-from dlt.sources._single_file_templates.fruitshop_pipeline import (
-    fruitshop as fruitshop_source,
-)
+from dlt.common.schema.typing import TColumnSchema
 from dlt.transformations import lineage
-from tests.utils import autouse_test_storage
 
-from dlt.destinations import duckdb
 from tests.load.utils import destinations_configs, DestinationTestConfiguration
 from dlt.transformations.exceptions import LineageFailedException
 
@@ -27,6 +21,7 @@ def example_schema(autouse_test_storage) -> Schema:
                     "data_type": "text",
                     "name": "name",
                     "x-pii": True,
+                    "x-annotation-pii": True,  # not propagated
                 },
                 "email": {"data_type": "text", "name": "email", "nullable": True},
             },
@@ -51,7 +46,6 @@ def example_schema(autouse_test_storage) -> Schema:
         # TODO: see if we can get sqlalchemy, snowflake to work natively
         default_sql_configs=True,
         local_filesystem_configs=True,
-        exclude=["sqlalchemy", "snowflake", "clickhouse"],
     ),
     ids=lambda x: x.name,
 )
@@ -60,42 +54,44 @@ def test_various_queries(destination_config: DestinationTestConfiguration, examp
     destination = destination_config.destination_factory(dataset_name="d1")
     caps = destination.client(example_schema).sql_client.capabilities
     dialect = caps.sqlglot_dialect
-    sqlglot_schema = lineage.create_sqlglot_schema(
-        example_schema, destination.client(example_schema).sql_client
-    )
+    sqlglot_schema = lineage.create_sqlglot_schema(example_schema, "d1", dialect)
 
-    # TODO: investigate if we can fix this, this is a side effect of going via duckdb dialect
-    # in snowflake bigint is the same as decimal(19,0)
-    id_result_type = "bigint" if ("snowflake" not in destination_config.name) else "decimal"
+    def _set_nullable(col: TColumnSchema) -> TColumnSchema:
+        # if not caps.enforces_nulls:
+        if destination.destination_type.endswith("clickhouse"):
+            # looks like a bug in clickhouse dialect? clickhouse does not enforce nulls so setting it to false
+            # does not make sense
+            col.setdefault("nullable", False)
+        return col
 
     # test star select
     sql_query = "SELECT * FROM customers"
-    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect) == {
-        "id": {"name": "id", "data_type": id_result_type},
-        "name": {"name": "name", "data_type": "text", "x-pii": True},
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect)[0] == {
+        "id": {"name": "id", "data_type": "bigint"},
+        "name": {"name": "name", "data_type": "text", "x-annotation-pii": True},
         "email": {"name": "email", "data_type": "text", "nullable": True},
     }
 
     # test select with fully qualified table and column names
-    sql_query = "SELECT ID, d1.customers.name, d1.customers.email FROM d1.customers"
-    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect) == {
-        "id": {"name": "id", "data_type": id_result_type},
-        "name": {"name": "name", "data_type": "text", "x-pii": True},
+    sql_query = "SELECT id, d1.customers.name, d1.customers.email FROM d1.customers"
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect)[0] == {
+        "id": {"name": "id", "data_type": "bigint"},
+        "name": {"name": "name", "data_type": "text", "x-annotation-pii": True},
         "email": {"name": "email", "data_type": "text", "nullable": True},
     }
 
     # test select with casting and avg
     sql_query = "SELECT AVG(id) as mean_id, name, email, CAST(LEN(name) as DOUBLE) FROM customers"
-    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect) == {
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect)[0] == {
         "mean_id": {"name": "mean_id", "data_type": "double"},
-        "name": {"name": "name", "data_type": "text", "x-pii": True},
+        "name": {"name": "name", "data_type": "text", "x-annotation-pii": True},
         "email": {"name": "email", "data_type": "text", "nullable": True},
-        "_col_3": {"name": "_col_3", "data_type": "double"},  # anonymous columns
+        "_col_3": _set_nullable({"name": "_col_3", "data_type": "double"}),  # anonymous columns
     }
 
     # test concat
     sql_query = "SELECT CONCAT(name, email) as concat FROM customers"
-    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect) == {
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, dialect)[0] == {
         "concat": {"name": "concat", "data_type": "text"},
     }
 
@@ -104,8 +100,8 @@ def test_various_queries(destination_config: DestinationTestConfiguration, examp
         "SELECT customers.name, orders.amount FROM customers JOIN orders ON customers.id ="
         " orders.customer_id"
     )
-    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
-        "name": {"name": "name", "data_type": "text", "x-pii": True},
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb")[0] == {
+        "name": {"name": "name", "data_type": "text", "x-annotation-pii": True},
         "amount": {"name": "amount", "data_type": "double"},
     }
 
@@ -115,7 +111,7 @@ def test_various_queries(destination_config: DestinationTestConfiguration, examp
         orders GROUP BY 1 ) AS "t1" ORDER BY t1.count DESC
         LIMIT 10
     """
-    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb")[0] == {
         "count": {"name": "count", "data_type": "bigint"},
         "amount": {"name": "amount", "data_type": "double"},
     }
@@ -133,8 +129,8 @@ def test_various_queries(destination_config: DestinationTestConfiguration, examp
         FROM orders o
         JOIN customers c ON o.customer_id = c.id
     """
-    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
-        "name": {"name": "name", "data_type": "text", "x-pii": True},
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb")[0] == {
+        "name": {"name": "name", "data_type": "text", "x-annotation-pii": True},
         "total_amount": {"name": "total_amount"},  # , "data_type": "double"},
     }
 
@@ -147,7 +143,9 @@ def test_various_queries(destination_config: DestinationTestConfiguration, examp
         )
         SELECT customer_id, total_amount FROM customer_orders
     """
-    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb") == {
+    assert lineage.compute_columns_schema(sql_query, sqlglot_schema, "duckdb")[0] == {
         "customer_id": {"name": "customer_id", "data_type": "bigint"},
         "total_amount": {"name": "total_amount", "data_type": "double"},
     }
+
+    # TODO: please test UNION and UNION ALL this works now!

--- a/tests/load/transformations/utils.py
+++ b/tests/load/transformations/utils.py
@@ -48,6 +48,7 @@ def transformation_configs(only_duckdb: bool = False):
         table_format_filesystem_configs=True,
         exclude=[
             "athena",  # NOTE: athena iceberg will probably work, we need to implement the model files for it
+            # TODO: can we enable it and just disable specific tests
             "sqlalchemy_sqlite-no-staging",  # NOTE: sqlalchemy has no uuid support
             (  # NOTE: duckdb parquet does not need to be tested explicitely if we have the regular
                 "duckdb-parquet-no-staging"

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -217,8 +217,9 @@ class DestinationTestConfiguration:
 
     def setup(self) -> None:
         """Sets up environment variables for this destination configuration"""
+        env_key_prefix = "DESTINATION__" + (self.destination_name or self.destination_type).upper()
         for k, v in self.factory_kwargs.items():
-            os.environ[f"DESTINATION__{k.upper()}"] = str(v)
+            os.environ[f"{env_key_prefix}__{k.upper()}"] = str(v)
 
         # For the filesystem destinations we disable compression to make analyzing the result easier
         os.environ["DATA_WRITER__DISABLE_COMPRESSION"] = str(
@@ -229,10 +230,10 @@ class DestinationTestConfiguration:
 
         if self.credentials is not None:
             if isinstance(self.credentials, str):
-                os.environ["DESTINATION__CREDENTIALS"] = self.credentials
+                os.environ[f"{env_key_prefix}__CREDENTIALS"] = self.credentials
             else:
                 for key, value in dict(self.credentials).items():
-                    os.environ[f"DESTINATION__CREDENTIALS__{key.upper()}"] = str(value)
+                    os.environ[f"{env_key_prefix}__CREDENTIALS__{key.upper()}"] = str(value)
 
         if self.env_vars is not None:
             for k, v in self.env_vars.items():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -173,6 +173,10 @@ def autouse_test_storage() -> FileStorage:
 
 @pytest.fixture(scope="function", autouse=True)
 def preserve_environ() -> Iterator[None]:
+    yield from _preserve_environ()
+
+
+def _preserve_environ() -> Iterator[None]:
     saved_environ = environ.copy()
     # delta-rs sets those keys without updating environ and there's no
     # method to refresh environ
@@ -185,6 +189,7 @@ def preserve_environ() -> Iterator[None]:
             "AWS_SESSION_TOKEN",
         ]
     }
+    # print("PRE ENV", saved_environ)
     try:
         yield
     finally:
@@ -195,6 +200,7 @@ def preserve_environ() -> Iterator[None]:
                 environ[key_] = value_ or ""
             else:
                 del environ[key_]
+        # print("POST ENV", environ)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
1. Makes schemas generated by lineage and ibis modules to use dlt schema identifiers without any table name expansion (clickhouse), case folding (snowflake) etc.
2. this makes queries and expressions destination agnosting.
3. identifier normalization, expansions and qualification of tables, star expansion etc. is done after sqlglot schema generation and lineage
4. all queries are aliased (top select) so dlt identifiers are preserved - all the identifier adaptation to destination is hidden in the query
5. I allowed for UNION selects to work with lineage (row counts didn't)
6. I also added native cursor for arrow in Snowflake

Tests
1. I was able to enable all destinations for lineage and read interface tests. all queries are destination agnostic. column selection uses schema identifiers etc. so many exceptions are removed
2. several tests will fail. I will need help with fxing them. I'm pretty sure we can enable more test cases now
3. Snowflake native cursor does not let setting chunk size. some test must be fixed for sure
