### PR TITLE
fix: text and binary precision via sqlglot

### DIFF
--- a/tests/libs/test_sqlglot.py
+++ b/tests/libs/test_sqlglot.py
@@ -332,6 +332,8 @@ def test_from_sqlglot_timestamp_with_precision(
             {"data_type": "time", "precision": 5, "timezone": True},
             sge.DataType.Type.TIMETZ,
         ),
+        ({"data_type": "text", "precision": 100}, sge.DataType.Type.TEXT),
+        ({"data_type": "binary", "precision": 98}, sge.DataType.Type.VARBINARY),
     ],
 )
 def test_from_and_to_sqlglot_parameterized_types(


### PR DESCRIPTION
## Description
The SQLGlot libs module had a remaining breakpoint() and didn't support dlt data types text and binary. This is now fixed and implemented

Previous issue got mangled #2713 