### PR TITLE
docs: adds documentation for column subset selection in sql_database source

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
@@ -140,6 +140,26 @@ print(read_table.compute_table_schema())
 
 You can call `remove_nullability_adapter` from your custom table adapter if you need to combine both.
 
+### Selecting a subset of columns
+
+You can use `table_adapter_callback` to select only specific columns from a table by removing unwanted columns from the table definition.
+
+```py
+from dlt.sources.sql_database import sql_database
+
+def table_adapter_callback(table):
+    if table.name == 'my_table':
+        columns_to_keep = ['id', 'name', 'email']
+        for col in list(table._columns):
+            if col.name not in columns_to_keep:
+                table._columns.remove(col)
+    return table
+
+source = sql_database(
+    table_names=["my_table"],
+    table_adapter_callback=table_adapter_callback
+)
+```
 
 ## Configuring with TOML or environment variables
 You can set most of the arguments of `sql_database()` and `sql_table()` directly in the TOML files or as environment variables. `dlt` automatically injects these values into the pipeline script.


### PR DESCRIPTION
### Description

This PR adds documentation on how to select a subset of columns from database tables when using the `sql_database` source. It shows how to use the `table_adapter_callback` parameter to filter columns at the table definition level, ensuring that schema inference works correctly with only the selected columns.

### Related Issues

- Fixes #2551

### Additional Context

This documentation addresses a schema inference issue ([#2551](https://github.com/dlt-hub/dlt/issues/2551)) where using a `query_adapter_callback ` to select a subset of columns caused an `UnboundColumnException` during normalization. The normalizer incorrectly expected all columns from the original table schema, including non-nullable columns that were excluded from the selection.

While a code-level change to the inference logic was considered, it would introduce significant complexity. This PR instead documents a simple and effective workaround using `table_adapter_callback`. By modifying the table metadata directly, users can align the schema with the selected columns, providing a clean solution without altering the core logic (See https://github.com/dlt-hub/dlt/issues/2551#issuecomment-3063393177)
