### PR TITLE
repo: use `ruff check` for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ lint:
 	uv pip uninstall docstring_parser
 	uv pip install docstring_parser_fork --reinstall
 	uv run ruff check
+	# NOTE: we exclude all D lint errors (docstrings)
+	uv run flake8 --extend-ignore=D --max-line-length=200 dlt
+	uv run flake8 --extend-ignore=D --max-line-length=200 tests --exclude tests/reflection/module_cases,tests/common/reflection/cases/modules/
 	uv run black dlt docs tests --check --diff --color --extend-exclude=".*syntax_error.py"
 	$(MAKE) lint-security
 	$(MAKE) lint-docstrings
@@ -70,12 +73,14 @@ lint-and-test-snippets: lint-snippets
 	uv pip install docstring_parser_fork --reinstall
 	uv run mypy --config-file mypy.ini docs/website docs/tools --exclude docs/tools/lint_setup --exclude docs/website/docs_processed --exclude docs/website/versioned_docs/ --exclude docs/website/docs/general-usage/transformations/transformation-snippets.py
 	uv run ruff check
+	uv run flake8 --max-line-length=200 docs/website docs/tools --exclude docs/website/.dlt-repo --exclude docs/website/docs/general-usage/transformations/transformation-snippets.py
 	cd docs/website/docs && uv run pytest --ignore=node_modules --ignore general-usage/transformations/transformation-snippets.py
 
 lint-and-test-examples:
 	uv pip install docstring_parser_fork --reinstall
 	cd docs/tools && uv run python prepare_examples_tests.py
 	uv run ruff check
+	uv run flake8 --max-line-length=200 docs/examples
 	uv run mypy --config-file mypy.ini docs/examples
 	cd docs/examples && uv run pytest
 

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,8 @@ lint:
 	# NOTE: we need to make sure docstring_parser_fork is the only version of docstring_parser installed
 	uv pip uninstall docstring_parser
 	uv pip install docstring_parser_fork --reinstall
-	# NOTE: we exclude all D lint errors (docstrings)
-	uv run flake8 --extend-ignore=D --max-line-length=200 dlt
-	uv run flake8 --extend-ignore=D --max-line-length=200 tests --exclude tests/reflection/module_cases,tests/common/reflection/cases/modules/
+	uv run ruff check
 	uv run black dlt docs tests --check --diff --color --extend-exclude=".*syntax_error.py"
-	# uv run isort ./ --diff
 	$(MAKE) lint-security
 	$(MAKE) lint-docstrings
 
@@ -72,13 +69,13 @@ lint-and-test-snippets: lint-snippets
 	# TODO: re-enable transformation snippets tests
 	uv pip install docstring_parser_fork --reinstall
 	uv run mypy --config-file mypy.ini docs/website docs/tools --exclude docs/tools/lint_setup --exclude docs/website/docs_processed --exclude docs/website/versioned_docs/ --exclude docs/website/docs/general-usage/transformations/transformation-snippets.py
-	uv run flake8 --max-line-length=200 docs/website docs/tools --exclude docs/website/.dlt-repo --exclude docs/website/docs/general-usage/transformations/transformation-snippets.py
+	uv run ruff check
 	cd docs/website/docs && uv run pytest --ignore=node_modules --ignore general-usage/transformations/transformation-snippets.py
 
 lint-and-test-examples:
 	uv pip install docstring_parser_fork --reinstall
 	cd docs/tools && uv run python prepare_examples_tests.py
-	uv run flake8 --max-line-length=200 docs/examples
+	uv run ruff check
 	uv run mypy --config-file mypy.ini docs/examples
 	cd docs/examples && uv run pytest
 

--- a/dlt/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/helpers/dashboard/dlt_dashboard.py
@@ -852,7 +852,7 @@ def ui_controls(mo_cli_arg_with_test_identifiers: bool):
     """
 
     dlt_refresh_button: mo.ui.run_button = mo.ui.run_button(
-        label=f"<small>Refresh</small>",
+        label="<small>Refresh</small>",
     )
 
     # page switches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -355,6 +355,7 @@ include = [
 ]
 exclude = [
     "tests/reflection/module_cases/syntax_error.py",
+    "docs/website/docs/general-usage/transformations/transformation-snippets.py",
 ]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,6 +343,44 @@ include = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+src = ["dlt"]
+include = [
+    "dlt/**/*.py",
+    "tests/**/*.py",
+    "docs/**/*.py",
+]
+exclude = [
+    "tests/reflection/module_cases/syntax_error.py",
+]
+
+[tool.ruff.lint]
+preview = true
+ignore = [
+    # from tox.ini
+    "E1",
+    "E2",
+    "E3",
+    "E4",
+    "F401",
+    "W391",
+    "W292",
+    "E501",
+    # additional ignores to appease ruff
+    "E713",
+    "E721",
+    "E731",
+    "E741",
+    "E999",
+    "F601",
+    "F821",
+    "F841",
+    "F811",
+]
+
 [tool.black]
 line-length = 100
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -354,6 +354,7 @@ include = [
     "docs/**/*.py",
 ]
 exclude = [
+    "docs/website/.dlt-repo",
     "tests/reflection/module_cases/syntax_error.py",
     "docs/website/docs/general-usage/transformations/transformation-snippets.py",
 ]


### PR DESCRIPTION
This uses `ruff` for linting (keeps `black` for formatting). I configured using rules defined in `tox.ini`. Then, I added exclusions such that `make lint` would succeed.

## Next steps
- use `ruff format` instead of `black`. Formatting **will not** break any code, but it will produce a large diff because of [know deviations between ruff and black](https://docs.astral.sh/ruff/formatter/black/). I would do that in a follow-up PR and add the commit to `.git-blame-ignore-revs`.
- move all configs to `pyproject.toml` (e.g.,`pytest.init`, `mypy.ini`) and delete unused files
- discuss additional linting rules to apply (sorting imports, remove unused imports, etc.)