### PR TITLE
feat: add `has_more` boolean flag logic to RESTClient OffsetPaginator

### DIFF
--- a/docs/website/docs/general-usage/http/rest-client.md
+++ b/docs/website/docs/general-usage/http/rest-client.md
@@ -183,6 +183,7 @@ Note: Normally, you don't need to specify this paginator explicitly, as it is us
 - `total_path`: A JSONPath expression for the total number of items. If not provided, pagination is controlled by `maximum_offset` and `stop_after_empty_page`.
 - `maximum_offset`: Optional maximum offset value. Limits pagination even without a total count.
 - `stop_after_empty_page`: Whether pagination should stop when a page contains no result items. Defaults to `True`.
+- `has_more_path`: A JSONPath expression for a boolean indicator of whether additional pages exist. Defaults to `None`.
 
 **Example:**
 
@@ -234,7 +235,20 @@ client = RESTClient(
 )
 ```
 
-You can disable automatic stoppage of pagination by setting `stop_after_empty_page = False`. In this case, you must provide either `total_path` or `maximum_offset` to guarantee that the paginator terminates.
+If the API provides a boolean flag when all pages have been returned, you can use `has_more_path` to recognize this indicator and end pagination:
+
+```py
+client = RESTClient(
+    base_url="https://api.example.com",
+    paginator=OffsetPaginator(
+        limit=10,
+        total_path=None,
+        has_more_path="has_more",
+    )
+)
+```
+
+You can disable automatic stoppage of pagination by setting `stop_after_empty_page = False`. In this case, you must provide either `total_path`, `maximum_offset`, or `has_more_path` to guarantee that the paginator terminates.
 
 #### PageNumberPaginator
 


### PR DESCRIPTION
- add `has_more_path` parameter to `OffsetParameter` class
- add `update_state` method to read and handle `has_more_path` and end pagination when indicated
- add positive and negative unit tests within `test_paginators.py` for `has_more_path` property and data types
- update `http/rest-client` docs to include documentation of `has_more_path` option

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Add additional functionality to `rest_client.paginators.OffsetPaginator` to support API implementations providing a boolean flag to indicate when pagination has ended, including related tests and documentation updates.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Closes #2816

<!--
Provide any additional context about the PR here.
-->
### Additional Context

Included in issue - many APIs provide boolean flag in pagination and may not fully respect limit / offset parameters.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
