### PR TITLE
fix: prevent DuplicateSchema error when using public schema in Redshift

### DIFF
--- a/dlt/destinations/impl/redshift/redshift.py
+++ b/dlt/destinations/impl/redshift/redshift.py
@@ -51,7 +51,7 @@ class RedshiftSqlClient(Psycopg2SqlClient):
         # returned by INFORMATION_SCHEMA.SCHEMATA query, so we handle it as a special case
         if self.dataset_name == "public":
             return True
-        
+
         return super().has_dataset()
 
     @staticmethod

--- a/dlt/destinations/impl/redshift/redshift.py
+++ b/dlt/destinations/impl/redshift/redshift.py
@@ -46,6 +46,14 @@ HINT_TO_REDSHIFT_ATTR: Dict[TColumnHint, str] = {
 
 
 class RedshiftSqlClient(Psycopg2SqlClient):
+    def has_dataset(self) -> bool:
+        # In Redshift, the 'public' schema always exists but may not be
+        # returned by INFORMATION_SCHEMA.SCHEMATA query, so we handle it as a special case
+        if self.dataset_name == "public":
+            return True
+        
+        return super().has_dataset()
+
     @staticmethod
     def _maybe_make_terminal_exception_from_data_error(
         pg_ex: psycopg2.DataError,

--- a/tests/load/redshift/test_redshift_client.py
+++ b/tests/load/redshift/test_redshift_client.py
@@ -169,7 +169,7 @@ def test_maximum_query_size(client: RedshiftClient, file_storage: FileStorage) -
 def test_public_schema_has_dataset_override() -> None:
     """Test that the has_dataset override correctly identifies public schema as existing."""
     schema = Schema("test_schema")
-    
+
     config_public = RedshiftClientConfiguration(credentials=RedshiftCredentials())._bind_dataset_name("public")
     client_public = RedshiftClient(schema, config_public, redshift().capabilities())
     assert client_public.sql_client.has_dataset() is True

--- a/tests/load/redshift/test_redshift_client.py
+++ b/tests/load/redshift/test_redshift_client.py
@@ -170,6 +170,8 @@ def test_public_schema_has_dataset_override() -> None:
     """Test that the has_dataset override correctly identifies public schema as existing."""
     schema = Schema("test_schema")
 
-    config_public = RedshiftClientConfiguration(credentials=RedshiftCredentials())._bind_dataset_name("public")
+    config_public = RedshiftClientConfiguration(
+        credentials=RedshiftCredentials()
+    )._bind_dataset_name("public")
     client_public = RedshiftClient(schema, config_public, redshift().capabilities())
     assert client_public.sql_client.has_dataset() is True

--- a/tests/load/redshift/test_redshift_client.py
+++ b/tests/load/redshift/test_redshift_client.py
@@ -164,3 +164,12 @@ def test_maximum_query_size(client: RedshiftClient, file_storage: FileStorage) -
             expect_load_file(client, file_storage, insert_sql, user_table_name)
         # psycopg2.errors.SyntaxError: Statement is too large. Statement Size: 20971754 bytes. Maximum Allowed: 16777216 bytes
         assert type(exv.value.dbapi_exception) is psycopg2.errors.SyntaxError
+
+
+def test_public_schema_has_dataset_override() -> None:
+    """Test that the has_dataset override correctly identifies public schema as existing."""
+    schema = Schema("test_schema")
+    
+    config_public = RedshiftClientConfiguration(credentials=RedshiftCredentials())._bind_dataset_name("public")
+    client_public = RedshiftClient(schema, config_public, redshift().capabilities())
+    assert client_public.sql_client.has_dataset() is True


### PR DESCRIPTION
### Description

Override has_dataset() method in RedshiftSqlClient to return True for 'public' schema

### Related Issues

- Closes #2770

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
