### PR TITLE
Psycopg2SqlClient: accept extra options

### DIFF
--- a/dlt/destinations/impl/postgres/sql_client.py
+++ b/dlt/destinations/impl/postgres/sql_client.py
@@ -45,9 +45,13 @@ class Psycopg2SqlClient(SqlClientBase["psycopg2.connection"], DBTransaction):
         self.credentials = credentials
 
     def open_connection(self) -> "psycopg2.connection":
+        options=f"-c search_path={self.fully_qualified_dataset_name()},public"
+        extra_options = self.credentials.query.get("options")
+        if extra_options:
+            options = f"{extra_options} {options}"
         self._conn = psycopg2.connect(
             dsn=self.credentials.to_native_representation(),
-            options=f"-c search_path={self.fully_qualified_dataset_name()},public",
+            options=options,
         )
         # we'll provide explicit transactions see _reset
         self._reset_connection()

--- a/docs/website/docs/dlt-ecosystem/destinations/postgres.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/postgres.md
@@ -57,12 +57,13 @@ password = "<password>" # replace with your password
 host = "localhost" # or the IP address location of your database
 port = 5432
 connect_timeout = 15
+query.options = "-ctimezone=Europe/Paris"
 ```
 
 You can also pass a database connection string similar to the one used by the `psycopg2` library or [SQLAlchemy](https://docs.sqlalchemy.org/en/20/core/engines.html#postgresql). The credentials above will look like this:
 ```toml
 # Keep it at the top of your TOML file, before any section starts
-destination.postgres.credentials="postgresql://loader:<password>@localhost/dlt_data?connect_timeout=15"
+destination.postgres.credentials="postgresql://loader:<password>@localhost/dlt_data?connect_timeout=15&options=-ctimezone=Europe/Paris"
 ```
 
 To pass credentials directly, use the [explicit instance of the destination](../../general-usage/destination.md#pass-explicit-credentials)

--- a/tests/load/postgres/test_postgres_client.py
+++ b/tests/load/postgres/test_postgres_client.py
@@ -73,11 +73,12 @@ def test_postgres_credentials_native_value(environment) -> None:
 
 def test_postgres_query_params() -> None:
     # test postgres timeout
-    dsn = "postgres://loader:pass@localhost:5432/dlt_data?client_encoding=utf-8&connect_timeout=600"
+    dsn = "postgres://loader:pass@localhost:5432/dlt_data?client_encoding=utf-8&connect_timeout=600&options=-ctimezone%3dEurope/Paris"
     csc = PostgresCredentials()
     csc.parse_native_representation(dsn)
     assert csc.connect_timeout == 600
     assert csc.client_encoding == "utf-8"
+    assert csc.get_query().get("options") == "-ctimezone%3dEurope/Paris"
     assert csc.to_native_representation() == dsn
 
 


### PR DESCRIPTION
see #2656

### Description

Add ability to add Postgres runtime server config via Psycopg2SqlClient.

Example of PostgresCredentials usage with "my_setting" server setting :
```
from dlt.destinations.impl.postgres.configuration import PostgresCredentials

creds = PostgresCredentials("postgresql://user:password@host:port/db?options=-cmy_setting=value")
```

### Additional Context

I needed to transmit a parameter (such as a session option) to the PostgreSQL server, but the current implementation of Psycopg2SqlClient did not allow me to do this easily.