### PR TITLE
Fix broken links in 30+ SQL DBs page

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/index.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/index.md
@@ -34,13 +34,13 @@ Check out [dlt+](../../../plus/ecosystem/ms-sql.md) for support of change tracki
 We support all [SQLAlchemy dialects](https://docs.sqlalchemy.org/en/20/dialects/), which include, but are not limited to, the following database engines:
 
 
-* [PostgreSQL](./sql_database/troubleshooting#postgres--mssql)
-* [MySQL](./sql_database/troubleshooting#mysql)
+* [PostgreSQL](troubleshooting#postgres--mssql)
+* [MySQL](troubleshooting#mysql)
 * SQLite
-* [Oracle](./sql_database/troubleshooting#oracle)
-* [Microsoft SQL Server](./sql_database/troubleshooting#postgres--mssql)
+* [Oracle](troubleshooting#oracle)
+* [Microsoft SQL Server](troubleshooting#postgres--mssql)
 * MariaDB
-* [IBM DB2 and Informix](./sql_database/troubleshooting#db2)
+* [IBM DB2 and Informix](troubleshooting#db2)
 * Google BigQuery
 * Snowflake
 * Redshift


### PR DESCRIPTION
### Description

The links in the "Supported databases" section of https://dlthub.com/docs/dlt-ecosystem/verified-sources/sql_database are currently broken, this PR is to fix that,

### Related Issues


### Additional Context


