### PR TITLE
fix: added `@dlt.transformation` to `__all__`

### DIFF
--- a/dlt/__init__.py
+++ b/dlt/__init__.py
@@ -83,6 +83,7 @@ __all__ = [
     "destinations",
     "Dataset",
     "dataset",
+    "transformation",
 ]
 
 # verify that no injection context was created


### PR DESCRIPTION
Gets rid of red squiggly lines

![image](https://github.com/user-attachments/assets/5e1f5115-5c85-4bac-b6fd-7c82d74da0b8)
