### PR TITLE
fix: avoid private interfaces; explicit compiler mapping

### DIFF
--- a/dlt/helpers/ibis.py
+++ b/dlt/helpers/ibis.py
@@ -1,6 +1,6 @@
 from typing import cast, Any
 
-from dlt.common.exceptions import MissingDependencyException
+from dlt.common.exceptions import MissingDependencyException, ValueErrorWithKnownValues
 from dlt.common.destination import TDestinationReferenceArg, Destination
 from dlt.common.destination.client import JobClientBase
 from dlt.common.schema import Schema
@@ -22,6 +22,7 @@ from dlt.destinations.impl.synapse.configuration import SynapseClientConfigurati
 try:
     import ibis
     import sqlglot
+    import sqlglot.expressions as sge
     from ibis import BaseBackend, Expr, Table
     import ibis.backends.sql.compilers as sc
     from ibis.backends.sql.compilers.base import SQLGlotCompiler
@@ -214,28 +215,54 @@ def create_unbound_ibis_table(schema: Schema, dataset_name: str, table_name: str
     return unbound_table
 
 
-def get_compiler_for_dialect(dialect: TSqlGlotDialect) -> SQLGlotCompiler:
+def _get_ibis_to_sqlglot_compiler(dialect: TSqlGlotDialect) -> SQLGlotCompiler:
     """Get the compiler for a given dialect."""
-
-    ibis_dialect: str = dialect
-    if dialect == "tsql":
-        ibis_dialect = "mssql"
-    if dialect == "redshift":
-        ibis_dialect = "postgres"
-
-    try:
-        compiler_provider = getattr(sc, ibis_dialect)
-    except AttributeError:
-        # default is duckdb
-        compiler_provider = sc.duckdb
-
-    if (compiler := getattr(compiler_provider, "compiler", None)) is None:
-        raise NotImplementedError(f"{compiler_provider} is not a SQL backend")
+    if dialect == "athena":
+        compiler = sc.AthenaCompiler()
+    elif dialect == "bigquery":
+        compiler = sc.BigQueryCompiler()
+    elif dialect == "clickhouse":
+        compiler = sc.ClickHouseCompiler()
+    elif dialect == "databricks":
+        compiler = sc.DatabricksCompiler()
+    elif dialect == "druid":
+        compiler = sc.DruidCompiler()
+    elif dialect == "duckdb":
+        compiler = sc.DuckDBCompiler()
+    elif dialect == "mysql":
+        compiler = sc.MySQLCompiler()
+    elif dialect == "oracle":
+        compiler = sc.OracleCompiler()
+    elif dialect == "postgres":
+        compiler = sc.PostgresCompiler()
+    elif dialect == "presto":
+        compiler = sc.TrinoCompiler()
+    elif dialect == "prql":
+        compiler = sc.DuckDBCompiler()
+    elif dialect == "redshift":
+        compiler = sc.PostgresCompiler()
+    elif dialect == "risingwave":
+        compiler = sc.RisingWaveCompiler()
+    elif dialect == "snowflake":
+        compiler = sc.SnowflakeCompiler()
+    # NOTE I'm unsure if both `spark` and `spark2` are supported by the same compiler
+    elif dialect == "spark":
+        compiler = sc.PySparkCompiler()
+    elif dialect == "spark2":
+        compiler = sc.PySparkCompiler()
+    elif dialect == "sqlite":
+        compiler = sc.SQLiteCompiler()
+    elif dialect == "trino":
+        compiler = sc.TrinoCompiler()
+    elif dialect == "tsql":
+        compiler = sc.MSSQLCompiler()
+    else:
+        compiler = sc.DuckDBCompiler()
 
     return compiler
 
 
-def compile_ibis_to_sqlglot(ibis_expr: Expr, dialect: TSqlGlotDialect) -> sqlglot.expressions.Query:
+def compile_ibis_to_sqlglot(ibis_expr: Expr, dialect: TSqlGlotDialect) -> sge.Query:
     """Compile an ibis expression to a sqlglot query."""
-    compiler = get_compiler_for_dialect(dialect)
-    return cast(sqlglot.expressions.Query, compiler.to_sqlglot(ibis_expr))
+    compiler = _get_ibis_to_sqlglot_compiler(dialect)
+    return cast(sge.Query, compiler.to_sqlglot(ibis_expr))

--- a/tests/helpers/test_ibis.py
+++ b/tests/helpers/test_ibis.py
@@ -1,0 +1,38 @@
+import pytest
+import ibis.backends.sql.compilers as sc
+
+from dlt.helpers.ibis import _get_ibis_to_sqlglot_compiler
+
+
+@pytest.mark.parametrize("dialect, expected_compiler", [
+    ("athena", sc.AthenaCompiler),
+    ("bigquery", sc.BigQueryCompiler),
+    ("clickhouse", sc.ClickHouseCompiler),
+    ("databricks", sc.DatabricksCompiler),
+    ("doris", sc.DuckDBCompiler),  # default value
+    ("drill", sc.DuckDBCompiler),  # default value
+    ("druid", sc.DruidCompiler),
+    ("duckdb", sc.DuckDBCompiler),
+    ("dune", sc.DuckDBCompiler),  # default value
+    ("hive", sc.DuckDBCompiler),  # default value
+    ("materialize", sc.DuckDBCompiler),  # default value
+    ("mysql", sc.MySQLCompiler),
+    ("oracle", sc.OracleCompiler),
+    ("postgres", sc.PostgresCompiler),
+    ("presto", sc.TrinoCompiler),
+    ("prql", sc.DuckDBCompiler),  # default value
+    ("redshift", sc.PostgresCompiler),
+    ("risingwave", sc.RisingWaveCompiler),
+    ("snowflake", sc.SnowflakeCompiler),
+    ("spark", sc.PySparkCompiler),
+    ("spark2", sc.PySparkCompiler),
+    ("sqlite", sc.SQLiteCompiler),
+    ("starrocks", sc.DuckDBCompiler),  # default value
+    ("tableau", sc.DuckDBCompiler),  # default value
+    ("teradata", sc.DuckDBCompiler),  # default value
+    ("trino", sc.TrinoCompiler),
+    ("tsql", sc.MSSQLCompiler),
+])
+def test_get_ibis_to_sqlglot_compiler(dialect, expected_compiler) -> None:
+    compiler = _get_ibis_to_sqlglot_compiler(dialect)
+    assert isinstance(compiler, expected_compiler)


### PR DESCRIPTION
### Description
The `dlt.helpers.ibis` module had two instances of accessing private modules of 3rd libraries:
- `sqlglot.expressions` without importing it
- dynamically retrieved `ibis.backends.sql.compilers.NAME` (`duckdb`, `postgres`, etc.)

Changes:
- use public interfaces from sqlglot and ibis
- remove dynamic mapping `dialect -> compiler`; changes to either library could break our code.
- add tests for the mapping `dialect -> compiler` to make explicit when the default `DuckDBCompiler` is expected to be retrieved
- the explicit mapping adds support for `presto -> TrinoCompiler`, `spark -> PySparkCompiler` and `spark2 -> PySparkCompiler`, which was previously unsupported


### Related
- adds features previously implemented in #2498 