### PR TITLE
fix: typing for updated datasets and relations `Protocols` 

### DIFF
--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -1,44 +1,35 @@
+from __future__ import annotations
+
+import abc
 from types import TracebackType
-
-
 from typing import (
-    Optional,
-    Sequence,
-    Union,
-    List,
-    Any,
-    Generator,
     TYPE_CHECKING,
-    Protocol,
-    Tuple,
-    AnyStr,
-    Literal,
     overload,
+    Any,
+    AnyStr,
+    Generator,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
     Type,
+    Union,
 )
 
-from sqlglot.schema import Schema as SQLGlotSchema
 import sqlglot.expressions as sge
+from sqlglot.schema import Schema as SQLGlotSchema
 from sqlglot.expressions import ExpOrStr as SqlglotExprOrStr
 
-from dlt.common.typing import Self, Generic, TypeVar
+from dlt.common.typing import Self
 from dlt.common.schema.schema import Schema
-from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.common.schema.typing import TTableSchema, TTableSchemaColumns
 from dlt.common.libs.sqlglot import TSqlGlotDialect
-from dlt.common.schema.typing import TTableSchema
 
 if TYPE_CHECKING:
     from dlt.common.libs.pandas import DataFrame
     from dlt.common.libs.pyarrow import Table as ArrowTable
     from dlt.helpers.ibis import BaseBackend as IbisBackend, Table as IbisTable, Expr as IbisExpr
     from dlt.common.destination.client import SupportsOpenTables
-else:
-    DataFrame = Any
-    ArrowTable = Any
-    IbisBackend = Any
-    IbisTable = Any
-    IbisExpr = Any
-    SupportsOpenTables = Any
 
 
 TFilterOperation = Literal["eq", "ne", "gt", "lt", "gte", "lte", "in", "not_in"]
@@ -53,26 +44,29 @@ class DataAccess(Protocol):
         Returns the expected columns schema for the result of the relation. Column types are discovered with
         sql glot query analysis and lineage. dlt hints for columns are kept in some cases. Refere to <docs-page> for more details.
         """
+        ...
 
-    def df(self, chunk_size: int = None) -> Optional[DataFrame]:
+    def df(self, chunk_size: Optional[int] = None) -> Optional[DataFrame]:
         """Fetches the results as arrow table. Uses the native pandas implementation of the destination client cursor if available.
 
         Args:
-            chunk_size (int, optional): The number of rows to fetch for this call. Defaults to None which will fetch all rows.
+            chunk_size (Optional[int]): The number of rows to fetch for this call. Defaults to None which will fetch all rows.
 
         Returns:
             Optional[DataFrame]: A data frame with query results.
         """
+        ...
 
-    def arrow(self, chunk_size: int = None) -> Optional[ArrowTable]:
+    def arrow(self, chunk_size: Optional[int] = None) -> Optional[ArrowTable]:
         """Fetches the results as arrow table. Uses the native arrow implementation of the destination client cursor if available.
 
         Args:
-            chunk_size (int, optional): The number of rows to fetch for this call. Defaults to None which will fetch all rows.
+            chunk_size (Optional[int]): The number of rows to fetch for this call. Defaults to None which will fetch all rows.
 
         Returns:
             Optional[ArrowTable]: An arrow table with query results.
         """
+        ...
 
     def iter_df(self, chunk_size: int) -> Generator[DataFrame, None, None]:
         """Iterates over data frames of 'chunk_size' items. Uses the native pandas implementation of the destination client cursor if available.
@@ -83,6 +77,7 @@ class DataAccess(Protocol):
         Returns:
             Generator[DataFrame, None, None]: A generator of data frames with query results.
         """
+        ...
 
     def iter_arrow(self, chunk_size: int) -> Generator[ArrowTable, None, None]:
         """Iterates over arrow tables of 'chunk_size' items. Uses the native arrow implementation of the destination client cursor if available.
@@ -93,43 +88,48 @@ class DataAccess(Protocol):
         Returns:
             Generator[ArrowTable, None, None]: A generator of arrow tables with query results.
         """
+        ...
 
-    def fetchall(self) -> List[Tuple[Any, ...]]:
+    def fetchall(self) -> list[tuple[Any, ...]]:
         """Fetches all items as a list of python tuples. Uses the native dbapi fetchall implementation of the destination client cursor.
 
         Returns:
-            List[Tuple[Any, ...]]: A list of python tuples w
+            list[tuple[Any, ...]]: A list of python tuples w
         """
+        ...
 
-    def fetchmany(self, chunk_size: int) -> List[Tuple[Any, ...]]:
+    def fetchmany(self, chunk_size: int) -> list[tuple[Any, ...]]:
         """Fetches the first 'chunk_size' items as a list of python tuples. Uses the native dbapi fetchmany implementation of the destination client cursor.
 
         Args:
             chunk_size (int): The number of rows to fetch for this call.
 
         Returns:
-            List[Tuple[Any, ...]]: A list of python tuples with query results.
+            list[tuple[Any, ...]]: A list of python tuples with query results.
         """
+        ...
 
-    def iter_fetch(self, chunk_size: int) -> Generator[List[Tuple[Any, ...]], Any, Any]:
+    def iter_fetch(self, chunk_size: int) -> Generator[list[tuple[Any, ...]], Any, Any]:
         """Iterates in lists of Python tuples in 'chunk_size' chunks. Uses the native dbapi fetchmany implementation of the destination client cursor.
 
         Args:
             chunk_size (int): The number of rows to fetch for each iteration.
 
         Returns:
-            Generator[List[Tuple[Any, ...]], Any, Any]: A generator of lists of python tuples with query results.
+            Generator[list[tuple[Any, ...]], Any, Any]: A generator of lists of python tuples with query results.
         """
+        ...
 
-    def fetchone(self) -> Optional[Tuple[Any, ...]]:
+    def fetchone(self) -> Optional[tuple[Any, ...]]:
         """Fetches the first item as a python tuple. Uses the native dbapi fetchone implementation of the destination client cursor.
 
         Returns:
-            Optional[Tuple[Any, ...]]: A python tuple with the first item of the query results.
+            Optional[tuple[Any, ...]]: A python tuple with the first item of the query results.
         """
+        ...
 
 
-class Relation(DataAccess):
+class Relation(DataAccess, Protocol):
     """A readable relation retrieved from a destination that supports it"""
 
     schema: TTableSchema
@@ -141,6 +141,7 @@ class Relation(DataAccess):
         Returns:
             Any: The first value of the first column on the first row as a python primitive.
         """
+        ...
 
     # modifying access parameters
     def limit(self, limit: int, **kwargs: Any) -> Self:
@@ -153,6 +154,7 @@ class Relation(DataAccess):
         Returns:
             Self: The relation with the limit applied.
         """
+        ...
 
     def head(self, limit: int = 5) -> Self:
         """By default returns a relation with the first 5 rows selected.
@@ -163,6 +165,7 @@ class Relation(DataAccess):
         Returns:
             Self: The relation with the limit applied.
         """
+        ...
 
     def select(self, *columns: str) -> Self:
         """Returns a new relation with the given columns selected.
@@ -173,6 +176,7 @@ class Relation(DataAccess):
         Returns:
             Self: The relation with the columns selected.
         """
+        ...
 
     def max(self) -> Self:  # noqa: A003
         """Returns a new relation with the MAX aggregate applied.
@@ -181,6 +185,7 @@ class Relation(DataAccess):
         Returns:
             Self: The relation with the MAX aggregate expression.
         """
+        ...
 
     def min(self) -> Self:  # noqa: A003
         """Returns a new relation with the MIN aggregate applied.
@@ -189,6 +194,7 @@ class Relation(DataAccess):
         Returns:
             Self: The relation with the MIN aggregate expression.
         """
+        ...
 
     @overload
     def where(self, column_or_expr: SqlglotExprOrStr) -> Self: ...
@@ -217,6 +223,7 @@ class Relation(DataAccess):
         Returns:
             Self: A copy of the relation with the where clause applied.
         """
