### PR TITLE
Chore: Pyiceberg's python contsraint moved from project wide constraints

### DIFF
--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import Dict, Any, List, Optional
 
 from fsspec import AbstractFileSystem
@@ -20,6 +21,12 @@ from dlt.common.configuration.specs.mixins import WithPyicebergConfig
 
 from dlt.destinations.impl.filesystem.filesystem import FilesystemClient
 
+if sys.version_info[:3] == (3, 9, 7):
+    raise MissingDependencyException(
+        "dlt pycieberg helpers",
+        [f"{version.DLT_PKG_NAME}[pyiceberg]"],
+        "PyIceberg is not compatible with Python 3.9.7. Use a different Python version.",
+    )
 
 try:
     from pyiceberg.table import Table as IcebergTable

--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from typing import Dict, Any, List, Optional
 
 from fsspec import AbstractFileSystem
@@ -21,12 +20,6 @@ from dlt.common.configuration.specs.mixins import WithPyicebergConfig
 
 from dlt.destinations.impl.filesystem.filesystem import FilesystemClient
 
-if sys.version_info[:3] == (3, 9, 7):
-    raise MissingDependencyException(
-        "dlt pycieberg helpers",
-        [f"{version.DLT_PKG_NAME}[pyiceberg]"],
-        "PyIceberg is not compatible with Python 3.9.7. Use a different Python version.",
-    )
 
 try:
     from pyiceberg.table import Table as IcebergTable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,7 @@ sqlalchemy = [
     "alembic>1.10.0",
 ]
 pyiceberg = [
-    "pyiceberg>=0.9.1 ; python_version != '3.9.7'",
+    "pyiceberg>=0.9.1",
     "pyarrow>=16.0.0 ; python_version < '3.13'",
     "pyarrow>=18.0.0 ; python_version >= '3.13'",
     "sqlalchemy>=1.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "dlt"
 version = "1.12.4a0"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 authors = [{ name = "dltHub Inc.", email = "services@dlthub.com" }]
-requires-python = ">=3.9.2, <3.14, !=3.9.7"
+requires-python = ">=3.9.2, <3.14"
 readme = "README.md"
 license = "Apache-2.0"
 maintainers = [
@@ -173,7 +173,7 @@ sqlalchemy = [
     "alembic>1.10.0",
 ]
 pyiceberg = [
-    "pyiceberg>=0.9.1",
+    "pyiceberg>=0.9.1 ; python_version != '3.9.7'",
     "pyarrow>=16.0.0 ; python_version < '3.13'",
     "pyarrow>=18.0.0 ; python_version >= '3.13'",
     "sqlalchemy>=1.4",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
`pyproject.toml` excluded python version 3.9.7 just because pyiceberg doesn't support it.
This was moved to pyiceberg specifically.