### PR TITLE
added constants for `load_id` col in `_dlt_loads` table

### DIFF
--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -46,6 +46,11 @@ C_DLT_ID = "_dlt_id"
 """unique id of current row"""
 C_DLT_LOAD_ID = "_dlt_load_id"
 """load id to identify records loaded in a single load package"""
+# NOTE C_DLT_LOAD_ID != C_DLT_LOADS_TABLE_LOAD_ID but they refer to the exact same entity / value.
+# They differ for backwards compatiblity reasons
+# TODO add schema migration to use `_dlt_load_id` in `_dlt_loads` table
+C_DLT_LOADS_TABLE_LOAD_ID = "load_id"
+"""load id column in the table {LOADS_TABLE_NAME}. Meant to be joined with {C_DLT_LOAD_ID} of data tables"""
 
 TColumnProp = Literal[
     "name",

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -19,6 +19,7 @@ from dlt.common.validation import TCustomValidator, validate_dict_ignoring_xkeys
 from dlt.common.schema import detections
 from dlt.common.schema.typing import (
     C_DLT_ID,
+    C_DLT_LOADS_TABLE_LOAD_ID,
     SCHEMA_ENGINE_VERSION,
     LOADS_TABLE_NAME,
     SIMPLE_REGEX_PREFIX,
@@ -961,7 +962,7 @@ def loads_table() -> TTableSchema:
     table = new_table(
         LOADS_TABLE_NAME,
         columns=[
-            {"name": "load_id", "data_type": "text", "nullable": False},
+            {"name": C_DLT_LOADS_TABLE_LOAD_ID, "data_type": "text", "nullable": False},
             {"name": "schema_name", "data_type": "text", "nullable": True},
             {"name": "status", "data_type": "bigint", "nullable": False},
             {"name": "inserted_at", "data_type": "timestamp", "nullable": False},

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -27,6 +27,7 @@ from dlt.common.metrics import LoadJobMetrics
 from dlt.common.schema.exceptions import TableNotFound
 from dlt.common.schema.typing import (
     C_DLT_LOAD_ID,
+    C_DLT_LOADS_TABLE_LOAD_ID,
     TTableFormat,
     TTableSchemaColumns,
     DLT_NAME_PREFIX,
@@ -637,7 +638,7 @@ class FilesystemClient(
         # write entry to load "table"
         # TODO: this is also duplicate across all destinations. DRY this.
         load_data = {
-            "load_id": load_id,
+            C_DLT_LOADS_TABLE_LOAD_ID: load_id,
             "schema_name": self.schema.name,
             "status": 0,
             "inserted_at": pendulum.now().isoformat(),

--- a/dlt/destinations/impl/lancedb/lancedb_client.py
+++ b/dlt/destinations/impl/lancedb/lancedb_client.py
@@ -46,6 +46,7 @@ from dlt.common.destination.client import (
 from dlt.common.pendulum import timedelta
 from dlt.common.schema import Schema, TSchemaTables
 from dlt.common.schema.typing import (
+    C_DLT_LOADS_TABLE_LOAD_ID,
     TColumnType,
     TTableSchemaColumns,
     TWriteDisposition,
@@ -571,7 +572,7 @@ class LanceDBClient(JobClientBase, WithStateSync):
         loads_table_.checkout_latest()
 
         # normalize property names
-        p_load_id = self.schema.naming.normalize_identifier("load_id")
+        p_load_id = self.schema.naming.normalize_identifier(C_DLT_LOADS_TABLE_LOAD_ID)
         p_dlt_load_id = self.schema.naming.normalize_identifier(
             self.schema.data_item_normalizer.c_dlt_load_id  # type: ignore[attr-defined]
         )
@@ -690,7 +691,7 @@ class LanceDBClient(JobClientBase, WithStateSync):
     def complete_load(self, load_id: str) -> None:
         records = [
             {
-                self.schema.naming.normalize_identifier("load_id"): load_id,
+                self.schema.naming.normalize_identifier(C_DLT_LOADS_TABLE_LOAD_ID): load_id,
                 self.schema.naming.normalize_identifier("schema_name"): self.schema.name,
                 self.schema.naming.normalize_identifier("status"): 0,
                 self.schema.naming.normalize_identifier("inserted_at"): pendulum.now(),

--- a/dlt/destinations/impl/qdrant/qdrant_job_client.py
+++ b/dlt/destinations/impl/qdrant/qdrant_job_client.py
@@ -6,7 +6,7 @@ from dlt.common import logger
 from dlt.common.json import json
 from dlt.common.pendulum import pendulum
 from dlt.common.schema import Schema, TSchemaTables
-from dlt.common.schema.typing import C_DLT_LOAD_ID
+from dlt.common.schema.typing import C_DLT_LOAD_ID, C_DLT_LOADS_TABLE_LOAD_ID
 from dlt.common.schema.utils import (
     get_columns_names_with_prop,
     loads_table,
@@ -316,7 +316,7 @@ class QdrantClient(JobClientBase, WithStateSync):
         By finding a load id that was completed
         """
         # normalize property names
-        p_load_id = self.schema.naming.normalize_identifier("load_id")
+        p_load_id = self.schema.naming.normalize_identifier(C_DLT_LOADS_TABLE_LOAD_ID)
         p_dlt_load_id = self.schema.naming.normalize_identifier(C_DLT_LOAD_ID)
         p_pipeline_name = self.schema.naming.normalize_identifier("pipeline_name")
         p_created_at = self.schema.naming.normalize_identifier("created_at")

--- a/dlt/destinations/impl/sqlalchemy/sqlalchemy_job_client.py
+++ b/dlt/destinations/impl/sqlalchemy/sqlalchemy_job_client.py
@@ -17,7 +17,7 @@ from dlt.common.destination.client import (
 from dlt.destinations.job_client_impl import SqlJobClientWithStagingDataset, SqlLoadJob
 from dlt.common.destination.capabilities import DestinationCapabilitiesContext
 from dlt.common.schema import Schema, TTableSchema, TColumnSchema, TSchemaTables
-from dlt.common.schema.typing import TColumnType, TTableSchemaColumns
+from dlt.common.schema.typing import C_DLT_LOAD_ID, C_DLT_LOADS_TABLE_LOAD_ID, TColumnType, TTableSchemaColumns
 from dlt.common.schema.utils import (
     pipeline_state_table,
     normalize_table_identifiers,
@@ -294,7 +294,7 @@ class SqlalchemyJobClient(SqlJobClientWithStagingDataset):
 
         c_load_id, c_dlt_load_id, c_pipeline_name, c_status = map(
             self.schema.naming.normalize_identifier,
-            ("load_id", "_dlt_load_id", "pipeline_name", "status"),
+            (C_DLT_LOADS_TABLE_LOAD_ID, C_DLT_LOAD_ID, "pipeline_name", "status"),
         )
 
         query = (

--- a/dlt/destinations/impl/weaviate/weaviate_client.py
+++ b/dlt/destinations/impl/weaviate/weaviate_client.py
@@ -30,7 +30,7 @@ from dlt.common.pendulum import pendulum
 from dlt.common.typing import StrAny, TFun
 from dlt.common.time import ensure_pendulum_datetime
 from dlt.common.schema import Schema, TSchemaTables, TTableSchemaColumns
-from dlt.common.schema.typing import C_DLT_LOAD_ID, TColumnSchema, TColumnType
+from dlt.common.schema.typing import C_DLT_LOAD_ID, C_DLT_LOADS_TABLE_LOAD_ID, TColumnSchema, TColumnType
 from dlt.common.schema.utils import (
     get_columns_names_with_prop,
     loads_table,
@@ -474,7 +474,7 @@ class WeaviateClient(JobClientBase, WithStateSync):
     def get_stored_state(self, pipeline_name: str) -> Optional[StateInfo]:
         """Loads compressed state from destination storage"""
         # normalize properties
-        p_load_id = self.schema.naming.normalize_identifier("load_id")
+        p_load_id = self.schema.naming.normalize_identifier(C_DLT_LOADS_TABLE_LOAD_ID)
         p_dlt_load_id = self.schema.naming.normalize_identifier(C_DLT_LOAD_ID)
         p_pipeline_name = self.schema.naming.normalize_identifier("pipeline_name")
         p_status = self.schema.naming.normalize_identifier("status")

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -29,6 +29,7 @@ from dlt.common.destination.utils import resolve_replace_strategy
 from dlt.common.json import json
 from dlt.common.schema.typing import (
     C_DLT_LOAD_ID,
+    C_DLT_LOADS_TABLE_LOAD_ID,
     COLUMN_HINTS,
     TColumnType,
     TColumnSchemaBase,
@@ -542,7 +543,7 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
         state_table = self.sql_client.make_qualified_table_name(self.schema.state_table_name)
         loads_table = self.sql_client.make_qualified_table_name(self.schema.loads_table_name)
         c_load_id, c_dlt_load_id, c_pipeline_name, c_status = self._norm_and_escape_columns(
-            "load_id", C_DLT_LOAD_ID, "pipeline_name", "status"
+            C_DLT_LOADS_TABLE_LOAD_ID, C_DLT_LOAD_ID, "pipeline_name", "status"
         )
 
         maybe_limit_clause_1, maybe_limit_clause_2 = self.sql_client._limit_clause_sql(1)

--- a/tests/common/schema/test_schema.py
+++ b/tests/common/schema/test_schema.py
@@ -18,6 +18,7 @@ from dlt.common.schema.exceptions import (
     ParentTableNotFoundException,
 )
 from dlt.common.schema.typing import (
+    C_DLT_LOADS_TABLE_LOAD_ID,
     LOADS_TABLE_NAME,
     VERSION_TABLE_NAME,
     TColumnName,
@@ -776,7 +777,7 @@ def assert_new_schema_props(schema: Schema) -> None:
     assert "_dlt_version" in tables
     assert "version" in tables["_dlt_version"]["columns"]
     assert "_dlt_loads" in tables
-    assert "load_id" in tables["_dlt_loads"]["columns"]
+    assert C_DLT_LOADS_TABLE_LOAD_ID in tables["_dlt_loads"]["columns"]
 
 
 def test_group_tables_by_resource(schema: Schema) -> None:


### PR DESCRIPTION
### Description
The column `load_id` in the table `_dlt_loads` matches the column `_dlt_load_id` in data tables. However, this value wasn't explicitly encoded as a constant. This PR makes this more obvious and robust.

Motivation: I wanted to set a constant because work on transformations will frequently require joining columns `load_id` and `_dlt_load_id`.