### PR TITLE
fix failing top level module imports on projects in dirs that start with a dot

### DIFF
--- a/dlt/common/runtime/run_context.py
+++ b/dlt/common/runtime/run_context.py
@@ -81,7 +81,7 @@ class RunContext(SupportsRunContext):
     def module(self) -> Optional[ModuleType]:
         try:
             return self.import_run_dir_module(self.run_dir)
-        except ImportError:
+        except (ImportError, TypeError):
             return None
 
     @property


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
When running dlt from a folder that has a dot as the first character, `def import_run_dir_module` will fail with a TypeError because the import is interpreted as relative due to the dot. This PR ignores this error.