### PR TITLE
Fix: Null column type not inferred info/warning floods the output

### DIFF
--- a/dlt/common/schema/exceptions.py
+++ b/dlt/common/schema/exceptions.py
@@ -236,27 +236,36 @@ class ColumnNameConflictException(SchemaException):
 
 
 class UnboundColumnException(SchemaException):
-    def __init__(self, schema_name: str, table_name: str, column: TColumnSchemaBase) -> None:
-        self.column = column
+    def __init__(self, schema_name: str, table_name: str, columns: List[TColumnSchemaBase]) -> None:
+        self.columns = columns
         self.schema_name = schema_name
         self.table_name = table_name
-        nullable: bool = column.get("nullable", False)
-        key_type: str = ""
-        if column.get("merge_key"):
-            key_type = "merge key"
-        elif column.get("primary_key"):
-            key_type = "primary key"
+
+        col_infos: List[str] = []
+        for column in columns:
+            key_type: str = ""
+            if column.get("merge_key"):
+                key_type = "merge key"
+            elif column.get("primary_key"):
+                key_type = "primary key"
+
+            line = f"  - {column['name']}"
+            if key_type or not column.get("nullable", True):
+                suffix = " (marked as non-nullable"
+                if key_type:
+                    suffix += f" {key_type}"
+                suffix += " and must have values)"
+                line += suffix
+            col_infos.append(line)
 
         msg = (
-            f"The column `{column['name']}` in table `{table_name}` did not receive any data during"
-            " this load. "
+            f"The following columns in table `{table_name}` did not receive any data during"
+            " this load:\n"
+            + "\n".join(col_info for col_info in col_infos)
         )
-        if key_type or not nullable:
-            msg += f"It is marked as non-nullable{' '+key_type} and it must have values. "
-
         msg += (
-            "This can happen if you specify the column manually, for example using the `merge_key`,"
-            " `primary_key` or `columns` argument but it does not exist in the data."
+            "\n\nThis can happen if you specify columns manually, for example, using the"
+            " `merge_key`, `primary_key` or `columns` argument but they do not exist in the data.\n"
         )
         super().__init__(schema_name, msg)
 

--- a/dlt/common/schema/exceptions.py
+++ b/dlt/common/schema/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 
 from dlt.common.exceptions import DltException
 from dlt.common.data_types import TDataType
@@ -262,18 +262,22 @@ class UnboundColumnException(SchemaException):
 
 
 class UnboundColumnWithoutTypeException(SchemaException):
-    def __init__(self, schema_name: str, table_name: str, column: TColumnSchemaBase) -> None:
-        self.column = column
+    def __init__(self, schema_name: str, table_name: str, columns: List[TColumnSchemaBase]) -> None:
+        self.columns = columns
         self.schema_name = schema_name
         self.table_name = table_name
 
+        column_names = [col["name"] for col in columns]
+
         msg = (
-            f"The column {column['name']} in table {table_name} did not receive any data during"
-            " this load. Therefore, its type couldn't be inferred. Unless a type hint is provided,"
-            " the column will not be materialized in the destination. One way to provide a type"
-            " hint is to use the 'columns' argument in the '@dlt.resource' decorator. For"
-            f" example:\n\n@dlt.resource(columns={{{repr(column['name'])}: {{'data_type':"
-            " 'text'}})\n\n"
+            f"The following columns in table '{table_name}' did not receive any data during this"
+            " load and therefore could not have their types inferred:\n"
+            + "\n".join(f"  - {name}" for name in column_names)
+            + "\n\nUnless type hints are provided, these columns will not be materialized in the"
+            " destination.\nOne way to provide type hints is to use the 'columns' argument in"
+            " the '@dlt.resource' decorator.  For"
+            f" example:\n\n@dlt.resource(columns={{{repr(column_names[0])}: {{'data_type':"
+            " 'text'}})\n"
         )
 
         super().__init__(schema_name, msg)

--- a/dlt/normalize/validate.py
+++ b/dlt/normalize/validate.py
@@ -2,7 +2,7 @@ from typing import List
 
 from dlt.common.destination.capabilities import DestinationCapabilitiesContext
 from dlt.common.schema import Schema
