### PR TITLE
add marimo flag to show command

### DIFF
--- a/dlt/cli/pipeline_command.py
+++ b/dlt/cli/pipeline_command.py
@@ -113,30 +113,35 @@ def pipeline_command(
     fmt.echo("Found pipeline %s in %s" % (fmt.bold(p.pipeline_name), fmt.bold(p.pipelines_dir)))
 
     if operation == "show":
-        from dlt.common.runtime import signals
-        from dlt.helpers.streamlit_app import index
+        if command_kwargs.get("marimo"):
+            from dlt.helpers.studio.runner import run_studio
 
-        with signals.delayed_signals():
-            streamlit_cmd = [
-                "streamlit",
-                "run",
-                index.__file__,
-                "--client.showSidebarNavigation",
-                "false",
-            ]
+            run_studio()
+        else:
+            from dlt.common.runtime import signals
+            from dlt.helpers.streamlit_app import index
 
-            if hot_reload:
-                streamlit_cmd.append("--server.runOnSave")
-                streamlit_cmd.append("true")
+            with signals.delayed_signals():
+                streamlit_cmd = [
+                    "streamlit",
+                    "run",
+                    index.__file__,
+                    "--client.showSidebarNavigation",
+                    "false",
+                ]
 
-            streamlit_cmd.append("--")
-            streamlit_cmd.append(pipeline_name)
-            streamlit_cmd.append("--pipelines-dir")
-            streamlit_cmd.append(p.pipelines_dir)
+                if hot_reload:
+                    streamlit_cmd.append("--server.runOnSave")
+                    streamlit_cmd.append("true")
 
-            venv = Venv.restore_current()
-            for line in iter_stdout(venv, *streamlit_cmd):
-                fmt.echo(line)
+                streamlit_cmd.append("--")
+                streamlit_cmd.append(pipeline_name)
+                streamlit_cmd.append("--pipelines-dir")
+                streamlit_cmd.append(p.pipelines_dir)
+
+                venv = Venv.restore_current()
+                for line in iter_stdout(venv, *streamlit_cmd):
+                    fmt.echo(line)
 
     if operation == "info":
         state: TSourceState = p.state  # type: ignore

--- a/dlt/cli/plugins.py
+++ b/dlt/cli/plugins.py
@@ -202,7 +202,7 @@ schemas, resources in schemas, list of completed and normalized load packages, a
 pipeline state set by the resources during the extraction process.
 """,
         )
-        pipeline_subparsers.add_parser(
+        show_cmd = pipeline_subparsers.add_parser(
             "show",
             help=(
                 "Generates and launches Streamlit app with the loading status and dataset explorer"
@@ -212,8 +212,14 @@ Generates and launches Streamlit (https://streamlit.io/) app with the loading st
 
 This is a simple app that you can use to inspect the schemas and data in the destination as well as your pipeline state and loading status/stats. It should be executed from the same folder from which you ran the pipeline script to access destination credentials.
 
-Requires `streamlit` to be installed in the current environment: `pip install streamlit`.
+Requires `streamlit` to be installed in the current environment: `pip install streamlit`. Using --marimo flag to launch marimo app preview instead of streamlit.
 """,
+        )
+        show_cmd.add_argument(
+            "--marimo",
+            default=False,
+            action="store_true",
+            help="Launch marimo app preview instead of streamlit",
         )
         pipeline_subparsers.add_parser(
             "failed-jobs",

--- a/docs/website/docs/reference/command-line-interface.md
+++ b/docs/website/docs/reference/command-line-interface.md
@@ -187,7 +187,7 @@ Generates and launches Streamlit app with the loading status and dataset explore
 
 **Usage**
 ```sh
-dlt pipeline [pipeline_name] show [-h]
+dlt pipeline [pipeline_name] show [-h] [--marimo]
 ```
 
 **Description**
@@ -196,7 +196,7 @@ Generates and launches Streamlit (https://streamlit.io/) app with the loading st
 
 This is a simple app that you can use to inspect the schemas and data in the destination as well as your pipeline state and loading status/stats. It should be executed from the same folder from which you ran the pipeline script to access destination credentials.
 
-Requires `streamlit` to be installed in the current environment: `pip install streamlit`.
+Requires `streamlit` to be installed in the current environment: `pip install streamlit`. Using --marimo flag to launch marimo app preview instead of streamlit.
 
 <details>
 
@@ -206,6 +206,7 @@ Inherits arguments from [`dlt pipeline`](#dlt-pipeline).
 
 **Options**
 * `-h, --help` - Show this help message and exit
+* `--marimo` - Launch marimo app preview instead of streamlit
 
 </details>
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
We removed the studio command, but now it is really hard to start the marimo preview app, since the notebook file is somewhere in the package. This PR adds a `marimo` flag to the `pipeline show` command to make it easier to access this preview.