### PR TITLE
feat: SQLGlot for DDL parsing

### DIFF
--- a/dlt/destinations/dataset/dataset.py
+++ b/dlt/destinations/dataset/dataset.py
@@ -22,7 +22,7 @@ from dlt.destinations.dataset.ibis_relation import ReadableIbisRelation
 from dlt.destinations.dataset.relation import ReadableDBAPIRelation, BaseReadableDBAPIRelation
 from dlt.destinations.dataset.utils import get_destination_clients
 
-from dlt.transformations import lineage
+from dlt.common.libs import sqlglot
 
 
 if TYPE_CHECKING:
@@ -87,7 +87,7 @@ class ReadableDBAPIDataset(SupportsReadableDataset[ReadableIbisRelation]):
         # NOTE: no cache for now, it is probably more expensive to compute the current schema hash
         # to see wether this is stale than to compute a new sqlglot schema
         dialect: str = self.sql_client.capabilities.sqlglot_dialect
-        return lineage.create_sqlglot_schema(self.schema, self.dataset_name, dialect=dialect)
+        return sqlglot.dlt_schema_to_sqlglot_schema(self.schema, self.dataset_name, dialect=dialect)
 
     @property
     def dataset_name(self) -> str:

--- a/tests/libs/test_sqlglot.py
+++ b/tests/libs/test_sqlglot.py
@@ -408,18 +408,17 @@ def test_from_and_to_sqlglot_constraint(
     Not all dlt hints map to a constraint.
     """
     key = next(iter(hint))
-    #
+    # exit early for exceptions
     if isinstance(constraint, Exception):
         with pytest.raises(constraint.__class__):
-            _to_sqlglot_constraint(key, hint[key])
+            _to_sqlglot_constraint(key, hint[key])  # type: ignore
         return
 
-    inferred_constraint = _to_sqlglot_constraint(key, hint[key])
+    inferred_constraint = _to_sqlglot_constraint(key, hint[key])  # type: ignore
     assert inferred_constraint == constraint
     if inferred_constraint is None:
         return
 
-    # we should be able to retrieve the original hint
     inferred_hint = _from_sqlglot_constraint(inferred_constraint)
     assert inferred_hint == hint
 
@@ -429,7 +428,9 @@ def test_from_and_to_sqlglot_constraint(
     [
         (
             {"name": "foo", "data_type": "text"},
-            sge.ColumnDef(this=sge.Identifier(this="foo", quoted=False), kind=sge.DataType.build("text")),
+            sge.ColumnDef(
+                this=sge.Identifier(this="foo", quoted=False), kind=sge.DataType.build("text")
+            ),
         ),
         (
             {"name": "foo", "data_type": "text", "nullable": False},
@@ -470,7 +471,9 @@ def test_from_and_to_sqlglot_column_def(hints: TColumnSchema, column_def: sge.Co
         )
     ],
 )
-def test_from_and_to_sqlglot_reference(reference: TTableReference, foreign_key: sge.ForeignKey) -> None:
+def test_from_and_to_sqlglot_reference(
+    reference: TTableReference, foreign_key: sge.ForeignKey
+) -> None:
     inferred_reference = _from_sqlglot_reference(foreign_key)
     assert inferred_reference == reference
 
@@ -522,20 +525,18 @@ def test_from_and_to_sqlglot_reference(reference: TTableReference, foreign_key: 
                         "referenced_table": "customer",
                         "referenced_columns": ["customer_id"],
                     }
-                ]
+                ],
             ),
         )
     ],
 )
-def test_from_and_to_sqlglot_table_def(
-    ddl_query: str, table_schema: TTableSchema
-) -> None:
+def test_from_and_to_sqlglot_table_def(ddl_query: str, table_schema: TTableSchema) -> None:
     """Convert from and to table def
-    
+
     We're not testing `SQL string -> dlt schema` or `dlt schema -> SQL string` here.
     The SQL string is simply more convenient than writing the SQLGlot expression in full.
     """
-    ddl_expr = sqlglot.maybe_parse(ddl_query)
+    ddl_expr: sge.Create = sqlglot.maybe_parse(ddl_query)
 
     inferred_table_schema = _from_sqlglot_table_def(ddl_expr)
     assert inferred_table_schema == table_schema

--- a/tests/load/test_lineage.py
+++ b/tests/load/test_lineage.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dlt import Schema
+import dlt.common.libs.sqlglot
 from dlt.common.schema.typing import TColumnSchema
 from dlt.transformations import lineage
 
@@ -54,7 +55,9 @@ def test_various_queries(destination_config: DestinationTestConfiguration, examp
     destination = destination_config.destination_factory(dataset_name="d1")
     caps = destination.client(example_schema).sql_client.capabilities
     dialect = caps.sqlglot_dialect
-    sqlglot_schema = lineage.create_sqlglot_schema(example_schema, "d1", dialect)
+    sqlglot_schema = dlt.common.libs.sqlglot.dlt_schema_to_sqlglot_schema(
+        example_schema, "d1", dialect
+    )
 
     def _set_nullable(col: TColumnSchema) -> TColumnSchema:
         # if not caps.enforces_nulls:


### PR DESCRIPTION
## Description
This maps dlt hints to SQLGlot DDL expressions. This internal feature could enable future usage:

### Table discovery
To enable `@dlt.transformation`, it's useful to know about tables manages outside of dlt.

It would make sense to discover from the `dlt.Dataset` API to add tables to its schema. Discovery should be limited to the same "database/dataset" namespace on the destination. Retrieving DDL from destination is a very cheap operation.

We would need a new hint for external tables.

tentative API.
```python
dataset = dlt.Dataset(...)
table_foo = dataset.table("foo")  # regular access
table_bar = dataset.table("bar")  # raise TableNotExist

dataset.discover()  # all tables within "database/dataset" namespace
dataset.discover("bar")  # single specific table
dataset.discover(["bar", "baz"])  # multiple specific tables 
dataset.discover(pattern="ba.*")  # unknown number using regex

table_bar = dataset.table("bar")  # succeeds because table is now in schema
```
This effect is persisted to the schema storage and the destination.

### Table creation
We have a lot of templated SQL strings for destination clients. We also use destination-specific SDK libraries.

Generating DDL from dlt hints could simplify internals and help with maintenance. This potentially simplifies supporting and testing new SQL backends.

More importantly, `dlt -> DDL` allows more powerful user configuration (e.g., create an index).
