### PR TITLE
fix: use modern string formatting to set dataset name

### DIFF
--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -1535,7 +1535,7 @@ class Pipeline(SupportsPipeline):
 
         # normalizes the dataset name using the dataset_name_layout
         if self.config.dataset_name_layout:
-            new_dataset_name = self.config.dataset_name_layout % new_dataset_name
+            new_dataset_name = self.config.dataset_name_layout.format(new_dataset_name)
         return new_dataset_name
 
     def _set_default_schema_name(self, schema: Schema) -> None:


### PR DESCRIPTION
### Description

No need to use [% formatting](https://docs.python.org/3/tutorial/inputoutput.html#old-string-formatting), we can [avoid runtime errors](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting) by adopting `.format` instead.

This can avoid unexpected pipeline failures during the `"sync"` stage, I encountered this quite often:

> "Pipeline execution failed at `step=sync` with exception:\n\n<class 'TypeError'>\nnot all arguments converted during string formatting",