### PR TITLE
restclient: misc Paginators improvements

### DIFF
--- a/dlt/common/jsonpath.py
+++ b/dlt/common/jsonpath.py
@@ -92,7 +92,7 @@ def extract_simple_field_name(path: Union[str, JSONPath]) -> Optional[str]:
     return None
 
 
-def set_value_at_path(obj: dict[str, Any], path: TJsonPath, value: Any) -> None:
+def set_value_at_path(obj: dict[str, Any], path: str, value: Any) -> None:
     """Sets a value in a nested dictionary at the specified path.
 
     Args:

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -101,13 +101,13 @@ class RangePaginator(BasePaginator):
         stop_after_empty_page: Optional[bool] = True,
         *,
         has_more_path: Optional[jsonpath.TJsonPath] = None,
-        param_body_path: Optional[jsonpath.TJsonPath] = None,
+        param_body_path: Optional[str] = None,
     ):
         """
         Args:
             param_name (str): The query parameter name for the numeric value.
                 For example, 'page'.
-            param_body_path (jsonpath.TJsonPath): The JSONPath expression specifying
+            param_body_path (str): The dot-separated path specifying
                 where to place the numeric parameter in the request JSON body.
                 Defaults to `None`.
             initial_value (int): The initial value of the numeric parameter.
@@ -246,7 +246,7 @@ class RangePaginator(BasePaginator):
 
     @staticmethod
     def _update_request_with_body_path(
-        request: Request, body_path: jsonpath.TJsonPath, current_value: int
+        request: Request, body_path: str, current_value: int
     ) -> None:
         if request.json is None:
             request.json = {}
@@ -331,7 +331,7 @@ class PageNumberPaginator(RangePaginator):
         stop_after_empty_page: Optional[bool] = True,
         *,
         has_more_path: Optional[jsonpath.TJsonPath] = None,
-        page_body_path: Optional[jsonpath.TJsonPath] = None,
+        page_body_path: Optional[str] = None,
     ):
         """
         Args:
@@ -343,7 +343,7 @@ class PageNumberPaginator(RangePaginator):
                 the initial value will be set to `base_page`.
             page_param (str): The query parameter name for the page number.
                 Defaults to 'page'.
-            page_body_path (jsonpath.TJsonPath): A JSONPath expression specifying where
+            page_body_path (str): A dot-separated path specifying where
                 to place the page number in the request JSON body. Use this instead
                 of `page_param` when sending the page number in the request body.
                 Defaults to `None`.
@@ -486,8 +486,8 @@ class OffsetPaginator(RangePaginator):
         stop_after_empty_page: Optional[bool] = True,
         *,
         has_more_path: Optional[jsonpath.TJsonPath] = None,
-        offset_body_path: Optional[jsonpath.TJsonPath] = None,
-        limit_body_path: Optional[jsonpath.TJsonPath] = None,
+        offset_body_path: Optional[str] = None,
+        limit_body_path: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -497,13 +497,13 @@ class OffsetPaginator(RangePaginator):
                 Defaults to 0.
             offset_param (str): The query parameter name for the offset.
                 Defaults to 'offset'.
-            offset_body_path (jsonpath.TJsonPath): A JSONPath expression specifying
+            offset_body_path (str): A dot-separated path specifying
                 where to place the offset in the request JSON body.
                 If provided, the paginator will use this instead of `offset_param`
                 to send the offset in the request body. Defaults to `None`.
             limit_param (str): The query parameter name for the limit.
                 Defaults to 'limit'.
-            limit_body_path (jsonpath.TJsonPath): A JSONPath expression specifying
+            limit_body_path (str): A dot-separated path specifying
                 where to place the limit in the request JSON body.
                 If provided, the paginator will use this instead of `limit_param`
                 to send the limit in the request body. Defaults to `None`.
@@ -834,7 +834,7 @@ class JSONResponseCursorPaginator(BaseReferencePaginator):
         self,
         cursor_path: jsonpath.TJsonPath = "cursors.next",
         cursor_param: Optional[str] = None,
-        cursor_body_path: Optional[jsonpath.TJsonPath] = None,
+        cursor_body_path: Optional[str] = None,
     ):
         """
         Args:
@@ -842,7 +842,7 @@ class JSONResponseCursorPaginator(BaseReferencePaginator):
                 the response.
             cursor_param: The name of the query parameter to be used in
                 the request to get the next page.
