### PR TITLE
feat: Smart `dlt.Relation.join()`

### DIFF
--- a/dlt/destinations/dataset/dataset.py
+++ b/dlt/destinations/dataset/dataset.py
@@ -3,7 +3,6 @@ from typing import Any, Type, Union, TYPE_CHECKING, List, Literal, overload
 
 
 from sqlglot.schema import Schema as SQLGlotSchema
-import sqlglot.expressions as sge
 
 from dlt.common.destination.exceptions import (
     OpenTableClientNotAvailable,

--- a/dlt/destinations/dataset/dataset.py
+++ b/dlt/destinations/dataset/dataset.py
@@ -1,7 +1,7 @@
 from types import TracebackType
 from typing import Any, Type, Union, TYPE_CHECKING, List, Literal, overload
 
-
+from sqlglot import expressions as sge
 from sqlglot.schema import Schema as SQLGlotSchema
 
 from dlt.common.destination.exceptions import (

--- a/dlt/destinations/queries.py
+++ b/dlt/destinations/queries.py
@@ -4,7 +4,12 @@ import sqlglot
 import sqlglot.expressions as sge
 from sqlglot.schema import Schema as SQLGlotSchema
 
-from dlt.common.schema.typing import C_DLT_LOAD_ID, TTableReference, TTableReferenceParam, TTableSchema
+from dlt.common.schema.typing import (
+    C_DLT_LOAD_ID,
+    TTableReference,
+    TTableReferenceParam,
+    TTableSchema,
+)
 from dlt.destinations.sql_client import SqlClientBase
 
 
@@ -134,7 +139,7 @@ def _create_column_alias(
     *,
     prefix: Optional[str] = None,
     separator: str = "__",
-):
+) -> str:
     if prefix is None:
         prefix = table_name
 
@@ -150,10 +155,7 @@ def _create_join_condition_from_reference(table_name: str, reference: TTableRefe
     other_table_name = reference["referenced_table"]
     join_conditions = [
         _create_join_condition(
-            table=table_name,
-            column=col,
-            other_table=other_table_name,
-            other_column=referenced_col
+            table=table_name, column=col, other_table=other_table_name, other_column=referenced_col
         )
         for col, referenced_col in zip(reference["columns"], reference["referenced_columns"])
     ]
@@ -162,7 +164,7 @@ def _create_join_condition_from_reference(table_name: str, reference: TTableRefe
         return join_conditions[0]
     else:
         return " AND ".join(join_conditions)
-    
+
 
 def _get_valid_reference(
     *,


### PR DESCRIPTION
This adds convenience methods `dlt.Relation(...).join()` and `dlt.Relation(...).join_child(...)` to simplify joins between tables that have `TTableReference` on `dlt.Schema`.

#### Design decisions
- Joins for parent-child or root-child relationships are likely always `LEFT` joins.
- Joins for arbitrary references defaults to `INNER`, but could be any type
- For parent-child / root-child relationships, trim the name of the table based on their common prefix
- Namespace all columns with origin table name
- Add "metadata columns" at the beginning of the table
- Special renaming for metadata columns
- `.join()` can receive:
   - `dlt.Relation` to join on (if column is unambiguous) 
   - `"table_name"` (if column is unambiguous)
   - `"table_name.column_name"` in case of multiple references between tables

#### Open questions
- What is the public API? Is it useful to have `.join()` and `.join_parent_child()` separately?