### PR TITLE
fix: replace `arrow2` with `arrow` backend for `connectorx`

### DIFF
--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -214,7 +214,7 @@ class TableLoader:
 
         # default settings
         backend_kwargs = {
-            "return_type": "arrow2",
+            "return_type": "arrow",
             "protocol": "binary",
             **backend_kwargs,
         }
@@ -338,7 +338,7 @@ def unwrap_json_connector_x(field: str) -> TDataItem:
         column = pc.replace_with_mask(
             column,
             pc.equal(column, "null").combine_chunks(),
-            pa.scalar(None, pa.large_string()),
+            pa.scalar(None, pa.string()),
         )
         return table.set_column(col_index, table.schema.field(col_index), column)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,7 @@ dev = [
 # NOTE: those dependencies are used to test built in sources
 sources = [
     "connectorx>=0.3.3 ; python_version >= '3.9'",
-    "connectorx>=0.4.0,<0.4.2 ; python_version >= '3.10'",
+    "connectorx>=0.4.0 ; python_version >= '3.10'",
     "pymysql>=1.1.0,<2",
     "openpyxl>=3,<4",
     "mimesis>=7.0.0,<8",
@@ -301,7 +301,7 @@ docs = [
     "psycopg2-binary>=2.9",
     "lancedb>=0.8.2 ; python_version < '3.13'",
     "openai>=1.45",
-    "connectorx>=0.3.2,<0.4.2",
+    "connectorx>=0.3.2",
     "modal>=0.64.170",
     # google secrets provider
     "google-api-python-client>=1.7.11",

--- a/tests/load/sources/sql_database/test_sql_database_source.py
+++ b/tests/load/sources/sql_database/test_sql_database_source.py
@@ -648,7 +648,9 @@ def test_reflection_levels(
 
     assert col_names == expected_col_names
 
-    # Pk col is always reflected
+    # TODO move to separate test
+    # in `sql_source_db`,  column `id` from table `app_user` is a primary key
+    # primary key hint should always be reflected
     pk_col = schema.tables["app_user"]["columns"]["id"]
     assert pk_col["primary_key"] is True
 
@@ -1417,6 +1419,7 @@ def assert_row_counts(
         ), f"Table {table} counts do not match with the source"
 
 
+# TODO tests shouldn't modify the return values of the tested functions
 def assert_precision_columns(
     columns: TTableSchemaColumns, backend: TableBackend, nullable: bool
 ) -> None:
@@ -1427,16 +1430,17 @@ def assert_precision_columns(
     if backend == "sqlalchemy":
         expected = remove_timestamp_precision(expected)
         actual = remove_dlt_columns(actual)
-    if backend == "pyarrow":
+    elif backend == "pyarrow":
         expected = add_default_decimal_precision(expected)
-    if backend == "pandas":
+    elif backend == "pandas":
         expected = remove_timestamp_precision(expected, with_timestamps=False)
-    if backend == "connectorx":
+    elif backend == "connectorx":
         # connector x emits 32 precision which gets merged with sql alchemy schema
         del columns["int_col"]["precision"]
     assert actual == expected
 
 
+# TODO tests shouldn't modify the return values of the tested functions
 def assert_no_precision_columns(
     columns: TTableSchemaColumns, backend: TableBackend, nullable: bool
 ) -> None:
@@ -1525,6 +1529,8 @@ def convert_connectorx_types(columns: List[TColumnSchema]) -> List[TColumnSchema
         if column["data_type"] == "bigint":
             if column["name"] == "int_col":
                 column["precision"] = 32  # only int and bigint in connectorx
+            elif column["name"] == "smallint_col":
+                column["precision"] = 16  # only int and bigint in connectorx
         if column["data_type"] == "text" and column.get("precision"):
             del column["precision"]
     return columns


### PR DESCRIPTION
### Description
`Connectorx` dropped support for `arrow2` backend in version `0.4.2`. This was the default version used in `dlt`, creating a breaking change. 

issues: #2661 #2669 
related PR fixing timestamp issue: #2879 

### Changes
- `arrow` is now the default backend in `dlt`
- two small changes because of disparities between `arrow` and  `arrow2` behavior
- relax connectorx constraints in `pyproject.toml`