### PR TITLE
rest_api: fix: make ProcessingSteps filter and map fields optional

### DIFF
--- a/dlt/sources/rest_api/typing.py
+++ b/dlt/sources/rest_api/typing.py
@@ -258,7 +258,7 @@ class Endpoint(TypedDict, total=False):
     headers: Optional[Dict[str, Any]]
 
 
-class ProcessingSteps(TypedDict):
+class ProcessingSteps(TypedDict, total=False):
     filter: Optional[Callable[[Any], bool]]  # noqa: A003
     map: Optional[Callable[[Any], Any]]  # noqa: A003
 

--- a/tests/sources/rest_api/integration/test_processing_steps.py
+++ b/tests/sources/rest_api/integration/test_processing_steps.py
@@ -25,7 +25,7 @@ def test_rest_api_source_filtered(mock_api_server) -> None:
                 "name": "posts",
                 "endpoint": "posts",
                 "processing_steps": [
-                    {"filter": lambda x: x["id"] == 1},  # type: ignore[typeddict-item]
+                    {"filter": lambda x: x["id"] == 1},
                 ],
             },
         ],
@@ -56,7 +56,7 @@ def test_rest_api_source_exclude_columns(mock_api_server) -> None:
                 "endpoint": "posts",
                 "processing_steps": [
                     {
-                        "map": exclude_columns(["title"]),  # type: ignore[typeddict-item]
+                        "map": exclude_columns(["title"]),
                     },
                 ],
             },
@@ -88,7 +88,7 @@ def test_rest_api_source_anonymize_columns(mock_api_server) -> None:
                 "endpoint": "posts",
                 "processing_steps": [
                     {
-                        "map": anonymize_columns(["title"]),  # type: ignore[typeddict-item]
+                        "map": anonymize_columns(["title"]),
                     },
                 ],
             },
@@ -115,7 +115,7 @@ def test_rest_api_source_map(mock_api_server) -> None:
                 "name": "posts",
                 "endpoint": "posts",
                 "processing_steps": [
-                    {"map": lower_title},  # type: ignore[typeddict-item]
+                    {"map": lower_title},
                 ],
             },
         ],
@@ -141,16 +141,16 @@ def test_rest_api_source_filter_and_map(mock_api_server) -> None:
                 "name": "posts",
                 "endpoint": "posts",
                 "processing_steps": [
-                    {"map": id_by_10},  # type: ignore[typeddict-item]
-                    {"filter": lambda x: x["id"] == 10},  # type: ignore[typeddict-item]
+                    {"map": id_by_10},
+                    {"filter": lambda x: x["id"] == 10},
                 ],
             },
             {
                 "name": "posts_2",
                 "endpoint": "posts",
                 "processing_steps": [
-                    {"filter": lambda x: x["id"] == 10},  # type: ignore[typeddict-item]
-                    {"map": id_by_10},  # type: ignore[typeddict-item]
+                    {"filter": lambda x: x["id"] == 10},
+                    {"map": id_by_10},
                 ],
             },
         ],
@@ -193,14 +193,14 @@ def test_rest_api_source_filtered_child(mock_api_server, comments_endpoint) -> N
                 "name": "posts",
                 "endpoint": "posts",
                 "processing_steps": [
-                    {"filter": lambda x: x["id"] in (1, 2)},  # type: ignore[typeddict-item]
+                    {"filter": lambda x: x["id"] in (1, 2)},
                 ],
             },
             {
                 "name": "comments",
                 "endpoint": comments_endpoint,
                 "processing_steps": [
-                    {"filter": lambda x: x["id"] == 1},  # type: ignore[typeddict-item]
+                    {"filter": lambda x: x["id"] == 1},
                 ],
             },
         ],
@@ -241,7 +241,7 @@ def test_rest_api_source_filtered_and_map_child(mock_api_server, comments_endpoi
                 "name": "posts",
                 "endpoint": "posts",
                 "processing_steps": [
-                    {"filter": lambda x: x["id"] in (1, 2)},  # type: ignore[typeddict-item]
+                    {"filter": lambda x: x["id"] in (1, 2)},
                 ],
             },
             {
@@ -249,8 +249,8 @@ def test_rest_api_source_filtered_and_map_child(mock_api_server, comments_endpoi
                 "endpoint": comments_endpoint,
                 "include_from_parent": ["title"],
                 "processing_steps": [
-                    {"map": extend_body},  # type: ignore[typeddict-item]
-                    {"filter": lambda x: x["body"].startswith("Post 2")},  # type: ignore[typeddict-item]
+                    {"map": extend_body},
+                    {"filter": lambda x: x["body"].startswith("Post 2")},
                 ],
             },
         ],


### PR DESCRIPTION
Set total=False on ProcessingSteps TypedDict

Fixes #2767