-            cursor_body_path: The JSON path where to place the cursor in the request body.
+            cursor_body_path: The dot-separated path where to place the cursor in the request body.
         """
         super().__init__()
         self.cursor_path = jsonpath.compile_path(cursor_path)

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -99,6 +99,7 @@ class RangePaginator(BasePaginator):
         total_path: Optional[jsonpath.TJsonPath] = None,
         error_message_items: str = "items",
         stop_after_empty_page: Optional[bool] = True,
+        *,
         has_more_path: Optional[jsonpath.TJsonPath] = None,
         param_body_path: Optional[jsonpath.TJsonPath] = None,
     ):
@@ -328,6 +329,7 @@ class PageNumberPaginator(RangePaginator):
         total_path: Optional[jsonpath.TJsonPath] = "total",
         maximum_page: Optional[int] = None,
         stop_after_empty_page: Optional[bool] = True,
+        *,
         has_more_path: Optional[jsonpath.TJsonPath] = None,
         page_body_path: Optional[jsonpath.TJsonPath] = None,
     ):
@@ -482,6 +484,7 @@ class OffsetPaginator(RangePaginator):
         total_path: Optional[jsonpath.TJsonPath] = "total",
         maximum_offset: Optional[int] = None,
         stop_after_empty_page: Optional[bool] = True,
+        *,
         has_more_path: Optional[jsonpath.TJsonPath] = None,
         offset_body_path: Optional[jsonpath.TJsonPath] = None,
         limit_body_path: Optional[jsonpath.TJsonPath] = None,

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -109,7 +109,8 @@ class RangePaginator(BasePaginator):
                 For example, 'page'.
             param_body_path (str): The dot-separated path specifying
                 where to place the numeric parameter in the request JSON body.
-                Defaults to `None`.
+                Defaults to `None`. Either `param_name` or `param_body_path`
+                must be provided, not both.
             initial_value (int): The initial value of the numeric parameter.
             value_step (int): The step size to increment the numeric parameter.
             base_index (int, optional): The index of the initial element.
@@ -142,6 +143,10 @@ class RangePaginator(BasePaginator):
                 "One of `total_path`, `maximum_value`, `has_more_path`, or `stop_after_empty_page`"
                 " must be provided."
             )
+
+        if (not param_name and not param_body_path) or (param_name and param_body_path):
+            raise ValueError("Either 'param_name' or 'param_body_path' must be provided, not both.")
+
         self.param_name = param_name
         self.param_body_path = param_body_path
         self.initial_value = initial_value
@@ -240,6 +245,8 @@ class RangePaginator(BasePaginator):
     def _update_request_with_param_name(
         request: Request, param_name: str, current_value: int
     ) -> None:
+        if not param_name:
+            raise ValueError("`param_name` must not be empty.")
         if request.params is None:
             request.params = {}
         request.params[param_name] = current_value
@@ -248,6 +255,8 @@ class RangePaginator(BasePaginator):
     def _update_request_with_body_path(
         request: Request, body_path: str, current_value: int
     ) -> None:
+        if not body_path:
+            raise ValueError("`body_path` must not be empty.")
         if request.json is None:
             request.json = {}
         jsonpath.set_value_at_path(request.json, body_path, current_value)
@@ -342,7 +351,8 @@ class PageNumberPaginator(RangePaginator):
             page (int): The page number for the first request. If not provided,
                 the initial value will be set to `base_page`.
             page_param (str): The query parameter name for the page number.
-                Defaults to 'page'.
+                Defaults to 'page'. Either `page_param` or `page_body_path`
+                must be provided, not both.
             page_body_path (str): A dot-separated path specifying where
                 to place the page number in the request JSON body. Use this instead
                 of `page_param` when sending the page number in the request body.
@@ -363,8 +373,9 @@ class PageNumberPaginator(RangePaginator):
         if page_param is None and page_body_path is None:
             page_param = "page"
         # Check that only one of page_param or page_body_path is provided
-        elif page_param is not None and page_body_path is not None:
+        elif (not page_param and not page_body_path) or (page_param and page_body_path):
             raise ValueError("Either 'page_param' or 'page_body_path' must be provided, not both.")
+
         if (
             total_path is None
             and maximum_page is None
@@ -523,7 +534,7 @@ class OffsetPaginator(RangePaginator):
         if offset_param is None and offset_body_path is None:
             offset_param = "offset"
         # Check that only one of offset_param or offset_body_path is provided
-        if offset_param is not None and offset_body_path is not None:
+        elif (not offset_param and not offset_body_path) or (offset_param and offset_body_path):
             raise ValueError(
                 "Either 'offset_param' or 'offset_body_path' must be provided, not both."
             )
@@ -531,7 +542,7 @@ class OffsetPaginator(RangePaginator):
         if limit_param is None and limit_body_path is None:
             limit_param = "limit"
         # Check that only one of limit_param or limit_body_path is provided
-        if limit_param is not None and limit_body_path is not None:
+        elif (not limit_param and not limit_body_path) or (limit_param and limit_body_path):
             raise ValueError(
                 "Either 'limit_param' or 'limit_body_path' must be provided, not both."
             )


### PR DESCRIPTION
A follow up to #2910:

- Added keyword-only arguments separator to REST client paginators (RangePaginator, PageNumberPaginator, OffsetPaginator)
- Changed body paths from TJsonPath to str type in jsonpath module
- Added parameter validation 
- Added new tests for paginators