### PR TITLE
Bump default python version in CI from 3.10 to 3.11

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -31,7 +31,7 @@ jobs:
             python-version: "3.9"
             shell: bash
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             shell: bash
           - os: ubuntu-latest
             python-version: "3.11"

--- a/.github/workflows/test_destinations_local.yml
+++ b/.github/workflows/test_destinations_local.yml
@@ -165,12 +165,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/test_destinations_remote.yml
+++ b/.github/workflows/test_destinations_remote.yml
@@ -159,12 +159,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/test_docs_snippets.yml
+++ b/.github/workflows/test_docs_snippets.yml
@@ -59,12 +59,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/test_plus.yml
+++ b/.github/workflows/test_plus.yml
@@ -23,11 +23,11 @@ jobs:
         # Test all python versions on ubuntu only
         exclude:
         - os: "macos-latest"
-          python-version: "3.10"
+          python-version: "3.11"
         - os: "macos-latest"
           python-version: "3.12"
         - os: "windows-latest"
-          python-version: "3.10"
+          python-version: "3.11"
         - os: "windows-latest"
           python-version: "3.12"
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/test_sources_local.yml
+++ b/.github/workflows/test_sources_local.yml
@@ -51,12 +51,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/test_tools_airflow.yml
+++ b/.github/workflows/test_tools_airflow.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/test_tools_build_images.yml
+++ b/.github/workflows/test_tools_build_images.yml
@@ -16,12 +16,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/test_tools_dbt_cloud.yml
+++ b/.github/workflows/test_tools_dbt_cloud.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/test_tools_dbt_runner.yml
+++ b/.github/workflows/test_tools_dbt_runner.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 

--- a/.github/workflows/tools_deploy_notebooks.yml
+++ b/.github/workflows/tools_deploy_notebooks.yml
@@ -27,12 +27,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           activate-environment: true
           enable-cache: true
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Our default python version for tests on CI still is 3.10, we should be testing on newer versions by default, 3.11 or 3.12.