-from dlt.common.schema.typing import TTableSchema, TSchemaUpdate
+from dlt.common.schema.typing import TTableSchema, TSchemaUpdate, TColumnSchemaBase
 from dlt.common.schema.utils import (
     ensure_compatible_tables,
     find_incomplete_columns,
@@ -38,23 +38,34 @@ def verify_normalized_table(
     2. Raise `UnboundColumnException` on incomplete non-nullable columns (e.g. missing merge/primary key)
     3. Log warning if table format is not supported by destination capabilities
     """
-    null_first_cols = []
+    incomplete_nullable_not_seen_data: List[TColumnSchemaBase] = []
+    incomplete_nullable_seen_data: List[TColumnSchemaBase] = []
 
     for column, nullable in find_incomplete_columns(table):
-        exc = UnboundColumnException(schema.name, table["name"], column)
         if nullable:
-            # warn if null column
             seen_null_first = column.get("x-normalizer", {}).get("seen-null-first")
+            # warn if column exists in source, but has no data
             if seen_null_first is True:
-                null_first_cols.append(column)
+                incomplete_nullable_not_seen_data.append(column)
+            # warn if column doesn't exist in source
             else:
-                logger.warning(str(exc))
+                incomplete_nullable_seen_data.append(column)
         else:
-            raise exc
+            raise UnboundColumnException(schema.name, table["name"], [column])
 
-    if null_first_cols:
-        null_exc = UnboundColumnWithoutTypeException(schema.name, table["name"], null_first_cols)
-        logger.info(str(null_exc))
+    if incomplete_nullable_not_seen_data:
+        logger.warning(
+            str(
+                UnboundColumnWithoutTypeException(
+                    schema.name, table["name"], incomplete_nullable_not_seen_data
+                )
+            )
+        )
+
+    if incomplete_nullable_seen_data:
+        logger.warning(
+            str(UnboundColumnException(schema.name, table["name"], incomplete_nullable_seen_data))
+        )
 
     # TODO: 3. raise if we detect name conflict for SCD2 columns
     # until we track data per column we won't be able to implement this
@@ -81,6 +92,6 @@ def verify_normalized_table(
             f"Table {table['name']} has parent_key on column {parent_key} but no corresponding"
             " `parent` table hint to refer to parent table.Such table is not considered a nested"
             " table and relational normalizer will not generate linking data. The most probable"
-            " cause is manual modification of the dtl schema for the table. The most probable"
+            " cause is manual modification of the dlt schema for the table. The most probable"
             f" outcome will be NULL violation during the load process on {parent_key}."
         )

--- a/tests/load/pipeline/test_arrow_loading.py
+++ b/tests/load/pipeline/test_arrow_loading.py
@@ -333,19 +333,19 @@ def test_warning_from_arrow_normalizer_on_null_column(
 
         return [my_resource()]
 
-    logger_spy = mocker.spy(logger, "warning")
+    logger_spy = mocker.spy(logger, "info")
 
     pipeline = destination_config.setup_pipeline("arrow_" + uniq_id())
 
     pipeline.extract(my_source())
     pipeline.normalize()
 
+    expected_warning = (
+        "columns in table 'my_resource' did not receive any data during this load "
+        "and therefore could not have their types inferred:\n"
+        "  - col1"
+    )
     if is_none:
-        logger_spy.assert_called_once()
-        expected_warning = (
-            "The column col1 in table my_resource did not receive any data during this load."
-            " Therefore, its type couldn't be inferred."
-        )
-        assert expected_warning in logger_spy.call_args_list[0][0][0]
+        assert any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)
     else:
-        logger_spy.assert_not_called()
+        assert not any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)

--- a/tests/load/pipeline/test_arrow_loading.py
+++ b/tests/load/pipeline/test_arrow_loading.py
@@ -333,19 +333,20 @@ def test_warning_from_arrow_normalizer_on_null_column(
 
         return [my_resource()]
 
-    logger_spy = mocker.spy(logger, "info")
+    logger_spy = mocker.spy(logger, "warning")
 
     pipeline = destination_config.setup_pipeline("arrow_" + uniq_id())
 
     pipeline.extract(my_source())
     pipeline.normalize()
 
-    expected_warning = (
-        "columns in table 'my_resource' did not receive any data during this load "
-        "and therefore could not have their types inferred:\n"
-        "  - col1"
-    )
     if is_none:
-        assert any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)
+        logger_spy.assert_called_once()
+        expected_warning = (
+            "columns in table 'my_resource' did not receive any data during this load "
+            "and therefore could not have their types inferred:\n"
+            "  - col1"
+        )
+        assert expected_warning in logger_spy.call_args_list[0][0][0]
     else:
-        assert not any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)
+        logger_spy.assert_not_called()

--- a/tests/load/sources/sql_database/test_sql_database_source.py
+++ b/tests/load/sources/sql_database/test_sql_database_source.py
@@ -910,20 +910,19 @@ def test_null_column_warning(
         .add_limit(1)
     )
 
-    logger_spy = mocker.spy(logger, "warning")
+    logger_spy = mocker.spy(logger, "info")
 
     pipeline = dlt.pipeline(
         pipeline_name="blabla", destination="duckdb", dataset_name="anuuns_test"
     )
     pipeline.run(source)
 
-    logger_spy.assert_called()
-    assert logger_spy.call_count == 1
     expected_warning = (
-        "The column empty_col in table app_user did not receive any data during this load."
-        " Therefore, its type couldn't be inferred."
+        "columns in table 'app_user' did not receive any data during this load "
+        "and therefore could not have their types inferred:\n"
+        "  - empty_col"
     )
-    assert expected_warning in logger_spy.call_args_list[0][0][0]
+    assert any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)
     assert (
         pipeline.default_schema.get_table("app_user")["columns"]["empty_col"]["x-normalizer"][
             "seen-null-first"

--- a/tests/load/sources/sql_database/test_sql_database_source.py
+++ b/tests/load/sources/sql_database/test_sql_database_source.py
@@ -910,19 +910,21 @@ def test_null_column_warning(
         .add_limit(1)
     )
 
-    logger_spy = mocker.spy(logger, "info")
+    logger_spy = mocker.spy(logger, "warning")
 
     pipeline = dlt.pipeline(
         pipeline_name="blabla", destination="duckdb", dataset_name="anuuns_test"
     )
     pipeline.run(source)
 
+    logger_spy.assert_called()
+    assert logger_spy.call_count == 1
     expected_warning = (
         "columns in table 'app_user' did not receive any data during this load "
         "and therefore could not have their types inferred:\n"
         "  - empty_col"
     )
-    assert any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)
+    assert expected_warning in logger_spy.call_args_list[0][0][0]
     assert (
         pipeline.default_schema.get_table("app_user")["columns"]["empty_col"]["x-normalizer"][
             "seen-null-first"
@@ -957,7 +959,7 @@ def test_null_column_warning(
         .add_limit(1)
     )
 
-    logger_spy = mocker.spy(logger, "warning")
+    logger_spy.reset_mock()
     pipeline.run(source)
     assert logger_spy.call_count == 0
     assert (

--- a/tests/normalize/test_normalize.py
+++ b/tests/normalize/test_normalize.py
@@ -844,7 +844,7 @@ def test_warning_from_json_normalizer_on_null_column(
         ],
     }
 
-    logger_spy = mocker.spy(logger, "info")
+    logger_spy = mocker.spy(logger, "warning")
 
     extract_items(
         raw_normalize.normalize_storage,
@@ -855,13 +855,14 @@ def test_warning_from_json_normalizer_on_null_column(
     with ThreadPoolExecutor(max_workers=1) as pool:
         raw_normalize.run(pool)
 
-    expected_warning = (
-        "columns in table 'nested_table__children' did not receive any data during this load "
-        "and therefore could not have their types inferred:\n"
-        "  - col1"
-    )
     if is_none:
         logger_spy.assert_called()
-        assert any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)
+        assert logger_spy.call_count == 1
+        expected_warning = (
+            "columns in table 'nested_table__children' did not receive any data during this load "
+            "and therefore could not have their types inferred:\n"
+            "  - col1"
+        )
+        assert expected_warning in logger_spy.call_args_list[0][0][0]
     else:
-        assert not any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)
+        logger_spy.assert_not_called()

--- a/tests/normalize/test_normalize.py
+++ b/tests/normalize/test_normalize.py
@@ -844,7 +844,7 @@ def test_warning_from_json_normalizer_on_null_column(
         ],
     }
 
-    logger_spy = mocker.spy(logger, "warning")
+    logger_spy = mocker.spy(logger, "info")
 
     extract_items(
         raw_normalize.normalize_storage,
@@ -855,16 +855,13 @@ def test_warning_from_json_normalizer_on_null_column(
     with ThreadPoolExecutor(max_workers=1) as pool:
         raw_normalize.run(pool)
 
+    expected_warning = (
+        "columns in table 'nested_table__children' did not receive any data during this load "
+        "and therefore could not have their types inferred:\n"
+        "  - col1"
+    )
     if is_none:
         logger_spy.assert_called()
-        assert logger_spy.call_count == 1
-        expected_warning = (
-            "The column col1 in table nested_table__children did not receive any data during this"
-            " load. Therefore, its type couldn't be inferred. Unless a type hint is provided, the"
-            " column will not be materialized in the destination. One way to provide a type hint is"
-            " to use the 'columns' argument in the '@dlt.resource' decorator. For"
-            " example:\n\n@dlt.resource(columns={'col1': {'data_type': 'text'}})\n\n"
-        )
-        assert expected_warning in logger_spy.call_args_list[0][0][0]
+        assert any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)
     else:
-        logger_spy.assert_not_called()
+        assert not any(expected_warning in str(call.args[0]) for call in logger_spy.call_args_list)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR collect the columns for which the type could not be inferred and uses one `UnboundColumnWIthoutTypeException` per table. Previously it was one `UnboundColumnWIthoutTypeException` per column, and the stdout was flooded with warning messages if there are too many of such columns. 

### Additional context
Since this is not a critical warning, I suggest that we move this to info 👀 - which will underneath involve just having an info message instead of an Exception object.  For now, the `UnboundColumnWIthoutTypeException` is kept.