### PR TITLE
avoid setting "None" string for aws session token

### DIFF
--- a/dlt/common/configuration/specs/aws_credentials.py
+++ b/dlt/common/configuration/specs/aws_credentials.py
@@ -183,7 +183,8 @@ class AwsCredentials(AwsCredentialsWithoutDefaults, CredentialsWithDefault):
             return None
         self.aws_access_key_id = default.access_key
         self.aws_secret_access_key = TSecretStrValue(default.secret_key)
-        self.aws_session_token = TSecretStrValue(default.token)
+        if default.token is not None:
+            self.aws_session_token = TSecretStrValue(default.token)
         return default
 
     def to_native_credentials(self) -> Optional[Any]:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
When using AWS Profiles and retrieving credentials from boto I noticed that it can have AWS access keys but not a session token (`None`). 

If we assign the session token to the string `"None"` boto/Pyathena thinks a session token is being used for credentials and we end up with the error: 
```
dlt.destinations.exceptions.DatabaseTransientException: 
   An error occurred (UnrecognizedClientException) when calling the StartQueryExecution operation: The security token included in the request is invalid
```
<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
Fixes #2407 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
I didn't run into this issue when providing access keys to dlt only when using profiles.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
