### PR TITLE
docs: fix incorrect github_source function calls in tutorial

### DIFF
--- a/docs/website/docs/tutorial/load-data-from-an-api.md
+++ b/docs/website/docs/tutorial/load-data-from-an-api.md
@@ -518,7 +518,7 @@ pipeline = dlt.pipeline(
     destination="duckdb",
     dataset_name="github_data",
 )
-load_info = pipeline.run(github_source())
+load_info = pipeline.run(github_source_with_token())
 ```
 
 ## Configurable sources
@@ -562,7 +562,7 @@ pipeline = dlt.pipeline(
     destination="duckdb",
     dataset_name="github_data",
 )
-load_info = pipeline.run(github_source())
+load_info = pipeline.run(github_source_with_token_and_repo())
 ```
 
 Next, create a `.dlt/config.toml` file in the project folder and add the `repo_name` parameter to it:


### PR DESCRIPTION
### Description

Fixed incorrect code example in the documentation file: [Build a dlt pipeline](https://dlthub.com/docs/tutorial/load-data-from-an-api).   
The sections [Handle secrets](https://dlthub.com/docs/tutorial/load-data-from-an-api#handle-secrets) and [Configurable sources](https://dlthub.com/docs/tutorial/load-data-from-an-api#configurable-sources) were using the wrong function for running the pipeline.

**Changes made:**
- Updated function calls in the "Handle secrets" section
- Updated function calls in the "Configurable sources" section


**Before:**
```python
load_info = pipeline.run(github_source())
```

**After**:
```python
load_info = pipeline.run(github_source_with_token())
```

This fix ensures users can successfully follow the tutorial without encountering undefined function errors.