### PR TITLE
re-enable python 3.10 common tests

### DIFF
--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -31,7 +31,7 @@ jobs:
             python-version: "3.9"
             shell: bash
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.10"
             shell: bash
           - os: ubuntu-latest
             python-version: "3.11"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Re-enables python 3.10 tests for the common tests that I accidentally removed.