### PR TITLE
remove marimo from dev deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ has-poetry:
 	poetry --version
 
 dev: has-poetry
-	poetry install --all-extras --with docs,providers,pipeline,sources,sentry-sdk,ibis,adbc,marimo
+	poetry install --all-extras --with docs,providers,pipeline,sources,sentry-sdk,ibis,adbc
 
 
 dev-airflow: has-poetry


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Removes the marimo group from the dev dependencies.