+        ...
 
     def filter(  # noqa: A003
         self,
@@ -234,6 +241,7 @@ class Relation(DataAccess):
         Returns:
             Self: A copy of the relation with the where clause applied.
         """
+        ...
 
     def order_by(self, column_name: str, direction: Literal["asc", "desc"] = "asc") -> Self:
         """Returns a new relation with the given order by clause applied.
@@ -245,9 +253,10 @@ class Relation(DataAccess):
         Returns:
             Self: A copy of the relation with the order by clause applied.
         """
+        ...
 
     @overload
-    def __getitem__(self, column: str) -> Self: ...
+    def __getitem__(self, columns: str) -> Self: ...
 
     @overload
     def __getitem__(self, columns: Sequence[str]) -> Self: ...
@@ -261,6 +270,7 @@ class Relation(DataAccess):
         Returns:
             Self: The relation with the columns selected.
         """
+        ...
 
     def __copy__(self) -> Self:
         """create a copy of the relation object
@@ -268,15 +278,38 @@ class Relation(DataAccess):
         Returns:
             Self: The copy of the relation object
         """
+        ...
 
 
-class DBApiCursor(DataAccess):
+class DBApiCursorProtocol(DataAccess, Protocol):
     """Protocol for the DBAPI cursor"""
 
-    description: Tuple[Any, ...]
-
+    description: tuple[Any, ...]
     native_cursor: "DBApiCursor"
     """Cursor implementation native to current destination"""
+
+    @property
+    def columns_schema(self) -> TTableSchemaColumns: ...
+
+    def execute(self, query: AnyStr, *args: Any, **kwargs: Any) -> None:
+        """Execute a query on the cursor"""
+        ...
+
+    def close(self) -> None:
+        """Close the cursor"""
+        ...
+
+
+class DBApiCursor(abc.ABC, DBApiCursorProtocol):
+    """Protocol for the DBAPI cursor"""
+
+    description: tuple[Any, ...]
+    native_cursor: "DBApiCursor"
+    """Cursor implementation native to current destination"""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._columns_schema: TTableSchemaColumns = {}
 
     @property
     def columns_schema(self) -> TTableSchemaColumns:
@@ -285,10 +318,6 @@ class DBApiCursor(DataAccess):
     @columns_schema.setter
     def columns_schema(self, value: TTableSchemaColumns) -> None:
         self._columns_schema = value
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._columns_schema = None
 
     def execute(self, query: AnyStr, *args: Any, **kwargs: Any) -> None:
         """Execute a query on the cursor"""
@@ -307,6 +336,7 @@ class Dataset(Protocol):
         Returns:
             Schema: The schema of the dataset
         """
+        ...
 
     @property
     def sqlglot_schema(self) -> SQLGlotSchema:
@@ -315,6 +345,7 @@ class Dataset(Protocol):
         Returns:
             SQLGlotSchema: The sqlglot schema of the dataset
         """
+        ...
 
     @property
     def dataset_name(self) -> str:
@@ -323,51 +354,57 @@ class Dataset(Protocol):
         Returns:
             str: The name of the dataset
         """
+        ...
 
     def __call__(
         self,
         query: Union[str, sge.Select, IbisExpr],
-        query_dialect: TSqlGlotDialect = None,
+        query_dialect: Optional[TSqlGlotDialect] = None,
         _execute_raw_query: bool = False,
     ) -> Relation:
         """Returns a readable relation for a given sql query
 
         Args:
             query (Union[str, sge.Select, IbisExpr]): The sql query to base the relation on. Can be a raw sql query, a sqlglot select expression or an ibis expression.
-            query_dialect (TSqlGlotDialect, optional): The dialect of the query. Defaults to the dataset's destination dialect. You can use this to write queries in a different dialect than the destination.
+            query_dialect (Optional[TSqlGlotDialect]): The dialect of the query. Defaults to the dataset's destination dialect. You can use this to write queries in a different dialect than the destination.
                 This settings will only be user fo the initial parsing of the query. When executing the query, the query will be executed in the underlying destination dialect.
             _execute_raw_query (bool, optional): Whether to run the query as is (raw)or perform query normalization and lineage. Experimental.
 
         Returns:
             Relation: The readable relation for the query
         """
+        ...
 
     def query(
         self,
         query: Union[str, sge.Select, IbisExpr],
-        query_dialect: TSqlGlotDialect = None,
+        query_dialect: Optional[TSqlGlotDialect] = None,
         _execute_raw_query: bool = False,
     ) -> Relation:
         """Returns a readable relation for a given sql query
 
         Args:
             query (Union[str, sge.Select, IbisExpr]): The sql query to base the relation on. Can be a raw sql query, a sqlglot select expression or an ibis expression.
-            query_dialect (TSqlGlotDialect, optional): The dialect of the query. Defaults to the dataset's destination dialect. You can use this to write queries in a different dialect than the destination.
+            query_dialect (Optional[TSqlGlotDialect]): The dialect of the query. Defaults to the dataset's destination dialect. You can use this to write queries in a different dialect than the destination.
                 This settings will only be user fo the initial parsing of the query. When executing the query, the query will be executed in the underlying destination dialect.
             _execute_raw_query (bool, optional): Whether to run the query as is (raw)or perform query normalization and lineage. Experimental.
 
         Returns:
             Relation: The readable relation for the query
         """
+        ...
 
     @overload
     def table(self, table_name: str) -> Relation: ...
 
     @overload
+    def table(self, table_name: str, table_type: Literal["relation"]) -> Relation: ...
+
+    @overload
     def table(self, table_name: str, table_type: Literal["ibis"]) -> IbisTable: ...
 
     def table(
-        self, table_name: str, table_type: Literal["relation", "ibis"] = None
+        self, table_name: str, table_type: Literal["relation", "ibis"] = "relation"
     ) -> Union[Relation, IbisTable]:
         """Returns an object representing a table named `table_name`
 
@@ -378,6 +415,7 @@ class Dataset(Protocol):
         Returns:
             Union[Relation, IbisTable]: The object representing the table
         """
+        ...
 
     def __getitem__(self, table: str) -> Relation:
         """Returns a readable relation for the table named `table`
@@ -388,6 +426,7 @@ class Dataset(Protocol):
         Returns:
             Relation: The readable relation for the table
         """
+        ...
 
     def __getattr__(self, table: str) -> Relation:
         """Returns a readable relation for the table named `table`
@@ -398,14 +437,17 @@ class Dataset(Protocol):
         Returns:
             Relation: The readable relation for the table
         """
+        ...
 
     def __enter__(self) -> Self:
         """Context manager to keep the connection to the destination open between queries"""
+        ...
 
     def __exit__(
         self, exc_type: Type[BaseException], exc_val: BaseException, exc_tb: TracebackType
     ) -> None:
         """Context manager to keep the connection to the destination open between queries"""
+        ...
 
     def ibis(self) -> IbisBackend:
         """Returns a connected ibis backend for the dataset. Not implemented for all destinations.
@@ -413,22 +455,24 @@ class Dataset(Protocol):
         Returns:
             IbisBackend: The ibis backend for the dataset
         """
+        ...
 
     def row_counts(
         self,
         *,
         data_tables: bool = True,
         dlt_tables: bool = False,
-        table_names: List[str] = None,
-        load_id: str = None,
+        table_names: Optional[list[str]] = None,
+        load_id: Optional[str] = None,
     ) -> Relation:
         """Returns the row counts of the dataset
 
         Args:
-            data_tables (bool, optional): Whether to include data tables. Defaults to True.
-            dlt_tables (bool, optional): Whether to include dlt tables. Defaults to False.
-            table_names (List[str], optional): The names of the tables to include. Defaults to None. Will override data_tables and dlt_tables if set
-            load_id (str, optional): If set, only count rows associated with a given load id. Will exclude tables that do not have a load id.
+            data_tables (bool): Whether to include data tables. Defaults to True.
+            dlt_tables (bool): Whether to include dlt tables. Defaults to False.
+            table_names (Optional[list[str]]): The names of the tables to include. Defaults to None. Will override data_tables and dlt_tables if set
+            load_id (Optional[str]): If set, only count rows associated with a given load id. Will exclude tables that do not have a load id.
         Returns:
             Relation: The row counts of the dataset as ReadableRelation
         """
+        ...

--- a/dlt/destinations/dataset/dataset.py
+++ b/dlt/destinations/dataset/dataset.py
@@ -196,12 +196,12 @@ class ReadableDBAPIDataset(Dataset):
     def table(self, table_name: str) -> Relation: ...
 
     @overload
-    def table(self, table_name: str, table_type: Literal["ibis"]) -> IbisTable: ...
-
-    @overload
     def table(self, table_name: str, table_type: Literal["relation"]) -> Relation: ...
 
-    def table(self, table_name: str, table_type: Literal["relation", "ibis"] = None) -> Any:
+    @overload
+    def table(self, table_name: str, table_type: Literal["ibis"]) -> IbisTable: ...
+
+    def table(self, table_name: str, table_type: Literal["relation", "ibis"] = "relation") -> Any:
         # dataset only provides access to tables known in dlt schema, direct query may cirumvent this
         if table_name not in self.schema.tables.keys():
             raise ValueError(

--- a/dlt/extract/utils.py
+++ b/dlt/extract/utils.py
@@ -73,9 +73,9 @@ def get_data_item_format(items: TDataItems) -> TDataItemFormat:
     """
 
     # if incoming item is hints meta, check if item format is forced
-    from dlt.common.destination.dataset import Relation
+    from dlt.destinations.dataset.relation import ReadableDBAPIRelation
 
-    if isinstance(items, Relation):
+    if isinstance(items, ReadableDBAPIRelation):
         return "model"
 
     if not pyarrow and not pandas:

--- a/tests/transformations/test_transformation_decorator.py
+++ b/tests/transformations/test_transformation_decorator.py
@@ -132,7 +132,7 @@ def test_base_transformation_spec() -> None:
 
     # we return SQL so we expect a model to be created
     model = list(default_spec(ds_))[0]
-    assert isinstance(model, Relation)
+    assert isinstance(model, ReadableDBAPIRelation)
     # TODO: why dialect is not set??
     # assert model.dialect is not None
 
@@ -152,7 +152,7 @@ def test_base_transformation_spec() -> None:
     os.environ["LAST_ID"] = "test_last_id"
 
     model = list(default_transformation_with_args(ds_))[0]
-    assert isinstance(model, Relation)
+    assert isinstance(model, ReadableDBAPIRelation)
     assert get_fun_last_config(default_transformation_with_args)["last_id"] == "test_last_id"
 
     # test explicit spec

--- a/tests/transformations/test_transformations.py
+++ b/tests/transformations/test_transformations.py
@@ -6,6 +6,7 @@ import dlt, os, sys
 
 from dlt.common.destination.dataset import Dataset
 from dlt.common.destination.dataset import Relation
+from dlt.destinations.dataset.relation import ReadableDBAPIRelation
 from tests.pipeline.utils import load_table_counts
 
 from tests.load.utils import DestinationTestConfiguration
@@ -139,7 +140,7 @@ def test_extract_without_source_name_or_pipeline(
     fruit_p.deactivate()
     model_rows = list(buffer_size_test(fruit_p.dataset()))
     assert len(model_rows) == 1
-    assert isinstance(model_rows[0], Relation)
+    assert isinstance(model_rows[0], ReadableDBAPIRelation)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Follow-up to [this discussion](https://github.com/dlt-hub/dlt/pull/2718#discussion_r2196295544) 

- As mentioned, protocols need to directly inherit from `typing.Protocol` ([source](https://mypy.readthedocs.io/en/stable/protocols.html#defining-subprotocols-and-subclassing-protocols), reported by pylance in the screenshots I shared in the previous discussion). 
- mypy didn't fail because `Relation` was inadvertently not a `Protocol`. Similarly, some tests were making assumptions against `Relation` with `isinstance()` calls (which wouldn't be possible if it was a proper protocol). 
- `DataAccess` was implementing method such as `__init__` and property setters, which is not possible on a `Protocol`. To maintain the desired approach, I created a `DBApiCursorProtocol` that is inherited by the abstract base class `DBApiCursor`.
- I removed the uncessary `else` block after `if TYPE_CHECKING`
- import `from __future__ import annotations` to avoid circular imports

### Additional context
I still in favor of removing this abstraction layer as long as we have a single set of `Dataset` and `Relation` implementations. Having to modify their superclass / protocols makes maintenance more complex