### PR TITLE
Docs: Some additions to the filesystem gdrive source

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/filesystem/basic.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/filesystem/basic.md
@@ -106,6 +106,7 @@ To get GCS/GDrive access:
 4. In IAM & Admin > Service Accounts, find your account, click the three-dot menu > "Manage Keys" >
    "ADD KEY" > "CREATE" to get a JSON credential file.
 5. Grant the service account appropriate permissions for cloud storage access.
+6. In the case of GDrive, share the respective folders/files with the service account.
 
 For more info, see how to
 [create a service account](https://support.google.com/a/answer/7378726?hl=en).
@@ -200,7 +201,7 @@ project_id="Please set me up!"
 # config.toml
 # gdrive
 [gdrive_pipeline_name.sources.filesystem]
-bucket_url="gdrive://<folder_name>/<subfolder_or_file_path>/"
+bucket_url="gdrive://<folder_name>/<subfolder_or_file_path>/" # set file_glob="" if file path
 
 # config.toml
 # Google storage
@@ -304,7 +305,12 @@ Full list of `filesystem` resource parameters:
 
 * `bucket_url` - full URL of the bucket (could be a relative path in the case of the local filesystem).
 * `credentials` - cloud storage credentials of `AbstractFilesystem` instance (should be empty for the local filesystem). We recommend not specifying this parameter in the code, but putting it in a secrets file instead.
-* `file_glob` -  file filter in glob format. Defaults to listing all non-recursive files in the bucket URL.
+* `file_glob` -  file filter in glob format. Defaults to listing all non-recursive files in the bucket URL. 
+
+  :::info
+  If the `bucket_url` is a specific file path, set `file_glob=""`.
+  :::
+
 * `files_per_page` - number of files processed at once. The default value is `100`.
 * `extract_content` - if true, the content of the file will be read and returned in the resource. The default value is `False`.
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR just adds a note that if the bucket url is a specific file path, the file_glob needs to be set to an empty string. The issue was raised in community, which I opened here #2907. 

Additionally, an explicit step to share the relevant folders/files with the service account is added to the setup part, as the user was confused since the docs don't mention it.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #2907 

