### PR TITLE
(QoL):adds `str` and `repr` to dataset and relation

### DIFF
--- a/dlt/common/configuration/specs/base_configuration.py
+++ b/dlt/common/configuration/specs/base_configuration.py
@@ -276,7 +276,7 @@ def configspec(
         if synth_init != init and has_default_init:
             warnings.warn(
                 f"__init__ method will not be generated on {cls.__name__} because base class didn't"
-                " synthesize __init__. Please correct `init` flag in confispec decorator. You are"
+                " synthesize __init__. Please correct `init` flag in configspec decorator. You are"
                 " probably receiving incorrect __init__ signature for type checking"
             )
         # mark exactly this class as processed by configspec so we can warn the user if it is not done

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -10,15 +10,11 @@ from typing import (
     Tuple,
     AnyStr,
     overload,
-    runtime_checkable,
 )
-
-from abc import ABC, abstractmethod
 
 from sqlglot.schema import Schema as SQLGlotSchema
 
 from dlt.common.typing import Self, Generic, TypeVar
-from dlt.common.exceptions import MissingDependencyException
 from dlt.common.schema.schema import Schema
 from dlt.common.schema.typing import TTableSchemaColumns
 

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -146,6 +146,9 @@ class Destination(ABC, Generic[TDestinationConfig, TDestinationClient]):
         ...
 
     def __repr__(self) -> str:
+        # TODO: consider not showing default values of base SPEC
+        #   consider showing physical location (when implemented) and
+        #   props of the client ie. if it supports state, datasets or open tables
         kwargs = {**self.spec(), **self.config_params}
         return simple_repr(self.destination_type, **without_none(kwargs))
 

--- a/dlt/destinations/dataset/relation.py
+++ b/dlt/destinations/dataset/relation.py
@@ -1,3 +1,4 @@
+from textwrap import indent
 from typing import Any, Dict, Generator, Optional, Sequence, Tuple, Type, Union, TYPE_CHECKING
 from contextlib import contextmanager
 
@@ -159,6 +160,8 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
         """
         # TODO: the docstrings above seem not right!
         # NOTE: if we do not have a schema, we cannot compute the columns schema
+        # TODO: it is impossible to not have a schema, new schema will be created if dataset is not
+        #       on the destination. try to remove the condition
         if self._dataset.schema is None or (
             hasattr(self, "_table_name")
             and self._table_name
@@ -201,6 +204,17 @@ class BaseReadableDBAPIRelation(SupportsReadableRelation, WithSqlClient):
                 self._dataset.sqlglot_schema, self.qualified_query, self._dataset.sql_client
             )
         return self._normalized_query
+
+    def __str__(self) -> str:
+        # TODO: have base table name for each relation is a good idea. consider to have it in the interface
+        # TODO: merge detection of "simple" transformation that preserve table schema
+        table_name = getattr(self, "_table_name", None)
+        msg = ""
+        for column in self.columns_schema.values():
+            # TODO: show x-annotation hints
+            msg += f"{column['name']} {column['data_type']}\n"
+        msg = f"{table_name}:\n{indent(msg, prefix='  ')}" if table_name else msg
+        return msg
 
 
 class ReadableDBAPIRelation(BaseReadableDBAPIRelation):

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -20,8 +20,6 @@ import zlib
 import re
 
 import sqlglot.expressions
-import sqlglot.optimizer
-import sqlglot.optimizer.normalize_identifiers
 
 from dlt.common import pendulum, logger
 from dlt.common.destination.capabilities import DataTypeMapper

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -686,7 +686,7 @@ def test_column_selection(populated_pipeline: Pipeline) -> None:
     ids=lambda x: x.name,
 )
 def test_unknown_table_access(populated_pipeline: Pipeline) -> None:
-    with pytest.raises(ValueError, match="Table unknown_table not found in schema"):
+    with pytest.raises(ValueError, match="Table `unknown_table` not found in schema"):
         populated_pipeline.dataset().unknown_table
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
it is easier to work with datasets and relations in a notebook:
* adds `__repr__` to dataset
* adds str to dataset (display table list)
* adds str to relation (display expression schema)
