### PR TITLE
qol: exception formatting

### DIFF
--- a/dlt/common/configuration/container.py
+++ b/dlt/common/configuration/container.py
@@ -59,7 +59,7 @@ class Container:
     def __getitem__(self, spec: Type[TInjectableContext]) -> TInjectableContext:
         # return existing config object or create it from spec
         if not is_subclass(spec, ContainerInjectableContext):
-            raise KeyError(f"{spec.__name__} is not a context")
+            raise KeyError(f"`{spec.__name__}` is not a context")
 
         context, item = self._thread_getitem(spec)
         if item is None:

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -147,7 +147,7 @@ class ConfigValueCannotBeCoercedException(ConfigurationValueError):
         self.field_value = field_value
         self.hint = hint
         super().__init__(
-            f"Configured value for field {field_name} cannot be coerced into type {str(hint)}"
+            f"Configured value for field `{field_name}` cannot be coerced into type `{str(hint)}`"
         )
 
 

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -122,6 +122,9 @@ class UnmatchedConfigHintResolversException(ConfigurationException):
             f"The config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}`"
             " but these fields are not defined in the spec.\nWhen using @resolve_type() decorator,"
             f" Add the fields with 'Any' or another common type hint, example:\n\n{example}"
+            f"The config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}` but"
+            " these fields are not defined in the spec.\nWhen using `@resolve_type()` decorator, Add"
+            f" the fields with 'Any' or another common type hint, example:\n\n{example}"
         )
         super().__init__(msg)
 
@@ -131,8 +134,7 @@ class FinalConfigFieldException(ConfigurationException):
 
     def __init__(self, spec_name: str, field: str) -> None:
         super().__init__(
-            f"Field `{field}` in spec `{spec_name}` is final but is being changed by a config"
-            " provider"
+            f"Field `{field}` in spec `{spec_name}` is final but is being changed by a config provider"
         )
 
 
@@ -144,7 +146,7 @@ class ConfigValueCannotBeCoercedException(ConfigurationValueError):
         self.field_value = field_value
         self.hint = hint
         super().__init__(
-            f"Can't coerce value for config field `{field_name}` into type {str(hint)}"
+            f"Configured value for field {field_name} cannot be coerced into type {str(hint)}"
         )
 
 
@@ -172,7 +174,7 @@ class ConfigFieldMissingTypeHintException(ConfigurationException):
         self.field_name = field_name
         self.typ_ = spec
         super().__init__(
-            f"Field {field_name} on configspec {spec} does not provide required type hint"
+            f"Field `{field_name}` on configspec `{spec}` does not provide required type hint"
         )
 
 
@@ -183,7 +185,7 @@ class ConfigFieldTypeHintNotSupported(ConfigurationException):
         self.field_name = field_name
         self.typ_ = spec
         super().__init__(
-            f"Field {field_name} on configspec {spec} has hint with unsupported type {typ_}"
+            f"Field `{field_name}` on configspec `{spec}` has hint with unsupported type `{typ_}`"
         )
 
 
@@ -192,7 +194,7 @@ class ValueNotSecretException(ConfigurationException):
         self.provider_name = provider_name
         self.key = key
         super().__init__(
-            f"Provider {provider_name} cannot hold secret values but key {key} with secret value is"
+            f"Provider `{provider_name}` cannot hold secret values but key `{key}` with secret value is"
             " present"
         )
 
@@ -211,10 +213,9 @@ class InvalidNativeValue(ConfigurationException):
         self.inner_exception = inner_exception
         inner_msg = f" {self.inner_exception}" if inner_exception is not ValueError else ""
         super().__init__(
-            f"{spec.__name__} cannot parse the configuration value provided. The value is of type"
-            f" {native_value_type.__name__} and comes from the"
-            " {embedded_sections} section(s). Value may be a secret and is not shown. "
-            f"Details: {inner_msg}"
+            f"`{spec.__name__}` cannot parse the configuration value provided. The value is of type "
+            f"`{native_value_type.__name__}` and comes from the sections `{embedded_sections}` "
+            f"Value may be a secret and is not shown. Details: {inner_msg}"
         )
 
 
@@ -224,20 +225,20 @@ class ContainerInjectableContextMangled(ContainerException):
         self.existing_config = existing_config
         self.expected_config = expected_config
         super().__init__(
-            f"When restoring context {spec.__name__}, instance {expected_config} was expected,"
-            f" instead instance {existing_config} was found."
+            f"When restoring context `{spec.__name__}`, instance `{expected_config}` was expected,"
+            f" instead instance `{existing_config}` was found."
         )
 
 
 class ContextDefaultCannotBeCreated(ContainerException, KeyError):
     def __init__(self, spec: Type[Any]) -> None:
         self.spec = spec
-        super().__init__(f"Container cannot create the default value of context {spec.__name__}.")
+        super().__init__(f"Container cannot create the default value of context `{spec.__name__}`.")
 
 
 class DuplicateConfigProviderException(ConfigProviderException):
     def __init__(self, provider_name: str) -> None:
         super().__init__(
             provider_name,
-            f"Provider with name {provider_name} already present in ConfigProvidersContext",
+            f"Provider with name `{provider_name}` already present in `ConfigProvidersContext`",
         )

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -33,8 +33,8 @@ class ConfigProviderException(ConfigurationException):
 class ConfigurationWrongTypeException(ConfigurationException):
     def __init__(self, _typ: type) -> None:
         super().__init__(
-            f"Invalid configuration instance type `{_typ}`. Configuration instances must derive from"
-            " BaseConfiguration and must be decorated with @configspec."
+            f"Invalid configuration instance type `{_typ}`. Configuration instances must derive"
+            " from BaseConfiguration and must be decorated with @configspec."
         )
 
 
@@ -48,12 +48,11 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
         super().__init__(spec_name)
 
     def __str__(self) -> str:
-        msg = (
-            f"Missing fields in configuration: {str(self.fields)}"
-            f" {self.spec_name}\n"
-        )
+        msg = f"Missing fields in configuration: {str(self.fields)} {self.spec_name}\n"
         for f, field_traces in self.traces.items():
-            msg += f"\tfor field `{f}` the following (config providers, keys) were tried in order:\n"
+            msg += (
+                f"\tfor field `{f}` the following (config providers, keys) were tried in order:\n"
+            )
             for tr in field_traces:
                 msg += f"\t\t({tr.provider}, {tr.key})\n"
 
@@ -69,7 +68,10 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
                 msg += f"Provider `{provider.name}` loaded values from locations:\n{locations}\n"
 
             if provider.is_empty:
-                msg += f"WARNING: provider `{provider.name}` is empty. Locations (i.e., files) are missing or empty.\n"
+                msg += (
+                    f"WARNING: provider `{provider.name}` is empty. Locations (i.e., files) are"
+                    " missing or empty.\n"
+                )
 
         # check if entry point is run with path. this is common problem so warn the user
         main_path = main_module_file_path()
@@ -94,9 +96,7 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
                         " but run your script from some other folder, secrets/configs will not be"
                         " found\n"
                     )
-        msg += (
-            "Learn more: https://dlthub.com/docs/general-usage/credentials/\n"
-        )
+        msg += "Learn more: https://dlthub.com/docs/general-usage/credentials/\n"
         return msg
 
     def attrs(self) -> Dict[str, Any]:
@@ -119,9 +119,9 @@ class UnmatchedConfigHintResolversException(ConfigurationException):
             f">>>    {name}: Any" for name in field_names
         )
         msg = (
-            f"The config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}` but"
-            " these fields are not defined in the spec.\nWhen using @resolve_type() decorator, Add"
-            f" the fields with 'Any' or another common type hint, example:\n\n{example}"
+            f"The config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}`"
+            " but these fields are not defined in the spec.\nWhen using @resolve_type() decorator,"
+            f" Add the fields with 'Any' or another common type hint, example:\n\n{example}"
         )
         super().__init__(msg)
 
@@ -131,7 +131,8 @@ class FinalConfigFieldException(ConfigurationException):
 
     def __init__(self, spec_name: str, field: str) -> None:
         super().__init__(
-            f"Field `{field}` in spec `{spec_name}` is final but is being changed by a config provider"
+            f"Field `{field}` in spec `{spec_name}` is final but is being changed by a config"
+            " provider"
         )
 
 

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -121,10 +121,10 @@ class UnmatchedConfigHintResolversException(ConfigurationException):
         msg = (
             f"The config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}`"
             " but these fields are not defined in the spec.\nWhen using @resolve_type() decorator,"
+            f" Add the fields with 'Any' or another common type hint, example:\n\n{example}The"
+            f" config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}` but"
+            " these fields are not defined in the spec.\nWhen using `@resolve_type()` decorator,"
             f" Add the fields with 'Any' or another common type hint, example:\n\n{example}"
-            f"The config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}` but"
-            " these fields are not defined in the spec.\nWhen using `@resolve_type()` decorator, Add"
-            f" the fields with 'Any' or another common type hint, example:\n\n{example}"
         )
         super().__init__(msg)
 
@@ -134,7 +134,8 @@ class FinalConfigFieldException(ConfigurationException):
 
     def __init__(self, spec_name: str, field: str) -> None:
         super().__init__(
-            f"Field `{field}` in spec `{spec_name}` is final but is being changed by a config provider"
+            f"Field `{field}` in spec `{spec_name}` is final but is being changed by a config"
+            " provider"
         )
 
 
@@ -194,8 +195,8 @@ class ValueNotSecretException(ConfigurationException):
         self.provider_name = provider_name
         self.key = key
         super().__init__(
-            f"Provider `{provider_name}` cannot hold secret values but key `{key}` with secret value is"
-            " present"
+            f"Provider `{provider_name}` cannot hold secret values but key `{key}` with secret"
+            " value is present"
         )
 
 
@@ -213,9 +214,9 @@ class InvalidNativeValue(ConfigurationException):
         self.inner_exception = inner_exception
         inner_msg = f" {self.inner_exception}" if inner_exception is not ValueError else ""
         super().__init__(
-            f"`{spec.__name__}` cannot parse the configuration value provided. The value is of type "
-            f"`{native_value_type.__name__}` and comes from the sections `{embedded_sections}` "
-            f"Value may be a secret and is not shown. Details: {inner_msg}"
+            f"`{spec.__name__}` cannot parse the configuration value provided. The value is of type"
+            f" `{native_value_type.__name__}` and comes from the sections `{embedded_sections}`"
+            f" Value may be a secret and is not shown. Details: {inner_msg}"
         )
 
 

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -23,8 +23,6 @@ class ConfigurationValueError(ConfigurationException, ValueError):
 class ContainerException(DltException):
     """base exception for all exceptions related to injectable container"""
 
-    pass
-
 
 class ConfigProviderException(ConfigurationException):
     def __init__(self, provider_name: str, *args: Any) -> None:
@@ -35,7 +33,7 @@ class ConfigProviderException(ConfigurationException):
 class ConfigurationWrongTypeException(ConfigurationException):
     def __init__(self, _typ: type) -> None:
         super().__init__(
-            f"Invalid configuration instance type {_typ}. Configuration instances must derive from"
+            f"Invalid configuration instance type `{_typ}`. Configuration instances must derive from"
             " BaseConfiguration and must be decorated with @configspec."
         )
 
@@ -51,13 +49,13 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
 
     def __str__(self) -> str:
         msg = (
-            f"Following fields are missing: {str(self.fields)} in configuration with spec"
+            f"Missing fields in configuration: {str(self.fields)}"
             f" {self.spec_name}\n"
         )
         for f, field_traces in self.traces.items():
-            msg += f'\tfor field "{f}" config providers and keys were tried in following order:\n'
+            msg += f"\tfor field `{f}` the following (config providers, keys) were tried in order:\n"
             for tr in field_traces:
-                msg += f"\t\tIn {tr.provider} key {tr.key} was not found.\n"
+                msg += f"\t\t({tr.provider}, {tr.key})\n"
 
         from dlt.common.configuration.container import Container
         from dlt.common.configuration.specs import PluggableRunContext
@@ -68,15 +66,10 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
         for provider in providers.providers:
             if provider.locations:
                 locations = "\n".join([f"\t- {os.path.abspath(loc)}" for loc in provider.locations])
-                msg += (
-                    f"Provider {provider.name} used following locations to load"
-                    f" values:\n{locations}\n"
-                )
+                msg += f"Provider `{provider.name}` loaded values from locations:\n{locations}\n"
+
             if provider.is_empty:
-                msg += (
-                    f"WARNING: provider {provider.name} is empty. Locations (ie. files) may not"
-                    " exist or may be empty.\n"
-                )
+                msg += f"WARNING: provider `{provider.name}` is empty. Locations (i.e., files) are missing or empty.\n"
 
         # check if entry point is run with path. this is common problem so warn the user
         main_path = main_module_file_path()
@@ -102,8 +95,7 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
                         " found\n"
                     )
         msg += (
-            "Please refer to https://dlthub.com/docs/general-usage/credentials/ for more"
-            " information\n"
+            "Learn more: https://dlthub.com/docs/general-usage/credentials/\n"
         )
         return msg
 
@@ -127,7 +119,7 @@ class UnmatchedConfigHintResolversException(ConfigurationException):
             f">>>    {name}: Any" for name in field_names
         )
         msg = (
-            f"The config spec {spec_name} has dynamic type resolvers for fields: {field_names} but"
+            f"The config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}` but"
             " these fields are not defined in the spec.\nWhen using @resolve_type() decorator, Add"
             f" the fields with 'Any' or another common type hint, example:\n\n{example}"
         )
@@ -139,7 +131,7 @@ class FinalConfigFieldException(ConfigurationException):
 
     def __init__(self, spec_name: str, field: str) -> None:
         super().__init__(
-            f"Field {field} in spec {spec_name} is final but is being changed by a config provider"
+            f"Field `{field}` in spec `{spec_name}` is final but is being changed by a config provider"
         )
 
 
@@ -151,7 +143,7 @@ class ConfigValueCannotBeCoercedException(ConfigurationValueError):
         self.field_value = field_value
         self.hint = hint
         super().__init__(
-            "Configured value for field %s cannot be coerced into type %s" % (field_name, str(hint))
+            f"Can't coerce value for config field `{field_name}` into type {str(hint)}"
         )
 
 
@@ -169,7 +161,7 @@ class ConfigFileNotFoundException(ConfigurationException):
     """thrown when configuration file cannot be found in config folder"""
 
     def __init__(self, path: str) -> None:
-        super().__init__(f"Missing config file in {path}")
+        super().__init__(f"Missing config file in `{path}`")
 
 
 class ConfigFieldMissingTypeHintException(ConfigurationException):

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -121,9 +121,6 @@ class UnmatchedConfigHintResolversException(ConfigurationException):
         msg = (
             f"The config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}`"
             " but these fields are not defined in the spec.\nWhen using @resolve_type() decorator,"
-            f" Add the fields with 'Any' or another common type hint, example:\n\n{example}The"
-            f" config spec `{spec_name}` has dynamic type resolvers for fields: `{field_names}` but"
-            " these fields are not defined in the spec.\nWhen using `@resolve_type()` decorator,"
             f" Add the fields with 'Any' or another common type hint, example:\n\n{example}"
         )
         super().__init__(msg)

--- a/dlt/common/configuration/inject.py
+++ b/dlt/common/configuration/inject.py
@@ -287,8 +287,7 @@ def with_config(
 
     if not callable(func):
         raise ValueError(
-            "First parameter to the with_config must be callable ie. by using it as function"
-            " decorator"
+            "First parameter of `with_config` must be callable i.e., by using it as a decorator `@with_config`"
         )
 
     # We're called as @with_config without parens.

--- a/dlt/common/configuration/inject.py
+++ b/dlt/common/configuration/inject.py
@@ -287,7 +287,8 @@ def with_config(
 
     if not callable(func):
         raise ValueError(
-            "First parameter of `with_config` must be callable i.e., by using it as a decorator `@with_config`"
+            "First parameter of `with_config` must be callable i.e., by using it as a decorator"
+            " `@with_config`"
         )
 
     # We're called as @with_config without parens.

--- a/dlt/common/configuration/providers/google_secrets.py
+++ b/dlt/common/configuration/providers/google_secrets.py
@@ -173,7 +173,7 @@ class GoogleSecretsProvider(VaultDocProvider):
             if status_code == 403:
                 raise ConfigProviderException(
                     self.name,
-                    f"Cannot list secrets: {self.credentials.client_email} does not have "
+                    f"Cannot list secrets: `{self.credentials.client_email}` does not have "
                     "roles/secretmanager.secretViewer role. Secret listing is required when "
                     "list_secrets=True to optimize vault access by skipping lookups for "
                     f"non-existent secrets. Error: {error_message} [{error_status}]",

--- a/dlt/common/configuration/specs/exceptions.py
+++ b/dlt/common/configuration/specs/exceptions.py
@@ -35,9 +35,9 @@ class InvalidConnectionString(NativeValueError):
 class InvalidGoogleNativeCredentialsType(NativeValueError):
     def __init__(self, spec: Type[Any], native_value: Any):
         msg = (
-            f"Credentials `{spec.__name__}` accept a string with serialized credentials json file or"
-            " an instance of `Credentials` object from Google.* namespace. The value passed is of"
-            f" type `{type(native_value)}`"
+            f"Credentials `{spec.__name__}` accept a string with serialized credentials json file"
+            " or an instance of `Credentials` object from Google.* namespace. The value passed is"
+            f" of type `{type(native_value)}`"
         )
         super().__init__(spec, native_value, msg)
 

--- a/dlt/common/configuration/specs/exceptions.py
+++ b/dlt/common/configuration/specs/exceptions.py
@@ -10,7 +10,7 @@ class OAuth2ScopesRequired(SpecException):
     def __init__(self, spec: type) -> None:
         self.spec = spec
         super().__init__(
-            "Scopes are required to retrieve refresh_token. Use 'openid' scope for a token without"
+            "Scopes are required to retrieve refresh_token. Use `openid` scope for a token without"
             " any permissions to resources."
         )
 
@@ -26,8 +26,8 @@ class InvalidConnectionString(NativeValueError):
     def __init__(self, spec: Type[Any], native_value: str, driver: str):
         driver = driver or "driver"
         msg = (
-            f"The expected representation for {spec.__name__} is a standard database connection"
-            f" string with the following format: {driver}://username:password@host:port/database."
+            f"The expected representation for `{spec.__name__}` is a standard database connection"
+            f" string with the following format: `{driver}://username:password@host:port/database`"
         )
         super().__init__(spec, native_value, msg)
 
@@ -35,9 +35,9 @@ class InvalidConnectionString(NativeValueError):
 class InvalidGoogleNativeCredentialsType(NativeValueError):
     def __init__(self, spec: Type[Any], native_value: Any):
         msg = (
-            f"Credentials {spec.__name__} accept a string with serialized credentials json file or"
-            " an instance of Credentials object from google.* namespace. The value passed is of"
-            f" type {type(native_value)}"
+            f"Credentials `{spec.__name__}` accept a string with serialized credentials json file or"
+            " an instance of `Credentials` object from Google.* namespace. The value passed is of"
+            f" type `{type(native_value)}`"
         )
         super().__init__(spec, native_value, msg)
 
@@ -45,8 +45,8 @@ class InvalidGoogleNativeCredentialsType(NativeValueError):
 class InvalidGoogleServicesJson(NativeValueError):
     def __init__(self, spec: Type[Any], native_value: Any):
         msg = (
-            f"The expected representation for {spec.__name__} is a string with serialized service"
-            " account credentials, where at least 'project_id', 'private_key' and 'client_email`"
+            f"The expected representation for `{spec.__name__}` is a string with serialized service"
+            " account credentials, where at least `project_id`, `private_key` and `client_email`"
             " keys are present"
         )
         super().__init__(spec, native_value, msg)
@@ -55,7 +55,7 @@ class InvalidGoogleServicesJson(NativeValueError):
 class InvalidGoogleOauth2Json(NativeValueError):
     def __init__(self, spec: Type[Any], native_value: Any):
         msg = (
-            f"The expected representation for {spec.__name__} is a string with serialized oauth2"
+            f"The expected representation for `{spec.__name__}` is a string with serialized oauth2"
             " user info and may be wrapped in 'install'/'web' node - depending of oauth2 app type."
         )
         super().__init__(spec, native_value, msg)
@@ -64,7 +64,7 @@ class InvalidGoogleOauth2Json(NativeValueError):
 class InvalidBoto3Session(NativeValueError):
     def __init__(self, spec: Type[Any], native_value: Any):
         msg = (
-            f"The expected representation for {spec.__name__} is and instance of boto3.Session"
+            f"The expected representation for `{spec.__name__}` is and instance of boto3.Session"
             " containing credentials"
         )
         super().__init__(spec, native_value, msg)

--- a/dlt/common/configuration/specs/pluggable_run_context.py
+++ b/dlt/common/configuration/specs/pluggable_run_context.py
@@ -172,7 +172,7 @@ class PluggableRunContext(ContainerInjectableContext):
         """Pops context from stack and re-initializes it if in container"""
         _c, context, providers, runtime_config = self._context_stack.pop()
         if cookie != _c:
-            raise ValueError(f"Run context stack mangled. Got cookie {_c} but expected {cookie}")
+            raise ValueError(f"Run context stack mangled. Got cookie `{_c}` but expected `{cookie}`")
         self.runtime_config = runtime_config
         self.reload(context)
 
@@ -181,4 +181,4 @@ class PluggableRunContext(ContainerInjectableContext):
         state_ = self._context_stack.pop()
         _c = state_[0]
         if cookie != _c:
-            raise ValueError(f"Run context stack mangled. Got cookie {_c} but expected {cookie}")
+            raise ValueError(f"Run context stack mangled. Got cookie `{_c}` but expected `{cookie}`")

--- a/dlt/common/configuration/specs/pluggable_run_context.py
+++ b/dlt/common/configuration/specs/pluggable_run_context.py
@@ -172,7 +172,9 @@ class PluggableRunContext(ContainerInjectableContext):
         """Pops context from stack and re-initializes it if in container"""
         _c, context, providers, runtime_config = self._context_stack.pop()
         if cookie != _c:
-            raise ValueError(f"Run context stack mangled. Got cookie `{_c}` but expected `{cookie}`")
+            raise ValueError(
+                f"Run context stack mangled. Got cookie `{_c}` but expected `{cookie}`"
+            )
         self.runtime_config = runtime_config
         self.reload(context)
 
@@ -181,4 +183,6 @@ class PluggableRunContext(ContainerInjectableContext):
         state_ = self._context_stack.pop()
         _c = state_[0]
         if cookie != _c:
-            raise ValueError(f"Run context stack mangled. Got cookie `{_c}` but expected `{cookie}`")
+            raise ValueError(
+                f"Run context stack mangled. Got cookie `{_c}` but expected `{cookie}`"
+            )

--- a/dlt/common/data_types/type_helpers.py
+++ b/dlt/common/data_types/type_helpers.py
@@ -88,7 +88,7 @@ def coerce_from_date_types(
         return ensure_pendulum_date(v)
     if to_type == "time":
         return v.time()
-    raise TypeError(f"Cannot convert timestamp to {to_type}")
+    raise TypeError(f"Cannot convert timestamp to `{to_type}`")
 
 
 def coerce_value(to_type: TDataType, from_type: TDataType, value: Any) -> Any:

--- a/dlt/common/data_writers/exceptions.py
+++ b/dlt/common/data_writers/exceptions.py
@@ -37,7 +37,8 @@ class DestinationCapabilitiesRequired(DataWriterException, ValueError):
     def __init__(self, file_format: TLoaderFileFormat):
         self.file_format = file_format
         super().__init__(
-            f"Writer for `{file_format=:}` requires destination capabilities which were not provided."
+            f"Writer for `{file_format=:}` requires destination capabilities which were not"
+            " provided."
         )
 
 
@@ -59,7 +60,8 @@ class FileSpecNotFound(KeyError, DataWriterNotFound):
         self.file_format = file_format
         self.data_item_format = data_item_format
         super().__init__(
-            f"Can't find a file writer for spec with `{file_format=:}` and `{data_item_format=:}` where the full spec is `{spec}`"
+            f"Can't find a file writer for spec with `{file_format=:}` and `{data_item_format=:}`"
+            f" where the full spec is `{spec}`"
         )
 
 
@@ -84,5 +86,6 @@ class InvalidDataItem(DataWriterException):
         self.file_format = file_format
         self.data_item_format = data_item_format
         super().__init__(
-            f"A data item of type {data_item_format=:} cannot be written as `{file_format}: {details}`"
+            f"A data item of type {data_item_format=:} cannot be written as `{file_format}:"
+            f" {details}`"
         )

--- a/dlt/common/data_writers/exceptions.py
+++ b/dlt/common/data_writers/exceptions.py
@@ -12,7 +12,7 @@ class InvalidFileNameTemplateException(DataWriterException, ValueError):
     def __init__(self, file_name_template: str):
         self.file_name_template = file_name_template
         super().__init__(
-            f"Wrong file name template {file_name_template}. File name template must contain"
+            f"Wrong file name template `{file_name_template}`. File name template must contain"
             " exactly one %s formatter"
         )
 
@@ -20,7 +20,7 @@ class InvalidFileNameTemplateException(DataWriterException, ValueError):
 class BufferedDataWriterClosed(DataWriterException):
     def __init__(self, file_name: str):
         self.file_name = file_name
-        super().__init__(f"Writer with recent file name {file_name} is already closed")
+        super().__init__(f"Writer with recent file name `{file_name}` is already closed")
 
 
 class FileImportNotFound(DataWriterException, FileNotFoundError):
@@ -28,8 +28,8 @@ class FileImportNotFound(DataWriterException, FileNotFoundError):
         self.import_file_path = import_file_path
         self.local_file_path = local_file_path
         super().__init__(
-            f"Attempt to import non existing file {import_file_path} into extract storage file"
-            f" {local_file_path}"
+            f"Attempt to import non existing file `{import_file_path}` into extract storage file"
+            f" `{local_file_path}`"
         )
 
 
@@ -37,7 +37,7 @@ class DestinationCapabilitiesRequired(DataWriterException, ValueError):
     def __init__(self, file_format: TLoaderFileFormat):
         self.file_format = file_format
         super().__init__(
-            f"Writer for {file_format} requires destination capabilities which were not provided."
+            f"Writer for `{file_format=:}` requires destination capabilities which were not provided."
         )
 
 
@@ -50,8 +50,7 @@ class FileFormatForItemFormatNotFound(DataWriterNotFound):
         self.file_format = file_format
         self.data_item_format = data_item_format
         super().__init__(
-            f"Can't find a file writer for file format {file_format} and item format"
-            f" {data_item_format}"
+            f"Can't find a file writer for `{file_format=:}` and item format `{data_item_format=:}`"
         )
 
 
@@ -60,8 +59,7 @@ class FileSpecNotFound(KeyError, DataWriterNotFound):
         self.file_format = file_format
         self.data_item_format = data_item_format
         super().__init__(
-            f"Can't find a file writer for spec with file format {file_format} and item format"
-            f" {data_item_format} where the full spec is {spec}"
+            f"Can't find a file writer for spec with `{file_format=:}` and `{data_item_format=:}` where the full spec is `{spec}`"
         )
 
 
@@ -76,8 +74,8 @@ class SpecLookupFailed(DataWriterNotFound):
         self.possible_file_formats = possible_file_formats
         self.data_item_format = data_item_format
         super().__init__(
-            f"Lookup for best file writer for item format {data_item_format} among file formats"
-            f" {possible_file_formats} failed. The preferred file format was {file_format}."
+            f"Failed to find file writer for {data_item_format=:} among file formats"
+            f" {possible_file_formats=:}. The preferred file format was `{file_format=:}`."
         )
 
 
@@ -86,5 +84,5 @@ class InvalidDataItem(DataWriterException):
         self.file_format = file_format
         self.data_item_format = data_item_format
         super().__init__(
-            f"A data item of type {data_item_format} cannot be written as {file_format}: {details}"
+            f"A data item of type {data_item_format=:} cannot be written as `{file_format}: {details}`"
         )

--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -155,7 +155,7 @@ class ImportFileWriter(DataWriter):
 
     def write_header(self, columns_schema: TTableSchemaColumns) -> None:
         raise NotImplementedError(
-            "`ImportFileWriter` cannot write any files. You have bug in your code."
+            "`ImportFileWriter` cannot write any files. You have a bug in your code."
         )
 
     @classmethod

--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -35,6 +35,7 @@ from dlt.common.destination import (
     TLoaderFileFormat,
     LOADER_FILE_FORMATS,
 )
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.common.metrics import DataWriterMetrics
 from dlt.common.schema.typing import TTableSchemaColumns
 from dlt.common.schema.utils import is_nullable_column
@@ -470,9 +471,10 @@ class CsvWriter(DataWriter):
                             raise InvalidDataItem(
                                 "csv",
                                 "object",
-                                f"'{key}' contains bytes that cannot be decoded with encoding `{self.bytes_encoding}`. "
-                                "Remove binary columns or replace their content with a hex representation: "
-                                "\\x... while keeping data type as binary.",
+                                f"'{key}' contains bytes that cannot be decoded with encoding"
+                                f" `{self.bytes_encoding}`. Remove binary columns or replace their"
+                                " content with a hex representation: \\x... while keeping data"
+                                " type as binary.",
                             )
 
         self.writer.writerows(items)
@@ -754,9 +756,10 @@ def resolve_best_writer_spec(
     # check if preferred format has native item_format writer
     if preferred_format:
         if preferred_format not in possible_file_formats:
-            raise ValueError(
-                f"Preferred format `{preferred_format}` not possible in `{possible_file_formats}`"
+            raise ValueErrorWithKnownValues(
+                "preferred_format", preferred_format, possible_file_formats
             )
+
         try:
             return DataWriter.class_factory(
                 preferred_format, item_format, native_writers

--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -125,7 +125,7 @@ class DataWriter(abc.ABC):
         elif extension in LOADER_FILE_FORMATS:
             return "file"
         else:
-            raise ValueError(f"Cannot figure out data item format for extension {extension}")
+            raise ValueError(f"No `data_item_format` associated with file extension: `{extension}`")
 
     @staticmethod
     def writer_class_from_spec(spec: FileWriterSpec) -> Type["DataWriter"]:
@@ -154,12 +154,12 @@ class ImportFileWriter(DataWriter):
 
     def write_header(self, columns_schema: TTableSchemaColumns) -> None:
         raise NotImplementedError(
-            "ImportFileWriter cannot write any files. You have bug in your code."
+            "`ImportFileWriter` cannot write any files. You have bug in your code."
         )
 
     @classmethod
     def writer_spec(cls) -> FileWriterSpec:
-        raise NotImplementedError("ImportFileWriter has no single spec")
+        raise NotImplementedError("`ImportFileWriter` has no single spec")
 
 
 class JsonlWriter(DataWriter):
@@ -470,10 +470,9 @@ class CsvWriter(DataWriter):
                             raise InvalidDataItem(
                                 "csv",
                                 "object",
-                                f"'{key}' contains bytes that cannot be decoded with"
-                                f" {self.bytes_encoding}. Remove binary columns or replace their"
-                                " content with a hex representation: \\x... while keeping data"
-                                " type as binary.",
+                                f"'{key}' contains bytes that cannot be decoded with encoding `{self.bytes_encoding}`. "
+                                "Remove binary columns or replace their content with a hex representation: "
+                                "\\x... while keeping data type as binary.",
                             )
 
         self.writer.writerows(items)
@@ -590,7 +589,7 @@ class ArrowToCsvWriter(DataWriter):
                                 "csv",
                                 "arrow",
                                 "Arrow data contains a column that cannot be written to csv file"
-                                f" ({inv_ex}). Remove nested columns (struct, map) or convert them"
+                                f" `{inv_ex}`. Remove nested columns (struct, map) or convert them"
                                 " to json strings.",
                             )
                         raise
@@ -627,7 +626,7 @@ class ArrowToCsvWriter(DataWriter):
                         )
                     raise
             else:
-                raise ValueError(f"Unsupported type {type(item)}")
+                raise ValueError(f"Unsupported type `{type(item)}`")
             # count rows that got written
             self.items_count += item.num_rows
 
@@ -756,7 +755,7 @@ def resolve_best_writer_spec(
     if preferred_format:
         if preferred_format not in possible_file_formats:
             raise ValueError(
-                f"Preferred format {preferred_format} not possible in {possible_file_formats}"
+                f"Preferred format `{preferred_format}` not possible in `{possible_file_formats}`"
             )
         try:
             return DataWriter.class_factory(

--- a/dlt/common/destination/client.py
+++ b/dlt/common/destination/client.py
@@ -264,7 +264,7 @@ class DestinationClientDwhConfiguration(DestinationClientConfiguration):
 
     def _make_dataset_name(self, schema_name: str) -> str:
         if not schema_name:
-            raise ValueError("schema_name is None or empty")
+            raise ValueError("`schema_name` is `None` or empty")
 
         # if default schema is None then suffix is not added
         if self.default_schema_name is not None and schema_name != self.default_schema_name:

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -57,7 +57,9 @@ class SupportsReadableRelation:
         allow_partial: bool = True,
     ) -> TTableSchemaColumns:
         """Return the expected dlt schema of the execution result of self.query()"""
-        raise NotImplementedError("`compute_columns_schema()` method is not supported for this relation")
+        raise NotImplementedError(
+            "`compute_columns_schema()` method is not supported for this relation"
+        )
 
     def df(self, chunk_size: int = None) -> Optional[DataFrame]:
         """Fetches the results as arrow table. Uses the native pandas implementation of the destination client cursor if available.

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -48,7 +48,7 @@ class SupportsReadableRelation:
         Returns:
             Any: The qualified sql query that represents the relation
         """
-        raise NotImplementedError("Query is not supported for this relation")
+        raise NotImplementedError("`query()` method is not supported for this relation")
 
     def compute_columns_schema(
         self,
@@ -57,7 +57,7 @@ class SupportsReadableRelation:
         allow_partial: bool = True,
     ) -> TTableSchemaColumns:
         """Return the expected dlt schema of the execution result of self.query()"""
-        raise NotImplementedError("Compute columns schema is not supported for this relation")
+        raise NotImplementedError("`compute_columns_schema()` method is not supported for this relation")
 
     def df(self, chunk_size: int = None) -> Optional[DataFrame]:
         """Fetches the results as arrow table. Uses the native pandas implementation of the destination client cursor if available.
@@ -68,7 +68,7 @@ class SupportsReadableRelation:
         Returns:
             Optional[DataFrame]: A data frame with query results.
         """
-        raise NotImplementedError("Fetching as dataframe is not supported for this relation")
+        raise NotImplementedError("`df()` method is not supported for this relation")
 
     def arrow(self, chunk_size: int = None) -> Optional[ArrowTable]:
         """Fetches the results as arrow table. Uses the native arrow implementation of the destination client cursor if available.
@@ -79,7 +79,7 @@ class SupportsReadableRelation:
         Returns:
             Optional[ArrowTable]: An arrow table with query results.
         """
-        raise NotImplementedError("Fetching as arrow table is not supported for this relation")
+        raise NotImplementedError("`arrow()` method is not supported for this relation")
 
     def iter_df(self, chunk_size: int) -> Generator[DataFrame, None, None]:
         """Iterates over data frames of 'chunk_size' items. Uses the native pandas implementation of the destination client cursor if available.
@@ -90,7 +90,7 @@ class SupportsReadableRelation:
         Returns:
             Generator[DataFrame, None, None]: A generator of data frames with query results.
         """
-        raise NotImplementedError("Iterating over data frames is not supported for this relation")
+        raise NotImplementedError("`iter_df()` method is not supported for this relation")
 
     def iter_arrow(self, chunk_size: int) -> Generator[ArrowTable, None, None]:
         """Iterates over arrow tables of 'chunk_size' items. Uses the native arrow implementation of the destination client cursor if available.
@@ -101,7 +101,7 @@ class SupportsReadableRelation:
         Returns:
             Generator[ArrowTable, None, None]: A generator of arrow tables with query results.
         """
-        raise NotImplementedError("Iterating over arrow tables is not supported for this relation")
+        raise NotImplementedError("`iter_arrow()` method is not supported for this relation")
 
     def fetchall(self) -> List[Tuple[Any, ...]]:
         """Fetches all items as a list of python tuples. Uses the native dbapi fetchall implementation of the destination client cursor.
@@ -109,7 +109,7 @@ class SupportsReadableRelation:
         Returns:
             List[Tuple[Any, ...]]: A list of python tuples w
         """
-        raise NotImplementedError("Fetching all items is not supported for this relation")
+        raise NotImplementedError("`fetchall()` method is not supported for this relation")
 
     def fetchmany(self, chunk_size: int) -> List[Tuple[Any, ...]]:
         """Fetches the first 'chunk_size' items as a list of python tuples. Uses the native dbapi fetchmany implementation of the destination client cursor.
@@ -120,7 +120,7 @@ class SupportsReadableRelation:
         Returns:
             List[Tuple[Any, ...]]: A list of python tuples with query results.
         """
-        raise NotImplementedError("Fetching many items is not supported for this relation")
+        raise NotImplementedError("`fetchmany()` method is not supported for this relation")
 
     def iter_fetch(self, chunk_size: int) -> Generator[List[Tuple[Any, ...]], Any, Any]:
         """Iterates in lists of Python tuples in 'chunk_size' chunks. Uses the native dbapi fetchmany implementation of the destination client cursor.
@@ -131,7 +131,7 @@ class SupportsReadableRelation:
         Returns:
             Generator[List[Tuple[Any, ...]], Any, Any]: A generator of lists of python tuples with query results.
         """
-        raise NotImplementedError("Iterating over fetch results is not supported for this relation")
+        raise NotImplementedError("`iter_fetch()` method is not supported for this relation")
 
     def fetchone(self) -> Optional[Tuple[Any, ...]]:
         """Fetches the first item as a python tuple. Uses the native dbapi fetchone implementation of the destination client cursor.
@@ -139,7 +139,7 @@ class SupportsReadableRelation:
         Returns:
             Optional[Tuple[Any, ...]]: A python tuple with the first item of the query results.
         """
-        raise NotImplementedError("Fetching one item is not supported for this relation")
+        raise NotImplementedError("`fetchone()` method is not supported for this relation")
 
     def scalar(self) -> Any:
         """fetch first value of first column on first row as python primitive"""
@@ -168,7 +168,7 @@ class SupportsReadableRelation:
         Returns:
             Self: The relation with the limit applied.
         """
-        raise NotImplementedError("Limiting the relation is not supported for this relation")
+        raise NotImplementedError("`limit()` method is not supported for this relation")
 
     def head(self, limit: int = 5) -> Self:
         """By default returns a relation with the first 5 rows selected.
@@ -179,7 +179,7 @@ class SupportsReadableRelation:
         Returns:
             Self: The relation with the limit applied.
         """
-        raise NotImplementedError("Head is not supported for this relation")
+        raise NotImplementedError("`head()` method is not supported for this relation")
 
     def select(self, *columns: str) -> Self:
         """Returns a new relation with the given columns selected.
@@ -190,7 +190,7 @@ class SupportsReadableRelation:
         Returns:
             Self: The relation with the columns selected.
         """
-        raise NotImplementedError("Selecting columns is not supported for this relation")
+        raise NotImplementedError("`select()` method is not supported for this relation")
 
     @overload
     def __getitem__(self, column: str) -> Self: ...
@@ -207,7 +207,7 @@ class SupportsReadableRelation:
         Returns:
             Self: The relation with the columns selected.
         """
-        raise NotImplementedError("Getting an item is not supported for this relation")
+        raise NotImplementedError("`__getitem__()` method is not supported for this relation")
 
     def __getattr__(self, attr: str) -> Any:
         """get an attribute of the relation
@@ -218,7 +218,7 @@ class SupportsReadableRelation:
         Returns:
             Any: The attribute of the relation
         """
-        raise NotImplementedError("Getting an attribute is not supported for this relation")
+        raise NotImplementedError("`__getattr__()` method is not supported for this relation")
 
     def __copy__(self) -> Self:
         """create a copy of the relation object
@@ -226,7 +226,7 @@ class SupportsReadableRelation:
         Returns:
             Self: The copy of the relation object
         """
-        raise NotImplementedError("Copying the relation is not supported for this relation")
+        raise NotImplementedError("`__copy()__` method is not supported for this relation")
 
 
 class DBApiCursor(SupportsReadableRelation):

--- a/dlt/common/destination/exceptions.py
+++ b/dlt/common/destination/exceptions.py
@@ -97,9 +97,9 @@ class DestinationIncompatibleLoaderFileFormatException(DestinationTerminalExcept
                 )
         else:
             msg = (
-                f"Unsupported `{file_format=:}` for `{destination=:}`"
-                f"Supported formats: {supported_formats_str}. If {destination} supports loading data via"
-                " staging bucket, more formats may be available."
+                f"Unsupported `{file_format=:}` for `{destination=:}`Supported formats:"
+                f" {supported_formats_str}. If {destination} supports loading data via staging"
+                " bucket, more formats may be available."
             )
         super().__init__(msg)
 
@@ -168,12 +168,12 @@ class DestinationSchemaTampered(DestinationTerminalException):
         self.version_hash = version_hash
         self.stored_version_hash = stored_version_hash
         super().__init__(
-            f"Schema `{schema_name}` content was changed - by a loader or by destination code - from"
-            " the moment it was retrieved by load package. Such schema cannot reliably be updated"
-            " nor saved. If you are using destination client directly, without storing"
+            f"Schema `{schema_name}` content was changed - by a loader or by destination code -"
+            " from the moment it was retrieved by load package. Such schema cannot reliably be"
+            " updated nor saved. If you are using destination client directly, without storing"
             " schema in load package, you should first save it into schema storage. You can also"
-            " use schema._bump_version() in test code to remove modified flag."
-            f"Version hash: `{version_hash=:}` != {stored_version_hash=:}"
+            " use schema._bump_version() in test code to remove modified flag.Version hash:"
+            f" `{version_hash=:}` != {stored_version_hash=:}"
         )
 
 
@@ -189,7 +189,8 @@ class DestinationInvalidFileFormat(DestinationTerminalException):
         self.file_format = file_format
         self.message = message
         super().__init__(
-            f"Destination `{destination_type}` cannot process file `{file_name=:}` with {file_format=:}: {message}"
+            f"Destination `{destination_type}` cannot process file `{file_name=:}` with"
+            f" {file_format=:}: {message}"
         )
 
 
@@ -200,8 +201,8 @@ class OpenTableFormatNotSupported(DestinationTerminalException):
         self.detected_table_format = detected_table_format
         if detected_table_format:
             msg = (
-                f"Table `{table_name}` is stored as format `{detected_table_format}` while `{table_format=:}` was"
-                " requested"
+                f"Table `{table_name}` is stored as format `{detected_table_format}` while"
+                f" `{table_format=:}` was requested"
             )
         else:
             msg = f"Table `{table_name}` is not stored in any known open table format."
@@ -212,9 +213,7 @@ class OpenTableCatalogNotSupported(DestinationTerminalException):
     def __init__(self, table_format: str, destination_type: str):
         self.table_format = table_format
         self.destination_type = destination_type
-        super().__init__(
-            f"Catalog not supported for `{table_format=:}` in `{destination_type=:}`"
-        )
+        super().__init__(f"Catalog not supported for `{table_format=:}` in `{destination_type=:}`")
 
 
 class SqlClientNotAvailable(DestinationTerminalException):

--- a/dlt/common/destination/exceptions.py
+++ b/dlt/common/destination/exceptions.py
@@ -19,9 +19,9 @@ class UnknownDestinationModule(ReferenceImportError, DestinationException, KeyEr
 
     def __str__(self) -> str:
         if "." in self.ref:
-            msg = f"Destination module {self.ref} is not registered."
+            msg = f"Destination module `{self.ref}` is not registered."
         else:
-            msg = f"Destination {self.ref} is not one of the standard dlt destinations."
+            msg = f"Destination `{self.ref}` is not one of the standard dlt destinations."
 
         if len(self.qualified_refs) == 1 and self.qualified_refs[0] == self.ref:
             pass
@@ -39,7 +39,7 @@ class InvalidDestinationReference(DestinationException):
     def __init__(self, refs: Any) -> None:
         self.refs = refs
         msg = (
-            f"None of supplied destination refs: {refs} can be found in registry or imported as"
+            f"None of supplied destination refs: `{refs}` can be found in registry or imported as"
             " Python type."
         )
         super().__init__(msg)
@@ -60,19 +60,19 @@ class DestinationTransientException(DestinationException, TransientException):
 class DestinationLoadingViaStagingNotSupported(DestinationTerminalException):
     def __init__(self, destination: str) -> None:
         self.destination = destination
-        super().__init__(f"Destination {destination} does not support loading via staging.")
+        super().__init__(f"`{destination=:}` does not support loading via staging.")
 
 
 class DestinationLoadingWithoutStagingNotSupported(DestinationTerminalException):
     def __init__(self, destination: str) -> None:
         self.destination = destination
-        super().__init__(f"Destination {destination} does not support loading without staging.")
+        super().__init__(f"`{destination=:}` does not support loading without staging.")
 
 
 class DestinationNoStagingMode(DestinationTerminalException):
     def __init__(self, destination: str) -> None:
         self.destination = destination
-        super().__init__(f"Destination {destination} cannot be used as a staging")
+        super().__init__(f"`{destination=:}` cannot be used as a staging")
 
 
 class DestinationIncompatibleLoaderFileFormatException(DestinationTerminalException):
@@ -87,19 +87,18 @@ class DestinationIncompatibleLoaderFileFormatException(DestinationTerminalExcept
         if self.staging:
             if not supported_formats:
                 msg = (
-                    f"Staging {staging} cannot be used with destination {destination} because they"
+                    f"`{staging=:}` cannot be used with `{destination=:}` because they"
                     " have no file formats in common."
                 )
             else:
                 msg = (
-                    f"Unsupported file format {file_format} for destination {destination} in"
-                    f" combination with staging destination {staging}. Supported formats:"
-                    f" {supported_formats_str}"
+                    f"Unsupported `{file_format=:}` for `{destination=:}` with `{staging=:}` "
+                    f"Supported formats: `{supported_formats_str}`"
                 )
         else:
             msg = (
-                f"Unsupported file format {file_format} in destination {destination}. Supported"
-                f" formats: {supported_formats_str}. If {destination} supports loading data via"
+                f"Unsupported `{file_format=:}` for `{destination=:}`"
+                f"Supported formats: {supported_formats_str}. If {destination} supports loading data via"
                 " staging bucket, more formats may be available."
             )
         super().__init__(msg)
@@ -142,13 +141,13 @@ class UnsupportedDataType(DestinationTerminalException):
         self.available_in_formats = available_in_formats
         self.more_info = more_info
         msg = (
-            f"Destination {destination_type} cannot load data type '{data_type}' from"
-            f" '{file_format}' files. The affected table is '{table_name}' column '{column}'."
+            f"Destination `{destination_type}` cannot load `{data_type=:}` from"
+            f" `{file_format=:}` files. The affected table is `{table_name}` column `{column}`."
         )
         if available_in_formats:
-            msg += f" Note: '{data_type}' can be loaded from {available_in_formats} formats(s)."
+            msg += f" Note: `{data_type=:}` can be loaded from format(s): `{available_in_formats}`."
         else:
-            msg += f" None of available file formats support '{data_type}' for this destination."
+            msg += f" No available file formats for this destination support `{data_type=:}`"
         if more_info:
             msg += " More info: " + more_info
         super().__init__(msg)
@@ -160,7 +159,7 @@ class DestinationHasFailedJobs(DestinationTerminalException):
         self.load_id = load_id
         self.failed_jobs = failed_jobs
         super().__init__(
-            f"Destination {destination_name} has failed jobs in load package {load_id}"
+            f"Destination `{destination_name}` has failed jobs in load package `{load_id}`"
         )
 
 
@@ -169,12 +168,12 @@ class DestinationSchemaTampered(DestinationTerminalException):
         self.version_hash = version_hash
         self.stored_version_hash = stored_version_hash
         super().__init__(
-            f"Schema {schema_name} content was changed - by a loader or by destination code - from"
+            f"Schema `{schema_name}` content was changed - by a loader or by destination code - from"
             " the moment it was retrieved by load package. Such schema cannot reliably be updated"
-            f" nor saved. Current version hash: {version_hash} != stored version hash"
-            f" {stored_version_hash}. If you are using destination client directly, without storing"
+            " nor saved. If you are using destination client directly, without storing"
             " schema in load package, you should first save it into schema storage. You can also"
             " use schema._bump_version() in test code to remove modified flag."
+            f"Version hash: `{version_hash=:}` != {stored_version_hash=:}"
         )
 
 
@@ -190,8 +189,7 @@ class DestinationInvalidFileFormat(DestinationTerminalException):
         self.file_format = file_format
         self.message = message
         super().__init__(
-            f"Destination {destination_type} cannot process file {file_name} with format"
-            f" {file_format}: {message}"
+            f"Destination `{destination_type}` cannot process file `{file_name=:}` with {file_format=:}: {message}"
         )
 
 
@@ -202,11 +200,11 @@ class OpenTableFormatNotSupported(DestinationTerminalException):
         self.detected_table_format = detected_table_format
         if detected_table_format:
             msg = (
-                f"Table {table_name} is stored as {detected_table_format} while {table_format} was"
+                f"Table `{table_name}` is stored as format `{detected_table_format}` while `{table_format=:}` was"
                 " requested"
             )
         else:
-            msg = f"Table {table_name} is not stored in any known open table format."
+            msg = f"Table `{table_name}` is not stored in any known open table format."
         super().__init__(msg)
 
 
@@ -215,35 +213,34 @@ class OpenTableCatalogNotSupported(DestinationTerminalException):
         self.table_format = table_format
         self.destination_type = destination_type
         super().__init__(
-            f"Catalog not supported for table format {table_format} in {destination_type} "
-            "destination"
+            f"Catalog not supported for `{table_format=:}` in `{destination_type=:}`"
         )
 
 
 class SqlClientNotAvailable(DestinationTerminalException):
     def __init__(self, pipeline_name: str, destination_name: str) -> None:
         super().__init__(
-            f"SQL Client not available for destination {destination_name} in pipeline"
-            f" {pipeline_name}",
+            f"SQL Client not available for destination `{destination_name}` in pipeline"
+            f" `{pipeline_name}`",
         )
 
 
 class DatasetNotAvailable(DestinationTerminalException):
     def __init__(self, destination_name: str) -> None:
-        super().__init__(f"Destination {destination_name} does not support datasets.")
+        super().__init__(f"Destination `{destination_name}` does not support datasets.")
 
 
 class OpenTableClientNotAvailable(DestinationTerminalException):
     def __init__(self, dataset_name: str, destination_name: str) -> None:
         super().__init__(
-            f"Open table client not available for destination {destination_name} in dataset"
-            f" {dataset_name}",
+            f"Open table client not available for destination `{destination_name}` in dataset"
+            f" `{dataset_name}`",
         )
 
 
 class FSClientNotAvailable(DestinationTerminalException):
     def __init__(self, pipeline_name: str, destination_name: str) -> None:
         super().__init__(
-            f"Filesystem Client not available for destination {destination_name} in pipeline"
-            f" {pipeline_name}",
+            f"Filesystem Client not available for destination `{destination_name}` in pipeline"
+            f" `{pipeline_name}`",
         )

--- a/dlt/common/destination/utils.py
+++ b/dlt/common/destination/utils.py
@@ -304,8 +304,8 @@ def resolve_merge_strategy(
             merge_strategy = supported_strategies[0]
         if merge_strategy not in supported_strategies:
             raise DestinationCapabilitiesException(
-                f"`{merge_strategy}` merge strategy not supported"
-                f" for table `{table_name}`. Available strategies: {supported_strategies}"
+                f"`{merge_strategy}` merge strategy not supported for table `{table_name}`. "
+                "Available strategies: {supported_strategies}"
             )
         return merge_strategy
     return None

--- a/dlt/common/exceptions.py
+++ b/dlt/common/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, AnyStr, Dict, List, Sequence, Optional, Type
+from typing import Any, AnyStr, Collection, Dict, List, Sequence, Optional, Type
 from dlt.common.typing import TypedDict
 
 
@@ -66,6 +66,34 @@ class VenvNotFound(DltException):
     def __init__(self, interpreter: str) -> None:
         self.interpreter = interpreter
         super().__init__(f"Venv with interpreter {interpreter} not found in path")
+
+
+class ValueErrorWithKnownValues(ValueError):
+    """Raise after receiving an invalid value and a set of valid values is known."""
+
+    def __init__(self, key: str, value_received: Any, valid_values: Collection[Any]) -> None:
+        self.key = key
+        self.value_received = value_received
+        self.valid_values = valid_values
+        self.msg = (
+            f"Received invalid value `{self.key}={self.value_received}`. "
+            f"Valid values are: {self.valid_values}"
+        )
+        super().__init__(self.msg)
+
+
+class TypeErrorWithKnownTypes(TypeError):
+    """Raise after receiving an invalid value and a set of valid types is known."""
+
+    def __init__(self, key: str, value_received: Any, valid_types: Collection[Any]) -> None:
+        self.key = key
+        self.value_received = value_received
+        self.valid_types = valid_types
+        self.msg = (
+            f"Received invalid value `{self.key}={self.value_received}` of type"
+            f" {type(self.value_received).__name__}. Valid types are: {self.valid_types}"
+        )
+        super().__init__(self.msg)
 
 
 class TerminalException(BaseException):
@@ -163,6 +191,7 @@ class DependencyVersionException(DltException):
         return msg
 
 
+# NOTE MSSQL/Synapse is the only code using this
 class SystemConfigurationException(DltException):
     pass
 

--- a/dlt/common/exceptions.py
+++ b/dlt/common/exceptions.py
@@ -43,8 +43,8 @@ class UnsupportedProcessStartMethodException(DltException):
     def __init__(self, method: str) -> None:
         self.method = method
         super().__init__(
-            f"Process pool supports only fork start method, `{method}` not supported. Switch the pool"
-            " type to threading"
+            f"Process pool supports only fork start method, `{method}` not supported. Switch the"
+            " pool type to threading"
         )
 
 
@@ -216,8 +216,8 @@ class PipelineStateNotAvailable(PipelineException):
                 " active right now."
             )
         msg += (
-            " Call `dlt.pipeline(...)` before you call the `@dlt.source` or  `@dlt.resource` decorated"
-            " function."
+            " Call `dlt.pipeline(...)` before you call the `@dlt.source` or  `@dlt.resource`"
+            " decorated function."
         )
         self.source_state_key = source_state_key
         super().__init__(None, msg)

--- a/dlt/common/exceptions.py
+++ b/dlt/common/exceptions.py
@@ -43,7 +43,7 @@ class UnsupportedProcessStartMethodException(DltException):
     def __init__(self, method: str) -> None:
         self.method = method
         super().__init__(
-            f"Process pool supports only fork start method, {method} not supported. Switch the pool"
+            f"Process pool supports only fork start method, `{method}` not supported. Switch the pool"
             " type to threading"
         )
 
@@ -57,7 +57,7 @@ class CannotInstallDependencies(DltException):
         else:
             str_output = output
         super().__init__(
-            f"Cannot install dependencies {', '.join(dependencies)} with {interpreter} and"
+            f"Cannot install dependencies {', '.join(dependencies)} with `{interpreter=:}` and"
             f" pip:\n{str_output}\n"
         )
 
@@ -65,7 +65,7 @@ class CannotInstallDependencies(DltException):
 class VenvNotFound(DltException):
     def __init__(self, interpreter: str) -> None:
         self.interpreter = interpreter
-        super().__init__(f"Venv with interpreter {interpreter} not found in path")
+        super().__init__(f"Venv with `{interpreter=:}` not found in path")
 
 
 class ValueErrorWithKnownValues(ValueError):
@@ -91,7 +91,7 @@ class TypeErrorWithKnownTypes(TypeError):
         self.valid_types = valid_types
         self.msg = (
             f"Received invalid value `{self.key}={self.value_received}` of type"
-            f" {type(self.value_received).__name__}. Valid types are: {self.valid_types}"
+            f" `{type(self.value_received).__name__}`. Valid types are: {self.valid_types}"
         )
         super().__init__(self.msg)
 
@@ -119,7 +119,7 @@ class SignalReceivedException(KeyboardInterrupt, TerminalException):
 
     def __init__(self, signal_code: int) -> None:
         self.signal_code = signal_code
-        super().__init__(f"Received signal code: `{signal_code}`")
+        super().__init__(f"Received `{signal_code=:}`")
 
 
 class DictValidationException(DltException):
@@ -147,7 +147,7 @@ class DictValidationException(DltException):
 class ArgumentsOverloadException(DltException):
     def __init__(self, msg: str, func_name: str, *args: str) -> None:
         self.func_name = func_name
-        msg = f"Arguments combination not allowed when calling function {func_name}: {msg}"
+        msg = f"Arguments combination not allowed when calling function `{func_name}()`: {msg}"
         msg = "\n".join((msg, *args))
         super().__init__(msg)
 
@@ -160,7 +160,7 @@ class MissingDependencyException(DltException):
 
     def _get_msg(self, appendix: str) -> str:
         msg = f"""
-You must install additional dependencies to run {self.caller}. If you use pip you may do the following:
+You must install additional dependencies to run `{self.caller}`. If you use pip you may do the following:
 
 {self._to_pip_install()}
 """
@@ -207,7 +207,7 @@ class PipelineStateNotAvailable(PipelineException):
     def __init__(self, source_state_key: Optional[str] = None) -> None:
         if source_state_key:
             msg = (
-                f"The source {source_state_key} requested the access to pipeline state but no"
+                f"The source `{source_state_key}` requested the access to pipeline state but no"
                 " pipeline is active right now."
             )
         else:
@@ -216,7 +216,7 @@ class PipelineStateNotAvailable(PipelineException):
                 " active right now."
             )
         msg += (
-            " Call dlt.pipeline(...) before you call the @dlt.source or  @dlt.resource decorated"
+            " Call `dlt.pipeline(...)` before you call the `@dlt.source` or  `@dlt.resource` decorated"
             " function."
         )
         self.source_state_key = source_state_key
@@ -228,7 +228,7 @@ class ResourceNameNotAvailable(PipelineException):
         super().__init__(
             None,
             "A resource state was requested but no active extract pipe context was found. Resource"
-            " state may be only requested from @dlt.resource decorated function or with explicit"
+            " state may be only requested from `@dlt.resource` decorated function or with explicit"
             " resource name.",
         )
 
@@ -237,6 +237,6 @@ class SourceSectionNotAvailable(PipelineException):
     def __init__(self) -> None:
         msg = (
             "Access to state was requested without source section active. State should be requested"
-            " from within the @dlt.source and @dlt.resource decorated function."
+            " from within the `@dlt.source` and `@dlt.resource` decorated function."
         )
         super().__init__(None, msg)

--- a/dlt/common/exceptions.py
+++ b/dlt/common/exceptions.py
@@ -141,7 +141,7 @@ class DictValidationException(DltException):
         super().__init__(msg)
 
     def __str__(self) -> str:
-        return f"In path {self.path}: " + self.msg
+        return f"Path `{self.path}`: " + self.msg
 
 
 class ArgumentsOverloadException(DltException):

--- a/dlt/common/exceptions.py
+++ b/dlt/common/exceptions.py
@@ -91,7 +91,7 @@ class SignalReceivedException(KeyboardInterrupt, TerminalException):
 
     def __init__(self, signal_code: int) -> None:
         self.signal_code = signal_code
-        super().__init__(f"Signal {signal_code} received")
+        super().__init__(f"Received signal code: `{signal_code}`")
 
 
 class DictValidationException(DltException):

--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -13,6 +13,7 @@ except ImportError:
     PydanticBaseModel = None  # type: ignore[misc]
 
 from dlt.common import known_env
+from dlt.common.exceptions import TypeErrorWithKnownTypes
 from dlt.common.pendulum import pendulum
 from dlt.common.arithmetics import Decimal
 from dlt.common.wei import Wei
@@ -99,7 +100,8 @@ def _datetime_decoder(obj: str) -> pendulum.DateTime:
     # tz=None sets no timezone if if it not specified on string
     dt = pendulum.parse(obj, tz=None)
     if not isinstance(dt, pendulum.DateTime):
-        raise ValueError(f"Expected `pendulum.DateTime`, got `{type(dt)}`")
+        raise TypeErrorWithKnownTypes("obj", dt, ["pendulum.DateTime"])
+
     return dt
 
 

--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -71,7 +71,7 @@ def _custom_encode(obj: Any) -> JsonSerializable:
         return obj.value  # type: ignore[no-any-return]
     elif _custom_encoder is not None:
         return _custom_encoder(obj)
-    raise TypeError(repr(obj) + " is not JSON serializable")
+    raise TypeError(f"`{repr(obj)}` is not JSON serializable")
 
 
 custom_encode: JsonEncoder = _custom_encode
@@ -99,7 +99,7 @@ def _datetime_decoder(obj: str) -> pendulum.DateTime:
     # tz=None sets no timezone if if it not specified on string
     dt = pendulum.parse(obj, tz=None)
     if not isinstance(dt, pendulum.DateTime):
-        raise ValueError(f"Expected pendulum.DateTime, got {type(dt)}")
+        raise ValueError(f"Expected `pendulum.DateTime`, got `{type(dt)}`")
     return dt
 
 
@@ -156,7 +156,7 @@ def _custom_pua_encode(obj: Any) -> JsonSerializable:
         return obj.value  # type: ignore[no-any-return]
     elif _custom_encoder is not None:
         return _custom_encoder(obj)
-    raise TypeError(repr(obj) + " is not JSON serializable")
+    raise TypeError(f"`{repr(obj)}` is not JSON serializable")
 
 
 custom_pua_encode: JsonEncoder = _custom_pua_encode

--- a/dlt/common/libs/cryptography.py
+++ b/dlt/common/libs/cryptography.py
@@ -40,7 +40,7 @@ def decode_private_key(private_key: str, password: Optional[str] = None) -> byte
         except Exception as der_exc:
             raise ValueError(
                 "Could not decode private key for key pair authentication. Following formats were"
-                f" attempted:\n1. base64 encoded DER or PEM (error: {der_exc})\n2. plain-text PEM"
+                f" attempted:\n1. base64 encoded DER or PEM (error: `{der_exc}`)\n2. plain-text PEM"
                 " (error: BEGIN and END markers not found)\nIf you are using connection string and"
                 " are passing DER/PEM or password in query string, make sure you url-encode them."
             )
@@ -63,8 +63,8 @@ def decode_private_key(private_key: str, password: Optional[str] = None) -> byte
         except Exception as pem_exc:
             raise ValueError(
                 "Could not decode private key for key pair authentication. Following formats were"
-                f" attempted:\n1. base64 encoded DER (error: {der_exc})\n2. plain-text or base64"
-                f" encoded PEM (error: {pem_exc})\nIf you are using connection string and are"
+                f" attempted:\n1. base64 encoded DER (error: `{der_exc}`)\n2. plain-text or base64"
+                f" encoded PEM (error: `{pem_exc}`)\nIf you are using connection string and are"
                 " passing DER/PEM or password in query string, make sure you url-encode them."
             )
 

--- a/dlt/common/libs/deltalake.py
+++ b/dlt/common/libs/deltalake.py
@@ -9,7 +9,7 @@ from dlt.common.libs.pyarrow import cast_arrow_schema_types
 from dlt.common.libs.utils import load_open_tables
 from dlt.common.schema.typing import TWriteDisposition, TTableSchema
 from dlt.common.schema.utils import get_first_column_name_with_prop, get_columns_names_with_prop
-from dlt.common.exceptions import MissingDependencyException
+from dlt.common.exceptions import MissingDependencyException, ValueErrorWithKnownValues
 from dlt.common.storages import FilesystemConfiguration
 from dlt.common.utils import assert_min_pkg_version
 from dlt.common.configuration.specs.mixins import WithObjectStoreRsCredentials
@@ -84,9 +84,8 @@ def get_delta_write_mode(write_disposition: TWriteDisposition) -> str:
     elif write_disposition == "replace":
         return "overwrite"
     else:
-        raise ValueError(
-            "`write_disposition` must be `append`, `replace`, or `merge`,"
-            f" but `{write_disposition}` was provided."
+        raise ValueErrorWithKnownValues(
+            "write_disposition", write_disposition, ["append", "replace", "merge"]
         )
 
 

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -835,7 +835,7 @@ def transpose_rows_to_columns(
         logger.info(
             "Pandas not installed, reverting to numpy.asarray to create a table which is slower"
         )
-        pivoted_rows = np.asarray(rows, dtype="object", order="k").T
+        pivoted_rows = np.asarray(rows, dtype="object", order="K").T
     return {
         column_name: data.ravel()
         for column_name, data in zip(column_names, np.vsplit(pivoted_rows, len(pivoted_rows)))

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -431,7 +431,7 @@ def rename_columns(item: TAnyArrowItem, new_column_names: Sequence[str]) -> TAny
         ]
         return pyarrow.RecordBatch.from_arrays(item.columns, schema=pyarrow.schema(new_fields))
     else:
-        raise TypeError(f"Unsupported data item type {type(item)}")
+        raise TypeError(f"Unsupported data item type: `{type(item)}`")
 
 
 def should_normalize_arrow_schema(
@@ -805,7 +805,7 @@ def concat_batches_and_tables_in_order(
                 batches = []
             tables.append(item)
         else:
-            raise ValueError(f"Unsupported type {type(item)}")
+            raise ValueError(f"Unsupported type: `{type(item)}`")
     if batches:
         tables.append(pyarrow.Table.from_batches(batches))
     # "none" option ensures 0 copy concat
@@ -973,7 +973,7 @@ def convert_numpy_to_arrow(
                     raise PyToArrowConversionException(
                         data_type=dlt_data_type,
                         inferred_arrow_type=inferred_arrow_type,
-                        details="dlt failed to encode values to a Arrow compatible type.",
+                        details="dlt failed to encode values to an Arrow-compatible type.",
                     ) from e
 
             arrow_array = pa.array(encoded_values)

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -835,8 +835,7 @@ def transpose_rows_to_columns(
         logger.info(
             "Pandas not installed, reverting to numpy.asarray to create a table which is slower"
         )
-        pivoted_rows = np.asarray(rows, dtype="object", order="k").T  # type: ignore[call-overload]
-
+        pivoted_rows = np.asarray(rows, dtype="object", order="k").T
     return {
         column_name: data.ravel()
         for column_name, data in zip(column_names, np.vsplit(pivoted_rows, len(pivoted_rows)))

--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -221,7 +221,7 @@ def apply_schema_contract_to_model(
     """
     if data_mode == "evolve":
         # create a lenient model that accepts any data
-        model = create_model(model.__name__ + "Any", **{n: (Any, None) for n in model.model_fields})  # type: ignore[call-overload, attr-defined]
+        model = create_model(model.__name__ + "Any", **{n: (Any, None) for n in model.model_fields})  # type: ignore
     elif data_mode == "discard_value":
         raise NotImplementedError(
             "`data_mode='discard_value'`. Cannot discard defined fields with validation errors"

--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -221,10 +221,10 @@ def apply_schema_contract_to_model(
     """
     if data_mode == "evolve":
         # create a lenient model that accepts any data
-        model = create_model(model.__name__ + "Any", **{n: (Any, None) for n in model.__fields__})  # type: ignore[call-overload, attr-defined]
+        model = create_model(model.__name__ + "Any", **{n: (Any, None) for n in model.model_fields})  # type: ignore[call-overload, attr-defined]
     elif data_mode == "discard_value":
         raise NotImplementedError(
-            "data_mode is discard_value. Cannot discard defined fields with validation errors using"
+            "`data_mode='discard_value'`. Cannot discard defined fields with validation errors using"
             " Pydantic models."
         )
 
@@ -365,7 +365,7 @@ def validate_and_filter_items(
                     deleted.add(err_idx)
                 else:
                     raise NotImplementedError(
-                        f"{column_mode} column mode not implemented for Pydantic validation"
+                        f"`{column_mode}` column mode not implemented for Pydantic validation"
                     )
             else:
                 if data_mode == "freeze":
@@ -385,7 +385,7 @@ def validate_and_filter_items(
                     deleted.add(err_idx)
                 else:
                     raise NotImplementedError(
-                        f"{column_mode} column mode not implemented for Pydantic validation"
+                        f"`{column_mode}` column mode not implemented for Pydantic validation"
                     )
 
         # validate again with error items removed
@@ -423,7 +423,7 @@ def validate_and_filter_item(
                 elif column_mode == "discard_row":
                     return None
                 raise NotImplementedError(
-                    f"{column_mode} column mode not implemented for Pydantic validation"
+                    f"`{column_mode}` column mode not implemented for Pydantic validation"
                 )
             else:
                 if data_mode == "freeze":
@@ -441,6 +441,6 @@ def validate_and_filter_item(
                 elif data_mode == "discard_row":
                     return None
                 raise NotImplementedError(
-                    f"{data_mode} data mode not implemented for Pydantic validation"
+                    f"`{data_mode}` data mode not implemented for Pydantic validation"
                 )
         raise AssertionError("unreachable")

--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -224,8 +224,8 @@ def apply_schema_contract_to_model(
         model = create_model(model.__name__ + "Any", **{n: (Any, None) for n in model.model_fields})  # type: ignore[call-overload, attr-defined]
     elif data_mode == "discard_value":
         raise NotImplementedError(
-            "`data_mode='discard_value'`. Cannot discard defined fields with validation errors using"
-            " Pydantic models."
+            "`data_mode='discard_value'`. Cannot discard defined fields with validation errors"
+            " using Pydantic models."
         )
 
     extra = column_mode_to_extra(column_mode)
@@ -365,7 +365,7 @@ def validate_and_filter_items(
                     deleted.add(err_idx)
                 else:
                     raise NotImplementedError(
-                        f"`{column_mode}` column mode not implemented for Pydantic validation"
+                        f"`{column_mode=:}` not implemented for Pydantic validation"
                     )
             else:
                 if data_mode == "freeze":
@@ -385,7 +385,7 @@ def validate_and_filter_items(
                     deleted.add(err_idx)
                 else:
                     raise NotImplementedError(
-                        f"`{column_mode}` column mode not implemented for Pydantic validation"
+                        f"`{column_mode=:}` not implemented for Pydantic validation"
                     )
 
         # validate again with error items removed
@@ -423,7 +423,7 @@ def validate_and_filter_item(
                 elif column_mode == "discard_row":
                     return None
                 raise NotImplementedError(
-                    f"`{column_mode}` column mode not implemented for Pydantic validation"
+                    f"`{column_mode=:}` not implemented for Pydantic validation"
                 )
             else:
                 if data_mode == "freeze":
@@ -441,6 +441,6 @@ def validate_and_filter_item(
                 elif data_mode == "discard_row":
                     return None
                 raise NotImplementedError(
-                    f"`{data_mode}` data mode not implemented for Pydantic validation"
+                    f"`{data_mode=:}` not implemented for Pydantic validation"
                 )
         raise AssertionError("unreachable")

--- a/dlt/common/libs/sql_alchemy.py
+++ b/dlt/common/libs/sql_alchemy.py
@@ -13,7 +13,7 @@ except ModuleNotFoundError:
     raise MissingDependencyException(
         "dlt sql_database helpers ",
         [f"{version.DLT_PKG_NAME}[sql_database]"],
-        "Install the sql_database helpers for loading from sql_database sources. Note that you may"
+        "Install the `sql_database` helpers for loading from `sql_database` sources. Note that you may"
         " need to install additional SQLAlchemy dialects for your source database.",
     )
 

--- a/dlt/common/libs/sql_alchemy.py
+++ b/dlt/common/libs/sql_alchemy.py
@@ -13,8 +13,8 @@ except ModuleNotFoundError:
     raise MissingDependencyException(
         "dlt sql_database helpers ",
         [f"{version.DLT_PKG_NAME}[sql_database]"],
-        "Install the `sql_database` helpers for loading from `sql_database` sources. Note that you may"
-        " need to install additional SQLAlchemy dialects for your source database.",
+        "Install the `sql_database` helpers for loading from `sql_database` sources. Note that you"
+        " may need to install additional SQLAlchemy dialects for your source database.",
     )
 
 # TODO: maybe use sa.__version__?

--- a/dlt/common/libs/sql_alchemy_shims.py
+++ b/dlt/common/libs/sql_alchemy_shims.py
@@ -28,6 +28,7 @@ from urllib.parse import (
     quote,
     unquote,
 )
+from dlt.common.exceptions import TypeErrorWithKnownTypes
 
 _KT = TypeVar("_KT", bound=Any)
 _VT = TypeVar("_VT", bound=Any)
@@ -118,12 +119,12 @@ class URL(NamedTuple):
         try:
             return int(port)
         except TypeError:
-            raise TypeError("`port` must be of type `int` or `None`")
+            raise TypeErrorWithKnownTypes("port", port, ["int", None])
 
     @classmethod
     def _assert_str(cls, v: str, paramname: str) -> str:
         if not isinstance(v, str):
-            raise TypeError(f"{paramname} must be of type `str`")
+            raise TypeErrorWithKnownTypes("paramname", paramname, ["str"])
         return v
 
     @classmethod
@@ -164,11 +165,11 @@ class URL(NamedTuple):
             elif isinstance(val, collections_abc.Sequence):
                 return tuple(_assert_value(elem) for elem in val)
             else:
-                raise TypeError("Query dictionary values must be of type `str` or `Sequence[str]`")
+                raise TypeErrorWithKnownTypes("value", val, ["str", "Sequence[str]"])
 
         def _assert_str(v: str) -> str:
             if not isinstance(v, str):
-                raise TypeError("Query dictionary keys must be of type `str`")
+                raise TypeErrorWithKnownTypes("key", v, ["str"])
             return v
 
         dict_items: Iterable[Tuple[str, Union[Sequence[str], str]]]

--- a/dlt/common/libs/sql_alchemy_shims.py
+++ b/dlt/common/libs/sql_alchemy_shims.py
@@ -118,12 +118,12 @@ class URL(NamedTuple):
         try:
             return int(port)
         except TypeError:
-            raise TypeError("Port argument must be an integer or None")
+            raise TypeError("`port` must be of type `int` or `None`")
 
     @classmethod
     def _assert_str(cls, v: str, paramname: str) -> str:
         if not isinstance(v, str):
-            raise TypeError("%s must be a string" % paramname)
+            raise TypeError(f"{paramname} must be of type `str`")
         return v
 
     @classmethod
@@ -164,11 +164,11 @@ class URL(NamedTuple):
             elif isinstance(val, collections_abc.Sequence):
                 return tuple(_assert_value(elem) for elem in val)
             else:
-                raise TypeError("Query dictionary values must be strings or sequences of strings")
+                raise TypeError("Query dictionary values must be of type `str` or `Sequence[str]`")
 
         def _assert_str(v: str) -> str:
             if not isinstance(v, str):
-                raise TypeError("Query dictionary keys must be strings")
+                raise TypeError("Query dictionary keys must be of type `str`")
             return v
 
         dict_items: Iterable[Tuple[str, Union[Sequence[str], str]]]
@@ -380,7 +380,7 @@ def make_url(name_or_url: Union[str, URL]) -> URL:
     if isinstance(name_or_url, str):
         return _parse_url(name_or_url)
     elif not isinstance(name_or_url, URL):
-        raise ValueError(f"Expected string or URL object, got {name_or_url!r}")
+        raise ValueError(f"Expected string or URL object, got `{name_or_url!r}`")
     else:
         return name_or_url
 
@@ -440,4 +440,4 @@ def _parse_url(name: str) -> URL:
         return URL.create(name, **components)  # type: ignore
 
     else:
-        raise ValueError("Could not parse SQLAlchemy URL from string '%s'" % name)
+        raise ValueError(f"Could not parse SQLAlchemy URL from string '{name}'")

--- a/dlt/common/libs/utils.py
+++ b/dlt/common/libs/utils.py
@@ -32,8 +32,8 @@ def load_open_tables(
                 if len(available_schemas) > 1:
                     available_schemas_info = f" Available schemas are {available_schemas}"
                 raise ValueError(
-                    f"Schema {client.schema.name} does not contain {table_format} tables with these"
-                    f" names: {', '.join(invalid_tables)}.{available_schemas_info}"
+                    f"Schema `{client.schema.name}` does not contain `{table_format}` tables with names: "
+                    f"{', '.join(invalid_tables)}.{available_schemas_info}"
                 )
             schema_open_tables = [t for t in schema_open_tables if t in tables]
 

--- a/dlt/common/libs/utils.py
+++ b/dlt/common/libs/utils.py
@@ -32,8 +32,8 @@ def load_open_tables(
                 if len(available_schemas) > 1:
                     available_schemas_info = f" Available schemas are {available_schemas}"
                 raise ValueError(
-                    f"Schema `{client.schema.name}` does not contain `{table_format}` tables with names: "
-                    f"{', '.join(invalid_tables)}.{available_schemas_info}"
+                    f"Schema `{client.schema.name}` does not contain `{table_format=:}` tables with"
+                    f" names: {', '.join(invalid_tables)}.{available_schemas_info}"
                 )
             schema_open_tables = [t for t in schema_open_tables if t in tables]
 

--- a/dlt/common/normalizers/exceptions.py
+++ b/dlt/common/normalizers/exceptions.py
@@ -10,6 +10,6 @@ class InvalidJsonNormalizer(NormalizerException):
         self.required_normalizer = required_normalizer
         self.present_normalizer = present_normalizer
         super().__init__(
-            f"Operation requires {required_normalizer} normalizer while"
-            f" {present_normalizer} normalizer is present"
+            f"Operation requires `{required_normalizer}` normalizer while"
+            f" `{present_normalizer}` normalizer is present"
         )

--- a/dlt/common/normalizers/naming/exceptions.py
+++ b/dlt/common/normalizers/naming/exceptions.py
@@ -9,10 +9,10 @@ class UnknownNamingModule(ImportError, NormalizersException):
     def __init__(self, naming_module: str) -> None:
         self.naming_module = naming_module
         if "." in naming_module:
-            msg = f"Naming module {naming_module} could not be found and imported"
+            msg = f"Naming module `{naming_module}` could not be found and imported"
         else:
             msg = (
-                f"Naming module {naming_module} is not one of the standard dlt naming conventions"
+                f"Naming module `{naming_module} `is not one of the standard dlt naming conventions"
                 " and could not be locally imported"
             )
         super().__init__(msg)
@@ -22,7 +22,7 @@ class NamingTypeNotFound(ImportError, NormalizersException):
     def __init__(self, naming_module: str, naming_class: str) -> None:
         self.naming_module = naming_module
         self.naming_class = naming_class
-        msg = f"In naming module '{naming_module}' type '{naming_class}' does not exist"
+        msg = f"In naming module `{naming_module}` type `{naming_class}` does not exist"
         super().__init__(msg)
 
 
@@ -31,7 +31,7 @@ class InvalidNamingType(NormalizersException):
         self.naming_module = naming_module
         self.naming_class = naming_class
         msg = (
-            f"In naming module '{naming_module}' the class '{naming_class}' is not a"
-            " NamingConvention"
+            f"In naming module `{naming_module}` the class `{naming_class} `is not a"
+            " `NamingConvention`"
         )
         super().__init__(msg)

--- a/dlt/common/normalizers/naming/naming.py
+++ b/dlt/common/normalizers/naming/naming.py
@@ -29,7 +29,7 @@ class NamingConvention(ABC):
     def normalize_identifier(self, identifier: str) -> str:
         """Normalizes and shortens the identifier according to naming convention in this function code"""
         if identifier is None:
-            raise ValueError("name is None")
+            raise ValueError("`name` is None")
         identifier = identifier.strip()
         if not identifier:
             raise ValueError(identifier)

--- a/dlt/common/reflection/exceptions.py
+++ b/dlt/common/reflection/exceptions.py
@@ -14,7 +14,7 @@ class ReferenceImportError:
             return "No import traces were corrected"
         msg = "Modules and attributes were tried in the following order and failed to import:\n"
         for trace in self.traces:
-            msg += f"\tmod:{trace.module} attr: {trace.attr_name} failed due to {trace.reason}"
+            msg += f"\tmod:`{trace.module}` attr: `{trace.attr_name}` failed due to: {trace.reason}"
             if trace.exc:
                 msg += f" and causing exception: {trace.exc}"
             msg += "\n"

--- a/dlt/common/reflection/ref.py
+++ b/dlt/common/reflection/ref.py
@@ -4,7 +4,7 @@ from importlib import import_module
 from types import ModuleType, SimpleNamespace
 from typing import Any, Callable, Literal, NamedTuple, Tuple, Mapping, List, Sequence
 
-from dlt.common.exceptions import MissingDependencyException
+from dlt.common.exceptions import MissingDependencyException, TypeErrorWithKnownTypes
 from dlt.common.typing import TAny
 
 
@@ -93,7 +93,7 @@ class ImportTrace(NamedTuple):
 def callable_typechecker(o: TAny) -> TAny:
     if callable(o):
         return o  # type: ignore[no-any-return]
-    raise TypeError(f"Expected attr to be callable but got type `{type(o)}`")
+    raise TypeErrorWithKnownTypes("attr", o, ["Callable"])
 
 
 def object_from_ref(

--- a/dlt/common/reflection/ref.py
+++ b/dlt/common/reflection/ref.py
@@ -93,7 +93,7 @@ class ImportTrace(NamedTuple):
 def callable_typechecker(o: TAny) -> TAny:
     if callable(o):
         return o  # type: ignore[no-any-return]
-    raise TypeError(f"Expected attr to be callable but got type {type(o)}")
+    raise TypeError(f"Expected attr to be callable but got type `{type(o)}`")
 
 
 def object_from_ref(
@@ -112,7 +112,7 @@ def object_from_ref(
 
     """
     if "." not in ref:
-        raise ValueError("ref format is module.attr and must contain at leas one dot")
+        raise ValueError("`ref` format is `module.attr` and must contain at least one `.`")
     module_path, attr_name = ref.rsplit(".", 1)
     try:
         spec = importlib.util.find_spec(module_path)

--- a/dlt/common/runners/pool_runner.py
+++ b/dlt/common/runners/pool_runner.py
@@ -69,7 +69,7 @@ def run_pool(
     # validate the run function
     if not isinstance(run_f, Runnable) and not callable(run_f):
         raise ValueError(
-            run_f, "Pool runner entry point must be a function f(pool: TPool) or Runnable"
+            run_f, "Pool runner entry point must be a function `f(pool: TPool)` or `Runnable`"
         )
 
     # start pool

--- a/dlt/common/runtime/anon_tracker.py
+++ b/dlt/common/runtime/anon_tracker.py
@@ -28,7 +28,7 @@ requests: Session = None
 
 def init_anon_tracker(config: RuntimeConfiguration) -> None:
     if config.dlthub_telemetry_endpoint is None:
-        raise ValueError("dlthub_telemetry_endpoint not specified in RunConfiguration")
+        raise ValueError("`dlthub_telemetry_endpoint` not specified in `RunConfiguration`")
 
     if config.dlthub_telemetry_endpoint == "https://api.segment.io/v1/track":
         assert (

--- a/dlt/common/runtime/json_logging.py
+++ b/dlt/common/runtime/json_logging.py
@@ -74,7 +74,7 @@ def init(custom_formatter: Type[logging.Formatter] = None) -> None:
     if custom_formatter:
         if not issubclass(custom_formatter, logging.Formatter):
             raise ValueError(
-                "custom_formatter is not subclass of logging.Formatter", custom_formatter
+                "`custom_formatter` is not subclass of logging.Formatter", custom_formatter
             )
 
     _default_formatter = custom_formatter if custom_formatter else JSONLogFormatter

--- a/dlt/common/runtime/run_context.py
+++ b/dlt/common/runtime/run_context.py
@@ -103,13 +103,13 @@ class RunContext(SupportsRunContext):
         run_dir = os.path.abspath(run_dir)
         base_dir = os.path.basename(run_dir)
         if not base_dir:
-            raise ImportError(f"run dir {run_dir} looks like filesystem root")
+            raise ImportError(f"`run_dir={run_dir}` looks like filesystem root")
         m_ = importlib.import_module(base_dir)
         if m_.__file__ and m_.__file__.startswith(run_dir):
             return m_
         else:
             raise ImportError(
-                f"run dir {run_dir} does not belong to module {m_.__file__} which seems unrelated."
+                f"`run_dir={run_dir}` doesn't belong to module `{m_.__file__}` which seems unrelated."
             )
 
 

--- a/dlt/common/runtime/run_context.py
+++ b/dlt/common/runtime/run_context.py
@@ -103,7 +103,7 @@ class RunContext(SupportsRunContext):
         run_dir = os.path.abspath(run_dir)
         base_dir = os.path.basename(run_dir)
         if not base_dir:
-            raise ImportError(f"`run_dir={run_dir}` looks like filesystem root")
+            raise ImportError(f"`{run_dir=:}` looks like filesystem root")
         m_ = importlib.import_module(base_dir)
         if m_.__file__ and m_.__file__.startswith(run_dir):
             return m_

--- a/dlt/common/runtime/run_context.py
+++ b/dlt/common/runtime/run_context.py
@@ -109,7 +109,7 @@ class RunContext(SupportsRunContext):
             return m_
         else:
             raise ImportError(
-                f"`run_dir={run_dir}` doesn't belong to module `{m_.__file__}` which seems unrelated."
+                f"`{run_dir=:}` doesn't belong to module `{m_.__file__}` which seems unrelated."
             )
 
 

--- a/dlt/common/schema/exceptions.py
+++ b/dlt/common/schema/exceptions.py
@@ -15,7 +15,7 @@ class SchemaException(DltException):
     def __init__(self, schema_name: str, msg: str) -> None:
         self.schema_name = schema_name
         if schema_name:
-            msg = f"In schema: {schema_name}: " + msg
+            msg = f"In schema `{schema_name}`: " + msg
         super().__init__(msg)
 
 
@@ -26,7 +26,7 @@ class InvalidSchemaName(ValueError, SchemaException):
         self.name = schema_name
         super().__init__(
             schema_name,
-            f"{schema_name} is an invalid schema/source name. The source or schema name must be a"
+            f"`{schema_name}` is an invalid schema/source name. The source or schema name must be a"
             " valid Python identifier ie. a snake case function name and have maximum"
             f" {self.MAXIMUM_SCHEMA_NAME_LENGTH} characters. Ideally should contain only small"
             " letters, numbers and underscores.",
@@ -60,8 +60,8 @@ class CannotCoerceColumnException(SchemaException):
         self.coerced_value = coerced_value
         super().__init__(
             schema_name,
-            f"Cannot coerce type in table {table_name} column {column_name} existing type"
-            f" {from_type} coerced type {to_type} value: {coerced_value}",
+            f"Cannot coerce type `{from_type}` to `{to_type}` for value `{coerced_value}` "
+            f"in table `{table_name}` column `{column_name}`"
         )
 
 
@@ -74,7 +74,7 @@ class TablePropertiesConflictException(SchemaException):
         super().__init__(
             schema_name,
             f"Cannot merge partial tables into table `{table_name}` due to property `{prop_name}`"
-            f' with different values: "{val1}" != "{val2}"',
+            f' with different values: `{val1} != {val2}`',
         )
 
 
@@ -86,8 +86,8 @@ class ParentTableNotFoundException(SchemaException):
         self.parent_table_name = parent_table_name
         super().__init__(
             schema_name,
-            f"Parent table {parent_table_name} for {table_name} was not found in the"
-            f" schema.{explanation}",
+            f"Parent table `{parent_table_name}` for `{table_name}` was not found in "
+            f" `schema.{explanation}`",
         )
 
 
@@ -95,7 +95,7 @@ class CannotCoerceNullException(SchemaException):
     def __init__(self, schema_name: str, table_name: str, column_name: str) -> None:
         super().__init__(
             schema_name,
-            f"Cannot coerce NULL in table {table_name} column {column_name} which is not nullable",
+            f"Cannot coerce NULL in table `{table_name}` column `{column_name}` which is not nullable",
         )
 
 
@@ -115,12 +115,12 @@ class SchemaIdentifierNormalizationCollision(SchemaCorruptedException):
         collision_msg: str,
     ) -> None:
         if identifier_type == "column":
-            table_info = f"in table {table_name} "
+            table_info = f" in table `{table_name}`"
         else:
             table_info = ""
         msg = (
-            f"A {identifier_type} name {identifier_name} {table_info}collides with"
-            f" {conflict_identifier_name} after normalization with {naming_name} naming"
+            f"A `{identifier_type}` name `{identifier_name}`{table_info} collides with"
+            f" `{conflict_identifier_name}` after normalization with `{naming_name}` naming"
             " convention. "
             + collision_msg
         )
@@ -141,8 +141,8 @@ class SchemaEngineNoUpgradePathException(SchemaException):
         self.to_engine = to_engine
         super().__init__(
             schema_name,
-            f"No engine upgrade path in schema {schema_name} from {init_engine} to {to_engine},"
-            f" stopped at {from_engine}. You possibly tried to run an older dlt"
+            f"No engine upgrade path in schema `{schema_name}` from engine `{init_engine}` to `{to_engine}`,"
+            f" stopped at `{from_engine}`. You possibly tried to run an older dlt"
             " version against a destination you have previously loaded data to with a newer dlt"
             " version.",
         )
@@ -167,14 +167,14 @@ class DataValidationError(SchemaException):
         """
         msg = ""
         if schema_name:
-            msg = f"Schema: {schema_name} "
-        msg += f"Table: {table_name} "
+            msg = f"Schema: `{schema_name}` "
+        msg += f"Table: `{table_name}` "
         if column_name:
-            msg += f"Column: {column_name}"
+            msg += f"Column: `{column_name}`"
         msg = (
             "In "
             + msg
-            + f" . Contract on {schema_entity} with mode {contract_mode} is violated. "
+            + f" . Contract on `{schema_entity}` with `{contract_mode=:}` is violated. "
             + (extended_info or "")
         )
         super().__init__(schema_name, msg)
@@ -194,7 +194,7 @@ class DataValidationError(SchemaException):
 class TableNotFound(KeyError, SchemaException):
     def __init__(self, schema_name: str, table_name: str) -> None:
         self.table_name = table_name
-        super().__init__(schema_name, f"Table not found: {table_name}")
+        super().__init__(schema_name, f"Table not found: `{table_name}`")
 
 
 class TableIdentifiersFrozen(SchemaException):
@@ -210,8 +210,8 @@ class TableIdentifiersFrozen(SchemaException):
         self.to_naming = to_naming
         self.from_naming = from_naming
         msg = (
-            f"Attempt to normalize identifiers for a table {table_name} from naming"
-            f" {from_naming.name()} to {to_naming.name()} changed one or more identifiers. "
+            f"Attempt to normalize identifiers for a table `{table_name}` from naming"
+            f" `{from_naming.name()}` to `{to_naming.name()}` changed one or more identifiers. "
         )
         msg += (
             " This table already received data and tables were created at the destination. By"
@@ -223,7 +223,7 @@ class TableIdentifiersFrozen(SchemaException):
         )
         msg += (
             " You may disable this behavior by setting"
-            " schema.allow_identifier_change_on_table_with_data to True or removing `x-normalizer`"
+            " `schema.allow_identifier_change_on_table_with_data` to True or removing `x-normalizer`"
             " hints from particular tables. "
         )
         msg += f" Details: {details}"
@@ -247,15 +247,15 @@ class UnboundColumnException(SchemaException):
             key_type = "primary key"
 
         msg = (
-            f"The column {column['name']} in table {table_name} did not receive any data during"
+            f"The column `{column['name']}` in table `{table_name}` did not receive any data during"
             " this load. "
         )
         if key_type or not nullable:
             msg += f"It is marked as non-nullable{' '+key_type} and it must have values. "
 
         msg += (
-            "This can happen if you specify the column manually, for example using the 'merge_key',"
-            " 'primary_key' or 'columns' argument but it does not exist in the data."
+            "This can happen if you specify the column manually, for example using the `merge_key`,"
+            " `primary_key` or `columns` argument but it does not exist in the data."
         )
         super().__init__(schema_name, msg)
 

--- a/dlt/common/schema/exceptions.py
+++ b/dlt/common/schema/exceptions.py
@@ -61,7 +61,7 @@ class CannotCoerceColumnException(SchemaException):
         super().__init__(
             schema_name,
             f"Cannot coerce type `{from_type}` to `{to_type}` for value `{coerced_value}` "
-            f"in table `{table_name}` column `{column_name}`"
+            f"in table `{table_name}` column `{column_name}`",
         )
 
 
@@ -74,7 +74,7 @@ class TablePropertiesConflictException(SchemaException):
         super().__init__(
             schema_name,
             f"Cannot merge partial tables into table `{table_name}` due to property `{prop_name}`"
-            f' with different values: `{val1} != {val2}`',
+            f" with different values: `{val1} != {val2}`",
         )
 
 
@@ -95,7 +95,8 @@ class CannotCoerceNullException(SchemaException):
     def __init__(self, schema_name: str, table_name: str, column_name: str) -> None:
         super().__init__(
             schema_name,
-            f"Cannot coerce NULL in table `{table_name}` column `{column_name}` which is not nullable",
+            f"Cannot coerce NULL in table `{table_name}` column `{column_name}` which is not"
+            " nullable",
         )
 
 
@@ -141,8 +142,8 @@ class SchemaEngineNoUpgradePathException(SchemaException):
         self.to_engine = to_engine
         super().__init__(
             schema_name,
-            f"No engine upgrade path in schema `{schema_name}` from engine `{init_engine}` to `{to_engine}`,"
-            f" stopped at `{from_engine}`. You possibly tried to run an older dlt"
+            f"No engine upgrade path in schema `{schema_name}` from engine `{init_engine}` to"
+            f" `{to_engine}`, stopped at `{from_engine}`. You possibly tried to run an older dlt"
             " version against a destination you have previously loaded data to with a newer dlt"
             " version.",
         )
@@ -223,8 +224,8 @@ class TableIdentifiersFrozen(SchemaException):
         )
         msg += (
             " You may disable this behavior by setting"
-            " `schema.allow_identifier_change_on_table_with_data` to True or removing `x-normalizer`"
-            " hints from particular tables. "
+            " `schema.allow_identifier_change_on_table_with_data` to True or removing"
+            " `x-normalizer` hints from particular tables. "
         )
         msg += f" Details: {details}"
         super().__init__(schema_name, msg)

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -359,7 +359,7 @@ class Schema:
                         existing_table,
                         schema_contract,
                         data_item,
-                        f"Can't add create variant column `{column_name} for table `{table_name}`"
+                        f"Can't add variant column `{column_name}` for table `{table_name}`"
                         " because `data_types` are frozen.",
                     )
                 # filter column with name below
@@ -539,7 +539,7 @@ class Schema:
             raise SchemaCorruptedException(
                 self.name,
                 "A set of existing columns passed to `get_new_table_columns` table"
-                f" `{table_name} `has colliding names when case insensitive comparison is used."
+                f" `{table_name}` has colliding names when case insensitive comparison is used."
                 f" Original names: {list(existing_columns.keys())}. Case-folded names:"
                 f" {list(casefold_existing.keys())}",
             )

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -310,7 +310,7 @@ class Schema:
                     None,
                     schema_contract,
                     data_item,
-                    f"Trying to add table {table_name} but new tables are frozen.",
+                    f"Can't add table `{table_name}` because `tables` are frozen.",
                 )
             # filter tables with name below
             return None, [("tables", table_name, schema_contract["tables"])]
@@ -339,8 +339,7 @@ class Schema:
                         existing_table,
                         schema_contract,
                         data_item,
-                        f"Trying to add column {column_name} to table {table_name} but columns are"
-                        " frozen.",
+                        f"Can't add table column `{column_name}` to table `{table_name}` because `columns` are frozen.",
                     )
                 # filter column with name below
                 filters.append(("columns", column_name, column_mode))
@@ -359,8 +358,8 @@ class Schema:
                         existing_table,
                         schema_contract,
                         data_item,
-                        f"Trying to create new variant column {column_name} to table"
-                        f" {table_name} but data_types are frozen.",
+                        f"Can't add create variant column `{column_name} for table `{table_name}` because `data_types` are frozen.",
+`
                     )
                 # filter column with name below
                 filters.append(("columns", column_name, data_mode))
@@ -538,7 +537,7 @@ class Schema:
         if len(existing_columns) != len(casefold_existing):
             raise SchemaCorruptedException(
                 self.name,
-                f"A set of existing columns passed to get_new_table_columns table {table_name} has"
+                f"A set of existing columns passed to `get_new_table_columns` table `{table_name} `has"
                 " colliding names when case insensitive comparison is used. Original names:"
                 f" {list(existing_columns.keys())}. Case-folded names:"
                 f" {list(casefold_existing.keys())}",
@@ -1066,7 +1065,7 @@ class Schema:
                         table["name"],
                         to_naming,
                         from_naming,
-                        f"Attempt to rename table name to {norm_table['name']}.",
+                        f"Attempt to rename table to `{norm_table['name']}`.",
                     )
                 # if len(norm_table["columns"]) != len(table["columns"]):
                 #     print(norm_table["columns"])
@@ -1087,7 +1086,7 @@ class Schema:
                         table["name"],
                         to_naming,
                         from_naming,
-                        f"Some columns got renamed to {col_diff}.",
+                        f"Some columns got renamed to `{col_diff}`.",
                     )
 
         naming_changed = from_naming and type(from_naming) is not type(to_naming)
@@ -1135,7 +1134,7 @@ class Schema:
                     "-",
                     to_naming,
                     from_naming,
-                    "Schema contains tables that received data. As a precaution changing naming"
+                    "Schema contains tables that received data. As a precaution, changing naming"
                     " conventions is disallowed until full identifier lineage is implemented.",
                 )
             # re-index the table names
@@ -1165,7 +1164,7 @@ class Schema:
             if not table_name.startswith(self._dlt_tables_prefix):
                 raise SchemaCorruptedException(
                     self.name,
-                    f"A naming convention {self.naming.name()} mangles _dlt table prefix to"
+                    f"A naming convention `{self.naming.name()}` mangles `_dlt` table prefix to"
                     f" '{self._dlt_tables_prefix}'. A table '{table_name}' does not start with it.",
                 )
         # normalize default hints
@@ -1231,11 +1230,11 @@ class Schema:
         self._schema_tables = stored_schema.get("tables") or {}
         if self.version_table_name not in self._schema_tables:
             raise SchemaCorruptedException(
-                stored_schema["name"], f"Schema must contain table {self.version_table_name}"
+                stored_schema["name"], f"Schema must contain table `{self.version_table_name}`"
             )
         if self.loads_table_name not in self._schema_tables:
             raise SchemaCorruptedException(
-                stored_schema["name"], f"Schema must contain table {self.loads_table_name}"
+                stored_schema["name"], f"Schema must contain table `{self.loads_table_name}`"
             )
         self._stored_version = stored_schema["version"]
         self._stored_version_hash = stored_schema["version_hash"]

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -339,7 +339,8 @@ class Schema:
                         existing_table,
                         schema_contract,
                         data_item,
-                        f"Can't add table column `{column_name}` to table `{table_name}` because `columns` are frozen.",
+                        f"Can't add table column `{column_name}` to table `{table_name}` because"
+                        " `columns` are frozen.",
                     )
                 # filter column with name below
                 filters.append(("columns", column_name, column_mode))
@@ -358,8 +359,8 @@ class Schema:
                         existing_table,
                         schema_contract,
                         data_item,
-                        f"Can't add create variant column `{column_name} for table `{table_name}` because `data_types` are frozen.",
-`
+                        f"Can't add create variant column `{column_name} for table `{table_name}`"
+                        " because `data_types` are frozen.",
                     )
                 # filter column with name below
                 filters.append(("columns", column_name, data_mode))
@@ -537,9 +538,9 @@ class Schema:
         if len(existing_columns) != len(casefold_existing):
             raise SchemaCorruptedException(
                 self.name,
-                f"A set of existing columns passed to `get_new_table_columns` table `{table_name} `has"
-                " colliding names when case insensitive comparison is used. Original names:"
-                f" {list(existing_columns.keys())}. Case-folded names:"
+                "A set of existing columns passed to `get_new_table_columns` table"
+                f" `{table_name} `has colliding names when case insensitive comparison is used."
+                f" Original names: {list(existing_columns.keys())}. Case-folded names:"
                 f" {list(casefold_existing.keys())}",
             )
         diff_c: List[TColumnSchema] = []

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -443,7 +443,7 @@ def merge_columns(
     * incomplete columns in `columns_a` that got completed in `columns_b` are removed to preserve order
     """
     if columns_partial is False:
-        raise NotImplementedError("`columns_partial` must be `False` for `merge_columns`")
+        raise NotImplementedError("Using `merge_columns()` requires `columns_partial=False`")
 
     # remove incomplete columns in table that are complete in diff table
     for col_name, column_b in columns_b.items():

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -254,7 +254,8 @@ def simple_regex_validator(path: str, pk: str, pv: Any, t: Any) -> bool:
     if t is TSimpleRegex:
         if not isinstance(pv, str):
             raise DictValidationException(
-                f"field `{pk}` value `{pv}` has invalid type `{type(pv).__name__}` while `str` is expected",
+                f"field `{pk}` value `{pv}` has invalid type `{type(pv).__name__}` while `str` is"
+                " expected",
                 path,
                 t,
                 pk,

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -254,7 +254,7 @@ def simple_regex_validator(path: str, pk: str, pv: Any, t: Any) -> bool:
     if t is TSimpleRegex:
         if not isinstance(pv, str):
             raise DictValidationException(
-                f"field {pk} value {pv} has invalid type {type(pv).__name__} while str is expected",
+                f"field `{pk}` value `{pv}` has invalid type `{type(pv).__name__}` while `str` is expected",
                 path,
                 t,
                 pk,
@@ -266,7 +266,7 @@ def simple_regex_validator(path: str, pk: str, pv: Any, t: Any) -> bool:
                 re.compile(pv[3:])
             except Exception as e:
                 raise DictValidationException(
-                    f"field {pk} value {pv[3:]} does not compile as regex: {str(e)}",
+                    f"field `{pk}` value `{pv[3:]}` does not compile as regex: `{str(e)}`",
                     path,
                     t,
                     pk,
@@ -275,7 +275,7 @@ def simple_regex_validator(path: str, pk: str, pv: Any, t: Any) -> bool:
         else:
             if RE_NON_ALPHANUMERIC_UNDERSCORE.match(pv):
                 raise DictValidationException(
-                    f"field {pk} value {pv} looks like a regex, please prefix with re:",
+                    f"field `{pk}` value `{pv}` looks like a regex, please prefix with `re:`",
                     path,
                     t,
                     pk,
@@ -293,8 +293,8 @@ def column_name_validator(naming: NamingConvention) -> TCustomValidator:
         if t is TColumnName:
             if not isinstance(pv, str):
                 raise DictValidationException(
-                    f"field {pk} value {pv} has invalid type {type(pv).__name__} while"
-                    " str is expected",
+                    f"field `{pk}` value `{pv}` has invalid type `{type(pv).__name__}` while"
+                    " `str` is expected",
                     path,
                     t,
                     pk,
@@ -303,11 +303,11 @@ def column_name_validator(naming: NamingConvention) -> TCustomValidator:
             try:
                 if naming.normalize_path(pv) != pv:
                     raise DictValidationException(
-                        f"field {pk}: {pv} is not a valid column name", path, t, pk, pv
+                        f"field `{pk}` value `{pv}` is not a valid column name", path, t, pk, pv
                     )
             except ValueError:
                 raise DictValidationException(
-                    f"field {pk}: {pv} is not a valid column name", path, t, pk, pv
+                    f"field `{pk}` value `{pv}` is not a valid column name", path, t, pk, pv
                 )
             return True
         else:
@@ -442,7 +442,7 @@ def merge_columns(
     * incomplete columns in `columns_a` that got completed in `columns_b` are removed to preserve order
     """
     if columns_partial is False:
-        raise NotImplementedError("columns_partial must be False for merge_columns")
+        raise NotImplementedError("`columns_partial` must be `False` for `merge_columns`")
 
     # remove incomplete columns in table that are complete in diff table
     for col_name, column_b in columns_b.items():
@@ -806,7 +806,7 @@ def get_inherited_table_hint(
         return None
 
     raise ValueError(
-        f"No table hint '{table_hint_name} found in the chain of tables for '{table_name}'."
+        f"No table hint `{table_hint_name}` found in the chain of tables for table `{table_name}`."
     )
 
 

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -236,8 +236,8 @@ class FilesystemConfiguration(BaseConfiguration):
         if not url.path and not url.netloc:
             raise ConfigurationValueError(
                 "File `path` and `netloc` are missing. Field `bucket_url` of"
-                " `FilesystemClientConfiguration` must contain valid url with a path or host:password"
-                " component."
+                " `FilesystemClientConfiguration` must contain valid url with a path or"
+                " host:password component."
             )
         self.normalize_bucket_url()
 

--- a/dlt/common/storages/configuration.py
+++ b/dlt/common/storages/configuration.py
@@ -74,7 +74,7 @@ def ensure_canonical_az_url(
 
     if not storage_account_name and not account_host:
         raise TerminalValueError(
-            f"Could not convert azure blob storage url {bucket_url} into canonical form "
+            f"Could not convert azure blob storage url `{bucket_url}` into canonical form "
             f" ({target_scheme}://<container_name>@<storage_account_name>.dfs.core.windows.net/<path>)"
             f" because storage account name is not known. Please use {target_scheme}:// canonical"
             " url as bucket_url in filesystem credentials"
@@ -235,8 +235,8 @@ class FilesystemConfiguration(BaseConfiguration):
         url = urlparse(self.bucket_url)
         if not url.path and not url.netloc:
             raise ConfigurationValueError(
-                "File path and netloc are missing. Field bucket_url of"
-                " FilesystemClientConfiguration must contain valid url with a path or host:password"
+                "File `path` and `netloc` are missing. Field `bucket_url` of"
+                " `FilesystemClientConfiguration` must contain valid url with a path or host:password"
                 " component."
             )
         self.normalize_bucket_url()
@@ -299,9 +299,9 @@ class FilesystemConfiguration(BaseConfiguration):
         """
         url = urlparse(file_url)
         if url.scheme != "file":
-            raise ValueError(f"Must be file scheme but is {url.scheme}")
+            raise ValueError(f"Must be file scheme but is `{url.scheme}`")
         if not url.path and not url.netloc:
-            raise ConfigurationValueError("File path and netloc are missing.")
+            raise ConfigurationValueError("File `path` and `netloc` are missing.")
         local_path = unquote(url.path)
         if url.netloc:
             # or UNC file://localhost/path

--- a/dlt/common/storages/exceptions.py
+++ b/dlt/common/storages/exceptions.py
@@ -92,7 +92,8 @@ class LoadPackageNotCompleted(LoadStorageException):
     def __init__(self, load_id: str) -> None:
         self.load_id = load_id
         super().__init__(
-            f"Package with `{load_id=:}` is not yet completed, but method required that"
+            f"Package with `{load_id=:}` is not yet completed, but the calling function required a"
+            " complete package."
         )
 
 

--- a/dlt/common/storages/exceptions.py
+++ b/dlt/common/storages/exceptions.py
@@ -22,8 +22,8 @@ class NoMigrationPathException(StorageException):
         self.migrated_version = migrated_version
         self.target_version = target_version
         super().__init__(
-            f"Could not find migration path for {storage_path} from v {initial_version} to"
-            f" {target_version}, stopped at {migrated_version}"
+            f"Could not find migration path for `{storage_path}` from `{initial_version=:}` to"
+            f" `{target_version=:}`, stopped at `{migrated_version}`"
         )
 
 
@@ -38,7 +38,7 @@ class WrongStorageVersionException(StorageException):
         self.initial_version = initial_version
         self.target_version = target_version
         super().__init__(
-            f"Expected storage {storage_path} with v {target_version} but found {initial_version}"
+            f"Expected storage `{storage_path}` with `{target_version=:}` but found `{initial_version=:}`"
         )
 
 
@@ -54,7 +54,7 @@ class StorageMigrationError(StorageException):
         self.from_version = from_version
         self.target_version = target_version
         super().__init__(
-            f"Storage {storage_path} with target v {target_version} at {from_version}: " + info
+            f"Storage `{storage_path}` with `{target_version=:}` at `{from_version}`: " + info
         )
 
 
@@ -68,7 +68,7 @@ class JobFileFormatUnsupported(LoadStorageException, TerminalValueError):
         self.expected_file_formats = supported_formats
         self.wrong_job = wrong_job
         super().__init__(
-            f"Job {wrong_job} for load id {load_id} requires job file format that is not one of"
+            f"Job `{wrong_job}` for load id `{load_id}` requires job file format that is not one of:"
             f" {supported_formats}"
         )
 
@@ -76,14 +76,14 @@ class JobFileFormatUnsupported(LoadStorageException, TerminalValueError):
 class LoadPackageNotFound(LoadStorageException, FileNotFoundError):
     def __init__(self, load_id: str) -> None:
         self.load_id = load_id
-        super().__init__(f"Package with load id {load_id} could not be found")
+        super().__init__(f"Package with `{load_id=:}` could not be found")
 
 
 class LoadPackageAlreadyCompleted(LoadStorageException):
     def __init__(self, load_id: str) -> None:
         self.load_id = load_id
         super().__init__(
-            f"Package with load id {load_id} is already completed, but another complete was"
+            f"Package with `{load_id=:}` is already completed, but another complete was"
             " requested"
         )
 
@@ -92,7 +92,7 @@ class LoadPackageNotCompleted(LoadStorageException):
     def __init__(self, load_id: str) -> None:
         self.load_id = load_id
         super().__init__(
-            f"Package with load id {load_id} is not yet completed, but method required that"
+            f"Package with `{load_id=:}` is not yet completed, but method required that"
         )
 
 
@@ -103,7 +103,7 @@ class SchemaStorageException(StorageException):
 class InStorageSchemaModified(SchemaStorageException):
     def __init__(self, schema_name: str, storage_path: str) -> None:
         msg = (
-            f"Schema {schema_name} in {storage_path} was externally modified. This is not allowed"
+            f"Schema `{schema_name}` in `{storage_path}` was externally modified. This is not allowed"
             " as that would prevent correct version tracking. Use import/export capabilities of"
             " dlt to provide external changes."
         )
@@ -118,17 +118,17 @@ class SchemaNotFoundError(SchemaStorageException, FileNotFoundError, KeyError):
         import_path: str = None,
         import_format: str = None,
     ) -> None:
-        msg = f"Schema {schema_name} in {storage_path} could not be found."
+        msg = f"Schema `{schema_name}` in `{storage_path}` could not be found."
         if import_path:
-            msg += f"Import from {import_path} and format {import_format} failed."
+            msg += f"Failed to import using `{import_path=:}` and `{import_format=:}`."
         super().__init__(msg)
 
 
 class UnexpectedSchemaName(SchemaStorageException, ValueError):
     def __init__(self, schema_name: str, storage_path: str, stored_name: str) -> None:
         super().__init__(
-            f"A schema file name '{schema_name}' in {storage_path} does not correspond to the name"
-            f" of schema in the file {stored_name}"
+            f"A schema file name `{schema_name}` in `{storage_path}` does not correspond to the name"
+            f" of schema in the file `{stored_name}`"
         )
 
 
@@ -136,5 +136,5 @@ class CurrentLoadPackageStateNotAvailable(StorageException):
     def __init__(self) -> None:
         super().__init__(
             "State of the current load package is not available. Current load package state is"
-            " only available in a function decorated with @dlt.destination during loading."
+            " only available in a function decorated with `@dlt.destination` during loading."
         )

--- a/dlt/common/storages/exceptions.py
+++ b/dlt/common/storages/exceptions.py
@@ -38,7 +38,8 @@ class WrongStorageVersionException(StorageException):
         self.initial_version = initial_version
         self.target_version = target_version
         super().__init__(
-            f"Expected storage `{storage_path}` with `{target_version=:}` but found `{initial_version=:}`"
+            f"Expected storage `{storage_path}` with `{target_version=:}` but found"
+            f" `{initial_version=:}`"
         )
 
 
@@ -68,8 +69,8 @@ class JobFileFormatUnsupported(LoadStorageException, TerminalValueError):
         self.expected_file_formats = supported_formats
         self.wrong_job = wrong_job
         super().__init__(
-            f"Job `{wrong_job}` for load id `{load_id}` requires job file format that is not one of:"
-            f" {supported_formats}"
+            f"Job `{wrong_job}` for load id `{load_id}` requires job file format that is not one"
+            f" of: {supported_formats}"
         )
 
 
@@ -83,8 +84,7 @@ class LoadPackageAlreadyCompleted(LoadStorageException):
     def __init__(self, load_id: str) -> None:
         self.load_id = load_id
         super().__init__(
-            f"Package with `{load_id=:}` is already completed, but another complete was"
-            " requested"
+            f"Package with `{load_id=:}` is already completed, but another complete was requested"
         )
 
 
@@ -103,9 +103,9 @@ class SchemaStorageException(StorageException):
 class InStorageSchemaModified(SchemaStorageException):
     def __init__(self, schema_name: str, storage_path: str) -> None:
         msg = (
-            f"Schema `{schema_name}` in `{storage_path}` was externally modified. This is not allowed"
-            " as that would prevent correct version tracking. Use import/export capabilities of"
-            " dlt to provide external changes."
+            f"Schema `{schema_name}` in `{storage_path}` was externally modified. This is not"
+            " allowed as that would prevent correct version tracking. Use import/export"
+            " capabilities of dlt to provide external changes."
         )
         super().__init__(msg)
 
@@ -127,8 +127,8 @@ class SchemaNotFoundError(SchemaStorageException, FileNotFoundError, KeyError):
 class UnexpectedSchemaName(SchemaStorageException, ValueError):
     def __init__(self, schema_name: str, storage_path: str, stored_name: str) -> None:
         super().__init__(
-            f"A schema file name `{schema_name}` in `{storage_path}` does not correspond to the name"
-            f" of schema in the file `{stored_name}`"
+            f"A schema file name `{schema_name}` in `{storage_path}` does not correspond to the"
+            f" name of schema in the file `{stored_name}`"
         )
 
 

--- a/dlt/common/storages/file_storage.py
+++ b/dlt/common/storages/file_storage.py
@@ -204,7 +204,7 @@ class FileStorage:
         to_path = self.make_full_path(to_relative_path)
 
         if not os.path.isdir(from_path):
-            raise ValueError(f"{from_path} is not a directory")
+            raise ValueError(f"`{from_path}` is not a directory")
 
         # make sure the destination directory exists
         os.makedirs(to_path, exist_ok=True)

--- a/dlt/common/storages/fsspec_filesystem.py
+++ b/dlt/common/storages/fsspec_filesystem.py
@@ -32,7 +32,7 @@ from dlt.common.configuration.specs import (
     AzureCredentials,
     SFTPCredentials,
 )
-from dlt.common.exceptions import MissingDependencyException
+from dlt.common.exceptions import MissingDependencyException, ValueErrorWithKnownValues
 from dlt.common.storages.configuration import (
     FileSystemCredentials,
     FilesystemConfiguration,
@@ -264,7 +264,9 @@ class FileItemDict(DictStrAny):
         elif compression == "disable":
             compression_arg = None
         else:
-            raise ValueError("`compression` must be one of ['auto', 'enable', 'disable']")
+            raise ValueErrorWithKnownValues(
+                "compression", compression, ["auto", "enable", "disable"]
+            )
 
         # if the user has already extracted the content, we use it so there is no need to
         # download the file again.

--- a/dlt/common/storages/fsspec_filesystem.py
+++ b/dlt/common/storages/fsspec_filesystem.py
@@ -264,8 +264,7 @@ class FileItemDict(DictStrAny):
         elif compression == "disable":
             compression_arg = None
         else:
-            raise ValueError("""The argument `compression` must have one of the following values:
-                "auto", "enable", "disable".""")
+            raise ValueError("`compression` must be one of ['auto', 'enable', 'disable']")
 
         # if the user has already extracted the content, we use it so there is no need to
         # download the file again.

--- a/dlt/common/storages/fsspecs/google_drive.py
+++ b/dlt/common/storages/fsspecs/google_drive.py
@@ -362,14 +362,13 @@ class GoogleDriveFileSystem(AbstractFileSystem):
                 possible_children.append(child["id"])
 
         if len(possible_children) == 0:
-            raise FileNotFoundError(f"Directory {dir_file_id} has no child named {file_name}")
+            raise FileNotFoundError(f"Directory `{dir_file_id}` has no child named `{file_name}`")
         if len(possible_children) == 1:
             return possible_children[0]
         else:
             raise KeyError(
-                f"Directory {dir_file_id} has more than one "
-                f"child named {file_name}. Unable to resolve path "
-                "to file_id."
+                f"Directory `{dir_file_id}` has more than one "
+                f"child named `{file_name}`. Unable to resolve path to `file_id`."
             )
 
     def _open(self, path: str, mode: Optional[str] = "rb", **kwargs: Any) -> "GoogleDriveFile":

--- a/dlt/common/storages/normalize_storage.py
+++ b/dlt/common/storages/normalize_storage.py
@@ -65,7 +65,7 @@ class NormalizeStorage(VersionedStorage):
                     self.storage.storage_path,
                     from_version,
                     to_version,
-                    f"There are extract files in {NormalizeStorage.EXTRACTED_FOLDER} folder."
+                    f"There are extract files in folder `{NormalizeStorage.EXTRACTED_FOLDER}`."
                     " Storage will not migrate automatically duo to possible data loss. Delete the"
                     " files or normalize it with dlt 0.3.x",
                 )

--- a/dlt/common/storages/normalize_storage.py
+++ b/dlt/common/storages/normalize_storage.py
@@ -66,7 +66,7 @@ class NormalizeStorage(VersionedStorage):
                     from_version,
                     to_version,
                     f"There are extract files in folder `{NormalizeStorage.EXTRACTED_FOLDER}`."
-                    " Storage will not migrate automatically duo to possible data loss. Delete the"
+                    " Storage will not migrate automatically due to possible data loss. Delete the"
                     " files or normalize it with dlt 0.3.x",
                 )
             from_version = semver.Version.parse("1.0.1")

--- a/dlt/common/storages/transactional_file.py
+++ b/dlt/common/storages/transactional_file.py
@@ -114,7 +114,8 @@ class TransactionalFile:
             output.append(name)
         if not output:
             raise RuntimeError(
-                f"Lock syncing failed. No lock file found for path `{self.path}` and lock `{self.lock_path}`"
+                f"Lock syncing failed. No lock file found for path `{self.path}` and lock"
+                f" `{self.lock_path}`"
             )
         return output
 

--- a/dlt/common/storages/transactional_file.py
+++ b/dlt/common/storages/transactional_file.py
@@ -62,7 +62,7 @@ class TransactionalFile:
         parsed_path = Path(path)
         if not parsed_path.is_absolute():
             raise ValueError(
-                f"{path} is not absolute. Please pass only absolute paths to TransactionalFile"
+                f"`TransactionalFile` requires an absolute path. Received path: `{path}`"
             )
         self.path = path
         if proto == "file":
@@ -114,8 +114,7 @@ class TransactionalFile:
             output.append(name)
         if not output:
             raise RuntimeError(
-                f"When syncing locks for path {self.path} and lock {self.lock_path} no lock file"
-                " was found"
+                f"Lock syncing failed. No lock file found for path `{self.path}` and lock `{self.lock_path}`"
             )
         return output
 

--- a/dlt/common/time.py
+++ b/dlt/common/time.py
@@ -68,7 +68,7 @@ def parse_iso_like_datetime(value: Any) -> Union[pendulum.DateTime, pendulum.Dat
     if isinstance(dtv, datetime.datetime):
         return pendulum.instance(dtv, tz=dtv.tzinfo)
     if isinstance(dtv, pendulum.Duration):
-        raise ValueError("Interval ISO 8601 not supported: " + value)
+        raise ValueError(f"Interval ISO 8601 not supported: `{value}`")
     return pendulum.date(dtv.year, dtv.month, dtv.day)  # type: ignore[union-attr]
 
 
@@ -92,11 +92,11 @@ def ensure_pendulum_date(value: TAnyDateTime) -> pendulum.Date:
     elif isinstance(value, (int, float, str)):
         result = _datetime_from_ts_or_iso(value)
         if isinstance(result, datetime.time):
-            raise ValueError(f"Cannot coerce {value} to a pendulum.DateTime object.")
+            raise ValueError(f"Cannot coerce `{value}` to `pendulum.DateTime` object.")
         if isinstance(result, pendulum.DateTime):
             return result.in_tz(UTC).date()
         return pendulum.date(result.year, result.month, result.day)
-    raise TypeError(f"Cannot coerce {value} to a pendulum.DateTime object.")
+    raise TypeError(f"Cannot coerce `{value}` to `pendulum.DateTime` object.")
 
 
 def ensure_pendulum_datetime(value: TAnyDateTime) -> pendulum.DateTime:
@@ -119,11 +119,11 @@ def ensure_pendulum_datetime(value: TAnyDateTime) -> pendulum.DateTime:
     elif isinstance(value, (int, float, str)):
         result = _datetime_from_ts_or_iso(value)
         if isinstance(result, datetime.time):
-            raise ValueError(f"Cannot coerce {value} to a pendulum.DateTime object.")
+            raise ValueError(f"Cannot coerce `{value}` to `pendulum.DateTime` object.")
         if isinstance(result, pendulum.DateTime):
             return result.in_tz(UTC)
         return pendulum.datetime(result.year, result.month, result.day, tz=UTC)
-    raise TypeError(f"Cannot coerce {value} to a pendulum.DateTime object.")
+    raise TypeError(f"Cannot coerce `{value}` to `pendulum.DateTime` object.")
 
 
 def ensure_pendulum_datetime_non_utc(value: TAnyDateTime) -> pendulum.DateTime:
@@ -135,11 +135,11 @@ def ensure_pendulum_datetime_non_utc(value: TAnyDateTime) -> pendulum.DateTime:
     elif isinstance(value, (int, float, str)):
         result = _datetime_from_ts_or_iso(value)
         if isinstance(result, datetime.time):
-            raise ValueError(f"Cannot coerce {value} to a pendulum.DateTime object.")
+            raise ValueError(f"Cannot coerce `{value}` to `pendulum.DateTime` object.")
         if isinstance(result, pendulum.DateTime):
             return result
         return pendulum.datetime(result.year, result.month, result.day)
-    raise TypeError(f"Cannot coerce {value} to a pendulum.DateTime object.")
+    raise TypeError(f"Cannot coerce `{value}` to `pendulum.DateTime` object.")
 
 
 def datatime_obj_to_str(
@@ -153,7 +153,7 @@ def datatime_obj_to_str(
         if timezone_part.startswith(("-", "+")):
             return f"{datetime_str[:-5]}{timezone_part[:3]}:{timezone_part[3:]}"
 
-        raise ValueError(f"Invalid timezone format in datetime string: {datetime_str}")
+        raise ValueError(f"Invalid timezone format in datetime string: `{datetime_str}`")
 
     return datatime.strftime(datetime_format)
 
@@ -176,7 +176,7 @@ def ensure_pendulum_time(value: Union[str, datetime.time]) -> pendulum.Time:
         if isinstance(result, pendulum.Time):
             return result
         else:
-            raise ValueError(f"{value} is not a valid ISO time string.")
+            raise ValueError(f"Invalid ISO time string: `{value}`")
     elif isinstance(value, timedelta):
         # Assume timedelta is seconds passed since midnight. Some drivers (mysqlclient) return time in this format
         return pendulum.time(
@@ -185,7 +185,7 @@ def ensure_pendulum_time(value: Union[str, datetime.time]) -> pendulum.Time:
             value.seconds % 60,
             value.microseconds,
         )
-    raise TypeError(f"Cannot coerce {value} to a pendulum.Time object.")
+    raise TypeError(f"Cannot coerce `{value}` to `pendulum.Time` object.")
 
 
 def detect_datetime_format(value: str) -> Optional[str]:

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -299,7 +299,7 @@ def is_literal_type(hint: Type[Any]) -> bool:
 def get_literal_args(literal: Type[Any]) -> List[Any]:
     """Recursively get arguments from nested Literal types and return an unified list."""
     if not hasattr(literal, "__origin__") or literal.__origin__ is not Literal:
-        raise ValueError("Provided type is not a Literal")
+        raise ValueError(f"Provided object is not a `Literal`. Object: {literal}")
 
     unified_args = []
 

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -142,12 +142,12 @@ def flatten_list_of_str_or_dicts(seq: Sequence[Union[StrAny, str]]) -> DictStrAn
         if isinstance(e, dict):
             for k, v in e.items():
                 if k in o:
-                    raise KeyError(f"Cannot flatten with duplicate key {k}")
+                    raise KeyError(f"Failed to flatten because of duplicate key `{k}`")
                 o[k] = v
         else:
             key = str(e)
             if key in o:
-                raise KeyError(f"Cannot flatten with duplicate key {key}")
+                raise KeyError(f"Failed to flatten because of duplicate key `{key}`")
             o[key] = None
     return o
 

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -38,6 +38,7 @@ from dlt.common.exceptions import (
     ExceptionTrace,
     TerminalException,
     DependencyVersionException,
+    ValueErrorWithKnownValues,
 )
 from dlt.common.typing import AnyFun, StrAny, DictStrAny, StrStr, TAny, TFun, Generic
 
@@ -117,7 +118,9 @@ def str2bool(v: str) -> bool:
     elif v.lower() in ("no", "false", "f", "n", "0"):
         return False
     else:
-        raise ValueError("Boolean value expected.")
+        raise ValueErrorWithKnownValues(
+            "v", v, [True, "yes", "true", "t", "y", 1, False, "no", "false", "f", "n", "0"]
+        )
 
 
 # def flatten_list_of_dicts(dicts: Sequence[StrAny]) -> StrAny:

--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -108,7 +108,7 @@ def validate_dict(
                         failed_validations, key=lambda ex: ex.path.count("/"), reverse=True
                     )
                     for failed in failed_validations:
-                        msg += f"For {get_type_name(failed.expected_type)}: " + str(failed) + "\n"
+                        msg += f"For `{get_type_name(failed.expected_type)}`: " + str(failed) + "\n"
                     raise DictValidationException(
                         msg,
                         path,
@@ -204,8 +204,8 @@ def validate_dict(
                 if inspect.isclass(t):
                     if not isinstance(pv, t):
                         raise DictValidationException(
-                            f"field '{pk}' expects class '{type_name}' but got instance of"
-                            f" '{pv_type_name}'",
+                            f"field `{pk}` expects class `{type_name}` but got instance of"
+                            f" `{pv_type_name}`",
                             path,
                             t,
                             pk,
@@ -214,7 +214,7 @@ def validate_dict(
                 # dropped, just __name__ can be used
                 type_name = get_type_name(t)
                 raise DictValidationException(
-                    f"field '{pk}' has expected type '{type_name}' which lacks validator",
+                    f"field `{pk}` has expected type `{type_name}` which lacks validator",
                     path,
                     t,
                     pk,

--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -68,11 +68,11 @@ def validate_dict(
     # check missing props
     missing = set(required_props.keys()).difference(props.keys())
     if len(missing):
-        raise DictValidationException(f"following required fields are missing {missing}", path)
+        raise DictValidationException(f"Missing required fields: `{missing}`", path)
     # check unknown props
     unexpected = set(props.keys()).difference(allowed_props.keys())
     if len(unexpected):
-        raise DictValidationException(f"following fields are unexpected {unexpected}", path)
+        raise DictValidationException(f"Received unexpected fields: `{unexpected}`", path)
 
     def verify_prop(pk: str, pv: Any, t: Any) -> None:
         # covers none in optional and union types
@@ -121,12 +121,12 @@ def validate_dict(
             a_l = get_literal_args(t)
             if pv not in a_l:
                 raise DictValidationException(
-                    f"field '{pk}' with value {pv} is not one of: {a_l}", path, t, pk, pv
+                    f"field '{pk}' with value `{pv}` is not one of: {a_l}", path, t, pk, pv
                 )
         elif t in [int, bool, str, float]:
             if not isinstance(pv, t):
                 raise DictValidationException(
-                    f"field '{pk}' with value {pv} has invalid type '{type(pv).__name__}' while"
+                    f"field '{pk}' with value `{pv}` has invalid type '{type(pv).__name__}' while"
                     f" '{t.__name__}' is expected",
                     path,
                     t,
@@ -136,7 +136,7 @@ def validate_dict(
         elif is_typeddict(t):
             if not isinstance(pv, dict):
                 raise DictValidationException(
-                    f"field '{pk}' with value {pv} has invalid type '{type(pv).__name__}' while"
+                    f"field '{pk}' with value `{pv}` has invalid type '{type(pv).__name__}' while"
                     f" '{get_type_name(t)}' is expected",
                     path,
                     t,
@@ -147,7 +147,7 @@ def validate_dict(
         elif is_list_generic_type(t):
             if not isinstance(pv, list):
                 raise DictValidationException(
-                    f"field '{pk}' with value {pv} has invalid type '{type(pv).__name__}' while"
+                    f"field '{pk}' with value `{pv}` has invalid type '{type(pv).__name__}' while"
                     " 'list' is expected",
                     path,
                     t,
@@ -161,7 +161,7 @@ def validate_dict(
         elif is_dict_generic_type(t):
             if not isinstance(pv, dict):
                 raise DictValidationException(
-                    f"field '{pk}' with value {pv} has invalid type '{type(pv).__name__}' while"
+                    f"field '{pk}' with value `{pv}` has invalid type '{type(pv).__name__}' while"
                     " 'dict' is expected",
                     path,
                     t,
@@ -173,7 +173,7 @@ def validate_dict(
             for d_k, d_v in pv.items():
                 if not isinstance(d_k, str):
                     raise DictValidationException(
-                        f"field '{pk}' with key {d_k} must be a string", path, t, pk, d_k
+                        f"field '{pk}' with key `{d_k}` must be a string", path, t, pk, d_k
                     )
                 verify_prop(f"{pk}[{d_k}]", d_v, d_v_t)
         elif t is Any:
@@ -190,7 +190,7 @@ def validate_dict(
             else:
                 raise DictValidationException(
                     f"field '{pk}' expects callable (function or class instance) but got "
-                    f" '{pv}'. Mind that signatures are not validated",
+                    f"'{pv}'. Mind that signatures are not validated",
                     path,
                     t,
                     pk,

--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -99,9 +99,9 @@ def validate_dict(
                 if len(failed_validations) == len(union_types):
                     type_names = [get_type_name(ut) for ut in union_types]
                     msg = (
-                        f"field '{pk}' expects the following types: {type_names}."
-                        f" Provided value {pv} with type '{type(pv).__name__}' is invalid with the"
-                        " following errors:\n"
+                        f"field `{pk}` expects the following types: `{type_names}`. Provided value"
+                        f" `{pv}` with type `{type(pv).__name__}` is invalid with the following"
+                        " errors:\n"
                     )
                     # order failed_validations by path depth so the most "fitting" goes first
                     failed_validations = sorted(
@@ -126,8 +126,8 @@ def validate_dict(
         elif t in [int, bool, str, float]:
             if not isinstance(pv, t):
                 raise DictValidationException(
-                    f"field `{pk}={pv}` has invalid type '{type(pv).__name__}' while"
-                    f" '{t.__name__}' is expected",
+                    f"field `{pk}={pv}` has invalid type `{type(pv).__name__}` while"
+                    f" `{t.__name__}` is expected",
                     path,
                     t,
                     pk,
@@ -136,8 +136,8 @@ def validate_dict(
         elif is_typeddict(t):
             if not isinstance(pv, dict):
                 raise DictValidationException(
-                    f"field '{pk}' with value `{pv}` has invalid type '{type(pv).__name__}' while"
-                    f" '{get_type_name(t)}' is expected",
+                    f"field `{pk}` with value `{pv}` has invalid type `{type(pv).__name__}` while"
+                    f" `{get_type_name(t)}` is expected",
                     path,
                     t,
                     pk,
@@ -147,8 +147,8 @@ def validate_dict(
         elif is_list_generic_type(t):
             if not isinstance(pv, list):
                 raise DictValidationException(
-                    f"field '{pk}' with value `{pv}` has invalid type '{type(pv).__name__}' while"
-                    " 'list' is expected",
+                    f"field `{pk}` with value `{pv}` has invalid type `{type(pv).__name__}` while"
+                    " `list` is expected",
                     path,
                     t,
                     pk,
@@ -161,8 +161,8 @@ def validate_dict(
         elif is_dict_generic_type(t):
             if not isinstance(pv, dict):
                 raise DictValidationException(
-                    f"field '{pk}' with value `{pv}` has invalid type '{type(pv).__name__}' while"
-                    " 'dict' is expected",
+                    f"field `{pk}` with value `{pv}` has invalid type `{type(pv).__name__}` while"
+                    " `dict` is expected",
                     path,
                     t,
                     pk,
@@ -173,7 +173,7 @@ def validate_dict(
             for d_k, d_v in pv.items():
                 if not isinstance(d_k, str):
                     raise DictValidationException(
-                        f"field '{pk}' with key `{d_k}` must be a string", path, t, pk, d_k
+                        f"field `{pk}` with key `{d_k}` must be a `str`", path, t, pk, d_k
                     )
                 verify_prop(f"{pk}[{d_k}]", d_v, d_v_t)
         elif t is Any:
@@ -189,8 +189,8 @@ def validate_dict(
                 pass
             else:
                 raise DictValidationException(
-                    f"field '{pk}' expects callable (function or class instance) but got "
-                    f"'{pv}'. Mind that signatures are not validated",
+                    f"field `{pk}` expects `callable` (function or class instance) but got "
+                    f"`{pv}`. Mind that signatures are not validated",
                     path,
                     t,
                     pk,

--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -68,11 +68,11 @@ def validate_dict(
     # check missing props
     missing = set(required_props.keys()).difference(props.keys())
     if len(missing):
-        raise DictValidationException(f"Missing required fields: `{missing}`", path)
+        raise DictValidationException(f"missing required fields `{missing}`", path)
     # check unknown props
     unexpected = set(props.keys()).difference(allowed_props.keys())
     if len(unexpected):
-        raise DictValidationException(f"Received unexpected fields: `{unexpected}`", path)
+        raise DictValidationException(f"received unexpected fields `{unexpected}`", path)
 
     def verify_prop(pk: str, pv: Any, t: Any) -> None:
         # covers none in optional and union types
@@ -99,7 +99,7 @@ def validate_dict(
                 if len(failed_validations) == len(union_types):
                     type_names = [get_type_name(ut) for ut in union_types]
                     msg = (
-                        f"field '{pk}' expects the following types: {', '.join(type_names)}."
+                        f"field '{pk}' expects the following types: {type_names}."
                         f" Provided value {pv} with type '{type(pv).__name__}' is invalid with the"
                         " following errors:\n"
                     )
@@ -121,12 +121,12 @@ def validate_dict(
             a_l = get_literal_args(t)
             if pv not in a_l:
                 raise DictValidationException(
-                    f"field '{pk}' with value `{pv}` is not one of: {a_l}", path, t, pk, pv
+                    f"field `{pk}={pv}` is not one of: {a_l}", path, t, pk, pv
                 )
         elif t in [int, bool, str, float]:
             if not isinstance(pv, t):
                 raise DictValidationException(
-                    f"field '{pk}' with value `{pv}` has invalid type '{type(pv).__name__}' while"
+                    f"field `{pk}={pv}` has invalid type '{type(pv).__name__}' while"
                     f" '{t.__name__}' is expected",
                     path,
                     t,

--- a/dlt/destinations/configuration.py
+++ b/dlt/destinations/configuration.py
@@ -57,7 +57,7 @@ class WithLocalFiles(DestinationClientConfiguration):
             if self.pipeline_working_dir:
                 return os.path.join(self.pipeline_working_dir, default_location)
             raise RuntimeError(
-                "Attempting to use special location :pipeline: outside of pipeline context."
+                "Attempting to use special location `:pipeline:` outside of pipeline context."
             )
         else:
             # if explicit path is absolute, use it

--- a/dlt/destinations/dataset/dataset.py
+++ b/dlt/destinations/dataset/dataset.py
@@ -140,7 +140,7 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
             return client.sql_client
         else:
             raise Exception(
-                f"Destination {client.config.destination_type} does not support SqlClient."
+                f"Destination `{client.config.destination_type}` does not support `SqlClient`."
             )
 
     def _ensure_schema(self) -> None:

--- a/dlt/destinations/dataset/exceptions.py
+++ b/dlt/destinations/dataset/exceptions.py
@@ -9,7 +9,7 @@ class ReadableRelationHasQueryException(DatasetException):
     def __init__(self, attempted_change: str) -> None:
         msg = (
             "This readable relation was created with a provided sql query. You cannot change"
-            f" {attempted_change}. Please change the orignal sql query."
+            f" `{attempted_change}`. Please change the orignal sql query."
         )
         super().__init__(msg)
 
@@ -17,6 +17,6 @@ class ReadableRelationHasQueryException(DatasetException):
 class ReadableRelationUnknownColumnException(DatasetException):
     def __init__(self, column_name: str) -> None:
         msg = (
-            f"The selected column {column_name} is not known in the dlt schema for this releation."
+            f"The selected column `{column_name}` is not known in the dlt schema for this relation."
         )
         super().__init__(msg)

--- a/dlt/destinations/dataset/ibis_relation.py
+++ b/dlt/destinations/dataset/ibis_relation.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Any, Union, Sequence
 from functools import partial
 import sqlglot
 
+from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.common.exceptions import TypeErrorWithKnownTypes
 from dlt.destinations.dataset.relation import BaseReadableDBAPIRelation
 
 

--- a/dlt/destinations/dataset/ibis_relation.py
+++ b/dlt/destinations/dataset/ibis_relation.py
@@ -85,7 +85,7 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
 
         if attr is None:
             raise AttributeError(
-                f"'{self._ibis_object.__class__.__name__}' object has no attribute '{name}'"
+                f"`{self._ibis_object.__class__.__name__}` object has no attribute `{name}`"
             )
 
         if not callable(attr):
@@ -97,8 +97,8 @@ class ReadableIbisRelation(BaseReadableDBAPIRelation):
     def __getitem__(self, columns: Union[str, Sequence[str]]) -> "ReadableIbisRelation":
         if not isinstance(columns, (str, Sequence)):
             raise TypeError(
-                f"Invalid argument type: {type(columns).__name__}, requires a sequence of column"
-                " names Sequence[str] or a single column name str"
+                "Expected a sequence of column names `Sequence[str]` or a single column `str`. "
+                f"Received invalid argument of type: `{type(columns).__name__}`"
             )
 
         expr = self._ibis_object[columns]

--- a/dlt/destinations/dataset/ibis_relation.py
+++ b/dlt/destinations/dataset/ibis_relation.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING, Any, Union, Sequence
 from functools import partial
 import sqlglot
 
-from dlt.common.schema.typing import TTableSchemaColumns
-from dlt.common.exceptions import TypeErrorWithKnownTypes
 from dlt.destinations.dataset.relation import BaseReadableDBAPIRelation
 
 

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -291,9 +291,8 @@ class ReadableDBAPIRelation(BaseReadableDBAPIRelation):
 
         raise TypeError(
             f"Received invalid value `columns={columns}` of type"
-                f" {type(columns).__name__}`. Valid types are: ['Sequence[str]']"
+            f" {type(columns).__name__}`. Valid types are: ['Sequence[str]']"
         )
-
 
     def head(self, limit: int = 5) -> Self:
         return self.limit(limit)

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -282,13 +282,14 @@ class ReadableDBAPIRelation(BaseReadableDBAPIRelation):
     def __getitem__(self, columns: Sequence[str]) -> Self:
         if isinstance(columns, str):
             raise TypeError(
-                f"Invalid argument type: {type(columns).__name__}, requires a sequence of column"
+                "Expecte"
+                f"Invalid argument type: `{type(columns).__name__}`, requires a sequence of column"
                 " names Sequence[str]"
             )
         elif isinstance(columns, Sequence):
             return self.select(*columns)
         raise TypeError(
-            f"Invalid argument type: {type(columns).__name__}, requires a sequence of column names"
+            f"Invalid argument type: `{type(columns).__name__}`, requires a sequence of column names"
             " Sequence[str]"
         )
 

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -11,10 +11,8 @@ from dlt.common.destination.dataset import (
 from dlt.common.schema.typing import TTableSchemaColumns
 from dlt.common.typing import Self
 from dlt.common.exceptions import TypeErrorWithKnownTypes
-
-from dlt.destinations.sql_client import SqlClientBase, WithSqlClient
 from dlt.transformations import lineage
-
+from dlt.destinations.sql_client import SqlClientBase, WithSqlClient
 from dlt.destinations.dataset.exceptions import (
     ReadableRelationHasQueryException,
 )

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -10,9 +10,10 @@ from dlt.common.destination.dataset import (
 
 from dlt.common.schema.typing import TTableSchemaColumns
 from dlt.common.typing import Self
+from dlt.common.exceptions import TypeErrorWithKnownTypes
 
 from dlt.transformations import lineage
-from dlt.destinations.sql_client import SqlClientBase, WithSqlClient
+
 from dlt.destinations.dataset.exceptions import (
     ReadableRelationHasQueryException,
 )
@@ -280,18 +281,10 @@ class ReadableDBAPIRelation(BaseReadableDBAPIRelation):
         return rel
 
     def __getitem__(self, columns: Sequence[str]) -> Self:
-        if isinstance(columns, str):
-            raise TypeError(
-                "Expecte"
-                f"Invalid argument type: `{type(columns).__name__}`, requires a sequence of column"
-                " names Sequence[str]"
-            )
-        elif isinstance(columns, Sequence):
-            return self.select(*columns)
-        raise TypeError(
-            f"Invalid argument type: `{type(columns).__name__}`, requires a sequence of column names"
-            " Sequence[str]"
-        )
+        if not isinstance(columns, Sequence):
+            raise TypeErrorWithKnownTypes("columns", columns, ["Sequence[str]"])
+
+        return self.select(*columns)
 
     def head(self, limit: int = 5) -> Self:
         return self.limit(limit)

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -280,10 +280,20 @@ class ReadableDBAPIRelation(BaseReadableDBAPIRelation):
         return rel
 
     def __getitem__(self, columns: Sequence[str]) -> Self:
-        if not isinstance(columns, Sequence):
-            raise TypeErrorWithKnownTypes("columns", columns, ["Sequence[str]"])
+        # NOTE remember that `issubclass(str, Sequence) is True`
+        if isinstance(columns, str):
+            raise TypeError(
+                f"Received invalid value `columns={columns}` of type"
+                f" {type(columns).__name__}`. Valid types are: ['Sequence[str]']"
+            )
+        elif isinstance(columns, Sequence):
+            return self.select(*columns)
 
-        return self.select(*columns)
+        raise TypeError(
+            f"Received invalid value `columns={columns}` of type"
+                f" {type(columns).__name__}`. Valid types are: ['Sequence[str]']"
+        )
+
 
     def head(self, limit: int = 5) -> Self:
         return self.limit(limit)

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -12,6 +12,7 @@ from dlt.common.schema.typing import TTableSchemaColumns
 from dlt.common.typing import Self
 from dlt.common.exceptions import TypeErrorWithKnownTypes
 
+from dlt.destinations.sql_client import SqlClientBase, WithSqlClient
 from dlt.transformations import lineage
 
 from dlt.destinations.dataset.exceptions import (

--- a/dlt/destinations/exceptions.py
+++ b/dlt/destinations/exceptions.py
@@ -38,7 +38,7 @@ class DestinationConnectionError(DestinationTransientException):
         self.dataset_name = dataset_name
         self.inner_exc = inner_exc
         super().__init__(
-            f"Connection with {client_type} to dataset name {dataset_name} failed. Please check if"
+            f"Connection with `{client_type}` to `{dataset_name=:}` failed. Please check if"
             " you configured the credentials at all and provided the right credentials values. You"
             " can be also denied access or your internet connection may be down. The actual reason"
             f" given is: {reason}"
@@ -50,8 +50,8 @@ class LoadClientNotConnected(DestinationTransientException):
         self.client_type = client_type
         self.dataset_name = dataset_name
         super().__init__(
-            f"Connection with {client_type} to dataset {dataset_name} is closed. Open the"
-            " connection with 'client.open_connection' or with the 'with client:' statement"
+            f"Connection with `{client_type}` to `{dataset_name=:}` is closed. Open the"
+            " connection with `client.open_connection` or with the `with client:` context manager"
         )
 
 
@@ -60,19 +60,19 @@ class DestinationSchemaWillNotUpdate(DestinationTerminalException):
         self.table_name = table_name
         self.columns = columns
         super().__init__(
-            f"Schema for table {table_name} column(s) {columns} will not update: {msg}"
+            f"Schema for table `{table_name}` column(s) `{columns}` will not update: {msg}"
         )
 
 
 class LoadJobNotExistsException(DestinationTerminalException):
     def __init__(self, job_id: str) -> None:
-        super().__init__(f"Job with id/file name {job_id} not found")
+        super().__init__(f"Job with {job_id=:} not found")
 
 
 class LoadJobTerminalException(DestinationTerminalException):
     def __init__(self, file_path: str, message: str) -> None:
         super().__init__(
-            f"Job with id/file name {file_path} encountered unrecoverable problem: {message}"
+            f"Job with `{file_path=:}` encountered unrecoverable problem: {message}"
         )
 
 
@@ -80,13 +80,13 @@ class LoadJobInvalidStateTransitionException(DestinationTerminalException):
     def __init__(self, from_state: TLoadJobState, to_state: TLoadJobState) -> None:
         self.from_state = from_state
         self.to_state = to_state
-        super().__init__(f"Load job cannot transition form {from_state} to {to_state}")
+        super().__init__(f"Load job cannot transition from `{from_state}` to `{to_state}`")
 
 
 class LoadJobFileTooBig(DestinationTerminalException):
     def __init__(self, file_name: str, max_size: int) -> None:
         super().__init__(
-            f"File {file_name} exceeds {max_size} and cannot be loaded. Split the file and try"
+            f"File `{file_name}` exceeds `{max_size=:}` and cannot be loaded. Split the file and try"
             " again."
         )
 
@@ -100,11 +100,11 @@ class MergeDispositionException(DestinationTerminalException):
         self.tables = tables
         self.reason = reason
         msg = (
-            f"Merge sql job for dataset name {dataset_name}, staging dataset name"
-            f" {staging_dataset_name} COULD NOT BE GENERATED. Merge will not be performed. "
+            f"Merge sql job for `{dataset_name=:}` with `{staging_dataset_name=:}`"
+            f"COULD NOT BE GENERATED. Merge will not be performed. "
         )
         msg += (
-            f"Data for the following tables ({tables}) is loaded to staging dataset. You may need"
+            f"Data for the following tables `{tables}` is loaded to staging dataset. You may need"
             " to write your own materialization. The reason is:\n"
         )
         msg += reason
@@ -127,15 +127,15 @@ class InvalidFilesystemLayout(DestinationTerminalException):
         self.layout = layout
 
         message = (
-            f"Layout '{layout}' expected {', '.join(expected_placeholders)} placeholders."
-            f"Missing placeholders: {', '.join(invalid_placeholders)}."
+            f"`{layout=:}` expected placeholders: `{expected_placeholders}` "
+            f"Missing placeholders: `{invalid_placeholders}` "
         )
 
         if extra_placeholders:
-            message += f"Extra placeholders specified: {', '.join(extra_placeholders)}."
+            message += f"Extra placeholders specified: `{extra_placeholders}` "
 
         if unused_placeholders:
-            message += f"Unused placeholders: {', '.join(unused_placeholders)}."
+            message += f"Unused placeholders: `{unused_placeholders}`"
 
         super().__init__(message)
 
@@ -144,7 +144,7 @@ class InvalidPlaceholderCallback(DestinationTransientException):
     def __init__(self, callback_name: str) -> None:
         self.callback_name = callback_name
         super().__init__(
-            f"Invalid placeholder callback: {callback_name}, please make sure it can"
+            f"Invalid placeholder `{callback_name=:}`, please make sure it can"
             " accept parameters the following `schema name`, `table name`,"
             " `load_id`, `file_id` and an `extension`",
         )
@@ -152,7 +152,7 @@ class InvalidPlaceholderCallback(DestinationTransientException):
 
 class CantExtractTablePrefix(DestinationTerminalException):
     def __init__(self, layout: str, details: str) -> None:
-        msg = f"Cannot extract unique table prefix in layout '{layout}'. "
+        msg = f"Cannot extract unique table prefix in `{layout=:}`. "
         msg += details
-        msg += "An example of valid layout: {table_name}/{load_id}.{file_id}.{ext}"
+        msg += "An example of valid layout: `{table_name}/{load_id}.{file_id}.{ext}`"
         super().__init__(msg)

--- a/dlt/destinations/exceptions.py
+++ b/dlt/destinations/exceptions.py
@@ -38,7 +38,7 @@ class DestinationConnectionError(DestinationTransientException):
         self.dataset_name = dataset_name
         self.inner_exc = inner_exc
         super().__init__(
-            f"Connection with `{client_type}` to `{dataset_name=:}` failed. Please check if"
+            f"Connection with `{client_type=:}` to `{dataset_name=:}` failed. Please check if"
             " you configured the credentials at all and provided the right credentials values. You"
             " can be also denied access or your internet connection may be down. The actual reason"
             f" given is: {reason}"
@@ -50,7 +50,7 @@ class LoadClientNotConnected(DestinationTransientException):
         self.client_type = client_type
         self.dataset_name = dataset_name
         super().__init__(
-            f"Connection with `{client_type}` to `{dataset_name=:}` is closed. Open the"
+            f"Connection with `{client_type=:}` to `{dataset_name=:}` is closed. Open the"
             " connection with `client.open_connection` or with the `with client:` context manager"
         )
 

--- a/dlt/destinations/exceptions.py
+++ b/dlt/destinations/exceptions.py
@@ -71,9 +71,7 @@ class LoadJobNotExistsException(DestinationTerminalException):
 
 class LoadJobTerminalException(DestinationTerminalException):
     def __init__(self, file_path: str, message: str) -> None:
-        super().__init__(
-            f"Job with `{file_path=:}` encountered unrecoverable problem: {message}"
-        )
+        super().__init__(f"Job with `{file_path=:}` encountered unrecoverable problem: {message}")
 
 
 class LoadJobInvalidStateTransitionException(DestinationTerminalException):
@@ -86,8 +84,8 @@ class LoadJobInvalidStateTransitionException(DestinationTerminalException):
 class LoadJobFileTooBig(DestinationTerminalException):
     def __init__(self, file_name: str, max_size: int) -> None:
         super().__init__(
-            f"File `{file_name}` exceeds `{max_size=:}` and cannot be loaded. Split the file and try"
-            " again."
+            f"File `{file_name}` exceeds `{max_size=:}` and cannot be loaded. Split the file and"
+            " try again."
         )
 
 
@@ -101,7 +99,7 @@ class MergeDispositionException(DestinationTerminalException):
         self.reason = reason
         msg = (
             f"Merge sql job for `{dataset_name=:}` with `{staging_dataset_name=:}`"
-            f"COULD NOT BE GENERATED. Merge will not be performed. "
+            "COULD NOT BE GENERATED. Merge will not be performed. "
         )
         msg += (
             f"Data for the following tables `{tables}` is loaded to staging dataset. You may need"

--- a/dlt/destinations/impl/athena/factory.py
+++ b/dlt/destinations/impl/athena/factory.py
@@ -112,7 +112,7 @@ class AthenaTypeMapper(TypeMapperImpl):
         elif precision <= 64:
             return "bigint"
         raise TerminalValueError(
-            f"bigint with {precision} bits precision cannot be mapped into athena integer type"
+            f"bigint with `precision={precision}` can't be mapped to athena integer type"
         )
 
     def from_destination_type(

--- a/dlt/destinations/impl/athena/factory.py
+++ b/dlt/destinations/impl/athena/factory.py
@@ -112,7 +112,7 @@ class AthenaTypeMapper(TypeMapperImpl):
         elif precision <= 64:
             return "bigint"
         raise TerminalValueError(
-            f"bigint with `precision={precision}` can't be mapped to athena integer type"
+            f"bigint with `{precision=:}` can't be mapped to athena integer type"
         )
 
     def from_destination_type(

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -91,7 +91,7 @@ class BigQueryLoadJob(RunnableLoadJob, HasFollowupJobs):
             elif reason in BQ_TERMINAL_REASONS:
                 # google.api_core.exceptions.BadRequest - will not be processed ie bad job name
                 raise LoadJobTerminalException(
-                    self._file_path, f"The server reason was: {reason}"
+                    self._file_path, f"The server reason was: `{reason}`"
                 ) from gace
             else:
                 raise DatabaseTransientException(gace) from gace
@@ -110,19 +110,19 @@ class BigQueryLoadJob(RunnableLoadJob, HasFollowupJobs):
                 # the job permanently failed for the reason above
                 raise DatabaseTerminalException(
                     Exception(
-                        f"Bigquery Load Job failed, reason reported from bigquery: '{reason}'"
+                        f"Bigquery Load Job failed, reason reported from bigquery: `{reason}`"
                     )
                 )
             elif reason in ["internalError"]:
                 logger.warning(
-                    f"Got reason {reason} for job {self._file_name}, job considered still"
+                    f"Got reason `{reason}` for job `{self._file_name}`, job considered still"
                     f" running. ({self._bq_load_job.error_result})"
                 )
                 continue
             else:
                 raise DatabaseTransientException(
                     Exception(
-                        f"Bigquery Job needs to be retried, reason reported from bigquer '{reason}'"
+                        f"Bigquery Job needs to be retried, reason reported from bigquery `{reason}`"
                     )
                 )
 
@@ -223,9 +223,8 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
             if insert_api == "streaming":
                 if table["write_disposition"] != "append":
                     raise DestinationTerminalException(
-                        "BigQuery streaming insert can only be used with `append`"
-                        " write_disposition, while the given resource has"
-                        f" `{table['write_disposition']}`."
+                        "BigQuery streaming insert can only be used with `write_disposition='append'`."
+                        f"Resource received `write_disposition={table['write_disposition']}`"
                     )
                 if file_path.endswith(".jsonl"):
                     job_cls = DestinationJsonlLoadJob
@@ -233,7 +232,7 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
                     job_cls = DestinationParquetLoadJob  # type: ignore
                 else:
                     raise ValueError(
-                        f"Unsupported file type for BigQuery streaming inserts: {file_path}"
+                        f"Unsupported file type for BigQuery streaming inserts: `{file_path}`"
                     )
 
                 job = job_cls(

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -122,7 +122,8 @@ class BigQueryLoadJob(RunnableLoadJob, HasFollowupJobs):
             else:
                 raise DatabaseTransientException(
                     Exception(
-                        f"Bigquery Job needs to be retried, reason reported from bigquery `{reason}`"
+                        "Bigquery Job needs to be retried, reason reported from bigquery"
+                        f" `{reason}`"
                     )
                 )
 
@@ -223,8 +224,9 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
             if insert_api == "streaming":
                 if table["write_disposition"] != "append":
                     raise DestinationTerminalException(
-                        "BigQuery streaming insert can only be used with `write_disposition='append'`."
-                        f"Resource received `write_disposition={table['write_disposition']}`"
+                        "BigQuery streaming insert can only be used with"
+                        " `write_disposition='append'`.Resource received"
+                        f" `write_disposition={table['write_disposition']}`"
                     )
                 if file_path.endswith(".jsonl"):
                     job_cls = DestinationJsonlLoadJob

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -225,7 +225,7 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
                 if table["write_disposition"] != "append":
                     raise DestinationTerminalException(
                         "BigQuery streaming insert can only be used with"
-                        " `write_disposition='append'`.Resource received"
+                        " `write_disposition='append'`. Resource received"
                         f" `write_disposition={table['write_disposition']}`"
                     )
                 if file_path.endswith(".jsonl"):

--- a/dlt/destinations/impl/bigquery/bigquery_adapter.py
+++ b/dlt/destinations/impl/bigquery/bigquery_adapter.py
@@ -132,7 +132,7 @@ def bigquery_adapter(
     if partition:
         if not (isinstance(partition, str) or isinstance(partition, PartitionTransformation)):
             raise ValueError(
-                "`partition` must be a single column name as a string or a PartitionTransformation."
+                "`partition` must be a single column name as a `str` or a `PartitionTransformation`."
             )
 
         # Can only have one partition column.
@@ -211,7 +211,7 @@ def bigquery_adapter(
             )
             additional_table_hints[TABLE_EXPIRATION_HINT] = parsed_table_expiration_datetime
         except ValueError as e:
-            raise ValueError(f"{table_expiration_datetime} could not be parsed!") from e
+            raise ValueError(f"`table_expiration_datetime={table_expiration_datetime}` could not be parsed!") from e
 
     if partition_expiration_days is not None:
         assert isinstance(
@@ -222,8 +222,8 @@ def bigquery_adapter(
     if insert_api is not None:
         if insert_api == "streaming" and data.write_disposition != "append":
             raise ValueError(
-                "BigQuery streaming insert can only be used with `append` write_disposition, while "
-                f"the given resource has `{data.write_disposition}`."
+                "BigQuery streaming insert only accepts `write_disposition='append'`. "
+                f"Received `write_disposition={data.write_disposition}`."
             )
         additional_table_hints["x-insert-api"] = insert_api
 

--- a/dlt/destinations/impl/bigquery/bigquery_adapter.py
+++ b/dlt/destinations/impl/bigquery/bigquery_adapter.py
@@ -132,7 +132,8 @@ def bigquery_adapter(
     if partition:
         if not (isinstance(partition, str) or isinstance(partition, PartitionTransformation)):
             raise ValueError(
-                "`partition` must be a single column name as a `str` or a `PartitionTransformation`."
+                "`partition` must be a single column name as a `str` or a"
+                " `PartitionTransformation`."
             )
 
         # Can only have one partition column.
@@ -211,7 +212,9 @@ def bigquery_adapter(
             )
             additional_table_hints[TABLE_EXPIRATION_HINT] = parsed_table_expiration_datetime
         except ValueError as e:
-            raise ValueError(f"`table_expiration_datetime={table_expiration_datetime}` could not be parsed!") from e
+            raise ValueError(
+                f"`table_expiration_datetime={table_expiration_datetime}` could not be parsed!"
+            ) from e
 
     if partition_expiration_days is not None:
         assert isinstance(

--- a/dlt/destinations/impl/bigquery/factory.py
+++ b/dlt/destinations/impl/bigquery/factory.py
@@ -66,7 +66,7 @@ class BigQueryTypeMapper(TypeMapperImpl):
             and not should_autodetect_schema(table)
         ):
             raise TerminalValueError(
-                "Enable autodetect_schema in config or via BigQuery adapter", column["data_type"]
+                "Enable `autodetect_schema` in config or via BigQuery adapter", column["data_type"]
             )
 
     def to_db_decimal_type(self, column: TColumnSchema) -> str:

--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -103,7 +103,7 @@ class ClickHouseLoadJob(RunnableLoadJob, HasFollowupJobs):
             except clickhouse_connect.driver.exceptions.Error as e:
                 raise LoadJobTerminalException(
                     self._file_path,
-                    f"ClickHouse connection failed due to {e}.",
+                    f"ClickHouse connection failed due to `{e}`.",
                 ) from e
             return
 
@@ -164,7 +164,7 @@ class ClickHouseLoadJob(RunnableLoadJob, HasFollowupJobs):
         else:
             raise LoadJobTerminalException(
                 self._file_path,
-                f"ClickHouse loader does not support '{bucket_scheme}' filesystem.",
+                f"ClickHouse loader does not support `{bucket_scheme}` filesystem.",
             )
 
         statement = f"INSERT INTO {qualified_table_name} SELECT * FROM {table_function}"

--- a/dlt/destinations/impl/clickhouse/clickhouse_adapter.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse_adapter.py
@@ -53,8 +53,8 @@ def clickhouse_adapter(data: Any, table_engine_type: TTableEngineType = None) ->
         if table_engine_type not in TABLE_ENGINE_TYPES:
             allowed_types = ", ".join(TABLE_ENGINE_TYPES)
             raise ValueError(
-                f"Table engine type {table_engine_type} is invalid. Allowed table engine types are:"
-                f" {allowed_types}."
+                f"Table engine type `{table_engine_type}` is invalid. Allowed table engine types are:"
+                f" `{allowed_types}`."
             )
         additional_table_hints[TABLE_ENGINE_TYPE_HINT] = table_engine_type
     resource.apply_hints(additional_table_hints=additional_table_hints)

--- a/dlt/destinations/impl/clickhouse/clickhouse_adapter.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse_adapter.py
@@ -6,6 +6,7 @@ from dlt.destinations.impl.clickhouse.typing import (
     TABLE_ENGINE_TYPE_HINT,
 )
 from dlt.destinations.utils import get_resource_for_adapter
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.extract import DltResource
 from dlt.extract.items import TTableHintTemplate
 
@@ -51,11 +52,10 @@ def clickhouse_adapter(data: Any, table_engine_type: TTableEngineType = None) ->
     additional_table_hints: Dict[str, TTableHintTemplate[Any]] = {}
     if table_engine_type is not None:
         if table_engine_type not in TABLE_ENGINE_TYPES:
-            allowed_types = ", ".join(TABLE_ENGINE_TYPES)
-            raise ValueError(
-                f"Table engine type `{table_engine_type}` is invalid. Allowed table engine types are:"
-                f" `{allowed_types}`."
+            raise ValueErrorWithKnownValues(
+                "table_engine_type", table_engine_type, TABLE_ENGINE_TYPES
             )
+
         additional_table_hints[TABLE_ENGINE_TYPE_HINT] = table_engine_type
     resource.apply_hints(additional_table_hints=additional_table_hints)
     return resource

--- a/dlt/destinations/impl/clickhouse/factory.py
+++ b/dlt/destinations/impl/clickhouse/factory.py
@@ -110,7 +110,7 @@ class ClickHouseTypeMapper(TypeMapperImpl):
         if precision <= 64:
             return "Int64"
         raise TerminalValueError(
-            f"bigint with {precision=:} can't be mapped to ClickHouse integer type"
+            f"bigint with `{precision=:}` can't be mapped to ClickHouse integer type"
         )
 
 

--- a/dlt/destinations/impl/clickhouse/factory.py
+++ b/dlt/destinations/impl/clickhouse/factory.py
@@ -110,7 +110,7 @@ class ClickHouseTypeMapper(TypeMapperImpl):
         if precision <= 64:
             return "Int64"
         raise TerminalValueError(
-            f"bigint with {precision} bits precision cannot be mapped into ClickHouse integer type"
+            f"bigint with {precision=:} can't be mapped to ClickHouse integer type"
         )
 
 

--- a/dlt/destinations/impl/clickhouse/utils.py
+++ b/dlt/destinations/impl/clickhouse/utils.py
@@ -14,7 +14,7 @@ def convert_storage_to_http_scheme(
         elif isinstance(url, ParseResult):
             parsed_url = url
         else:
-            raise TypeError("Invalid URL type. Expected str or ParseResult.")
+            raise TypeError("Invalid URL type. Expected `str` or `ParseResult`.")
 
         bucket_name = parsed_url.netloc
         object_key = parsed_url.path.lstrip("/")
@@ -34,4 +34,4 @@ def convert_storage_to_http_scheme(
 
         return f"{protocol}://{bucket_name}.{domain}/{object_key}"
     except Exception as e:
-        raise Exception(f"Error converting storage URL to HTTP protocol: '{url}'") from e
+        raise Exception(f"Error converting storage URL to HTTP protocol: `{url}`") from e

--- a/dlt/destinations/impl/clickhouse/utils.py
+++ b/dlt/destinations/impl/clickhouse/utils.py
@@ -1,6 +1,8 @@
 from typing import Union
 from urllib.parse import urlparse, ParseResult
 
+from dlt.common.exceptions import TypeErrorWithKnownTypes
+
 
 def convert_storage_to_http_scheme(
     url: Union[str, ParseResult],
@@ -14,7 +16,7 @@ def convert_storage_to_http_scheme(
         elif isinstance(url, ParseResult):
             parsed_url = url
         else:
-            raise TypeError("Invalid URL type. Expected `str` or `ParseResult`.")
+            raise TypeErrorWithKnownTypes("url", url, ["str", "ParsedResult"])
 
         bucket_name = parsed_url.netloc
         object_key = parsed_url.path.lstrip("/")

--- a/dlt/destinations/impl/databricks/configuration.py
+++ b/dlt/destinations/impl/databricks/configuration.py
@@ -59,8 +59,8 @@ class DatabricksCredentials(CredentialsConfiguration):
             if not self.access_token:
                 raise ConfigurationValueError(
                     "Authentication failed: No valid authentication method detected. "
-                    "Provide either 'client_id' and 'client_secret' for OAuth authentication, "
-                    "or 'access_token' for token-based authentication."
+                    "Provide either `client_id` and `client_secret` for OAuth authentication, "
+                    "or `access_token` for token-based authentication."
                 )
 
         if not self.server_hostname or not self.http_path:
@@ -86,7 +86,7 @@ class DatabricksCredentials(CredentialsConfiguration):
         for param in ("catalog", "server_hostname", "http_path"):
             if not getattr(self, param):
                 raise ConfigurationValueError(
-                    f"Configuration error: Missing required parameter '{param}'. "
+                    f"Configuration error: Missing required parameter `{param}`. "
                     "Please provide it in the configuration."
                 )
 

--- a/dlt/destinations/impl/databricks/databricks.py
+++ b/dlt/destinations/impl/databricks/databricks.py
@@ -155,7 +155,7 @@ class DatabricksLoadJob(RunnableLoadJob, HasFollowupJobs):
         if bucket_scheme not in SUPPORTED_BLOB_STORAGE_PROTOCOLS:
             raise LoadJobTerminalException(
                 self._file_path,
-                f"Databricks cannot load data from staging bucket {bucket_path}. "
+                f"Databricks cannot load data from staging bucket `{bucket_path}`. "
                 "Only s3, azure and gcs buckets are supported. "
                 "Please note that gcs buckets are supported only via named credential.",
             )

--- a/dlt/destinations/impl/databricks/factory.py
+++ b/dlt/destinations/impl/databricks/factory.py
@@ -80,7 +80,7 @@ class DatabricksTypeMapper(TypeMapperImpl):
         if precision <= 64:
             return "BIGINT"
         raise TerminalValueError(
-            f"bigint with {precision=:} can't be mapped to Databricks integer type"
+            f"bigint with `{precision=:}` can't be mapped to Databricks integer type"
         )
 
     def from_destination_type(

--- a/dlt/destinations/impl/databricks/factory.py
+++ b/dlt/destinations/impl/databricks/factory.py
@@ -80,7 +80,7 @@ class DatabricksTypeMapper(TypeMapperImpl):
         if precision <= 64:
             return "BIGINT"
         raise TerminalValueError(
-            f"bigint with {precision} bits precision cannot be mapped into databricks integer type"
+            f"bigint with {precision=:} can't be mapped to Databricks integer type"
         )
 
     def from_destination_type(

--- a/dlt/destinations/impl/destination/configuration.py
+++ b/dlt/destinations/impl/destination/configuration.py
@@ -35,6 +35,6 @@ class CustomDestinationClientConfiguration(DestinationClientConfiguration):
             or self.destination_callable is dummy_custom_destination
         ):
             raise ConfigurationValueError(
-                f"A valid callable was not provided to {self.__class__.__name__}. Did you decorate"
+                f"A valid callable was not provided to `{self.__class__.__name__}`. Did you decorate"
                 " a function @dlt.destination correctly?"
             )

--- a/dlt/destinations/impl/destination/configuration.py
+++ b/dlt/destinations/impl/destination/configuration.py
@@ -35,6 +35,6 @@ class CustomDestinationClientConfiguration(DestinationClientConfiguration):
             or self.destination_callable is dummy_custom_destination
         ):
             raise ConfigurationValueError(
-                f"A valid callable was not provided to `{self.__class__.__name__}`. Did you decorate"
-                " a function @dlt.destination correctly?"
+                f"A valid callable was not provided to `{self.__class__.__name__}`. Did you"
+                " decorate a function @dlt.destination correctly?"
             )

--- a/dlt/destinations/impl/destination/configuration.py
+++ b/dlt/destinations/impl/destination/configuration.py
@@ -36,5 +36,5 @@ class CustomDestinationClientConfiguration(DestinationClientConfiguration):
         ):
             raise ConfigurationValueError(
                 f"A valid callable was not provided to `{self.__class__.__name__}`. Did you"
-                " decorate a function @dlt.destination correctly?"
+                " properly decorate the function with `@dlt.destination`?"
             )

--- a/dlt/destinations/impl/destination/factory.py
+++ b/dlt/destinations/impl/destination/factory.py
@@ -99,8 +99,7 @@ class destination(Destination[CustomDestinationClientConfiguration, "Destination
         """
         if spec and not issubclass(spec, CustomDestinationClientConfiguration):
             raise TerminalValueError(
-                "A SPEC for a sink destination must use CustomDestinationClientConfiguration as a"
-                " base."
+                "A SPEC for a sink destination must use `CustomDestinationClientConfiguration` as a base."
             )
         # resolve callable
         if callable(destination_callable):

--- a/dlt/destinations/impl/destination/factory.py
+++ b/dlt/destinations/impl/destination/factory.py
@@ -99,7 +99,8 @@ class destination(Destination[CustomDestinationClientConfiguration, "Destination
         """
         if spec and not issubclass(spec, CustomDestinationClientConfiguration):
             raise TerminalValueError(
-                "A SPEC for a sink destination must use `CustomDestinationClientConfiguration` as a base."
+                "A SPEC for a sink destination must use `CustomDestinationClientConfiguration` as a"
+                " base."
             )
         # resolve callable
         if callable(destination_callable):

--- a/dlt/destinations/impl/dremio/dremio.py
+++ b/dlt/destinations/impl/dremio/dremio.py
@@ -70,7 +70,7 @@ class DremioLoadJob(RunnableLoadJob, HasFollowupJobs):
         )
 
         if not bucket_path:
-            raise RuntimeError("Could not resolve bucket path.")
+            raise RuntimeError("Could not resolve `bucket_path`.")
 
         file_name = (
             FileStorage.get_file_name_from_file_path(bucket_path)

--- a/dlt/destinations/impl/dremio/factory.py
+++ b/dlt/destinations/impl/dremio/factory.py
@@ -65,7 +65,7 @@ class DremioTypeMapper(TypeMapperImpl):
             # binary not supported on parquet if precision is set
             if column.get("precision") is not None and column["data_type"] == "binary":
                 raise TerminalValueError(
-                    "Dremio cannot load fixed width 'binary' columns from parquet files. Switch to"
+                    "Dremio cannot load fixed width `binary` columns from parquet files. Switch to"
                     " other file format or use binary columns without precision.",
                     "binary",
                 )

--- a/dlt/destinations/impl/duckdb/factory.py
+++ b/dlt/destinations/impl/duckdb/factory.py
@@ -76,7 +76,7 @@ class DuckDbTypeMapper(TypeMapperImpl):
         elif precision <= 128:
             return "HUGEINT"
         raise TerminalValueError(
-            f"bigint with {precision=:} can't be mapped to DuckDB integer type"
+            f"bigint with `{precision=:}` can't be mapped to DuckDB integer type"
         )
 
     def to_db_datetime_type(

--- a/dlt/destinations/impl/duckdb/factory.py
+++ b/dlt/destinations/impl/duckdb/factory.py
@@ -76,7 +76,7 @@ class DuckDbTypeMapper(TypeMapperImpl):
         elif precision <= 128:
             return "HUGEINT"
         raise TerminalValueError(
-            f"bigint with {precision} bits precision cannot be mapped into duckdb integer type"
+            f"bigint with {precision=:} can't be mapped to DuckDB integer type"
         )
 
     def to_db_datetime_type(
@@ -110,8 +110,8 @@ class DuckDbTypeMapper(TypeMapperImpl):
             return "TIMESTAMP_NS"
 
         raise TerminalValueError(
-            f"DuckDB does not support precision '{precision}' for '{column_name}' in table"
-            f" '{table_name}'"
+            f"DuckDB doesn't support `{precision=:}` for datetime column `{column_name}` in table"
+            f" `{table_name}`"
         )
 
     def from_destination_type(

--- a/dlt/destinations/impl/duckdb/sql_client.py
+++ b/dlt/destinations/impl/duckdb/sql_client.py
@@ -307,7 +307,7 @@ class WithTableScanners(DuckDbSqlClient):
     def drop_secret(self, secret_name: str) -> None:
         if not secret_name.startswith(self.dataset_name):
             raise ValueError(
-                f"Secret name must start with dataset name {self.dataset_name}, got {secret_name}"
+                f"Secret name must start with dataset name `{self.dataset_name}`, got `{secret_name}`."
             )
 
         self._conn.sql(f"DROP SECRET {secret_name}")
@@ -418,7 +418,7 @@ class WithTableScanners(DuckDbSqlClient):
         elif self.persist_secrets:
             raise ValueError(
                 "Cannot create persistent secret for filesystem protocol"
-                f" {protocol}. If you are trying to use persistent secrets"
+                f" `{protocol}`. If you are trying to use persistent secrets"
                 " with gs/gcs, please use the s3 compatibility layer."
             )
         else:
@@ -524,7 +524,7 @@ class WithTableScanners(DuckDbSqlClient):
     def _setup_iceberg(conn: duckdb.DuckDBPyConnection) -> None:
         if semver.Version.parse(duckdb.__version__) <= semver.Version.parse("1.1.2"):
             raise NotImplementedError(
-                f"Iceberg scanner for duckdb {duckdb.__version__} does not implement recent"
+                f"Iceberg scanner for duckdb `{duckdb.__version__}` does not implement recent"
                 " snapshot discovery. Please install duckdb >= 1.1.3"
             )
         # needed to make persistent secrets work in new connection

--- a/dlt/destinations/impl/duckdb/sql_client.py
+++ b/dlt/destinations/impl/duckdb/sql_client.py
@@ -307,7 +307,8 @@ class WithTableScanners(DuckDbSqlClient):
     def drop_secret(self, secret_name: str) -> None:
         if not secret_name.startswith(self.dataset_name):
             raise ValueError(
-                f"Secret name must start with dataset name `{self.dataset_name}`, got `{secret_name}`."
+                f"Secret name must start with dataset name `{self.dataset_name}`, got"
+                f" `{secret_name}`."
             )
 
         self._conn.sql(f"DROP SECRET {secret_name}")

--- a/dlt/destinations/impl/dummy/dummy.py
+++ b/dlt/destinations/impl/dummy/dummy.py
@@ -156,7 +156,7 @@ class DummyClient(JobClientBase, SupportsStagingDestination, WithStagingDataset)
         applied_update = super().update_stored_schema(only_tables, expected_update)
         if self.config.fail_schema_update:
             raise DestinationTransientException(
-                "Raise on schema update due to fail_schema_update config flag"
+                "Raise on schema update due to `fail_schema_update` config flag"
             )
         return applied_update
 

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -882,7 +882,7 @@ class FilesystemClient(
             return DeltaTable(table_location, storage_options=storage_options)
         else:
             raise NotImplementedError(
-                f"Can't load tables using {table_format=:} using `filesystem` destination."
+                f"Can't load tables using `{table_format=:}` with `filesystem` destination."
             )
 
     def get_open_table_catalog(self, table_format: TTableFormat, catalog_name: str = None) -> Any:

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -882,7 +882,7 @@ class FilesystemClient(
             return DeltaTable(table_location, storage_options=storage_options)
         else:
             raise NotImplementedError(
-                f"Cannot load tables in {table_format} format in filesystem destination."
+                f"Can't load tables using {table_format=:} using `filesystem` destination."
             )
 
     def get_open_table_catalog(self, table_format: TTableFormat, catalog_name: str = None) -> Any:

--- a/dlt/destinations/impl/filesystem/sql_client.py
+++ b/dlt/destinations/impl/filesystem/sql_client.py
@@ -5,6 +5,7 @@ import duckdb
 from dlt.common import logger
 from dlt.common.destination.exceptions import DestinationUndefinedEntity
 from dlt.common.destination.typing import PreparedTableSchema
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.common.schema.utils import is_nullable_column
 from dlt.common.storages.configuration import FileSystemCredentials
 
@@ -32,10 +33,10 @@ class FilesystemSqlClient(WithTableScanners):
         persist_secrets: bool = False,
     ) -> None:
         if remote_client.config.protocol not in SUPPORTED_PROTOCOLS:
-            raise NotImplementedError(
-                f"Protocol `{remote_client.config.protocol}` currently not supported for"
-                f" FilesystemSqlClient. Supported protocols are `{SUPPORTED_PROTOCOLS}`."
+            raise ValueErrorWithKnownValues(
+                "protocol", remote_client.config.protocol, SUPPORTED_PROTOCOLS
             )
+
         super().__init__(remote_client, dataset_name, cache_db, persist_secrets=persist_secrets)
         self.remote_client: FilesystemClient = remote_client
         self.is_abfss = self.remote_client.config.protocol == "abfss"
@@ -79,9 +80,7 @@ class FilesystemSqlClient(WithTableScanners):
                 # authentication for local filesystem not needed
                 pass
             else:
-                raise ValueError(
-                    f"Cannot create secret or register filesystem for protocol `{protocol}`"
-                )
+                raise ValueError(f"Cannot create secret or register filesystem for `{protocol=:}`")
 
         return True
 

--- a/dlt/destinations/impl/filesystem/sql_client.py
+++ b/dlt/destinations/impl/filesystem/sql_client.py
@@ -33,8 +33,8 @@ class FilesystemSqlClient(WithTableScanners):
     ) -> None:
         if remote_client.config.protocol not in SUPPORTED_PROTOCOLS:
             raise NotImplementedError(
-                f"Protocol {remote_client.config.protocol} currently not supported for"
-                f" FilesystemSqlClient. Supported protocols are {SUPPORTED_PROTOCOLS}."
+                f"Protocol `{remote_client.config.protocol}` currently not supported for"
+                f" FilesystemSqlClient. Supported protocols are `{SUPPORTED_PROTOCOLS}`."
             )
         super().__init__(remote_client, dataset_name, cache_db, persist_secrets=persist_secrets)
         self.remote_client: FilesystemClient = remote_client
@@ -80,7 +80,7 @@ class FilesystemSqlClient(WithTableScanners):
                 pass
             else:
                 raise ValueError(
-                    f"Cannot create secret or register filesystem for protocol {protocol}"
+                    f"Cannot create secret or register filesystem for protocol `{protocol}`"
                 )
 
         return True

--- a/dlt/destinations/impl/filesystem/sql_client.py
+++ b/dlt/destinations/impl/filesystem/sql_client.py
@@ -5,7 +5,6 @@ import duckdb
 from dlt.common import logger
 from dlt.common.destination.exceptions import DestinationUndefinedEntity
 from dlt.common.destination.typing import PreparedTableSchema
-from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.common.schema.utils import is_nullable_column
 from dlt.common.storages.configuration import FileSystemCredentials
 
@@ -33,8 +32,9 @@ class FilesystemSqlClient(WithTableScanners):
         persist_secrets: bool = False,
     ) -> None:
         if remote_client.config.protocol not in SUPPORTED_PROTOCOLS:
-            raise ValueErrorWithKnownValues(
-                "protocol", remote_client.config.protocol, SUPPORTED_PROTOCOLS
+            raise NotImplementedError(
+                f"Received invalid value `protocol={remote_client.config.protocol}` for"
+                f" `FilesystemSqlClient`. Valid values are: {SUPPORTED_PROTOCOLS}"
             )
 
         super().__init__(remote_client, dataset_name, cache_db, persist_secrets=persist_secrets)

--- a/dlt/destinations/impl/lancedb/lancedb_adapter.py
+++ b/dlt/destinations/impl/lancedb/lancedb_adapter.py
@@ -51,7 +51,7 @@ def lancedb_adapter(
             embed = [embed]
         if not isinstance(embed, list):
             raise ValueError(
-                "'embed' must be a list of column names or a single column name as a string."
+                "`embed` must be a list of column names or a single column name as a string."
             )
         column_hints = {}
 
@@ -69,7 +69,7 @@ def lancedb_adapter(
         )
     else:
         raise ValueError(
-            "You must must provide at least either the 'embed' or 'merge_key' or 'remove_orphans'"
+            "You must must provide at least either the `embed` or `merge_key` or `remove_orphans`"
             " argument if using the adapter."
         )
 

--- a/dlt/destinations/impl/lancedb/lancedb_client.py
+++ b/dlt/destinations/impl/lancedb/lancedb_client.py
@@ -217,7 +217,7 @@ def write_records(
                 ).when_matched_update_all().when_not_matched_insert_all().execute(records)
         else:
             raise DestinationTerminalException(
-                f"Unsupported write disposition {write_disposition} for LanceDB Destination - batch"
+                f"Unsupported {write_disposition=:} for LanceDB Destination - batch"
                 " failed AND WILL **NOT** BE RETRIED."
             )
     except ArrowInvalid as e:
@@ -390,7 +390,7 @@ class LanceDBClient(JobClientBase, WithStateSync):
                     if len(merge_key) > 1:
                         raise DestinationTerminalException(
                             "You cannot specify multiple merge keys with LanceDB orphan remove"
-                            f" enabled: {merge_key}"
+                            f" enabled: `{merge_key}`"
                         )
         return loaded_tables
 

--- a/dlt/destinations/impl/lancedb/lancedb_client.py
+++ b/dlt/destinations/impl/lancedb/lancedb_client.py
@@ -217,7 +217,7 @@ def write_records(
                 ).when_matched_update_all().when_not_matched_insert_all().execute(records)
         else:
             raise DestinationTerminalException(
-                f"Unsupported {write_disposition=:} for LanceDB Destination - batch"
+                f"Unsupported `{write_disposition=:}` for LanceDB Destination - batch"
                 " failed AND WILL **NOT** BE RETRIED."
             )
     except ArrowInvalid as e:

--- a/dlt/destinations/impl/mssql/configuration.py
+++ b/dlt/destinations/impl/mssql/configuration.py
@@ -39,7 +39,7 @@ class MsSqlCredentials(ConnectionStringCredentials):
     def on_resolved(self) -> None:
         if self.driver not in self.SUPPORTED_DRIVERS:
             raise SystemConfigurationException(
-                f"""The specified driver "{self.driver}" is not supported."""
+                f"The specified driver `{self.driver}` is not supported."
                 f" Choose one of the supported drivers: {', '.join(self.SUPPORTED_DRIVERS)}."
             )
         self.database = self.database.lower()
@@ -68,7 +68,7 @@ class MsSqlCredentials(ConnectionStringCredentials):
         docs_url = "https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16"
         raise SystemConfigurationException(
             f"No supported ODBC driver found for MS SQL Server.  See {docs_url} for information on"
-            f" how to install the '{self.SUPPORTED_DRIVERS[0]}' on your platform."
+            f" how to install the `{self.SUPPORTED_DRIVERS[0]}` on your platform."
         )
 
     def _get_odbc_dsn_dict(self) -> Dict[str, Any]:

--- a/dlt/destinations/impl/mssql/factory.py
+++ b/dlt/destinations/impl/mssql/factory.py
@@ -65,9 +65,7 @@ class MsSqlTypeMapper(TypeMapperImpl):
             return "int"
         elif precision <= 64:
             return "bigint"
-        raise TerminalValueError(
-            f"bigint with {precision=:} can't be mapped to MSSQL integer type"
-        )
+        raise TerminalValueError(f"bigint with {precision=:} can't be mapped to MSSQL integer type")
 
     def from_destination_type(
         self, db_type: str, precision: Optional[int], scale: Optional[int]

--- a/dlt/destinations/impl/mssql/factory.py
+++ b/dlt/destinations/impl/mssql/factory.py
@@ -66,7 +66,7 @@ class MsSqlTypeMapper(TypeMapperImpl):
         elif precision <= 64:
             return "bigint"
         raise TerminalValueError(
-            f"bigint with {precision} bits precision cannot be mapped into mssql integer type"
+            f"bigint with {precision=:} can't be mapped to MSSQL integer type"
         )
 
     def from_destination_type(

--- a/dlt/destinations/impl/mssql/factory.py
+++ b/dlt/destinations/impl/mssql/factory.py
@@ -65,7 +65,9 @@ class MsSqlTypeMapper(TypeMapperImpl):
             return "int"
         elif precision <= 64:
             return "bigint"
-        raise TerminalValueError(f"bigint with {precision=:} can't be mapped to MSSQL integer type")
+        raise TerminalValueError(
+            f"bigint with `{precision=:}` can't be mapped to MSSQL integer type"
+        )
 
     def from_destination_type(
         self, db_type: str, precision: Optional[int], scale: Optional[int]

--- a/dlt/destinations/impl/postgres/factory.py
+++ b/dlt/destinations/impl/postgres/factory.py
@@ -96,8 +96,8 @@ class PostgresTypeMapper(TypeMapperImpl):
                 timestamp += f" ({precision})"
             else:
                 raise TerminalValueError(
-                    f"Postgres doesn't support {precision=:} for timestamp column `{column_name}` in"
-                    f" table `{table_name}`"
+                    f"Postgres doesn't support {precision=:} for timestamp column `{column_name}`"
+                    f" in table `{table_name}`"
                 )
 
         # append timezone part

--- a/dlt/destinations/impl/postgres/factory.py
+++ b/dlt/destinations/impl/postgres/factory.py
@@ -72,7 +72,7 @@ class PostgresTypeMapper(TypeMapperImpl):
         elif precision <= 64:
             return "bigint"
         raise TerminalValueError(
-            f"bigint with {precision} bits precision cannot be mapped into postgres integer type"
+            f"bigint with {precision=:} can't be mapped to PostgreSQL integer type"
         )
 
     def to_db_datetime_type(
@@ -96,8 +96,8 @@ class PostgresTypeMapper(TypeMapperImpl):
                 timestamp += f" ({precision})"
             else:
                 raise TerminalValueError(
-                    f"Postgres does not support precision '{precision}' for '{column_name}' in"
-                    f" table '{table_name}'"
+                    f"Postgres doesn't support {precision=:} for timestamp column `{column_name}` in"
+                    f" table `{table_name}`"
                 )
 
         # append timezone part

--- a/dlt/destinations/impl/postgres/factory.py
+++ b/dlt/destinations/impl/postgres/factory.py
@@ -72,7 +72,7 @@ class PostgresTypeMapper(TypeMapperImpl):
         elif precision <= 64:
             return "bigint"
         raise TerminalValueError(
-            f"bigint with {precision=:} can't be mapped to PostgreSQL integer type"
+            f"bigint with `{precision=:}` can't be mapped to PostgreSQL integer type"
         )
 
     def to_db_datetime_type(

--- a/dlt/destinations/impl/postgres/postgres.py
+++ b/dlt/destinations/impl/postgres/postgres.py
@@ -113,13 +113,14 @@ class PostgresCsvCopyJob(RunnableLoadJob, HasFollowupJobs):
                         "postgres",
                         "csv",
                         self._file_path,
-                        f"First row `{split_first_row}` has more columns than header `{split_headers}` in"
-                        f" table `{table_name}`",
+                        f"First row `{split_first_row}` has more columns than header"
+                        f" `{split_headers}` in table `{table_name}`",
                     )
                 if len(split_first_row) < len(split_headers):
                     logger.warning(
-                        f"First row {split_first_row} has less columns than header `{split_headers}` in"
-                        f" table `{table_name}`. We will not load data to superfluous columns."
+                        f"First row {split_first_row} has less columns than header"
+                        f" `{split_headers}` in table `{table_name}`. We will not load data to"
+                        " superfluous columns."
                     )
                     split_headers = split_headers[: len(split_first_row)]
                 # stream the first row again

--- a/dlt/destinations/impl/postgres/postgres.py
+++ b/dlt/destinations/impl/postgres/postgres.py
@@ -113,13 +113,13 @@ class PostgresCsvCopyJob(RunnableLoadJob, HasFollowupJobs):
                         "postgres",
                         "csv",
                         self._file_path,
-                        f"First row {split_first_row} has more rows than columns {split_headers} in"
-                        f" table {table_name}",
+                        f"First row `{split_first_row}` has more columns than header `{split_headers}` in"
+                        f" table `{table_name}`",
                     )
                 if len(split_first_row) < len(split_headers):
                     logger.warning(
-                        f"First row {split_first_row} has less rows than columns {split_headers} in"
-                        f" table {table_name}. We will not load data to superfluous columns."
+                        f"First row {split_first_row} has less columns than header `{split_headers}` in"
+                        f" table `{table_name}`. We will not load data to superfluous columns."
                     )
                     split_headers = split_headers[: len(split_first_row)]
                 # stream the first row again

--- a/dlt/destinations/impl/postgres/postgres_adapter.py
+++ b/dlt/destinations/impl/postgres/postgres_adapter.py
@@ -45,7 +45,7 @@ def postgres_adapter(
             geometry = [geometry]
         if not isinstance(geometry, list):
             raise ValueError(
-                "'geometry' must be a list of column names or a single column name as a string."
+                "`geometry` must be a list of column names or a single column name as a string."
             )
 
         for column_name in geometry:
@@ -57,7 +57,7 @@ def postgres_adapter(
                 column_hints[column_name][SRID_HINT] = srid  # type: ignore
 
     if not column_hints:
-        raise ValueError("A value for 'geometry' must be specified.")
+        raise ValueError("A value for `geometry` must be specified.")
     else:
         resource.apply_hints(columns=column_hints)
     return resource

--- a/dlt/destinations/impl/qdrant/qdrant_adapter.py
+++ b/dlt/destinations/impl/qdrant/qdrant_adapter.py
@@ -42,7 +42,7 @@ def qdrant_adapter(
             embed = [embed]
         if not isinstance(embed, list):
             raise ValueError(
-                "embed must be a list of column names or a single column name as a string"
+                "`embed` must be a list of column names or a single column name as a string"
             )
 
         column_hints = {}
@@ -53,7 +53,7 @@ def qdrant_adapter(
             }
 
     if not column_hints:
-        raise ValueError("A value for 'embed' must be specified.")
+        raise ValueError("A value for `embed` must be specified.")
     else:
         resource.apply_hints(columns=column_hints)
 

--- a/dlt/destinations/impl/redshift/factory.py
+++ b/dlt/destinations/impl/redshift/factory.py
@@ -97,7 +97,7 @@ class RedshiftTypeMapper(TypeMapperImpl):
         elif precision <= 64:
             return "bigint"
         raise TerminalValueError(
-            f"bigint with {precision} bits precision cannot be mapped into postgres integer type"
+            f"bigint with {precision=:} can't be mapped to Redshift integer type"
         )
 
     def from_destination_type(

--- a/dlt/destinations/impl/redshift/factory.py
+++ b/dlt/destinations/impl/redshift/factory.py
@@ -97,7 +97,7 @@ class RedshiftTypeMapper(TypeMapperImpl):
         elif precision <= 64:
             return "bigint"
         raise TerminalValueError(
-            f"bigint with {precision=:} can't be mapped to Redshift integer type"
+            f"bigint with `{precision=:}` can't be mapped to Redshift integer type"
         )
 
     def from_destination_type(

--- a/dlt/destinations/impl/redshift/redshift.py
+++ b/dlt/destinations/impl/redshift/redshift.py
@@ -115,7 +115,7 @@ class RedshiftCopyFileLoadJob(CopyRemoteFileLoadJob):
             if table_schema_has_type(self._load_table, "json"):
                 file_type += " SERIALIZETOJSON"
         else:
-            raise ValueError(f"Unsupported file type {ext} for Redshift.")
+            raise ValueError(f"Unsupported file type `{ext}` for Redshift.")
 
         with self._sql_client.begin_transaction():
             # TODO: if we ever support csv here remember to add column names to COPY

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -58,7 +58,8 @@ class SnowflakeCredentials(ConnectionStringCredentials):
                 )
         if not self.password and not self.private_key and not self.authenticator:
             raise ConfigurationValueError(
-                "`SnowflakeCredentials` requires one of the following to be specified: `password`, `private_key`, `authenticator`."
+                "`SnowflakeCredentials` requires one of the following to be specified: `password`,"
+                " `private_key`, `authenticator`."
             )
 
     def get_query(self) -> Dict[str, Any]:

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -53,14 +53,12 @@ class SnowflakeCredentials(ConnectionStringCredentials):
                 self.private_key = Path(self.private_key_path).read_text("ascii")
             except Exception:
                 raise ValueError(
-                    "Make sure that private key in dlt recognized format is at"
-                    f" {self.private_key_path}. Note that binary formats are not supported"
+                    "Make sure that `private_key` in dlt recognized format is at"
+                    f" `{self.private_key_path}`. Note that binary formats are not supported"
                 )
         if not self.password and not self.private_key and not self.authenticator:
             raise ConfigurationValueError(
-                "Please specify password or private_key or authenticator fields."
-                " SnowflakeCredentials supports password, private key and authenticator based (ie."
-                " oauth2) authentication and one of those must be specified."
+                "`SnowflakeCredentials` requires one of the following to be specified: `password`, `private_key`, `authenticator`."
             )
 
     def get_query(self) -> Dict[str, Any]:

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -59,7 +59,7 @@ class SnowflakeCredentials(ConnectionStringCredentials):
         if not self.password and not self.private_key and not self.authenticator:
             raise ConfigurationValueError(
                 "`SnowflakeCredentials` requires one of the following to be specified: `password`,"
-                " `private_key`, `authenticator`."
+                " `private_key`, `authenticator` (OAuth2)."
             )
 
     def get_query(self) -> Dict[str, Any]:

--- a/dlt/destinations/impl/snowflake/factory.py
+++ b/dlt/destinations/impl/snowflake/factory.py
@@ -85,8 +85,8 @@ class SnowflakeTypeMapper(TypeMapperImpl):
                 column_name = column["name"]
                 table_name = table["name"]
                 raise TerminalValueError(
-                    f"Snowflake does not support `{precision=:}` for timestamp column `{column_name}` in"
-                    f" table `{table_name}`"
+                    f"Snowflake does not support `{precision=:}` for timestamp column"
+                    f" `{column_name}` in table `{table_name}`"
                 )
 
         return timestamp

--- a/dlt/destinations/impl/snowflake/factory.py
+++ b/dlt/destinations/impl/snowflake/factory.py
@@ -85,8 +85,8 @@ class SnowflakeTypeMapper(TypeMapperImpl):
                 column_name = column["name"]
                 table_name = table["name"]
                 raise TerminalValueError(
-                    f"Snowflake does not support precision '{precision}' for '{column_name}' in"
-                    f" table '{table_name}'"
+                    f"Snowflake does not support `{precision=:}` for timestamp column `{column_name}` in"
+                    f" table `{table_name}`"
                 )
 
         return timestamp

--- a/dlt/destinations/impl/snowflake/utils.py
+++ b/dlt/destinations/impl/snowflake/utils.py
@@ -110,7 +110,7 @@ def gen_copy_sql(
         else:
             raise LoadJobTerminalException(
                 file_url,
-                f"Cannot load from S3 path {file_url} without either credentials or a stage name.",
+                f"Cannot load from S3 path `{file_url}` without either credentials or a stage name.",
             )
 
     elif parsed_file_url.scheme in AZURE_BLOB_STORAGE_PROTOCOLS:
@@ -127,13 +127,13 @@ def gen_copy_sql(
         else:
             raise LoadJobTerminalException(
                 file_url,
-                f"Cannot load from Azure path {file_url} without either credentials or a stage"
+                f"Cannot load from Azure path `{file_url}` without either credentials or a stage"
                 " name.",
             )
     else:
         raise LoadJobTerminalException(
             file_url,
-            f"Cannot load from bucket path {file_url} without a stage name. See "
+            f"Cannot load from bucket path `{file_url}` without a stage name. See "
             "https://dlthub.com/docs/dlt-ecosystem/destinations/snowflake for "
             "instructions on setting up the `stage_name`",
         )
@@ -180,7 +180,7 @@ def gen_copy_sql(
             f"ENCODING = '{csv_config.encoding}'",
         ]
     else:
-        raise ValueError(f"{loader_file_format} not supported for Snowflake COPY command.")
+        raise ValueError(f"{loader_file_format=:} not supported for Snowflake COPY command.")
 
     source_format = _build_format_clause(format_opts)
 

--- a/dlt/destinations/impl/snowflake/utils.py
+++ b/dlt/destinations/impl/snowflake/utils.py
@@ -181,7 +181,7 @@ def gen_copy_sql(
             f"ENCODING = '{csv_config.encoding}'",
         ]
     else:
-        raise ValueError(f"{loader_file_format=:} not supported for Snowflake COPY command.")
+        raise ValueError(f"`{loader_file_format=:}` not supported for Snowflake COPY command.")
 
     source_format = _build_format_clause(format_opts)
 

--- a/dlt/destinations/impl/snowflake/utils.py
+++ b/dlt/destinations/impl/snowflake/utils.py
@@ -110,7 +110,8 @@ def gen_copy_sql(
         else:
             raise LoadJobTerminalException(
                 file_url,
-                f"Cannot load from S3 path `{file_url}` without either credentials or a stage name.",
+                f"Cannot load from S3 path `{file_url}` without either credentials or a stage"
+                " name.",
             )
 
     elif parsed_file_url.scheme in AZURE_BLOB_STORAGE_PROTOCOLS:

--- a/dlt/destinations/impl/sqlalchemy/type_mapper.py
+++ b/dlt/destinations/impl/sqlalchemy/type_mapper.py
@@ -31,7 +31,7 @@ class SqlalchemyTypeMapper(DataTypeMapper):
             return sa.Integer()
         elif precision <= 64:
             return sa.BigInteger()
-        raise TerminalValueError(f"Unsupported precision for integer type: {precision}")
+        raise TerminalValueError(f"Unsupported {precision=:} for integer type.")
 
     def _create_date_time_type(
         self, sc_t: str, precision: Optional[int], timezone: Optional[bool]
@@ -115,7 +115,7 @@ class SqlalchemyTypeMapper(DataTypeMapper):
             return sa.Date()
         elif sc_t == "time":
             return self._create_date_time_type(sc_t, precision, column.get("timezone"))
-        raise TerminalValueError(f"Unsupported data type: {sc_t}")
+        raise TerminalValueError(f"Unsupported data type: `{sc_t}`")
 
     def _from_db_integer_type(self, db_type: sa.Integer) -> TColumnSchema:
         if isinstance(db_type, sa.SmallInteger):
@@ -161,7 +161,7 @@ class SqlalchemyTypeMapper(DataTypeMapper):
             return dict(data_type="date")
         elif isinstance(db_type, sa.Time):
             return dict(data_type="time")
-        raise TerminalValueError(f"Unsupported db type: {db_type}")
+        raise TerminalValueError(f"Unsupported db type: `{db_type}`")
 
         pass
 

--- a/dlt/destinations/impl/sqlalchemy/type_mapper.py
+++ b/dlt/destinations/impl/sqlalchemy/type_mapper.py
@@ -31,7 +31,7 @@ class SqlalchemyTypeMapper(DataTypeMapper):
             return sa.Integer()
         elif precision <= 64:
             return sa.BigInteger()
-        raise TerminalValueError(f"Unsupported {precision=:} for integer type.")
+        raise TerminalValueError(f"Unsupported `{precision=:}` for integer type.")
 
     def _create_date_time_type(
         self, sc_t: str, precision: Optional[int], timezone: Optional[bool]

--- a/dlt/destinations/impl/synapse/synapse.py
+++ b/dlt/destinations/impl/synapse/synapse.py
@@ -205,7 +205,7 @@ class SynapseCopyFileLoadJob(CopyRemoteFileLoadJob):
             # enabling AUTO_CREATE_TABLE prevents a MalformedInputException.
             auto_create_table = "ON"
         else:
-            raise ValueError(f"Unsupported file type {ext} for Synapse.")
+            raise ValueError(f"Unsupported file type `{ext}` for Synapse.")
 
         staging_credentials = self._staging_credentials
         assert staging_credentials is not None

--- a/dlt/destinations/impl/synapse/synapse_adapter.py
+++ b/dlt/destinations/impl/synapse/synapse_adapter.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal, Set, Final, Dict
 
 from dlt.common.typing import get_args
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.extract import DltResource, resource as make_resource
 from dlt.extract.items import TTableHintTemplate
 from dlt.extract.hints import TResourceHints
@@ -43,11 +44,8 @@ def synapse_adapter(data: Any, table_index_type: TTableIndexType = None) -> DltR
     additional_table_hints: Dict[str, TTableHintTemplate[Any]] = {}
     if table_index_type is not None:
         if table_index_type not in TABLE_INDEX_TYPES:
-            allowed_types = ", ".join(TABLE_INDEX_TYPES)
-            raise ValueError(
-                f"Table index type `{table_index_type}` is invalid. Allowed table index"
-                f" types are: `{allowed_types}`."
-            )
+            raise ValueErrorWithKnownValues("table_index_type", table_index_type, TABLE_INDEX_TYPES)
+
         additional_table_hints[TABLE_INDEX_TYPE_HINT] = table_index_type
     resource.apply_hints(additional_table_hints=additional_table_hints)
     return resource

--- a/dlt/destinations/impl/synapse/synapse_adapter.py
+++ b/dlt/destinations/impl/synapse/synapse_adapter.py
@@ -45,8 +45,8 @@ def synapse_adapter(data: Any, table_index_type: TTableIndexType = None) -> DltR
         if table_index_type not in TABLE_INDEX_TYPES:
             allowed_types = ", ".join(TABLE_INDEX_TYPES)
             raise ValueError(
-                f"Table index type {table_index_type} is invalid. Allowed table index"
-                f" types are: {allowed_types}."
+                f"Table index type `{table_index_type}` is invalid. Allowed table index"
+                f" types are: `{allowed_types}`."
             )
         additional_table_hints[TABLE_INDEX_TYPE_HINT] = table_index_type
     resource.apply_hints(additional_table_hints=additional_table_hints)

--- a/dlt/destinations/impl/weaviate/weaviate_adapter.py
+++ b/dlt/destinations/impl/weaviate/weaviate_adapter.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any, Literal, Set
 
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.common.schema.typing import TTableSchemaColumns
 from dlt.common.typing import TColumnNames, get_args
 from dlt.extract import DltResource, resource as make_resource
@@ -75,11 +76,8 @@ def weaviate_adapter(
     if tokenization:
         for column_name, method in tokenization.items():
             if method not in TOKENIZATION_METHODS:
-                allowed_methods = ", ".join(TOKENIZATION_METHODS)
-                raise ValueError(
-                    f"Tokenization type `{method}` for column `{column_name}` is invalid. Allowed"
-                    f" methods are: `{allowed_methods}`"
-                )
+                raise ValueErrorWithKnownValues("method", method, TOKENIZATION_METHODS)
+
             if column_name in column_hints:
                 column_hints[column_name][TOKENIZATION_HINT] = method  # type: ignore
             else:

--- a/dlt/destinations/impl/weaviate/weaviate_adapter.py
+++ b/dlt/destinations/impl/weaviate/weaviate_adapter.py
@@ -63,7 +63,7 @@ def weaviate_adapter(
             vectorize = [vectorize]
         if not isinstance(vectorize, list):
             raise ValueError(
-                "vectorize must be a list of column names or a single column name as a string"
+                "`vectorize` must be a list of column names or a single column name as a string"
             )
         # create weaviate-specific vectorize hints
         for column_name in vectorize:
@@ -77,8 +77,8 @@ def weaviate_adapter(
             if method not in TOKENIZATION_METHODS:
                 allowed_methods = ", ".join(TOKENIZATION_METHODS)
                 raise ValueError(
-                    f"Tokenization type {method} for column {column_name} is invalid. Allowed"
-                    f" methods are: {allowed_methods}"
+                    f"Tokenization type `{method}` for column `{column_name}` is invalid. Allowed"
+                    f" methods are: `{allowed_methods}`"
                 )
             if column_name in column_hints:
                 column_hints[column_name][TOKENIZATION_HINT] = method  # type: ignore

--- a/dlt/destinations/impl/weaviate/weaviate_client.py
+++ b/dlt/destinations/impl/weaviate/weaviate_client.py
@@ -113,12 +113,12 @@ def wrap_grpc_error(f: TFun) -> TFun:
             # TODO: actually put the job in failed/retry state and prepare exception message with full info on failing item
             if "invalid" in message and "property" in message and "on class" in message:
                 raise DestinationTerminalException(
-                    f"Grpc (batch, query) failed {errors} AND WILL **NOT** BE RETRIED"
+                    f"Grpc (batch, query) failed `{errors}` AND WILL **NOT** BE RETRIED"
                 )
             if "conflict for property" in message:
                 raise PropertyNameConflict(message)
             raise DestinationTransientException(
-                f"Grpc (batch, query) failed {errors} AND WILL BE RETRIED"
+                f"Grpc (batch, query) failed `{errors}` AND WILL BE RETRIED"
             )
         except Exception:
             raise DestinationTransientException("Batch failed AND WILL BE RETRIED")
@@ -596,7 +596,7 @@ class WeaviateClient(JobClientBase, WithStateSync):
         full_class_name = self.make_qualified_class_name(table_name)
         records = response["data"]["Get"][full_class_name]
         if records is None:
-            raise DestinationTransientException(f"Could not obtain records for {full_class_name}")
+            raise DestinationTransientException(f"Could not obtain records for `{full_class_name}`")
         return cast(List[Dict[str, Any]], records)
 
     def make_weaviate_class_schema(self, table_name: str) -> Dict[str, Any]:

--- a/dlt/destinations/path_utils.py
+++ b/dlt/destinations/path_utils.py
@@ -223,7 +223,7 @@ def create_path(
     if callable(current_datetime):
         current_datetime = current_datetime()
         if not isinstance(current_datetime, pendulum.DateTime):
-            raise RuntimeError("current_datetime is not an instance instance of pendulum.DateTime")
+            raise RuntimeError("`current_datetime` is not an instance of `pendulum.DateTime`")
 
     job_info = ParsedLoadJobFileName.parse(file_name)
     params = prepare_params(

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -466,7 +466,7 @@ class SqlMergeFollowupJob(SqlFollowupJob):
                 sql_client.fully_qualified_dataset_name(staging=True),
                 [t["name"] for t in table_chain],
                 f"Multiple primary key columns found in table `{table['name']}`. "
-                "Cannot use as row_key.",
+                "Cannot use as `row_key`.",
             )
 
         raise MergeDispositionException(

--- a/dlt/destinations/type_mapping.py
+++ b/dlt/destinations/type_mapping.py
@@ -12,6 +12,8 @@ from dlt.common.typing import TLoaderFileFormat
 from dlt.common.utils import without_none
 
 
+# NOTE it seems that multiple methods pass `table` only for logging/exception purposes
+# should refactor to remove `table` kwarg and have callers catch exceptions
 class TypeMapperImpl(DataTypeMapper):
     sct_to_unbound_dbt: Dict[TDataType, str]
     """Data types without precision or scale specified (e.g. `"text": "varchar"` in postgres)"""

--- a/dlt/destinations/utils.py
+++ b/dlt/destinations/utils.py
@@ -41,9 +41,10 @@ def get_resource_for_adapter(data: Any) -> DltResource:
         if len(data.selected_resources.keys()) == 1:
             return list(data.selected_resources.values())[0]
         else:
-             ValueError(
+            ValueError(
                 "You are trying to use an adapter on a `DltSource` with multiple resources. You can"
-                " only use adapters on: pure data, a `DltResouce` or a `DltSource` with a single `DltResource`."
+                " only use adapters on: pure data, a `DltResouce` or a `DltSource` with a single"
+                " `DltResource`."
             )
 
     resource_name = None

--- a/dlt/destinations/utils.py
+++ b/dlt/destinations/utils.py
@@ -41,7 +41,7 @@ def get_resource_for_adapter(data: Any) -> DltResource:
         if len(data.selected_resources.keys()) == 1:
             return list(data.selected_resources.values())[0]
         else:
-            ValueError(
+            raise ValueError(
                 "You are trying to use an adapter on a `DltSource` with multiple resources. You can"
                 " only use adapters on: pure data, a `DltResouce` or a `DltSource` with a single"
                 " `DltResource`."

--- a/dlt/destinations/utils.py
+++ b/dlt/destinations/utils.py
@@ -41,10 +41,9 @@ def get_resource_for_adapter(data: Any) -> DltResource:
         if len(data.selected_resources.keys()) == 1:
             return list(data.selected_resources.values())[0]
         else:
-            raise ValueError(
-                "You are trying to use an adapter on a DltSource with multiple resources. You can"
-                " only use adapters on pure data, directly on a DltResouce or a DltSource"
-                " containing a single DltResource."
+             ValueError(
+                "You are trying to use an adapter on a `DltSource` with multiple resources. You can"
+                " only use adapters on: pure data, a `DltResouce` or a `DltSource` with a single `DltResource`."
             )
 
     resource_name = None

--- a/dlt/extract/concurrency.py
+++ b/dlt/extract/concurrency.py
@@ -113,7 +113,7 @@ class FuturesPool:
         elif callable(item):
             future = self._ensure_thread_pool().submit(item)
         else:
-            raise ValueError(f"Unsupported item type: {type(item)}")
+            raise ValueError(f"Unsupported item type: `{type(item)}`")
 
         # Future is not removed from self.futures until it's been consumed by the
         # pipe iterator. But we always want to vacate a slot so new jobs can be submitted

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -427,7 +427,7 @@ def source(
     """
     if name and schema:
         raise ArgumentsOverloadException(
-            "'name' has no effect when `schema` argument is present", source.__name__
+            "`name` has no effect when `schema` argument is present", source.__name__
         )
 
     source_wrapper = (

--- a/dlt/extract/exceptions.py
+++ b/dlt/extract/exceptions.py
@@ -77,8 +77,8 @@ class ResourceExtractionError(PipeException):
         )
         super().__init__(
             pipe_name,
-            f"extraction of resource `{pipe_name}` in `{kind}` `{self.func_name}` caused an exception:"
-            f" {msg}",
+            f"extraction of resource `{pipe_name}` in `{kind}` `{self.func_name}` caused an"
+            f" exception: {msg}",
         )
 
 
@@ -149,7 +149,8 @@ class InvalidParallelResourceDataType(InvalidResourceDataType):
             resource_name,
             item,
             _typ,
-            f"Parallel resource data must be a generator or a generator function. Resource `{resource_name}` received data type `{_typ.__name__}`",
+            "Parallel resource data must be a generator or a generator function. Resource"
+            f" `{resource_name}` received data type `{_typ.__name__}`",
         )
 
 
@@ -159,9 +160,9 @@ class InvalidResourceDataTypeBasic(InvalidResourceDataType):
             resource_name,
             item,
             _typ,
-            f"Resources cannot be strings or dictionaries but type `{_typ.__name__}` was provided. Please"
-            " pass your data in a list or as a function yielding items. If you want to process"
-            " just one data item, enclose it in a list.",
+            f"Resources cannot be strings or dictionaries but type `{_typ.__name__}` was provided."
+            " Please pass your data in a list or as a function yielding items. If you want to"
+            " process just one data item, enclose it in a list.",
         )
 
 
@@ -245,8 +246,8 @@ class InvalidParentResourceDataType(InvalidResourceDataType):
             resource_name,
             item,
             _typ,
-            f"A parent resource of `{resource_name}` is of type `{_typ.__name__}`. Did you forget to"
-            " use `@dlt.resource` decorator or `resource` function?",
+            f"A parent resource of `{resource_name}` is of type `{_typ.__name__}`. Did you forget"
+            " to use `@dlt.resource` decorator or `resource` function?",
         )
 
 
@@ -262,7 +263,9 @@ class InvalidParentResourceIsAFunction(DltResourceException):
 
 class DeletingResourcesNotSupported(DltResourceException):
     def __init__(self, source_name: str, resource_name: str) -> None:
-        super().__init__(resource_name, f"Resource cannot be removed the the source `{source_name}`")
+        super().__init__(
+            resource_name, f"Resource cannot be removed the the source `{source_name}`"
+        )
 
 
 class ParametrizedResourceUnbound(DltResourceException):
@@ -272,8 +275,8 @@ class ParametrizedResourceUnbound(DltResourceException):
         self.func_name = func_name
         self.sig = sig
         msg = (
-            f"The `{kind}` `{resource_name}` is parametrized and expects following arguments: {sig}."
-            f" Did you forget to bind the {func_name} function? For example from"
+            f"The `{kind}` `{resource_name}` is parametrized and expects following arguments:"
+            f" {sig}. Did you forget to bind the {func_name} function? For example from"
             f" `source.{resource_name}.bind(...)`"
         )
         if error:
@@ -296,8 +299,10 @@ class DataItemRequiredForDynamicTableHints(DltResourceException):
     def __init__(self, resource_name: str) -> None:
         super().__init__(
             resource_name,
-            f"An instance of resource's data required to generate table schema in resource `{resource_name}`. "
-            "One of table hints for that resource (typically table name) is a function and hint is computed separately for each instance of data extracted from that resource."
+            "An instance of resource's data required to generate table schema in resource"
+            f" `{resource_name}`. One of table hints for that resource (typically table name) is a"
+            " function and hint is computed separately for each instance of data extracted from"
+            " that resource.",
         )
 
 
@@ -314,8 +319,8 @@ class SourceExhausted(DltSourceException):
     def __init__(self, source_name: str) -> None:
         self.source_name = source_name
         super().__init__(
-            f"Source `{source_name}` is exhausted or has active iterator. You can iterate or pass the"
-            " source to dlt pipeline only once."
+            f"Source `{source_name}` is exhausted or has active iterator. You can iterate or pass"
+            " the source to dlt pipeline only once."
         )
 
 
@@ -351,8 +356,8 @@ class SourceIsAClassTypeError(DltSourceException):
         self.typ = _typ
         super().__init__(
             f"First parameter to the source `{source_name}` is a class `{_typ.__name__}`. Do not"
-            " decorate classes with `@dlt.source`. Instead implement `.__call__()` in your class and pass"
-            " instance of such class to `dlt.source()` directly"
+            " decorate classes with `@dlt.source`. Instead implement `.__call__()` in your class"
+            " and pass instance of such class to `dlt.source()` directly"
         )
 
 
@@ -414,9 +419,9 @@ class IncrementalUnboundError(DltResourceException):
     def __init__(self, cursor_path: str) -> None:
         super().__init__(
             "",
-            f"The incremental definition with `{cursor_path=:}` is used without being bound"
-            " to the resource. This most often happens when you create dynamic resource from a"
-            " generator function that uses incremental. See"
+            f"The incremental definition with `{cursor_path=:}` is used without being bound to the"
+            " resource. This most often happens when you create dynamic resource from a generator"
+            " function that uses incremental. See"
             " https://dlthub.com/docs/general-usage/incremental-loading#incremental-loading-with-last-value"
             " for an example.",
         )

--- a/dlt/extract/exceptions.py
+++ b/dlt/extract/exceptions.py
@@ -25,7 +25,7 @@ class DltResourceException(DltSourceException):
 class PipeException(DltException):
     def __init__(self, pipe_name: str, msg: str) -> None:
         self.pipe_name = pipe_name
-        msg = f"In processing pipe {pipe_name}: " + msg
+        msg = f"In processing pipe `{pipe_name}`: " + msg
         super().__init__(msg)
 
 
@@ -45,8 +45,8 @@ class PipeNotBoundToData(PipeException):
         self.has_parent = has_parent
         if has_parent:
             msg = (
-                f"A pipe created from transformer {pipe_name} is unbound or its parent is unbound"
-                " or empty. Provide a resource in `data_from` argument or bind resources with |"
+                f"A pipe created from transformer `{pipe_name}` is unbound or its parent is unbound"
+                " or empty. Provide a resource in `data_from` argument or bind resources with `|`"
                 " operator."
             )
         else:
@@ -60,9 +60,9 @@ class InvalidStepFunctionArguments(PipeException):
         self.sig = sig
         super().__init__(
             pipe_name,
-            f"Unable to call {func_name}: {call_error}. The mapping/filtering function"
-            f" {func_name} requires first argument to take data item and optional second argument"
-            f" named 'meta', but the signature is {sig}",
+            f"Unable to call `{func_name}`: {call_error}. The mapping/filtering function"
+            f" `{func_name}` requires first argument to take data item and optional second argument"
+            f" named 'meta', but the signature is `{sig}`",
         )
 
 
@@ -77,7 +77,7 @@ class ResourceExtractionError(PipeException):
         )
         super().__init__(
             pipe_name,
-            f"extraction of resource {pipe_name} in {kind} {self.func_name} caused an exception:"
+            f"extraction of resource `{pipe_name}` in `{kind}` `{self.func_name}` caused an exception:"
             f" {msg}",
         )
 
@@ -107,8 +107,8 @@ class UnclosablePipe(PipeException):
     def __init__(self, pipe_name: str, gen: Any) -> None:
         type_name = str(type(gen))
         if gen_name := getattr(gen, "__name__", None):
-            type_name = f"{type_name} ({gen_name})"
-        msg = f"Pipe with gen of type {type_name} cannot be closed."
+            type_name = f"`{type_name}` ({gen_name})"
+        msg = f"Pipe with gen of type `{type_name}` cannot be closed."
         if callable(gen) and isgeneratorfunction(gen):
             msg += " Closing of partially evaluated transformers is not yet supported."
         super().__init__(pipe_name, msg)
@@ -127,7 +127,7 @@ class ResourceNotFoundError(DltResourceException, KeyError):
     def __init__(self, resource_name: str, context: str) -> None:
         self.resource_name = resource_name
         super().__init__(
-            resource_name, f"Resource with a name {resource_name} could not be found. {context}"
+            resource_name, f"Resource with `{resource_name=:}` could not be found: {context}"
         )
 
 
@@ -137,7 +137,7 @@ class InvalidResourceDataType(DltResourceException):
         self._typ = _typ
         super().__init__(
             resource_name,
-            f"Cannot create resource {resource_name} from specified data. If you want to process"
+            f"Cannot create resource `{resource_name}` from specified data. If you want to process"
             " just one data item, enclose it in a list. "
             + msg,
         )
@@ -149,8 +149,7 @@ class InvalidParallelResourceDataType(InvalidResourceDataType):
             resource_name,
             item,
             _typ,
-            "Parallel resource data must be a generator or a generator function. The provided"
-            f" data type for resource '{resource_name}' was {_typ.__name__}.",
+            f"Parallel resource data must be a generator or a generator function. Resource `{resource_name}` received data type `{_typ.__name__}`",
         )
 
 
@@ -160,7 +159,7 @@ class InvalidResourceDataTypeBasic(InvalidResourceDataType):
             resource_name,
             item,
             _typ,
-            f"Resources cannot be strings or dictionaries but {_typ.__name__} was provided. Please"
+            f"Resources cannot be strings or dictionaries but type `{_typ.__name__}` was provided. Please"
             " pass your data in a list or as a function yielding items. If you want to process"
             " just one data item, enclose it in a list.",
         )
@@ -194,13 +193,13 @@ class InvalidTransformerGeneratorFunction(DltResourceException):
         self.func_name = func_name
         self.sig = sig
         self.code = code
-        msg = f"Transformer function {func_name} must take data item as its first argument. "
+        msg = f"Transformer function `{func_name}` must take data item as its first argument. "
         if code == 1:
             msg += "The actual function does not take any arguments."
         elif code == 2:
-            msg += f"Only the first argument may be 'positional only', actual signature is {sig}"
+            msg += f"Only the first argument may be 'positional only', actual signature is `{sig}`"
         elif code == 3:
-            msg += f"The first argument cannot be keyword only, actual signature is {sig}"
+            msg += f"The first argument cannot be keyword only, actual signature is `{sig}`"
 
         super().__init__(resource_name, msg)
 
@@ -224,7 +223,7 @@ class InvalidResourceReturnsResource(InvalidResourceDataType):
             _typ,
             "Resource returned another resource but the signature of the resource function is "
             "missing a correct type annotation (DltResource or derived class). Please annotate "
-            f"function {item} correctly."
+            f"function `{item}` correctly."
             "",
         )
 
@@ -235,8 +234,8 @@ class ResourceFunctionExpected(InvalidResourceDataType):
             resource_name,
             item,
             _typ,
-            f"Expected function or callable as first parameter to resource {resource_name} but"
-            f" {_typ.__name__} found. Please decorate a function with @dlt.resource",
+            f"Expected function or callable as first parameter to resource `{resource_name}` but"
+            f" type `{_typ.__name__}` found. Please decorate a function with `@dlt.resource`",
         )
 
 
@@ -246,8 +245,8 @@ class InvalidParentResourceDataType(InvalidResourceDataType):
             resource_name,
             item,
             _typ,
-            f"A parent resource of {resource_name} is of type {_typ.__name__}. Did you forget to"
-            " use '@dlt.resource` decorator or `resource` function?",
+            f"A parent resource of `{resource_name}` is of type `{_typ.__name__}`. Did you forget to"
+            " use `@dlt.resource` decorator or `resource` function?",
         )
 
 
@@ -256,14 +255,14 @@ class InvalidParentResourceIsAFunction(DltResourceException):
         self.func_name = func_name
         super().__init__(
             resource_name,
-            f"A data source {func_name} of a transformer {resource_name} is an undecorated"
-            " function. Please decorate it with '@dlt.resource' or pass to 'resource' function.",
+            f"A data source `{func_name}` of a transformer `{resource_name}` is an undecorated"
+            " function. Please decorate it with `@dlt.resource` or pass to `resource` function.",
         )
 
 
 class DeletingResourcesNotSupported(DltResourceException):
     def __init__(self, source_name: str, resource_name: str) -> None:
-        super().__init__(resource_name, f"Resource cannot be removed the the source {source_name}")
+        super().__init__(resource_name, f"Resource cannot be removed the the source `{source_name}`")
 
 
 class ParametrizedResourceUnbound(DltResourceException):
@@ -273,9 +272,9 @@ class ParametrizedResourceUnbound(DltResourceException):
         self.func_name = func_name
         self.sig = sig
         msg = (
-            f"The {kind} {resource_name} is parametrized and expects following arguments: {sig}."
+            f"The `{kind}` `{resource_name}` is parametrized and expects following arguments: {sig}."
             f" Did you forget to bind the {func_name} function? For example from"
-            f" `source.{resource_name}.bind(...)"
+            f" `source.{resource_name}.bind(...)`"
         )
         if error:
             msg += f" .Details: {error}"
@@ -297,8 +296,8 @@ class DataItemRequiredForDynamicTableHints(DltResourceException):
     def __init__(self, resource_name: str) -> None:
         super().__init__(
             resource_name,
-            f"""An instance of resource's data required to generate table schema in resource {resource_name}.
-        One of table hints for that resource (typically table name) is a function and hint is computed separately for each instance of data extracted from that resource.""",
+            f"An instance of resource's data required to generate table schema in resource `{resource_name}`. "
+            "One of table hints for that resource (typically table name) is a function and hint is computed separately for each instance of data extracted from that resource."
         )
 
 
@@ -306,7 +305,7 @@ class SourceDataIsNone(DltSourceException):
     def __init__(self, source_name: str) -> None:
         self.source_name = source_name
         super().__init__(
-            f"No data returned or yielded from source function {source_name}. Did you forget the"
+            f"No data returned or yielded from source function `{source_name}`. Did you forget the"
             " return statement?"
         )
 
@@ -315,7 +314,7 @@ class SourceExhausted(DltSourceException):
     def __init__(self, source_name: str) -> None:
         self.source_name = source_name
         super().__init__(
-            f"Source {source_name} is exhausted or has active iterator. You can iterate or pass the"
+            f"Source `{source_name}` is exhausted or has active iterator. You can iterate or pass the"
             " source to dlt pipeline only once."
         )
 
@@ -329,7 +328,7 @@ class ResourcesNotFoundError(DltSourceException):
         self.requested_resources = requested_resources
         self.not_found_resources = requested_resources.difference(available_resources)
         msg = (
-            f"The following resources could not be found in source {source_name}:"
+            f"The following resources could not be found in source `{source_name}`:"
             f" {self.not_found_resources}. Available resources are: {available_resources}"
         )
         super().__init__(msg)
@@ -341,8 +340,8 @@ class SourceNotAFunction(DltSourceException):
         self.item = item
         self.typ = _typ
         super().__init__(
-            f"First parameter to the source {source_name} must be a function or callable but is"
-            f" {_typ.__name__}. Please decorate a function with @dlt.source"
+            f"First parameter to the source `{source_name}` must be a function or callable but is"
+            f" type `{_typ.__name__}`. Please decorate a function with @dlt.source"
         )
 
 
@@ -351,9 +350,9 @@ class SourceIsAClassTypeError(DltSourceException):
         self.source_name = source_name
         self.typ = _typ
         super().__init__(
-            f"First parameter to the source {source_name} is a class {_typ.__name__}. Do not"
-            " decorate classes with @dlt.source. Instead implement __call__ in your class and pass"
-            " instance of such class to dlt.source() directly"
+            f"First parameter to the source `{source_name}` is a class `{_typ.__name__}`. Do not"
+            " decorate classes with `@dlt.source`. Instead implement `.__call__()` in your class and pass"
+            " instance of such class to `dlt.source()` directly"
         )
 
 
@@ -378,8 +377,7 @@ class ExplicitSourceNameInvalid(DltSourceException):
         self.source_name = source_name
         self.schema_name = schema_name
         super().__init__(
-            f"Your explicit source name {source_name} does not match explicit schema name"
-            f" '{schema_name}'."
+            f"Your explicit `{source_name=:}` does not match explicit `{schema_name=:}`"
         )
 
 
@@ -392,7 +390,7 @@ class UnknownSourceReference(ReferenceImportError, DltSourceException, KeyError)
         super().__init__(traces=traces)
 
     def __str__(self) -> str:
-        msg = f"{self.ref} is not one of already registered sources. "
+        msg = f"`{self.ref}` is not one of already registered sources. "
         if len(self.qualified_refs) == 1 and self.qualified_refs[0] == self.ref:
             pass
         else:
@@ -408,7 +406,7 @@ class UnknownSourceReference(ReferenceImportError, DltSourceException, KeyError)
 class InvalidSourceReference(DltSourceException):
     def __init__(self, ref: str) -> None:
         self.ref = ref
-        msg = f"Destination reference {ref} has invalid format."
+        msg = f"Destination reference `{ref}` has invalid format."
         super().__init__(msg)
 
 
@@ -416,7 +414,7 @@ class IncrementalUnboundError(DltResourceException):
     def __init__(self, cursor_path: str) -> None:
         super().__init__(
             "",
-            f"The incremental definition with cursor path {cursor_path} is used without being bound"
+            f"The incremental definition with `{cursor_path=:}` is used without being bound"
             " to the resource. This most often happens when you create dynamic resource from a"
             " generator function that uses incremental. See"
             " https://dlthub.com/docs/general-usage/incremental-loading#incremental-loading-with-last-value"

--- a/dlt/extract/exceptions.py
+++ b/dlt/extract/exceptions.py
@@ -62,7 +62,7 @@ class InvalidStepFunctionArguments(PipeException):
             pipe_name,
             f"Unable to call `{func_name}`: {call_error}. The mapping/filtering function"
             f" `{func_name}` requires first argument to take data item and optional second argument"
-            f" named 'meta', but the signature is `{sig}`",
+            f" named `meta`, but the signature is `{sig}`",
         )
 
 
@@ -276,7 +276,7 @@ class ParametrizedResourceUnbound(DltResourceException):
         self.sig = sig
         msg = (
             f"The `{kind}` `{resource_name}` is parametrized and expects following arguments:"
-            f" {sig}. Did you forget to bind the {func_name} function? For example from"
+            f" `{sig}`. Did you forget to bind the `{func_name}` function? For example from"
             f" `source.{resource_name}.bind(...)`"
         )
         if error:
@@ -299,10 +299,10 @@ class DataItemRequiredForDynamicTableHints(DltResourceException):
     def __init__(self, resource_name: str) -> None:
         super().__init__(
             resource_name,
-            "An instance of resource's data required to generate table schema in resource"
-            f" `{resource_name}`. One of table hints for that resource (typically table name) is a"
-            " function and hint is computed separately for each instance of data extracted from"
-            " that resource.",
+            "Resource `{resource_name}` contains a dynamic hint (i.e., a value in the"
+            " `@dlt.resource` decorator is set by a function), but the data to generate the hint is"
+            " missing. Make sure that each data item contains the necessary field to compute the"
+            " dynamic hint value.",
         )
 
 

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -124,7 +124,7 @@ class SqlModel(NamedTuple):
 
         # Ensure the parsed query is a SELECT statement
         if not isinstance(parsed_query, sqlglot.exp.Select):
-            raise ValueError("Only SELECT statements are allowed to create a SqlModel.")
+            raise ValueError("Only SELECT statements are allowed to create a `SqlModel`.")
 
         normalized_query = parsed_query.sql(dialect=dialect)
         return cls(query=normalized_query, dialect=dialect)
@@ -453,8 +453,7 @@ class DltResourceHints:
         if create_table_variant:
             if not isinstance(table_name, str):
                 raise ValueError(
-                    "Please provide string table name if you want to create a table variant of"
-                    " hints"
+                    "Please provide `str` table name if you want to create a table variant of hints"
                 )
             # select hints variant
             t = self._hints_variants.get(table_name, None)
@@ -592,20 +591,20 @@ class DltResourceHints:
             # incremental cannot be specified in variant
             if hints_template.get("incremental"):
                 raise InconsistentTableTemplate(
-                    f"You can specify incremental only for the resource `{self.name}` hints, not in"
+                    f"You can specify `incremental` only for the resource `{self.name}` hints, not in"
                     f" table `{table_name}` variant-"
                 )
             if hints_template.get("validator"):
                 logger.warning(
-                    f"A data item validator was created from column schema in {self.name} for a"
+                    f"A data item validator was created from column schema in `{self.name}` for a"
                     f" table `{table_name}` variant. Currently such validator is ignored."
                 )
             # dynamic hints will be ignored
             for name, hint in hints_template.items():
                 if callable(hint) and name not in NATURAL_CALLABLES:
                     raise InconsistentTableTemplate(
-                        f"Table `{table_name}` variant hint is resource {self.name} cannot have"
-                        f" dynamic hint but {name} does."
+                        f"Table `{table_name}` variant hint is resource `{self.name}` can't have"
+                        f" dynamic hint but `{name}` does."
                     )
             self._hints_variants[table_name] = hints_template
         else:
@@ -777,7 +776,7 @@ class DltResourceHints:
             callable(v) for k, v in template.items() if k not in ["table_name", *NATURAL_CALLABLES]
         ) and not callable(table_name):
             raise InconsistentTableTemplate(
-                f"Table name {table_name} must be a function if any other table hint is a function"
+                f"Table name `{table_name}` must be a function if any other table hint is a function"
             )
 
     @staticmethod
@@ -804,7 +803,7 @@ class DltResourceHints:
                             ensure_pendulum_datetime(wd[ts])  # type: ignore[literal-required]
                         except Exception:
                             raise ValueError(
-                                f'could not parse `{ts}` value "{wd[ts]}"'  # type: ignore[literal-required]
+                                f'could not parse `{ts}` value `{wd[ts]}`'  # type: ignore[literal-required]
                             )
 
     @staticmethod

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -29,7 +29,7 @@ from dlt.common.schema.typing import (
     MERGE_STRATEGIES,
     TTableReferenceParam,
 )
-
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.common.typing import TTableNames, TypedDict, Unpack
 from dlt.common.schema.utils import (
     DEFAULT_WRITE_DISPOSITION,
@@ -591,8 +591,8 @@ class DltResourceHints:
             # incremental cannot be specified in variant
             if hints_template.get("incremental"):
                 raise InconsistentTableTemplate(
-                    f"You can specify `incremental` only for the resource `{self.name}` hints, not in"
-                    f" table `{table_name}` variant-"
+                    f"You can specify `incremental` only for the resource `{self.name}` hints, not"
+                    f" in table `{table_name}` variant-"
                 )
             if hints_template.get("validator"):
                 logger.warning(
@@ -776,7 +776,8 @@ class DltResourceHints:
             callable(v) for k, v in template.items() if k not in ["table_name", *NATURAL_CALLABLES]
         ) and not callable(table_name):
             raise InconsistentTableTemplate(
-                f"Table name `{table_name}` must be a function if any other table hint is a function"
+                f"Table name `{table_name}` must be a function if any other table hint is a"
+                " function"
             )
 
     @staticmethod
@@ -785,9 +786,8 @@ class DltResourceHints:
         if isinstance(wd, dict) and wd["disposition"] == "merge":
             wd = cast(TMergeDispositionDict, wd)
             if "strategy" in wd and wd["strategy"] not in MERGE_STRATEGIES:
-                raise ValueError(
-                    f'`{wd["strategy"]}` is not a valid merge strategy. '
-                    f"""Allowed values: {', '.join(['"' + s + '"' for s in MERGE_STRATEGIES])}."""
+                raise ValueErrorWithKnownValues(
+                    "write_disposition['strategy']", wd["strategy"], MERGE_STRATEGIES
                 )
 
             if wd.get("strategy") == "scd2":
@@ -803,7 +803,7 @@ class DltResourceHints:
                             ensure_pendulum_datetime(wd[ts])  # type: ignore[literal-required]
                         except Exception:
                             raise ValueError(
-                                f'could not parse `{ts}` value `{wd[ts]}`'  # type: ignore[literal-required]
+                                f"could not parse `{ts}` value `{wd[ts]}`"  # type: ignore[literal-required]
                             )
 
     @staticmethod

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -6,7 +6,7 @@ import inspect
 from functools import wraps
 
 from dlt.common import logger
-from dlt.common.exceptions import MissingDependencyException
+from dlt.common.exceptions import MissingDependencyException, ValueErrorWithKnownValues
 from dlt.common.pendulum import pendulum
 from dlt.common.jsonpath import compile_path, extract_simple_field_name
 from dlt.common.typing import (
@@ -154,7 +154,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
                 last_value_func = max
             else:
                 raise ValueError(
-                    f"Unknown `last_value_func={last_value_func}` passed as string. Provide a"
+                    f"Unknown `{last_value_func=:}` passed as string. Provide a"
                     " callable to use a custom function."
                 )
         self.last_value_func = last_value_func
@@ -168,10 +168,10 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         self.row_order = row_order
         self.allow_external_schedulers = allow_external_schedulers
         if on_cursor_value_missing not in ["raise", "include", "exclude"]:
-            raise ValueError(
-                f"Invalid value `on_cursor_value_missing={on_cursor_value_missing}`. "
-                "Valid values: ['raise', 'include', 'exclude']"
+            raise ValueErrorWithKnownValues(
+                "on_cursor_value_missing", on_cursor_value_missing, ["raise", "include", "exclude"]
             )
+
         self.on_cursor_value_missing = on_cursor_value_missing
 
         self._cached_state: IncrementalColumnState = None
@@ -285,7 +285,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
                 msg = (
                     f"Incremental `initial_value={self.initial_value}` is greater than"
                     f" `end_value={self.end_value}` as determined by the custom `last_value_func`."
-                    f" The result of '{self.last_value_func.__name__}(`[end_value, initial_value]`)' must equal `end_value`"
+                    f" The result of '{self.last_value_func.__name__}(`[end_value,"
+                    " initial_value]`)' must equal `end_value`"
                 )
             raise ConfigurationValueError(msg)
 

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -154,7 +154,7 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
                 last_value_func = max
             else:
                 raise ValueError(
-                    f"Unknown last_value_func '{last_value_func}' passed as string. Provide a"
+                    f"Unknown `last_value_func={last_value_func}` passed as string. Provide a"
                     " callable to use a custom function."
                 )
         self.last_value_func = last_value_func
@@ -169,7 +169,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         self.allow_external_schedulers = allow_external_schedulers
         if on_cursor_value_missing not in ["raise", "include", "exclude"]:
             raise ValueError(
-                f"Unexpected argument for on_cursor_value_missing. Got {on_cursor_value_missing}"
+                f"Invalid value `on_cursor_value_missing={on_cursor_value_missing}`. "
+                "Valid values: ['raise', 'include', 'exclude']"
             )
         self.on_cursor_value_missing = on_cursor_value_missing
 
@@ -263,8 +264,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
         compile_path(self.cursor_path)
         if self.end_value is not None and self.initial_value is None:
             raise ConfigurationValueError(
-                "Incremental 'end_value' was specified without 'initial_value'. 'initial_value' is"
-                " required when using 'end_value'."
+                "Incremental `end_value` was specified without `initial_value`."
+                "`initial_value` is required when using `end_value`."
             )
         self._cursor_datetime_check(self.initial_value, "initial_value")
         self._cursor_datetime_check(self.initial_value, "end_value")
@@ -276,17 +277,15 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
             if self.last_value_func in (min, max):
                 adject = "higher" if self.last_value_func is max else "lower"
                 msg = (
-                    f"Incremental 'initial_value' ({self.initial_value}) is {adject} than"
-                    f" 'end_value` ({self.end_value}). 'end_value' must be {adject} than"
-                    " 'initial_value'"
+                    f"Incremental `initial_value={self.initial_value}` is {adject} than"
+                    f" `end_value={self.end_value}`. 'end_value' must be {adject} than"
+                    " `initial_value`."
                 )
             else:
                 msg = (
-                    f"Incremental 'initial_value' ({self.initial_value}) is greater than"
-                    f" 'end_value' ({self.end_value}) as determined by the custom"
-                    " 'last_value_func'. The result of"
-                    f" '{self.last_value_func.__name__}([end_value, initial_value])' must equal"
-                    " 'end_value'"
+                    f"Incremental `initial_value={self.initial_value}` is greater than"
+                    f" `end_value={self.end_value}` as determined by the custom `last_value_func`."
+                    f" The result of '{self.last_value_func.__name__}(`[end_value, initial_value]`)' must equal `end_value`"
                 )
             raise ConfigurationValueError(msg)
 
@@ -296,8 +295,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
                 raise ValueError("Trying to resolve EMPTY Incremental")
             if native_value is self.EMPTY:
                 raise ValueError(
-                    "Do not use EMPTY Incremental as default or explicit values. Pass None to reset"
-                    " an incremental."
+                    "Do not use `EMPTY` Incremental as default or explicit values. "
+                    "Pass `None` to reset an incremental."
                 )
             merged = self.merge(native_value)
             self.cursor_path = merged.cursor_path
@@ -695,8 +694,8 @@ class IncrementalResourceWrapper(ItemTransform[TDataItem]):
                 explicit_value = bound_args.arguments[p.name]
                 if explicit_value is Incremental.EMPTY or p.default is Incremental.EMPTY:
                     raise ValueError(
-                        "Do not use EMPTY Incremental as default or explicit values. Pass None to"
-                        " reset an incremental."
+                        "Do not use `EMPTY` Incremental as default or explicit values. "
+                        "Pass `None` to reset an incremental."
                     )
                 elif isinstance(explicit_value, Incremental):
                     # Explicit Incremental instance is merged with default
@@ -717,8 +716,8 @@ class IncrementalResourceWrapper(ItemTransform[TDataItem]):
                     bound_args.arguments[p.name] = None  # Remove partial spec
                     return func(*bound_args.args, **bound_args.kwargs)
                 raise ValueError(
-                    f"{p.name} Incremental argument has no default. Please wrap its typing in"
-                    " Optional[] to allow no incremental"
+                    f"`{p.name}` incremental argument has no default. Please wrap its typing in"
+                    " `Optional[]` to allow no incremental"
                 )
             # pass Generic information from annotation to new_incremental
             if (

--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -285,8 +285,8 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
                 msg = (
                     f"Incremental `initial_value={self.initial_value}` is greater than"
                     f" `end_value={self.end_value}` as determined by the custom `last_value_func`."
-                    f" The result of '{self.last_value_func.__name__}(`[end_value,"
-                    " initial_value]`)' must equal `end_value`"
+                    f" The result of `{self.last_value_func.__name__}([end_value,"
+                    " initial_value])` must equal `end_value`"
                 )
             raise ConfigurationValueError(msg)
 

--- a/dlt/extract/incremental/exceptions.py
+++ b/dlt/extract/incremental/exceptions.py
@@ -47,8 +47,8 @@ class IncrementalCursorInvalidCoercion(PipeException):
         self.item = item
         msg = (
             f"Could not coerce `{cursor_value_type}` with value `{cursor_value}` and type"
-            f" `{type(cursor_value)}` to actual data item `{item}` at path `{cursor_path}` with type"
-            f" `{item_type}`: {details}. You need to use different data type for"
+            f" `{type(cursor_value)}` to actual data item `{item}` at path `{cursor_path}` with"
+            f" type `{item_type}`: {details}. You need to use different data type for"
             f" `{cursor_value_type}` or cast your data ie. by using `.add_map()` on this resource."
         )
         super().__init__(pipe_name, msg)

--- a/dlt/extract/incremental/exceptions.py
+++ b/dlt/extract/incremental/exceptions.py
@@ -25,7 +25,7 @@ class IncrementalCursorPathHasValueNone(PipeException):
         self.item = item
         msg = (
             msg
-            or f"Cursor element with JSON path `{json_path}` has the value `None` in extracted data item. All data items must contain a value != None. Construct the incremental with on_cursor_value_none='include' if you want to include such rows"
+            or f"Cursor element with JSON path `{json_path}` has the value `None` in extracted data item. All data items must contain a value != None. Construct the incremental with `on_cursor_value_none='include'` if you want to include such rows"
         )
         super().__init__(pipe_name, msg)
 
@@ -46,10 +46,10 @@ class IncrementalCursorInvalidCoercion(PipeException):
         self.cursor_value_type = cursor_value_type
         self.item = item
         msg = (
-            f"Could not coerce {cursor_value_type} with value {cursor_value} and type"
-            f" {type(cursor_value)} to actual data item {item} at path {cursor_path} with type"
-            f" {item_type}: {details}. You need to use different data type for"
-            f" {cursor_value_type} or cast your data ie. by using `add_map` on this resource."
+            f"Could not coerce `{cursor_value_type}` with value `{cursor_value}` and type"
+            f" `{type(cursor_value)}` to actual data item `{item}` at path `{cursor_path}` with type"
+            f" `{item_type}`: {details}. You need to use different data type for"
+            f" `{cursor_value_type}` or cast your data ie. by using `.add_map()` on this resource."
         )
         super().__init__(pipe_name, msg)
 
@@ -59,7 +59,7 @@ class IncrementalPrimaryKeyMissing(PipeException):
         self.primary_key_column = primary_key_column
         self.item = item
         msg = (
-            f"Primary key column {primary_key_column} was not found in extracted data item. All"
+            f"Primary key column `{primary_key_column}` was not found in extracted data item. All"
             " data items must contain this column. Use the same names of fields as in your JSON"
             " document."
         )

--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -301,7 +301,7 @@ class ArrowIncremental(IncrementalTransform):
             self.new_value_compare = pa.compute.less
         else:
             raise NotImplementedError(
-                "Only min or max last_value_func is supported for arrow tables"
+                "Only `min` or `max` of `last_value_func` is supported for arrow tables"
             )
 
     def compute_unique_values(self, item: "TAnyArrowItem", unique_columns: List[str]) -> List[str]:
@@ -370,7 +370,7 @@ class ArrowIncremental(IncrementalTransform):
                 cursor_path,
                 tbl,
                 f"Column name `{cursor_path}` was not found in the arrow table. Nested JSON paths"
-                " are not supported for arrow tables and dataframes, the incremental cursor_path"
+                " are not supported for arrow tables and dataframes, the incremental `cursor_path`"
                 " must be a column name.",
             ) from e
 

--- a/dlt/extract/pipe.py
+++ b/dlt/extract/pipe.py
@@ -206,7 +206,8 @@ class Pipe(SupportsPipe):
         if index == self._gen_idx:
             raise CreatePipeException(
                 self.name,
-                f"Step at index `{index}` holds a data generator for this pipe and cannot be removed",
+                f"Step at index `{index}` holds a data generator for this pipe and cannot be"
+                " removed",
             )
         self._steps.pop(index)
         if index < self._gen_idx:

--- a/dlt/extract/pipe.py
+++ b/dlt/extract/pipe.py
@@ -206,8 +206,7 @@ class Pipe(SupportsPipe):
         if index == self._gen_idx:
             raise CreatePipeException(
                 self.name,
-                f"Step at index `{index}` holds a data generator for this pipe and cannot be"
-                " removed",
+                f"Step at `{index=:}` holds a data generator for this pipe and cannot be removed",
             )
         self._steps.pop(index)
         if index < self._gen_idx:

--- a/dlt/extract/pipe.py
+++ b/dlt/extract/pipe.py
@@ -148,7 +148,7 @@ class Pipe(SupportsPipe):
 
     def fork(self, child_pipe: "Pipe", child_step: int = -1, copy_on_fork: bool = False) -> "Pipe":
         if len(self._steps) == 0:
-            raise CreatePipeException(self.name, f"Cannot fork to empty pipe {child_pipe}")
+            raise CreatePipeException(self.name, f"Cannot fork to empty pipe `{child_pipe}`")
         fork_step = self.tail
         if not isinstance(fork_step, ForkPipe):
             fork_step = ForkPipe(child_pipe, child_step, copy_on_fork)
@@ -206,7 +206,7 @@ class Pipe(SupportsPipe):
         if index == self._gen_idx:
             raise CreatePipeException(
                 self.name,
-                f"Step at index {index} holds a data generator for this pipe and cannot be removed",
+                f"Step at index `{index}` holds a data generator for this pipe and cannot be removed",
             )
         self._steps.pop(index)
         if index < self._gen_idx:
@@ -358,7 +358,7 @@ class Pipe(SupportsPipe):
         if not isinstance(step, (Iterable, Iterator, AsyncIterator)) and not callable(step):
             raise CreatePipeException(
                 self.name,
-                "A head of a resource pipe must be Iterable, Iterator, AsyncIterator or a Callable",
+                "A head of a resource pipe must be: [Iterable, Iterator, AsyncIterator, Callable]",
             )
 
     def _wrap_transform_step_meta(self, step_no: int, step: TPipeStep) -> TPipeStep:

--- a/dlt/extract/pipe_iterator.py
+++ b/dlt/extract/pipe_iterator.py
@@ -213,8 +213,10 @@ class PipeIterator(Iterator[PipeItem]):
                 if isinstance(item, (Iterator, Awaitable, AsyncIterator)) or callable(item):
                     raise PipeItemProcessingError(
                         pipe_item.pipe.name,
-                        f"Pipe item of type `{type(pipe_item.item).__name__}` was not fully evaluated at step `{pipe_item.step}`. "
-                        "This is an internal error or you're yielding unexpected object from resources (e.g., fucntions, awaitables)."
+                        f"Pipe item of type `{type(pipe_item.item).__name__}` was not fully"
+                        f" evaluated at step `{pipe_item.step}`. This is an internal error or"
+                        " you're yielding unexpected object from resources (e.g., fucntions,"
+                        " awaitables).",
                     )
                 # mypy not able to figure out that item was resolved
                 return pipe_item  # type: ignore

--- a/dlt/extract/pipe_iterator.py
+++ b/dlt/extract/pipe_iterator.py
@@ -213,9 +213,8 @@ class PipeIterator(Iterator[PipeItem]):
                 if isinstance(item, (Iterator, Awaitable, AsyncIterator)) or callable(item):
                     raise PipeItemProcessingError(
                         pipe_item.pipe.name,
-                        f"Pipe item at step {pipe_item.step} was not fully evaluated and is of type"
-                        f" {type(pipe_item.item).__name__}. This is internal error or you are"
-                        " yielding something weird from resources ie. functions or awaitables.",
+                        f"Pipe item of type `{type(pipe_item.item).__name__}` was not fully evaluated at step `{pipe_item.step}`. "
+                        "This is an internal error or you're yielding unexpected object from resources (e.g., fucntions, awaitables)."
                     )
                 # mypy not able to figure out that item was resolved
                 return pipe_item  # type: ignore

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -501,7 +501,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         """Binds the parametrized resource to passed arguments. Modifies resource pipe in place. Does not evaluate generators or iterators."""
         if self._args_bound:
             raise TypeError(
-                f"Parametrized resource {self.name} is not callable. You can call and pass"
+                f"Parametrized resource `{self.name}` is not callable. You can call and pass"
                 " arguments to a parametrized resource only once. Make sure you didn't call this"
                 " resource before."
             )
@@ -541,7 +541,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
     def explicit_args(self) -> StrAny:
         """Returns a dictionary of arguments used to parametrize the resource. Does not include defaults and injected args."""
         if not self._args_bound:
-            raise TypeError(f"Resource {self.name} is not yet parametrized")
+            raise TypeError(f"Resource `{self.name}` is not yet parametrized")
         return self._explicit_args
 
     @property
@@ -554,7 +554,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         """Binds the parametrized resources to passed arguments. Creates and returns a bound resource. Generators and iterators are not evaluated."""
         if self._args_bound:
             raise TypeError(
-                f"Parametrized resource {self.name} is not callable. You can call and pass"
+                f"Parametrized resource `{self.name}` is not callable. You can call and pass"
                 " arguments to a parametrized resource only once. Make sure you didn't call this"
                 " resource before."
             )

--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -482,9 +482,7 @@ class DltSource(Iterable[TDataItem]):
         try:
             return self._resources[resource_name]
         except KeyError:
-            raise AttributeError(
-                f"Resource `{resource_name}` not found in source `{self.name}`"
-            )
+            raise AttributeError(f"Resource `{resource_name}` not found in source `{self.name}`")
 
     def __setattr__(self, name: str, value: Any) -> None:
         if isinstance(value, DltResource):

--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -172,8 +172,8 @@ class DltResourceDict(Dict[str, DltResource]):
     def __setitem__(self, resource_name: str, resource: DltResource) -> None:
         if resource_name != resource.name:
             raise ValueError(
-                f"The index name {resource_name} does not correspond to resource name"
-                f" {resource.name}"
+                f"The index name `{resource_name}` does not correspond to resource name"
+                f" `{resource.name}`"
             )
         pipe_id = id(resource._pipe)
         # make shallow copy of the resource
@@ -483,7 +483,7 @@ class DltSource(Iterable[TDataItem]):
             return self._resources[resource_name]
         except KeyError:
             raise AttributeError(
-                f"Resource with name {resource_name} not found in source {self.name}"
+                f"Resource `{resource_name}` not found in source `{self.name}`"
             )
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/dlt/extract/utils.py
+++ b/dlt/extract/utils.py
@@ -127,7 +127,7 @@ def ensure_table_schema_columns(columns: TAnySchemaColumns) -> TTableSchemaColum
     ):
         return pydantic.pydantic_to_table_schema_columns(columns)
 
-    raise ValueError(f"Unsupported columns type: {type(columns)}")
+    raise ValueError(f"Unsupported columns type: `{type(columns)}`")
 
 
 def ensure_table_schema_columns_hint(

--- a/dlt/helpers/airflow_helper.py
+++ b/dlt/helpers/airflow_helper.py
@@ -430,7 +430,7 @@ class PipelineTasksGroup(TaskGroup):
                 if not isinstance(data, DltSource):
                     raise ValueError("Can only decompose dlt sources")
                 if pipeline.dev_mode:
-                    raise ValueError("Cannot decompose pipelines with dev_mode set")
+                    raise ValueError("Cannot decompose pipelines with `dev_mode=True`")
                 # serialize tasks
                 tasks = []
                 pt = None
@@ -446,7 +446,7 @@ class PipelineTasksGroup(TaskGroup):
                     raise ValueError("Can only decompose dlt sources")
 
                 if pipeline.dev_mode:
-                    raise ValueError("Cannot decompose pipelines with dev_mode set")
+                    raise ValueError("Cannot decompose pipelines with `dev_mode=True`")
 
                 tasks = []
                 sources = data.decompose("scc")
@@ -482,7 +482,7 @@ class PipelineTasksGroup(TaskGroup):
                     raise ValueError("Can only decompose dlt sources")
 
                 if pipeline.dev_mode:
-                    raise ValueError("Cannot decompose pipelines with dev_mode set")
+                    raise ValueError("Cannot decompose pipelines with `dev_mode=True`")
 
                 # parallel tasks
                 tasks = []
@@ -513,8 +513,7 @@ class PipelineTasksGroup(TaskGroup):
                 return [start, end]
             else:
                 raise ValueError(
-                    "decompose value must be one of ['none', 'serialize', 'parallel',"
-                    " 'parallel-isolated']"
+                    "`decompose` must be one of ['none', 'serialize', 'parallel', 'parallel-isolated']"
                 )
 
 

--- a/dlt/helpers/airflow_helper.py
+++ b/dlt/helpers/airflow_helper.py
@@ -12,7 +12,7 @@ from tenacity import (
 )
 
 from dlt.common.known_env import DLT_DATA_DIR, DLT_PROJECT_DIR, DLT_LOCAL_DIR
-from dlt.common.exceptions import MissingDependencyException
+from dlt.common.exceptions import MissingDependencyException, ValueErrorWithKnownValues
 
 try:
     from airflow.configuration import conf
@@ -512,8 +512,8 @@ class PipelineTasksGroup(TaskGroup):
                 start >> end
                 return [start, end]
             else:
-                raise ValueError(
-                    "`decompose` must be one of ['none', 'serialize', 'parallel', 'parallel-isolated']"
+                raise ValueErrorWithKnownValues(
+                    "decompose", decompose, ["none", "serialize", "parallel", "parallel-isolated"]
                 )
 
 

--- a/dlt/helpers/dbt/exceptions.py
+++ b/dlt/helpers/dbt/exceptions.py
@@ -30,4 +30,4 @@ class DBTProcessingError(DBTRunnerException):
         self.run_results = run_results
         # the results from DBT may be anything
         self.dbt_results = dbt_results
-        super().__init__(f"DBT command {command} could not be executed")
+        super().__init__(f"DBT command `{command}` could not be executed")

--- a/dlt/helpers/dbt_cloud/client.py
+++ b/dlt/helpers/dbt_cloud/client.py
@@ -102,7 +102,7 @@ class DBTCloudClientV2:
         if not (self.account_id and job_id):
             raise InvalidCredentialsException(
                 "`account_id` and `job_id` are required. "
-                f"Got `account_id={self.account_id} and `job_id={job_id}`"
+                f"Got `account_id={self.account_id}` and `{job_id=:}`"
             )
 
         json_body = {}
@@ -134,7 +134,7 @@ class DBTCloudClientV2:
         if not (self.account_id and run_id):
             raise InvalidCredentialsException(
                 "`account_id` and `run_id` are required. "
-                f"Got `account_id={self.account_id} and `run_id={run_id}`"
+                f"Got `account_id={self.account_id}` and `{run_id=:}`"
             )
 
         response = self.get_endpoint(f"{self.accounts_url}/runs/{run_id}")

--- a/dlt/helpers/dbt_cloud/client.py
+++ b/dlt/helpers/dbt_cloud/client.py
@@ -101,8 +101,8 @@ class DBTCloudClientV2:
         """
         if not (self.account_id and job_id):
             raise InvalidCredentialsException(
-                f"account_id and job_id are required, got account_id: {self.account_id} and job_id:"
-                f" {job_id}"
+                "`account_id` and `job_id` are required. "
+                f"Got `account_id={self.account_id} and `job_id={job_id}`"
             )
 
         json_body = {}
@@ -133,8 +133,8 @@ class DBTCloudClientV2:
         """
         if not (self.account_id and run_id):
             raise InvalidCredentialsException(
-                f"account_id and run_id are required, got account_id: {self.account_id} and run_id:"
-                f" {run_id}."
+                "`account_id` and `run_id` are required. "
+                f"Got `account_id={self.account_id} and `run_id={run_id}`"
             )
 
         response = self.get_endpoint(f"{self.accounts_url}/runs/{run_id}")

--- a/dlt/helpers/ibis.py
+++ b/dlt/helpers/ibis.py
@@ -186,8 +186,8 @@ def create_ibis_backend(
         # https://github.com/ibis-project/ibis/issues/7682 connecting with aws credentials
         # does not work yet.
         raise NotImplementedError(
-            f"Destination of type {Destination.from_reference(destination).destination_type} not"
-            " supported by ibis."
+            f"Destination type `{Destination.from_reference(destination).destination_type}` is not"
+            " supported."
         )
 
     return con

--- a/dlt/load/exceptions.py
+++ b/dlt/load/exceptions.py
@@ -16,7 +16,7 @@ class LoadClientJobFailed(DestinationTerminalException, LoadClientJobException):
         self.job_id = job_id
         self.failed_message = failed_message
         super().__init__(
-            f"Job for {job_id} failed terminally in load {load_id} with message {failed_message}."
+            f"Job with `{job_id=:}` and `{load_id=:}` failed terminally with message: {failed_message}."
             " The package is aborted and cannot be retried."
         )
 
@@ -31,9 +31,9 @@ class LoadClientJobRetry(DestinationTransientException, LoadClientJobException):
         self.max_retry_count = max_retry_count
         self.retry_message = retry_message
         super().__init__(
-            f"Job for {job_id} had {retry_count} retries which a multiple of {max_retry_count}."
+            f"Job with `{job_id=:}` had {retry_count} retries which is a multiple of `{max_retry_count=:}`."
             " Exiting retry loop. You can still rerun the load package to retry this job."
-            f" Last failure message was {retry_message}"
+            f" Last failure message was: {retry_message}"
         )
 
 
@@ -45,7 +45,7 @@ class LoadClientUnsupportedFileFormats(DestinationTerminalException):
         self.supported_types = supported_file_format
         self.file_path = file_path
         super().__init__(
-            f"Loader does not support writer {file_format} in  file {file_path}. Supported writers:"
+            f"Loader does not support writer for `{file_format=:}` in  file `{file_path}`. Supported writers:"
             f" {supported_file_format}"
         )
 
@@ -56,15 +56,15 @@ class LoadClientUnsupportedWriteDisposition(DestinationTerminalException):
         self.write_disposition = write_disposition
         self.file_name = file_name
         super().__init__(
-            f"Loader does not support {write_disposition} in table {table_name} when loading file"
-            f" {file_name}"
+            f"Loader does not support` {write_disposition=:}` in table `{table_name}` when loading file"
+            f" `{file_name}`"
         )
 
 
 class FollowupJobCreationFailedException(DestinationTransientException):
     def __init__(self, job_id: str) -> None:
         self.job_id = job_id
-        super().__init__(f"Failed to create followup job for job with id {job_id}")
+        super().__init__(f"Failed to create followup job for job with `{job_id=:}`")
 
 
 class TableChainFollowupJobCreationFailedException(DestinationTransientException):
@@ -72,5 +72,5 @@ class TableChainFollowupJobCreationFailedException(DestinationTransientException
         self.root_table_name = root_table_name
         super().__init__(
             "Failed creating table chain followup jobs for table chain with root table"
-            f" {root_table_name}."
+            f" `{root_table_name}`."
         )

--- a/dlt/load/exceptions.py
+++ b/dlt/load/exceptions.py
@@ -16,8 +16,8 @@ class LoadClientJobFailed(DestinationTerminalException, LoadClientJobException):
         self.job_id = job_id
         self.failed_message = failed_message
         super().__init__(
-            f"Job with `{job_id=:}` and `{load_id=:}` failed terminally with message: {failed_message}."
-            " The package is aborted and cannot be retried."
+            f"Job with `{job_id=:}` and `{load_id=:}` failed terminally with message:"
+            f" {failed_message}. The package is aborted and cannot be retried."
         )
 
 
@@ -31,9 +31,9 @@ class LoadClientJobRetry(DestinationTransientException, LoadClientJobException):
         self.max_retry_count = max_retry_count
         self.retry_message = retry_message
         super().__init__(
-            f"Job with `{job_id=:}` had {retry_count} retries which is a multiple of `{max_retry_count=:}`."
-            " Exiting retry loop. You can still rerun the load package to retry this job."
-            f" Last failure message was: {retry_message}"
+            f"Job with `{job_id=:}` had {retry_count} retries which is a multiple of"
+            f" `{max_retry_count=:}`. Exiting retry loop. You can still rerun the load package to"
+            f" retry this job. Last failure message was: {retry_message}"
         )
 
 
@@ -45,8 +45,8 @@ class LoadClientUnsupportedFileFormats(DestinationTerminalException):
         self.supported_types = supported_file_format
         self.file_path = file_path
         super().__init__(
-            f"Loader does not support writer for `{file_format=:}` in  file `{file_path}`. Supported writers:"
-            f" {supported_file_format}"
+            f"Loader does not support writer for `{file_format=:}` in  file `{file_path}`."
+            f" Supported writers: {supported_file_format}"
         )
 
 
@@ -56,8 +56,8 @@ class LoadClientUnsupportedWriteDisposition(DestinationTerminalException):
         self.write_disposition = write_disposition
         self.file_name = file_name
         super().__init__(
-            f"Loader does not support` {write_disposition=:}` in table `{table_name}` when loading file"
-            f" `{file_name}`"
+            f"Loader does not support` {write_disposition=:}` in table `{table_name}` when loading"
+            f" file `{file_name}`"
         )
 
 

--- a/dlt/load/exceptions.py
+++ b/dlt/load/exceptions.py
@@ -46,7 +46,7 @@ class LoadClientUnsupportedFileFormats(DestinationTerminalException):
         self.file_path = file_path
         super().__init__(
             f"Loader does not support writer for `{file_format=:}` in  file `{file_path}`."
-            f" Supported writers: {supported_file_format}"
+            f" Supported writers: `{supported_file_format}`"
         )
 
 
@@ -56,7 +56,7 @@ class LoadClientUnsupportedWriteDisposition(DestinationTerminalException):
         self.write_disposition = write_disposition
         self.file_name = file_name
         super().__init__(
-            f"Loader does not support` {write_disposition=:}` in table `{table_name}` when loading"
+            f"Loader does not support `{write_disposition=:}` in table `{table_name}` when loading"
             f" file `{file_name}`"
         )
 

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -287,7 +287,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         # list all files that were started but not yet completed
         started_jobs = self.load_storage.normalized_packages.list_started_jobs(load_id)
 
-        logger.info(f"Found {len(started_jobs)} that are already started and should be continued")
+        logger.info(f"{len(started_jobs)} started jobs found, which should be continued")
         if len(started_jobs) == 0:
             return jobs
 

--- a/dlt/normalize/exceptions.py
+++ b/dlt/normalize/exceptions.py
@@ -16,5 +16,6 @@ class NormalizeJobFailed(NormalizeException):
         self.failed_message = failed_message
         self.writer_metrics = writer_metrics
         super().__init__(
-            f"Job for `{job_id=:}` failed terminally in load with `{load_id=:}` with message: {failed_message}."
+            f"Job for `{job_id=:}` failed terminally in load with `{load_id=:}` with message:"
+            f" {failed_message}."
         )

--- a/dlt/normalize/exceptions.py
+++ b/dlt/normalize/exceptions.py
@@ -16,5 +16,5 @@ class NormalizeJobFailed(NormalizeException):
         self.failed_message = failed_message
         self.writer_metrics = writer_metrics
         super().__init__(
-            f"Job for {job_id} failed terminally in load {load_id} with message {failed_message}."
+            f"Job for `{job_id=:}` failed terminally in load with `{load_id=:}` with message: {failed_message}."
         )

--- a/dlt/normalize/items_normalizers.py
+++ b/dlt/normalize/items_normalizers.py
@@ -316,7 +316,7 @@ class ModelItemsNormalizer(ItemsNormalizer):
         # The query is ensured to be a select statement upstream,
         # but we double check here
         if not isinstance(parsed_select, sqlglot.exp.Select):
-            raise ValueError("Only SELECT statements should be used as SqlModel queries.")
+            raise ValueError("Only SELECT statements should be used as `SqlModel` queries.")
 
         # Star selects are not allowed
         if any(

--- a/dlt/pipeline/configuration.py
+++ b/dlt/pipeline/configuration.py
@@ -60,4 +60,4 @@ class PipelineConfiguration(BaseConfiguration):
 def ensure_correct_pipeline_kwargs(f: AnyFun, **kwargs: Any) -> None:
     for arg_name in kwargs:
         if not hasattr(PipelineConfiguration, arg_name) and not arg_name.startswith("_dlt"):
-            raise TypeError(f"`{f.__name__}` got an unexpected keyword argument '{arg_name}'")
+            raise TypeError(f"`{f.__name__}` got an unexpected keyword argument `{arg_name}`")

--- a/dlt/pipeline/configuration.py
+++ b/dlt/pipeline/configuration.py
@@ -60,4 +60,4 @@ class PipelineConfiguration(BaseConfiguration):
 def ensure_correct_pipeline_kwargs(f: AnyFun, **kwargs: Any) -> None:
     for arg_name in kwargs:
         if not hasattr(PipelineConfiguration, arg_name) and not arg_name.startswith("_dlt"):
-            raise TypeError(f"{f.__name__} got an unexpected keyword argument '{arg_name}'")
+            raise TypeError(f"`{f.__name__}` got an unexpected keyword argument '{arg_name}'")

--- a/dlt/pipeline/exceptions.py
+++ b/dlt/pipeline/exceptions.py
@@ -84,8 +84,8 @@ class PipelineStateEngineNoUpgradePathException(PipelineException):
         self.to_engine = to_engine
         super().__init__(
             pipeline_name,
-            f"No engine upgrade path for state in pipeline `{pipeline_name}` from `{init_engine}` to"
-            f" `{to_engine}`, stopped at `{from_engine}`. You possibly tried to run an older dlt"
+            f"No engine upgrade path for state in pipeline `{pipeline_name}` from `{init_engine}`"
+            f" to `{to_engine}`, stopped at `{from_engine}`. You possibly tried to run an older dlt"
             " version against a destination you have previously loaded data to with a newer dlt"
             " version.",
         )

--- a/dlt/pipeline/exceptions.py
+++ b/dlt/pipeline/exceptions.py
@@ -8,9 +8,9 @@ class InvalidPipelineName(PipelineException, ValueError):
     def __init__(self, pipeline_name: str, details: str) -> None:
         super().__init__(
             pipeline_name,
-            f"The pipeline name {pipeline_name} contains invalid characters. The pipeline name is"
-            " used to create a pipeline working directory and must be a valid directory name. The"
-            f" actual error is: {details}",
+            f"The pipeline name `{pipeline_name}` contains invalid characters. The pipeline name is"
+            " used to create a pipeline working directory and must be a valid directory name. "
+            f"Details: {details}",
         )
 
 
@@ -25,8 +25,8 @@ class PipelineConfigMissing(PipelineException):
         self.config_elem = config_elem
         self.step_or_func = step_or_func
         msg = (
-            f"Configuration element {config_elem} was not provided and step or function"
-            f" {step_or_func} cannot be executed"
+            f"Configuration element `{config_elem}` was not provided and step or function"
+            f" `{step_or_func}` cannot be executed"
         )
         if _help:
             msg += f"\n{_help}\n"
@@ -36,7 +36,7 @@ class PipelineConfigMissing(PipelineException):
 class CannotRestorePipelineException(PipelineException):
     def __init__(self, pipeline_name: str, pipelines_dir: str, reason: str) -> None:
         msg = (
-            f"Pipeline with name {pipeline_name} in working directory {pipelines_dir} could not be"
+            f"Pipeline with `{pipeline_name=:}` and `{pipelines_dir=:}` could not be"
             f" restored: {reason}"
         )
         super().__init__(pipeline_name, msg)
@@ -59,10 +59,10 @@ class PipelineStepFailed(PipelineException):
         self.exception = exception
         self.step_info = step_info
 
-        package_str = f" when processing package {load_id}" if load_id else ""
+        package_str = f" when processing package with `{load_id=:}`" if load_id else ""
         super().__init__(
             pipeline.pipeline_name,
-            f"Pipeline execution failed at stage {step}{package_str} with"
+            f"Pipeline execution failed at `{step=:}`{package_str} with"
             f" exception:\n\n{type(exception)}\n{exception}",
         )
 
@@ -84,8 +84,8 @@ class PipelineStateEngineNoUpgradePathException(PipelineException):
         self.to_engine = to_engine
         super().__init__(
             pipeline_name,
-            f"No engine upgrade path for state in pipeline {pipeline_name} from {init_engine} to"
-            f" {to_engine}, stopped at {from_engine}. You possibly tried to run an older dlt"
+            f"No engine upgrade path for state in pipeline `{pipeline_name}` from `{init_engine}` to"
+            f" `{to_engine}`, stopped at `{from_engine}`. You possibly tried to run an older dlt"
             " version against a destination you have previously loaded data to with a newer dlt"
             " version.",
         )
@@ -94,9 +94,9 @@ class PipelineStateEngineNoUpgradePathException(PipelineException):
 class PipelineHasPendingDataException(PipelineException):
     def __init__(self, pipeline_name: str, pipelines_dir: str) -> None:
         msg = (
-            f" Operation failed because pipeline with name {pipeline_name} in working directory"
-            f" {pipelines_dir} contains pending extracted files or load packages. Use `dlt pipeline"
-            " sync` to reset the local state then run this operation again."
+            f" Operation failed because pipeline with `{pipeline_name=:}` and `{pipelines_dir=:}`"
+            " contains pending extracted files or load packages. Use `dlt pipeline sync`"
+            " to reset the local state then run this operation again."
         )
         super().__init__(pipeline_name, msg)
 
@@ -104,10 +104,10 @@ class PipelineHasPendingDataException(PipelineException):
 class PipelineNeverRan(PipelineException):
     def __init__(self, pipeline_name: str, pipelines_dir: str) -> None:
         msg = (
-            f" Operation failed because pipeline with name {pipeline_name} in working directory"
-            f" {pipelines_dir} was never run or was never synced with destination. Use `dlt"
-            " pipeline sync` or call pipeline.sync_destination() to get pipeline state and set of"
-            " schemas  from destination."
+            f" Operation failed because pipeline with `{pipeline_name=:}` and `{pipelines_dir=:}`"
+            " was never run or was never synced with destination. Use `dlt pipeline sync`"
+            " or call `pipeline.sync_destination()` to get pipeline state and set of"
+            " schemas from destination."
         )
         super().__init__(pipeline_name, msg)
 
@@ -115,5 +115,5 @@ class PipelineNeverRan(PipelineException):
 class PipelineNotActive(PipelineException):
     def __init__(self, pipeline_name: str) -> None:
         super().__init__(
-            pipeline_name, f"Pipeline {pipeline_name} is not active so it cannot be deactivated"
+            pipeline_name, f"Pipeline `{pipeline_name}` is not active so it cannot be deactivated"
         )

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -434,7 +434,7 @@ class Pipeline(SupportsPipeline):
     ) -> ExtractInfo:
         """Extracts the `data` and prepare it for the normalization. Does not require destination or credentials to be configured. See `run` method for the arguments' description."""
         if loader_file_format and loader_file_format not in LOADER_FILE_FORMATS:
-            raise ValueError(f"{loader_file_format} is unknown.")
+            raise ValueError(f"`loader_file_format={loader_file_format}` is unknown.")
         with self._maybe_destination_capabilities() as caps:
             if caps:
                 self._verify_destination_capabilities(caps, loader_file_format)
@@ -1293,7 +1293,7 @@ class Pipeline(SupportsPipeline):
                 "destination",
                 "load",
                 "Please provide `destination` argument to `pipeline`, `run` or `load` method"
-                " directly or via .dlt config.toml file or environment variable.",
+                " directly or via .dlt/config.toml file or environment variable.",
             )
 
         destination_client, staging_client = get_destination_clients(
@@ -1314,8 +1314,8 @@ class Pipeline(SupportsPipeline):
         if isinstance(destination_client.config, DestinationClientStagingConfiguration):
             if not self.dataset_name and self.dev_mode:
                 logger.warning(
-                    "Dev mode may not work if dataset name is not set. Please set the"
-                    " dataset_name argument in dlt.pipeline or run method"
+                    "`dev_mode=True` may not work if `dataset_name` is not set. "
+                    "Please set `dataset_name` in `dlt.pipeline(...)` or `Pipeline.run(...)`."
                 )
 
         return destination_client, staging_client
@@ -1327,7 +1327,7 @@ class Pipeline(SupportsPipeline):
                 "destination",
                 "normalize",
                 "Please provide `destination` argument to `pipeline`, `run` or `load` method"
-                " directly or via .dlt config.toml file or environment variable.",
+                " directly or via .dlt/config.toml file or environment variable.",
             )
 
         # check if default schema is present

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -23,6 +23,7 @@ import dlt
 from dlt.common import logger
 from dlt.common.json import json
 from dlt.common.pendulum import pendulum
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.common.configuration import inject_section, known_sections
 from dlt.common.configuration.specs import RuntimeConfiguration
 from dlt.common.configuration.container import Container
@@ -434,7 +435,10 @@ class Pipeline(SupportsPipeline):
     ) -> ExtractInfo:
         """Extracts the `data` and prepare it for the normalization. Does not require destination or credentials to be configured. See `run` method for the arguments' description."""
         if loader_file_format and loader_file_format not in LOADER_FILE_FORMATS:
-            raise ValueError(f"`loader_file_format={loader_file_format}` is unknown.")
+            raise ValueErrorWithKnownValues(
+                "loader_file_format", loader_file_format, LOADER_FILE_FORMATS
+            )
+
         with self._maybe_destination_capabilities() as caps:
             if caps:
                 self._verify_destination_capabilities(caps, loader_file_format)

--- a/dlt/reflection/script_inspector.py
+++ b/dlt/reflection/script_inspector.py
@@ -27,7 +27,7 @@ def import_script_module(
     Optionally, missing imports will be ignored by importing a dummy module instead.
     """
     if os.path.isabs(script_relative_path):
-        raise ValueError(script_relative_path, f"Not relative path to {module_path}")
+        raise ValueError(script_relative_path, f"Not relative path to `{module_path}`")
 
     module, _ = os.path.splitext(script_relative_path)
     module = ".".join(Path(module).parts)
@@ -39,7 +39,7 @@ def import_script_module(
         # path must be first so we always load our module of
         sys.path.insert(0, sys_path)
     try:
-        logger.info(f"Importing pipeline script from path {module_path} and module: {module}")
+        logger.info(f"Importing pipeline script from module `{module}` with path `{module_path}`")
         if ignore_missing_imports:
             return import_module_with_missing(module)
         else:

--- a/dlt/sources/helpers/rest_client/auth.py
+++ b/dlt/sources/helpers/rest_client/auth.py
@@ -58,7 +58,7 @@ class BearerTokenAuth(AuthConfigBase):
             raise NativeValueError(
                 type(self),
                 value,
-                f"BearerTokenAuth token must be a string, got {type(value)}",
+                f"`token` argument of `BearerTokenAuth` must be a `str`. Got value of type `{type(value)}`",
             )
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
@@ -81,7 +81,7 @@ class APIKeyAuth(AuthConfigBase):
             raise NativeValueError(
                 type(self),
                 value,
-                f"APIKeyAuth api_key must be a string, got {type(value)}",
+                f"`api_key` argument of `APIKeyAuth` must be a `str`. Got value of type `{type(value)}`",
             )
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
@@ -110,8 +110,8 @@ class HttpBasicAuth(AuthConfigBase):
         raise NativeValueError(
             type(self),
             value,
-            "HttpBasicAuth username and password must be a tuple of two strings, got"
-            f" {type(value)}",
+            f"`username` and `password` arguments of `HttpBasicAuth` must be a `str` values. "
+            f"Got values of type `{type(value)}`",
         )
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
@@ -133,7 +133,7 @@ class OAuth2AuthBase(AuthConfigBase):
             raise NativeValueError(
                 type(self),
                 value,
-                f"OAuth2AuthBase access_token must be a string, got {type(value)}",
+                f"`access_token` argument of `OAuth2AuthBase` must be a `str`. Got value of type `{type(value)}`",
             )
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:

--- a/dlt/sources/helpers/rest_client/auth.py
+++ b/dlt/sources/helpers/rest_client/auth.py
@@ -58,7 +58,8 @@ class BearerTokenAuth(AuthConfigBase):
             raise NativeValueError(
                 type(self),
                 value,
-                f"`token` argument of `BearerTokenAuth` must be a `str`. Got value of type `{type(value)}`",
+                "`token` argument of `BearerTokenAuth` must be a `str`. Got value of type"
+                f" `{type(value)}`",
             )
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
@@ -81,7 +82,8 @@ class APIKeyAuth(AuthConfigBase):
             raise NativeValueError(
                 type(self),
                 value,
-                f"`api_key` argument of `APIKeyAuth` must be a `str`. Got value of type `{type(value)}`",
+                "`api_key` argument of `APIKeyAuth` must be a `str`. Got value of type"
+                f" `{type(value)}`",
             )
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:
@@ -110,7 +112,7 @@ class HttpBasicAuth(AuthConfigBase):
         raise NativeValueError(
             type(self),
             value,
-            f"`username` and `password` arguments of `HttpBasicAuth` must be a `str` values. "
+            "`username` and `password` arguments of `HttpBasicAuth` must be a `str` values. "
             f"Got values of type `{type(value)}`",
         )
 
@@ -133,7 +135,8 @@ class OAuth2AuthBase(AuthConfigBase):
             raise NativeValueError(
                 type(self),
                 value,
-                f"`access_token` argument of `OAuth2AuthBase` must be a `str`. Got value of type `{type(value)}`",
+                "`access_token` argument of `OAuth2AuthBase` must be a `str`. Got value of type"
+                f" `{type(value)}`",
             )
 
     def __call__(self, request: PreparedRequest) -> PreparedRequest:

--- a/dlt/sources/helpers/rest_client/client.py
+++ b/dlt/sources/helpers/rest_client/client.py
@@ -303,23 +303,22 @@ class RESTClient:
         paginator, score = self.pagination_factory.create_paginator(response)
         if paginator is None:
             raise PaginatorNotFound(
-                f"No suitable paginator found for the response at {response.url}"
+                f"No suitable `paginator` found for the response at `{response.url}`"
             )
         if score == 1.0:
-            logger.info(f"Detected paginator: {paginator}")
+            logger.info(f"Detected `paginator`: `{paginator}`")
         elif score == 0.0:
             if isinstance(data, list):
                 logger.warning(
-                    f"Fallback paginator used: {paginator}. Please provide right paginator"
-                    " manually."
+                    f"Fallback `paginator` used: `{paginator}`. Please provide paginator manually."
                 )
             else:
                 logger.info(
-                    f"Fallback paginator used: {paginator} to handle not paginated response."
+                    f"Fallback `paginator` used: `{paginator}` to handle not paginated response."
                 )
         else:
             logger.warning(
-                "Please verify the paginator settings. We strongly suggest to use explicit"
+                "Please verify the `paginator` settings. We strongly suggest to use explicit"
                 " instance of the paginator as some settings may not be guessed correctly."
             )
         return paginator

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -175,7 +175,7 @@ class RangePaginator(BasePaginator):
     def _handle_missing_total(self, response_json: Dict[str, Any]) -> None:
         raise ValueError(
             f"Total `{self.error_message_items}` not found in the response in"
-            f" `{self.__class__.__name__}`.Expected a response with a '{self.total_path}' key, got"
+            f" `{self.__class__.__name__}` .Expected a response with a `{self.total_path}` key, got"
             f" `{response_json}`."
         )
 

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -174,15 +174,14 @@ class RangePaginator(BasePaginator):
 
     def _handle_missing_total(self, response_json: Dict[str, Any]) -> None:
         raise ValueError(
-            f"Total {self.error_message_items} is not found in the response in"
-            f" {self.__class__.__name__}. Expected a response with a '{self.total_path}' key, got"
-            f" {response_json}"
+            f"Total `{self.error_message_items}` not found in the response in `{self.__class__.__name__}`."
+            f"Expected a response with a '{self.total_path}' key, got `{response_json}`."
         )
 
     def _handle_invalid_total(self, total: Any) -> None:
         raise ValueError(
-            f"'{self.total_path}' is not an integer in the response in {self.__class__.__name__}."
-            f" Expected an integer, got {total}"
+            f"'{self.total_path}' is not an `int` in the response in `{self.__class__.__name__}`."
+            f" Expected an integer, got `{total}`"
         )
 
     def update_request(self, request: Request) -> None:

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -174,8 +174,9 @@ class RangePaginator(BasePaginator):
 
     def _handle_missing_total(self, response_json: Dict[str, Any]) -> None:
         raise ValueError(
-            f"Total `{self.error_message_items}` not found in the response in `{self.__class__.__name__}`."
-            f"Expected a response with a '{self.total_path}' key, got `{response_json}`."
+            f"Total `{self.error_message_items}` not found in the response in"
+            f" `{self.__class__.__name__}`.Expected a response with a '{self.total_path}' key, got"
+            f" `{response_json}`."
         )
 
     def _handle_invalid_total(self, total: Any) -> None:

--- a/dlt/sources/helpers/transform.py
+++ b/dlt/sources/helpers/transform.py
@@ -71,7 +71,7 @@ def pivot(
         if not isinstance(match.value, C_Sequence):
             raise ValueError(
                 "Pivot transformer is only applicable to sequences "
-                f"fields, however, the value of {str(match.full_path)}"
+                f"fields, however, the value of `{str(match.full_path)}`"
                 " is not a sequence."
             )
 
@@ -79,7 +79,7 @@ def pivot(
             if not isinstance(item, C_Sequence):
                 raise ValueError(
                     "Pivot transformer is only applicable to sequences, "
-                    f"however, the value of {str(match.full_path)} "
+                    f"however, the value of `{str(match.full_path)}` "
                     "includes a non-sequence element."
                 )
 

--- a/dlt/sources/rest_api/__init__.py
+++ b/dlt/sources/rest_api/__init__.py
@@ -11,6 +11,7 @@ from dlt.common import jsonpath
 from dlt.common.schema.schema import Schema
 from dlt.common.schema.typing import TSchemaContract
 from dlt.common.utils import exclude_keys
+from dlt.common.exceptions import ValueErrorWithKnownValues
 
 from dlt.extract import Incremental, DltResource, DltSource, decorators
 
@@ -408,8 +409,6 @@ def _mask_secret(secret: Optional[str]) -> str:
 def _validate_param_type(
     request_params: Dict[str, Union[ResolveParamConfig, IncrementalParamConfig, Any]],
 ) -> None:
-    for _, value in request_params.items():
+    for param_name, value in request_params.items():
         if isinstance(value, dict) and value.get("type") not in PARAM_TYPES:
-            raise ValueError(
-                f"Invalid param type: `{value.get('type')}`. Available options: `{PARAM_TYPES}`"
-            )
+            raise ValueErrorWithKnownValues(f"{param_name}['type']", value.get("type"), PARAM_TYPES)

--- a/dlt/sources/rest_api/__init__.py
+++ b/dlt/sources/rest_api/__init__.py
@@ -258,7 +258,7 @@ def create_resources(
         include_from_parent: List[str] = endpoint_resource.get("include_from_parent", [])
         if not resolved_params and include_from_parent:
             raise ValueError(
-                f"Resource {resource_name} has include_from_parent but is not "
+                f"Resource `{resource_name}` has `include_from_parent` but is not "
                 "dependent on another resource"
             )
         _validate_param_type(request_params)
@@ -411,5 +411,5 @@ def _validate_param_type(
     for _, value in request_params.items():
         if isinstance(value, dict) and value.get("type") not in PARAM_TYPES:
             raise ValueError(
-                f"Invalid param type: {value.get('type')}. Available options: {PARAM_TYPES}"
+                f"Invalid param type: `{value.get('type')}`. Available options: `{PARAM_TYPES}`"
             )

--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -226,7 +226,8 @@ def setup_incremental_object(
                 raise ValueError(
                     "Only `initial_value` is allowed in the configuration of param:"
                     f" `{param_name}`. "
-                    "To set end_value too use the incremental configuration at the resource level. "
+                    "To set `end_value` too use the incremental configuration at the resource"
+                    " level. "
                     "See https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/basic#incremental-loading"
                 )
             return param_config, IncrementalParam(start=param_name, end=None), None
@@ -478,8 +479,8 @@ def _bind_path_params(resource: EndpointResource) -> None:
             else:
                 # Most likely mistyped placeholder context name
                 raise ValueError(
-                    f"The path '{path}' defined in resource '{resource['name']}' contains a"
-                    f" placeholder '{field_name}'. This placeholder is not a valid name."
+                    f"The `{path=:}` defined in resource `{resource['name']}` contains a"
+                    f" placeholder `{field_name}`. This placeholder is not a valid name."
                     " Valid names are: ['resources', 'incremental']."
                 )
 
@@ -491,7 +492,7 @@ def _bind_path_params(resource: EndpointResource) -> None:
             param_type = params[field_name].get("type")
             if param_type != "resolve":
                 raise ValueError(
-                    f"The path `{path}` defined in resource `{resource['name']} `tries to bind"
+                    f"The path `{path}` defined in resource `{resource['name']}` tries to bind"
                     f" param `{field_name}` with type `{param_type}`. Paths can only bind 'resolve'"
                     " type params."
                 )

--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -234,7 +234,7 @@ def setup_incremental_object(
             if param_config.get("end_value") or param_config.get("end_param"):
                 raise ValueError(
                     "Only `start_param` and `initial_value` are allowed in the configuration of"
-                    f" param: {param_name} "
+                    f" param: `{param_name}`. "
                     "To set `end_value` too use the incremental configuration at the resource"
                     " level. "
                     "See https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/basic#incremental-loading"
@@ -499,8 +499,8 @@ def _bind_path_params(resource: EndpointResource) -> None:
     if len(resolve_params) > 0:
         raise ValueError(
             f"Resource `{resource['name']}` defines resolve params `{resolve_params}` that are not"
-            f" bound in path `{path}`. To reference parent resource in query params use"
-            " resources.<parent_resource>.<field> syntax."
+            f" bound in path `{path}`. To reference parent resource in query params use syntax"
+            " 'resources.<parent_resource>.<field>'"
         )
 
     resource["endpoint"]["path"] = "".join(new_path_segments)
@@ -796,9 +796,9 @@ def collect_resolved_values(
             field_path = resolved_param.resolve_config["field"]
             raise ValueError(
                 f"Resource expects a field `{field_path}` to be present in the incoming data from"
-                f" resource `{parent_resource_name}` in order to bind it to path param"
+                f" resource `{parent_resource_name}` in order to bind it to path param:"
                 f" `{resolved_param.param_name}`. Available parent fields are:"
-                f" [{', '.join(item.keys())}]"
+                f" {list(item.keys())}"
             )
 
         params_values[resolved_param.param_name] = field_values[0]
@@ -893,7 +893,7 @@ def build_parent_record(
             raise ValueError(
                 f"Resource expects a field `{parent_key}` to be present in the incoming data "
                 f"from resource `{parent_resource_name}` in order to include it in child records"
-                f" under `{child_key}`. Available parent fields are: [{', '.join(item.keys())}]"
+                f" under `{child_key}`. Available parent fields are: {list(item.keys())}"
             )
         parent_record[child_key] = item[parent_key]
     return parent_record
@@ -976,7 +976,7 @@ def _raise_if_any_not_in(expressions: Set[str], available_contexts: Set[str], me
         if not any(expression.startswith(prefix + ".") for prefix in available_contexts):
             raise ValueError(
                 f"Expression `{expression}` defined in `{message}` is not valid. Valid expressions"
-                f" must start with one of: [{', '.join(available_contexts)}]. If you need to use"
+                f" must start with one of: `{available_contexts}`. If you need to use"
                 " literal curly braces in your expression, escape them by doubling them: {{ and"
                 " }}"
             )

--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -115,8 +115,8 @@ def register_paginator(
 ) -> None:
     if not issubclass(paginator_class, BasePaginator):
         raise ValueError(
-            f"Invalid paginator: {paginator_class.__name__}. "
-            "Your custom paginator has to be a subclass of BasePaginator"
+            f"Invalid paginator: `{paginator_class.__name__}`. "
+            "Your custom paginator has to be a subclass of `BasePaginator`"
         )
     PAGINATOR_MAP[paginator_name] = paginator_class
     add_value_to_literal(PaginatorType, paginator_name)
@@ -128,7 +128,7 @@ def get_paginator_class(paginator_name: str) -> Type[BasePaginator]:
     except KeyError:
         available_options = ", ".join(PAGINATOR_MAP.keys())
         raise ValueError(
-            f"Invalid paginator: {paginator_name}. Available options: {available_options}."
+            f"Invalid paginator: `{paginator_name}`. Available options: `{available_options}`."
         )
 
 
@@ -145,8 +145,8 @@ def create_paginator(
             return paginator_class() if paginator_class else None
         except TypeError:
             raise ValueError(
-                f"Paginator {paginator_config} requires arguments to create an instance. Use"
-                f" {paginator_class} instance instead."
+                f"Paginator `{paginator_config}` requires arguments to create an instance. Use"
+                f" `{paginator_class}` instance instead."
             )
 
     if isinstance(paginator_config, dict):
@@ -165,8 +165,8 @@ def register_auth(
 ) -> None:
     if not issubclass(auth_class, AuthConfigBase):
         raise ValueError(
-            f"Invalid auth: {auth_class.__name__}. "
-            "Your custom auth has to be a subclass of AuthConfigBase"
+            f"Invalid auth: `{auth_class.__name__}`. "
+            "Your custom auth has to be a subclass of `AuthConfigBase`"
         )
     AUTH_MAP[auth_name] = auth_class
 
@@ -179,7 +179,7 @@ def get_auth_class(auth_type: str) -> Type[AuthConfigBase]:
     except KeyError:
         available_options = ", ".join(AUTH_MAP.keys())
         raise ValueError(
-            f"Invalid authentication: {auth_type}. Available options: {available_options}."
+            f"Invalid authentication: `{auth_type}`. Available options: `{available_options}`."
         )
 
 
@@ -219,27 +219,25 @@ def setup_incremental_object(
             incremental_params.append(param_name)
     if len(incremental_params) > 1:
         raise ValueError(
-            "Only a single incremental parameter is allower per endpoint. Found:"
-            f" {incremental_params}"
+            "Only a single incremental parameter is allower per endpoint. Found parameters: "
+            f"`{incremental_params}`"
         )
     convert: Optional[Callable[..., Any]]
     for param_name, param_config in request_params.items():
         if isinstance(param_config, Incremental):
             if param_config.end_value is not None:
                 raise ValueError(
-                    f"Only initial_value is allowed in the configuration of param: {param_name}. To"
-                    " set end_value too use the incremental configuration at the resource level."
-                    " See"
-                    " https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/basic#incremental-loading"
+                    f"Only `initial_value` is allowed in the configuration of param: `{param_name}`. "
+                    "To set end_value too use the incremental configuration at the resource level. "
+                    "See https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/basic#incremental-loading"
                 )
             return param_config, IncrementalParam(start=param_name, end=None), None
         if isinstance(param_config, dict) and param_config.get("type") == "incremental":
             if param_config.get("end_value") or param_config.get("end_param"):
                 raise ValueError(
-                    "Only start_param and initial_value are allowed in the configuration of param:"
-                    f" {param_name}. To set end_value too use the incremental configuration at the"
-                    " resource level. See"
-                    " https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/basic#incremental-loading"
+                    f"Only start_param and initial_value are allowed in the configuration of param: {param_name} " 
+                    "To set end_value too use the incremental configuration at the resource level. "
+                    "See https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/basic#incremental-loading"
                 )
             convert = parse_convert_or_deprecated_transform(param_config)
 
@@ -341,15 +339,15 @@ def build_resource_dependency_graph(
         named_resources = {rp.resolve_config["resource"] for rp in resolved_params}
 
         if len(named_resources) > 1:
-            raise ValueError(f"Multiple parent resources for {resource_name}: {resolved_params}")
+            raise ValueError(f"Multiple parent resources for resource `{resource_name}` with params `{resolved_params}`")
         elif len(named_resources) == 1:
             # validate the first parameter (note the resource is the same for all params)
             first_param = resolved_params[0]
             predecessor = first_param.resolve_config["resource"]
             if predecessor not in endpoint_resource_map:
                 raise ValueError(
-                    f"A dependent resource {resource_name} refers to non existing parent resource"
-                    f" {predecessor} on {first_param}"
+                    f"A dependent resource `{resource_name}` refers to non existing parent resource"
+                    f" `{predecessor}` on param `{first_param}`"
                 )
 
             dependency_graph.add(resource_name, predecessor)
@@ -386,7 +384,7 @@ def expand_and_index_resources(
         ), f"Resource name must be a string, got {type(resource_name)}"
 
         if resource_name in endpoint_resource_map:
-            raise ValueError(f"Resource {resource_name} has already been defined")
+            raise ValueError(f"Resource `{resource_name}` is already defined.")
         endpoint_resource_map[resource_name] = endpoint_resource
 
     return endpoint_resource_map
@@ -479,7 +477,7 @@ def _bind_path_params(resource: EndpointResource) -> None:
                 raise ValueError(
                     f"The path '{path}' defined in resource '{resource['name']}' contains a"
                     f" placeholder '{field_name}'. This placeholder is not a valid name."
-                    " Valid names are: 'resources', 'incremental'."
+                    " Valid names are: ['resources', 'incremental']."
                 )
 
         if not isinstance(params[field_name], dict):
@@ -490,15 +488,15 @@ def _bind_path_params(resource: EndpointResource) -> None:
             param_type = params[field_name].get("type")
             if param_type != "resolve":
                 raise ValueError(
-                    f"The path {path} defined in resource {resource['name']} tries to bind"
-                    f" param {field_name} with type {param_type}. Paths can only bind 'resolve'"
+                    f"The path `{path}` defined in resource `{resource['name']} `tries to bind"
+                    f" param `{field_name}` with type `{param_type}`. Paths can only bind 'resolve'"
                     " type params."
                 )
 
     if len(resolve_params) > 0:
         raise ValueError(
-            f"Resource {resource['name']} defines resolve params {resolve_params} that are not"
-            f" bound in path {path}. To reference parent resource in query params use"
+            f"Resource `{resource['name']}` defines resolve params `{resolve_params}` that are not"
+            f" bound in path `{path}`. To reference parent resource in query params use"
             " resources.<parent_resource>.<field> syntax."
         )
 
@@ -577,8 +575,8 @@ def _handle_response_action(
             custom_hooks = response_action
         else:
             raise ValueError(
-                f"Action {response_action} does not conform to expected type. Expected: str or"
-                f" Callable or List[Callable]. Found: {type(response_action)}"
+                f"Action `{response_action}` does not conform to expected type. "
+                f"Expected: [str, Callable, List[Callable]]. Found: `{type(response_action)}`"
             )
 
     if status_code is not None and content_substr is not None:
@@ -711,7 +709,7 @@ def _expressions_to_resolved_params(expressions: Set[str]) -> List[ResolvedParam
         parts = expression.strip().split(".", maxsplit=2)
         if len(parts) != 3:
             raise ValueError(
-                f"Invalid definition of {expression}. Expected format:"
+                f"Invalid definition of `{expression}`. Expected format:"
                 " 'resources.<resource>.<field>'"
             )
         resolved_params.append(
@@ -785,7 +783,7 @@ def collect_resolved_values(
     (params_values) and a ResourcesContext that may store `resources.<name>.<field>`.
     """
     if not resolved_params:
-        raise ValueError("Resolved params are required to process parent data item")
+        raise ValueError("`resolved_params` is required to process parent data item")
 
     parent_resource_name = resolved_params[0].resolve_config["resource"]
     params_values: Dict[str, Any] = {}
@@ -795,10 +793,9 @@ def collect_resolved_values(
         if not field_values:
             field_path = resolved_param.resolve_config["field"]
             raise ValueError(
-                f"Resource expects a field '{field_path}' to be present in the incoming data"
-                f" from resource {parent_resource_name} in order to bind it to path param"
-                f" {resolved_param.param_name}. Available parent fields are"
-                f" {', '.join(item.keys())}"
+                f"Resource expects a field `{field_path}` to be present in the incoming data "
+                f"from resource `{parent_resource_name}` in order to bind it to path param "
+                f"`{resolved_param.param_name}`. Available parent fields are: [{', '.join(item.keys())}]"
             )
 
         params_values[resolved_param.param_name] = field_values[0]
@@ -892,8 +889,8 @@ def build_parent_record(
         if parent_key not in item:
             raise ValueError(
                 f"Resource expects a field '{parent_key}' to be present in the incoming data "
-                f"from resource {parent_resource_name} in order to include it in child records"
-                f" under {child_key}. Available parent fields are {', '.join(item.keys())}"
+                f"from resource `{parent_resource_name}` in order to include it in child records"
+                f" under `{child_key}`. Available parent fields are: [{', '.join(item.keys())}]"
             )
         parent_record[child_key] = item[parent_key]
     return parent_record
@@ -975,8 +972,8 @@ def _raise_if_any_not_in(expressions: Set[str], available_contexts: Set[str], me
     for expression in expressions:
         if not any(expression.startswith(prefix + ".") for prefix in available_contexts):
             raise ValueError(
-                f"Expression '{expression}' defined in {message} is not valid. Valid expressions"
-                f" must start with one of: {', '.join(available_contexts)}. If you need to use"
+                f"Expression '{expression}' defined in `{message}` is not valid. Valid expressions"
+                f" must start with one of: [{', '.join(available_contexts)}]. If you need to use"
                 " literal curly braces in your expression, escape them by doubling them: {{ and"
                 " }}"
             )

--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -116,7 +116,7 @@ def sql_database(
 
     if defer_table_reflect:
         if not table_names:
-            raise ValueError("You must pass table names to defer table reflection")
+            raise ValueError("You must pass `table_names` to defer table reflection")
         table_infos = [(schema, table) for table in table_names]
     else:
         # reflect tables

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -80,16 +80,14 @@ class TableLoader:
 
             if column_name is None:
                 raise ValueError(
-                    f"Cursor path '{incremental.cursor_path}' must be a simple column name (e.g."
-                    " 'created_at')"
+                    f"Cursor path '{incremental.cursor_path}' must be a simple column name (e.g. 'created_at')"
                 )
 
             try:
                 self.cursor_column = table.c[column_name]
             except KeyError as e:
                 raise KeyError(
-                    f"Cursor column '{incremental.cursor_path}' does not exist in table"
-                    f" '{table.name}'"
+                    f"Cursor column '{incremental.cursor_path}' does not exist in table '{table.name}'"
                 ) from e
             self.last_value = incremental.last_value
             self.end_value = incremental.end_value
@@ -228,9 +226,9 @@ class TableLoader:
             query_str = str(query.compile(self.engine, compile_kwargs={"literal_binds": True}))
         except CompileError as ex:
             raise NotImplementedError(
-                f"Query for table {self.table.name} could not be compiled to string to execute it"
+                f"Query for table `{self.table.name}` could not be compiled to string to execute it"
                 " on ConnectorX. If you are on SQLAlchemy 1.4.x the causing exception is due to"
-                f" literals that cannot be rendered, upgrade to 2.x: {str(ex)}"
+                f" literals that cannot be rendered, upgrade to 2.x: `{str(ex)}`"
             ) from ex
         df = cx.read_sql(conn, query_str, **backend_kwargs)
         yield df

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -88,7 +88,7 @@ class TableLoader:
                 self.cursor_column = table.c[column_name]
             except KeyError as e:
                 raise KeyError(
-                    f"Cursor column `{incremental.cursor_path} `does not exist in table"
+                    f"Cursor column `{incremental.cursor_path}` does not exist in table"
                     f" `{table.name}`"
                 ) from e
             self.last_value = incremental.last_value

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -80,14 +80,16 @@ class TableLoader:
 
             if column_name is None:
                 raise ValueError(
-                    f"Cursor path '{incremental.cursor_path}' must be a simple column name (e.g. 'created_at')"
+                    f"Cursor path `{incremental.cursor_path}` must be a simple column name (e.g."
+                    " `created_at`)"
                 )
 
             try:
                 self.cursor_column = table.c[column_name]
             except KeyError as e:
                 raise KeyError(
-                    f"Cursor column '{incremental.cursor_path}' does not exist in table '{table.name}'"
+                    f"Cursor column `{incremental.cursor_path} `does not exist in table"
+                    f" `{table.name}`"
                 ) from e
             self.last_value = incremental.last_value
             self.end_value = incremental.end_value

--- a/dlt/transformations/transformation.py
+++ b/dlt/transformations/transformation.py
@@ -73,7 +73,8 @@ def make_transformation_resource(
     if spec:
         if not issubclass(spec, TransformationConfiguration):
             raise TransformationException(
-                resource_name, "Please derive transformation spec from `TransformationConfiguration`"
+                resource_name,
+                "Please derive transformation spec from `TransformationConfiguration`",
             )
 
     @wraps(func)

--- a/dlt/transformations/transformation.py
+++ b/dlt/transformations/transformation.py
@@ -73,7 +73,7 @@ def make_transformation_resource(
     if spec:
         if not issubclass(spec, TransformationConfiguration):
             raise TransformationException(
-                resource_name, "Please derive transformation spec from TransformationConfiguration"
+                resource_name, "Please derive transformation spec from `TransformationConfiguration`"
             )
 
     @wraps(func)

--- a/tests/destinations/test_utils.py
+++ b/tests/destinations/test_utils.py
@@ -40,5 +40,5 @@ def test_get_resource_for_adapter() -> None:
     def other_source():
         return [some_resource, other_resource]
 
-    with pytest.raises(ValueErrorWithKnownValues):
+    with pytest.raises(ValueError):
         get_resource_for_adapter(other_source())

--- a/tests/destinations/test_utils.py
+++ b/tests/destinations/test_utils.py
@@ -1,7 +1,6 @@
 import dlt
 import pytest
 
-from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.destinations.utils import get_resource_for_adapter
 from dlt.extract import DltResource
 

--- a/tests/destinations/test_utils.py
+++ b/tests/destinations/test_utils.py
@@ -1,6 +1,7 @@
 import dlt
 import pytest
 
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.destinations.utils import get_resource_for_adapter
 from dlt.extract import DltResource
 
@@ -39,5 +40,5 @@ def test_get_resource_for_adapter() -> None:
     def other_source():
         return [some_resource, other_resource]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueErrorWithKnownValues):
         get_resource_for_adapter(other_source())

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -2061,15 +2061,13 @@ def test_end_value_initial_value_errors(item_type: TestDataItemFormat) -> None:
     with pytest.raises(ConfigurationValueError) as ex:
         list(some_data(updated_at=dlt.sources.incremental(end_value=22)))
 
-    assert str(ex.value).startswith("Incremental 'end_value' was specified without 'initial_value'")
+    assert str(ex.value).startswith("Incremental `end_value` was specified without `initial_value`")
 
     # max function and end_value lower than initial_value
     with pytest.raises(ConfigurationValueError) as ex:
         list(some_data(updated_at=dlt.sources.incremental(initial_value=42, end_value=22)))
 
-    assert str(ex.value).startswith(
-        "Incremental 'initial_value' (42) is higher than 'end_value` (22)"
-    )
+    assert str(ex.value).startswith("Incremental `initial_value=42` is higher than `end_value=22`")
 
     # max function and end_value higher than initial_value
     with pytest.raises(ConfigurationValueError) as ex:
@@ -2081,9 +2079,7 @@ def test_end_value_initial_value_errors(item_type: TestDataItemFormat) -> None:
             )
         )
 
-    assert str(ex.value).startswith(
-        "Incremental 'initial_value' (22) is lower than 'end_value` (42)."
-    )
+    assert str(ex.value).startswith("Incremental `initial_value=22` is lower than `end_value=42`.")
 
     def custom_last_value(items):
         return max(items)
@@ -2099,7 +2095,7 @@ def test_end_value_initial_value_errors(item_type: TestDataItemFormat) -> None:
         )
 
     assert (
-        "The result of 'custom_last_value([end_value, initial_value])' must equal 'end_value'"
+        "The result of `custom_last_value([end_value, initial_value])` must equal `end_value`"
         in str(ex.value)
     )
 

--- a/tests/helpers/dbt_tests/test_runner_dbt_versions.py
+++ b/tests/helpers/dbt_tests/test_runner_dbt_versions.py
@@ -134,7 +134,7 @@ def test_dbt_run_exception_pickle() -> None:
     assert obj.command == "test"
     assert obj.run_results == "A"
     assert obj.dbt_results == "B"
-    assert str(obj) == "DBT command test could not be executed"
+    assert str(obj) == "DBT command `test` could not be executed"
 
 
 def test_runner_setup(client: PostgresClient, test_storage: FileStorage) -> None:

--- a/tests/load/bigquery/test_bigquery_streaming_insert.py
+++ b/tests/load/bigquery/test_bigquery_streaming_insert.py
@@ -50,9 +50,10 @@ def test_bigquery_streaming_wrong_disposition():
     # pick the failed job
     assert isinstance(pip_ex.value.__cause__, LoadClientJobFailed)
     assert (
-        """BigQuery streaming insert can only be used with `append`"""
-        """ write_disposition, while the given resource has `merge`."""
-    ) in pip_ex.value.__cause__.failed_message
+        "BigQuery streaming insert can only be used with `write_disposition='append'`"
+        "Resource received `write_disposition=merge`"
+        in pip_ex.value.__cause__.failed_message
+    )
 
 
 def test_bigquery_streaming_nested_data():

--- a/tests/load/bigquery/test_bigquery_streaming_insert.py
+++ b/tests/load/bigquery/test_bigquery_streaming_insert.py
@@ -50,8 +50,8 @@ def test_bigquery_streaming_wrong_disposition():
     # pick the failed job
     assert isinstance(pip_ex.value.__cause__, LoadClientJobFailed)
     assert (
-        "BigQuery streaming insert can only be used with `write_disposition='append'`"
-        "Resource received `write_disposition=merge`"
+        "BigQuery streaming insert can only be used with `write_disposition='append'`."
+        " Resource received `write_disposition=merge`"
         in pip_ex.value.__cause__.failed_message
     )
 

--- a/tests/load/bigquery/test_bigquery_table_builder.py
+++ b/tests/load/bigquery/test_bigquery_table_builder.py
@@ -568,9 +568,7 @@ def test_adapter_hints_parsing_partitioning_more_than_one_column() -> None:
 
     with pytest.raises(
         ValueError,
-        match=(
-            "^`partition` must be a single column name as a string or a PartitionTransformation.$"
-        ),
+        match="`partition` must be a single column name as a `str` or a `PartitionTransformation`.",
     ):
         bigquery_adapter(some_data, partition=["col1", "col2"])
 

--- a/tests/load/databricks/test_databricks_configuration.py
+++ b/tests/load/databricks/test_databricks_configuration.py
@@ -110,7 +110,7 @@ def test_databricks_auth_invalid() -> None:
 
 def test_databricks_missing_config_catalog() -> None:
     with pytest.raises(
-        ConfigurationValueError, match="Configuration error: Missing required parameter 'catalog'*"
+        ConfigurationValueError, match="Configuration error: Missing required parameter `catalog`"
     ):
         os.environ["DESTINATION__DATABRICKS__CREDENTIALS__CATALOG"] = ""
         bricks = databricks()
@@ -120,7 +120,7 @@ def test_databricks_missing_config_catalog() -> None:
 def test_databricks_missing_config_http_path() -> None:
     with pytest.raises(
         ConfigurationValueError,
-        match="Configuration error: Missing required parameter 'http_path'*",
+        match="Configuration error: Missing required parameter `http_path`",
     ):
         os.environ["DESTINATION__DATABRICKS__CREDENTIALS__HTTP_PATH"] = ""
         bricks = databricks()
@@ -130,7 +130,7 @@ def test_databricks_missing_config_http_path() -> None:
 def test_databricks_missing_config_server_hostname() -> None:
     with pytest.raises(
         ConfigurationValueError,
-        match="Configuration error: Missing required parameter 'server_hostname'*",
+        match="Configuration error: Missing required parameter `server_hostname`",
     ):
         os.environ["DESTINATION__DATABRICKS__CREDENTIALS__SERVER_HOSTNAME"] = ""
         bricks = databricks()

--- a/tests/load/pipeline/test_model_item_format.py
+++ b/tests/load/pipeline/test_model_item_format.py
@@ -74,7 +74,7 @@ UNSUPPORTED_MODEL_QUERIES = [
 )
 def test_model_builder_with_non_select_query(unsupported_model_query: str) -> None:
     with pytest.raises(
-        ValueError, match="Only SELECT statements are allowed to create a SqlModel."
+        ValueError, match="Only SELECT statements are allowed to create a `SqlModel`."
     ):
         SqlModel.from_query_string(query=unsupported_model_query)
 

--- a/tests/load/sources/sql_database/test_sql_database_source.py
+++ b/tests/load/sources/sql_database/test_sql_database_source.py
@@ -231,7 +231,7 @@ def test_named_sql_table_config(sql_source_db: SQLAlchemySourceDB) -> None:
     table = sql_table(table="chat_message", schema=sql_source_db.schema)
     with pytest.raises(ResourceExtractionError) as ext_ex:
         len(list(table))
-    assert "'updated_at_x'" in str(ext_ex.value)
+    assert "`updated_at_x`" in str(ext_ex.value)
 
 
 def test_general_sql_database_config(sql_source_db: SQLAlchemySourceDB) -> None:
@@ -265,7 +265,7 @@ def test_general_sql_database_config(sql_source_db: SQLAlchemySourceDB) -> None:
     table = sql_table(table="chat_message", schema=sql_source_db.schema)
     with pytest.raises(ResourceExtractionError) as ext_ex:
         len(list(table))
-    assert "'updated_at_x'" in str(ext_ex.value)
+    assert "`updated_at_x`" in str(ext_ex.value)
     with pytest.raises(ResourceExtractionError) as ext_ex:
         list(sql_database(schema=sql_source_db.schema).with_resources("chat_message"))
     # other resources will be loaded, incremental is selective

--- a/tests/sources/rest_api/configurations/source_configs.py
+++ b/tests/sources/rest_api/configurations/source_configs.py
@@ -23,12 +23,12 @@ ConfigTest = namedtuple("ConfigTest", ["expected_message", "exception", "config"
 
 INVALID_CONFIGS = [
     ConfigTest(
-        expected_message="following required fields are missing {'resources'}",
+        expected_message="missing required fields `{'resources'}`",
         exception=DictValidationException,
         config={"client": {"base_url": ""}},
     ),
     ConfigTest(
-        expected_message="following required fields are missing {'client'}",
+        expected_message="missing required fields `{'client'}`",
         exception=DictValidationException,
         config={"resources": []},
     ),
@@ -61,8 +61,7 @@ INVALID_CONFIGS = [
     #   before secrets are bound, this must be changed
     ConfigTest(
         expected_message=(
-            "For ApiKeyAuthConfig: In path ./client/auth: following required fields are missing"
-            " {'api_key'}"
+            "For `ApiKeyAuthConfig`: Path `./client/auth`: missing required fields `{'api_key'}`"
         ),
         exception=DictValidationException,
         config={
@@ -74,7 +73,7 @@ INVALID_CONFIGS = [
         },
     ),
     ConfigTest(
-        expected_message="In path ./client: following fields are unexpected {'invalid_key'}",
+        expected_message="Path `./client`: received unexpected fields `{'invalid_key'}`",
         exception=DictValidationException,
         config={
             "client": {
@@ -85,7 +84,7 @@ INVALID_CONFIGS = [
         },
     ),
     ConfigTest(
-        expected_message="field 'paginator' with value invalid_paginator is not one of:",
+        expected_message="field `paginator='invalid_paginator'` is not one of:",
         exception=DictValidationException,
         config={
             "client": {

--- a/tests/sources/rest_api/configurations/source_configs.py
+++ b/tests/sources/rest_api/configurations/source_configs.py
@@ -84,7 +84,7 @@ INVALID_CONFIGS = [
         },
     ),
     ConfigTest(
-        expected_message="field `paginator='invalid_paginator'` is not one of:",
+        expected_message="field `paginator` expects the following types: ",
         exception=DictValidationException,
         config={
             "client": {

--- a/tests/sources/rest_api/configurations/test_auth_config.py
+++ b/tests/sources/rest_api/configurations/test_auth_config.py
@@ -314,5 +314,5 @@ def test_validation_masks_auth_secrets() -> None:
         rest_api_source(incorrect_config)
     assert (
         re.search("sensitive-secret", str(e.value)) is None
-    ), "unexpectedly printed 'sensitive-secret'"
-    assert e.match(re.escape("'{'type': 'bearer', 'location': 'header', 'token': 's*****t'}'"))
+    ), "unexpectedly printed `sensitive-secret`"
+    assert e.match(re.escape("`{'type': 'bearer', 'location': 'header', 'token': 's*****t'}`"))

--- a/tests/sources/rest_api/configurations/test_auth_config.py
+++ b/tests/sources/rest_api/configurations/test_auth_config.py
@@ -161,8 +161,8 @@ def test_error_message_invalid_auth_type() -> None:
         create_auth("non_existing_method")  # type: ignore
     assert (
         str(e.value)
-        == "Invalid authentication: non_existing_method."
-        " Available options: bearer, api_key, http_basic, oauth2_client_credentials."
+        == "Received invalid value `auth_type=non_existing_method`. "
+        "Valid values are: ['bearer', 'api_key', 'http_basic', 'oauth2_client_credentials']"
     )
 
 

--- a/tests/sources/rest_api/configurations/test_custom_auth_config.py
+++ b/tests/sources/rest_api/configurations/test_custom_auth_config.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, cast
 
 import pytest
 
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.sources import rest_api
 from dlt.sources.helpers.rest_client.auth import APIKeyAuth, OAuth2ClientCredentials
 from dlt.sources.rest_api.typing import ApiKeyAuthConfig, AuthConfig, RESTAPIConfig
@@ -46,10 +47,10 @@ class TestCustomAuth:
         assert auth.api_key == "test-secret"
 
     def test_not_registering_throws_error(self, custom_auth_config: AuthConfig) -> None:
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueErrorWithKnownValues) as e:
             rest_api.config_setup.create_auth(custom_auth_config)
 
-        assert e.match("Invalid authentication: custom_oauth_2.")
+        assert e.match("Received invalid value `auth_type=custom_oauth_2`. Valid values are:")
 
     def test_registering_adds_to_AUTH_MAP(self, custom_auth_config: AuthConfig) -> None:
         rest_api.config_setup.register_auth("custom_oauth_2", CustomOAuth2)
@@ -76,7 +77,7 @@ class TestCustomAuth:
             rest_api.config_setup.register_auth(
                 "not_an_auth_config_base", NotAuthConfigBase  # type: ignore
             )
-        assert e.match("Invalid auth: NotAuthConfigBase.")
+        assert e.match("Invalid auth: `NotAuthConfigBase`.")
 
     def test_valid_config_raises_no_error(self, custom_auth_config: AuthConfig) -> None:
         rest_api.config_setup.register_auth("custom_oauth_2", CustomOAuth2)

--- a/tests/sources/rest_api/configurations/test_custom_paginator_config.py
+++ b/tests/sources/rest_api/configurations/test_custom_paginator_config.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import pytest
 
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.sources import rest_api
 from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
 from dlt.sources.rest_api.typing import PaginatorConfig, RESTAPIConfig
@@ -43,10 +44,12 @@ class TestCustomPaginator:
         assert paginator.has_next_page is True
 
     def test_not_registering_throws_error(self, custom_paginator_config) -> None:
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueErrorWithKnownValues) as e:
             rest_api.config_setup.create_paginator(custom_paginator_config)
 
-        assert e.match("Invalid paginator: custom_paginator.")
+        assert e.match(
+            "Received invalid value `paginator_name=custom_paginator`. Valid values are:"
+        )
 
     def test_registering_adds_to_PAGINATOR_MAP(self, custom_paginator_config) -> None:
         rest_api.config_setup.register_paginator("custom_paginator", CustomPaginator)
@@ -66,7 +69,7 @@ class TestCustomPaginator:
 
         with pytest.raises(ValueError) as e:
             rest_api.config_setup.register_paginator("not_a_paginator", NotAPaginator)  # type: ignore[arg-type]
-        assert e.match("Invalid paginator: NotAPaginator.")
+        assert e.match("Invalid paginator: `NotAPaginator`.")
 
     def test_test_valid_config_raises_no_error(self, custom_paginator_config) -> None:
         rest_api.config_setup.register_paginator("custom_paginator", CustomPaginator)

--- a/tests/sources/rest_api/configurations/test_incremental_config.py
+++ b/tests/sources/rest_api/configurations/test_incremental_config.py
@@ -9,13 +9,11 @@ from typing import cast
 
 
 import dlt
-
+from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.extract.incremental import Incremental
-
 from dlt.sources.rest_api import (
     _validate_param_type,
 )
-
 from dlt.sources.rest_api.config_setup import (
     IncrementalParam,
     setup_incremental_object,
@@ -52,10 +50,10 @@ def test_invalid_incremental_type_is_not_accepted() -> None:
             "initial_value": "2024-01-01T00:00:00Z",
         },
     }
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueErrorWithKnownValues) as e:
         _validate_param_type(request_params)
 
-    assert e.match("Invalid param type: no_incremental.")
+    assert e.match("Received invalid value `since['type']=no_incremental`.")
 
 
 def test_one_resource_cannot_have_many_incrementals() -> None:
@@ -75,8 +73,8 @@ def test_one_resource_cannot_have_many_incrementals() -> None:
     with pytest.raises(ValueError) as e:
         setup_incremental_object(request_params)
     error_message = re.escape(
-        "Only a single incremental parameter is allower per endpoint. Found: ['first_incremental',"
-        " 'second_incremental']"
+        "Only a single incremental parameter is allower per endpoint. Found parameters:"
+        " `['first_incremental', 'second_incremental']`"
     )
     assert e.match(error_message)
 
@@ -94,8 +92,8 @@ def test_one_resource_cannot_have_many_incrementals_2(incremental_with_init) -> 
     with pytest.raises(ValueError) as e:
         setup_incremental_object(request_params)
     error_message = re.escape(
-        "Only a single incremental parameter is allower per endpoint. Found: ['first_incremental',"
-        " 'second_incremental']"
+        "Only a single incremental parameter is allower per endpoint. Found parameters:"
+        " `['first_incremental', 'second_incremental']`"
     )
     assert e.match(error_message)
 
@@ -171,7 +169,7 @@ def test_does_not_construct_incremental_from_request_param_with_unsupported_incr
         setup_incremental_object(param_config)
 
     assert e.match(
-        "Only start_param and initial_value are allowed in the configuration of param: since."
+        "Only `start_param` and `initial_value` are allowed in the configuration of param: `since`."
     )
 
     param_config_2 = {

--- a/tests/sources/rest_api/configurations/test_incremental_config.py
+++ b/tests/sources/rest_api/configurations/test_incremental_config.py
@@ -53,7 +53,7 @@ def test_invalid_incremental_type_is_not_accepted() -> None:
     with pytest.raises(ValueErrorWithKnownValues) as e:
         _validate_param_type(request_params)
 
-    assert e.match("Received invalid value `since['type']=no_incremental`.")
+    assert e.match(r"Received invalid value `since\['type'\]=no_incremental`.")
 
 
 def test_one_resource_cannot_have_many_incrementals() -> None:
@@ -185,7 +185,8 @@ def test_does_not_construct_incremental_from_request_param_with_unsupported_incr
         setup_incremental_object(param_config_2)
 
     assert e.match(
-        "Only start_param and initial_value are allowed in the configuration of param: since_2."
+        "Only `start_param` and `initial_value` are allowed in the configuration of param:"
+        " `since_2`."
     )
 
     param_config_3 = {"since_3": incremental_with_init_and_end}
@@ -193,7 +194,7 @@ def test_does_not_construct_incremental_from_request_param_with_unsupported_incr
     with pytest.raises(ValueError) as e:
         setup_incremental_object(param_config_3)
 
-    assert e.match("Only initial_value is allowed in the configuration of param: since_3.")
+    assert e.match("Only `initial_value` is allowed in the configuration of param: `since_3`.")
 
 
 def test_constructs_incremental_from_endpoint_config_incremental(

--- a/tests/sources/rest_api/configurations/test_paginator_config.py
+++ b/tests/sources/rest_api/configurations/test_paginator_config.py
@@ -150,6 +150,5 @@ def test_error_message_invalid_paginator() -> None:
         create_paginator("non_existing_method")  # type: ignore
     assert (
         str(e.value)
-        == "Invalid paginator: non_existing_method. Available options: json_link, json_response,"
-        " header_link, auto, single_page, cursor, offset, page_number."
+        == "Received invalid value `paginator_name=non_existing_method`. Valid values are:"
     )

--- a/tests/sources/rest_api/configurations/test_paginator_config.py
+++ b/tests/sources/rest_api/configurations/test_paginator_config.py
@@ -148,7 +148,6 @@ def test_allow_deprecated_json_response_paginator_2(mock_api_server) -> None:
 def test_error_message_invalid_paginator() -> None:
     with pytest.raises(ValueError) as e:
         create_paginator("non_existing_method")  # type: ignore
-    assert (
-        str(e.value)
-        == "Received invalid value `paginator_name=non_existing_method`. Valid values are:"
+    assert e.match(
+        r"Received invalid value `paginator_name=non_existing_method`\. Valid values are:"
     )

--- a/tests/sources/rest_api/configurations/test_resolve_config.py
+++ b/tests/sources/rest_api/configurations/test_resolve_config.py
@@ -209,7 +209,7 @@ def test_process_parent_data_item() -> None:
             resolved_params=resolved_params,
             include_from_parent=None,
         )
-    assert "Resource expects a field 'obj_id'" in str(val_ex.value)
+    assert "Resource expects a field `obj_id`" in str(val_ex.value)
 
     # Included path not found
     with pytest.raises(ValueError) as val_ex:
@@ -221,8 +221,8 @@ def test_process_parent_data_item() -> None:
             include_from_parent=["obj_id", "node"],
         )
     assert (
-        "Resource expects a field 'obj_id' to be present in the incoming data from resource"
-        " issues in order to bind it to"
+        "Resource expects a field `obj_id` to be present in the incoming data from resource"
+        " `issues` in order to bind it to"
         in str(val_ex.value)
     )
 
@@ -253,7 +253,7 @@ def test_process_parent_data_item() -> None:
             resolved_params=multi_resolve_params,
             include_from_parent=None,
         )
-    assert "Resource expects a field 'issue'" in str(val_ex.value)
+    assert "Resource expects a field `issue`" in str(val_ex.value)
 
 
 def test_two_resources_can_depend_on_one_parent_resource() -> None:
@@ -429,7 +429,7 @@ def test_one_resource_cannot_bind_two_parents(
         rest_api_resources(config)
 
     error_msg = str(exc_info.value)
-    assert "Multiple parent resources for user_details:" in error_msg
+    assert "Multiple parent resources for `user_details`" in error_msg
     assert resolved_param1 in error_msg, f"{resolved_param1} not found in {error_msg}"
     assert resolved_param2 in error_msg, f"{resolved_param2} not found in {error_msg}"
 

--- a/tests/sources/rest_api/configurations/test_resolve_config.py
+++ b/tests/sources/rest_api/configurations/test_resolve_config.py
@@ -429,7 +429,7 @@ def test_one_resource_cannot_bind_two_parents(
         rest_api_resources(config)
 
     error_msg = str(exc_info.value)
-    assert "Multiple parent resources for `user_details`" in error_msg
+    assert "Multiple parent resources for resource `user_details`" in error_msg
     assert resolved_param1 in error_msg, f"{resolved_param1} not found in {error_msg}"
     assert resolved_param2 in error_msg, f"{resolved_param2} not found in {error_msg}"
 

--- a/tests/sources/rest_api/configurations/test_response_actions_config.py
+++ b/tests/sources/rest_api/configurations/test_response_actions_config.py
@@ -1,10 +1,10 @@
 import pytest
 from typing import List
 
+from dlt.common.exceptions import TypeErrorWithKnownTypes
 from dlt.sources.rest_api import (
     rest_api_source,
 )
-
 from dlt.sources.rest_api.config_setup import (
     create_response_hooks,
     _handle_response_action,
@@ -43,13 +43,13 @@ def test_response_action_raises_type_error(mocker):
     response = mocker.Mock()
     response.status_code = 200
 
-    with pytest.raises(ValueError) as e_1:
+    with pytest.raises(TypeErrorWithKnownTypes) as e_1:
         _handle_response_action(response, {"status_code": 200, "action": C()})  # type: ignore[typeddict-item]
-    assert e_1.match("does not conform to expected type")
+    assert e_1.match("Received invalid value `action['action']=*` of type `C`. Valid types are:")
 
-    with pytest.raises(ValueError) as e_2:
+    with pytest.raises(TypeErrorWithKnownTypes) as e_2:
         _handle_response_action(response, {"status_code": 200, "action": 123})  # type: ignore[typeddict-item]
-    assert e_2.match("does not conform to expected type")
+    assert e_2.match("Received invalid value `action['action']=*` of type `C`. Valid types are:")
 
     assert ("ignore", None) == _handle_response_action(
         response, {"status_code": 200, "action": "ignore"}

--- a/tests/sources/rest_api/configurations/test_response_actions_config.py
+++ b/tests/sources/rest_api/configurations/test_response_actions_config.py
@@ -45,11 +45,15 @@ def test_response_action_raises_type_error(mocker):
 
     with pytest.raises(TypeErrorWithKnownTypes) as e_1:
         _handle_response_action(response, {"status_code": 200, "action": C()})  # type: ignore[typeddict-item]
-    assert e_1.match("Received invalid value `action['action']=*` of type `C`. Valid types are:")
+    assert e_1.match(
+        r"Received invalid value `action\['action'\]=.*` of type `C`\. Valid types are:"
+    )
 
     with pytest.raises(TypeErrorWithKnownTypes) as e_2:
         _handle_response_action(response, {"status_code": 200, "action": 123})  # type: ignore[typeddict-item]
-    assert e_2.match("Received invalid value `action['action']=*` of type `C`. Valid types are:")
+    assert e_2.match(
+        r"Received invalid value `action\['action'\]=.*` of type `int`\. Valid types are:"
+    )
 
     assert ("ignore", None) == _handle_response_action(
         response, {"status_code": 200, "action": "ignore"}

--- a/tests/sources/rest_api/integration/test_offline.py
+++ b/tests/sources/rest_api/integration/test_offline.py
@@ -723,10 +723,9 @@ def test_raises_error_for_incorrect_interpolation(mock_api_server, config, locat
     with pytest.raises(ValueError) as exc_info:
         rest_api_source(config)
 
-    assert (
+    assert exc_info.match(
         f"Expression `unknown.posts.id` defined in `{location}` is not valid. Valid expressions"
-        " must start with one of: ['resources']"
-        in str(exc_info.value)
+        " must start with one of: `{'resources'}`"
     )
 
 

--- a/tests/sources/rest_api/integration/test_offline.py
+++ b/tests/sources/rest_api/integration/test_offline.py
@@ -672,9 +672,9 @@ def test_raises_error_for_unused_resolve_params(mock_api_server):
         )
 
     assert (
-        "Resource post_details defines resolve params ['post_id'] that are not bound in path posts."
-        " To reference parent resource in query params use resources.<parent_resource>.<field>"
-        " syntax."
+        "Resource `post_details` defines resolve params `['post_id']` that are not bound in path"
+        " `posts`. To reference parent resource in query params use syntax"
+        " 'resources.<parent_resource>.<field>'"
         in str(exc_info.value)
     )
 
@@ -724,8 +724,8 @@ def test_raises_error_for_incorrect_interpolation(mock_api_server, config, locat
         rest_api_source(config)
 
     assert (
-        f"Expression 'unknown.posts.id' defined in {location} is not valid. Valid expressions must"
-        " start with one of: resources"
+        f"Expression `unknown.posts.id` defined in `{location}` is not valid. Valid expressions"
+        " must start with one of: ['resources']"
         in str(exc_info.value)
     )
 

--- a/tests/sources/rest_api/test_interpolation.py
+++ b/tests/sources/rest_api/test_interpolation.py
@@ -562,5 +562,5 @@ def test_expressions_raise_error_for_invalid_format():
 
     assert (
         str(exc_info.value)
-        == "Invalid definition of resources.name. Expected format: 'resources.<resource>.<field>'"
+        == "Invalid definition of `resources.name`. Expected format: 'resources.<resource>.<field>'"
     )


### PR DESCRIPTION
### Description
The majority of exceptions use f-strings and interpolate variables into the exception message. However, they don't highlight when values are interpolated nor name the entities. This makes some user-facing message confusing.

Example
```python
# current exception
f"A data source {func_name} of a transformer {resource_name} is an undecorated function."
# could render as
"A data source source of a transformer transformer is an undecorated function." 

# after changes
"A data source `source` of a transformer `transformer` is an undecorated function."
```

### Changes
- Use backticks \` to enclose reference to code objects and interpolated variables
- Use f-string formating `{variable_name=:}` for clearer exception messages. This also simplifies maintenance when renaming args
  ```python
  column_mode = "freeze"
  # from
  f"{column_mode} column mode not implemented for Pydantic validation"
  # to 
  f"`{column_mode=:}` not implemented for Pydantic validation"
  # interpolates to
  "`column_mode='freeze'` not implemented for Pydantic validation"
  ``` 
- Add to `dlt.common.exceptions` the `TypeErrorWithKnownTypes` and `ValueErrorWithKnownValues` to streamline a two common error messages
  ```python
  compression = "foo"
  # from
  ValueError('The argument `compression` must have one of the following values: "auto", "enable", "disable".')
  # to
  ValueErrorWithKnownValues("compression", compression, ["auto", "enable", "disable"])
  # renders as
  'Received invalid value `compression="foo"`.  Valid values are: ["auto", "enable", "disable"]'
  ```