### PR TITLE
fix sync destination warning logging call

### DIFF
--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -806,11 +806,10 @@ class Pipeline(SupportsPipeline):
                         if self.has_pending_data:
                             logger.warning(
                                 f"Pipeline {self.pipeline_name} got restored from destination"
-                                " including new version",
-                                "of pipeline state but it has pending load packages that were not"
-                                " yet normalized or loaded. If those packages contain extracted"
-                                " state or schema migrations - those will not be affected and will"
-                                " still be loaded to destination.",
+                                " including new version of pipeline state but it has pending load"
+                                " packages that were not yet normalized or loaded. If those"
+                                " packages contain extracted state or schema migrations - those"
+                                " will not be affected and will still be loaded to destination."
                             )
                 # if we didn't full refresh schemas, get only missing schemas
                 if restored_schemas is None:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
It is a bit hard to see, but this warning call was called with three arguments, because there where commas between the string. On Lambda this is producing problems for at least one user.