### PR TITLE
fix: `MissingDependencyException` should inherit `ImportError`

### DIFF
--- a/dlt/common/exceptions.py
+++ b/dlt/common/exceptions.py
@@ -152,7 +152,7 @@ class ArgumentsOverloadException(DltException):
         super().__init__(msg)
 
 
-class MissingDependencyException(DltException):
+class MissingDependencyException(DltException, ImportError):
     def __init__(self, caller: str, dependencies: Sequence[str], appendix: str = "") -> None:
         self.caller = caller
         self.dependencies = dependencies

--- a/dlt/common/reflection/ref.py
+++ b/dlt/common/reflection/ref.py
@@ -53,13 +53,7 @@ def import_module_with_missing(name: str, missing_modules: Tuple[str, ...] = ())
         while True:
             try:
                 return import_module(name)
-            except ImportError as ie:
-                if ie.name is None:
-                    raise
-                # print(f"ADD {ie.name} {ie.path} vs {name} vs {str(ie)}")
-                if ie.name in missing_modules:
-                    raise
-                missing_modules += (ie.name,)
+            # `MissingDependencyException` is an `ImportError`
             except MissingDependencyException as me:
                 if isinstance(me.__context__, ImportError):
                     if me.__context__.name is None:
@@ -71,6 +65,14 @@ def import_module_with_missing(name: str, missing_modules: Tuple[str, ...] = ())
                     missing_modules += (me.__context__.name,)
                 else:
                     raise
+            # catch `ImportError` that are not `MissingDependencyException`
+            except ImportError as ie:
+                if ie.name is None:
+                    raise
+                # print(f"ADD {ie.name} {ie.path} vs {name} vs {str(ie)}")
+                if ie.name in missing_modules:
+                    raise
+                missing_modules += (ie.name,)
     finally:
         builtins.__import__ = real_import
 


### PR DESCRIPTION
Both `MissingDependencyException` and `ImportError` are semantically related. dlt typically raises `MissingDependencyException` this way

```python
  try:
      import botocore.session
      from botocore.config import Config
  except ModuleNotFoundError:
      raise MissingDependencyException(
          self.__class__.__name__, [f"{version.DLT_PKG_NAME}[s3]"]
      )
```

or

```python
try:
    from pydantic import BaseModel, ValidationError, Json, create_model
except ImportError:
    raise MissingDependencyException(
        "dlt Pydantic helpers", ["pydantic"], "Both Pydantic 1.x and 2.x are supported"
    )
```

Both `ModuleNotFoundError` and `ImportError` are part of the standard library. `ModuleNotFoundError` inherits from `ImportError`.

### Related
In marimo, when an `ImportError` is raised, a widget pops-up to help the user install the missing dependency. This currently doesn't work with dlt because it's wrapping import errors as `MissingDependencyException` without inheritance.

The changes in this PR enable proper marimo widget behavior

#### Before
<img width="1726" height="1588" alt="image" src="https://github.com/user-attachments/assets/a598f0c1-79d9-4632-b064-9bed961e5013" />

#### After
<img width="1728" height="1750" alt="image" src="https://github.com/user-attachments/assets/b0fca0ad-11ba-44df-a5b8-900a60ba1ca2" />
