### PR TITLE
Fix: Max table nesting is ignored for the first run when import schema path is specified

### DIFF
--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -677,23 +677,15 @@ def remove_processing_hints(tables: TSchemaTables) -> TSchemaTables:
     table_hints, col_hints = get_processing_hints(tables)
 
     # Remove table-level hints
-    for table_name, hint_groups in table_hints.items():
-        for hint_group in hint_groups:
-            if hint_group == "x-normalizer":
-                # Keep only max_nesting in x-normalizer, remove all other keys
-                hints: Dict[str, Any] = tables[table_name].get(hint_group)  # type: ignore[assignment]
-                if "max_nesting" in hints:
-                    max_nesting_value = hints["max_nesting"]
-                    tables[table_name]["x-normalizer"] = {"max_nesting": max_nesting_value}
-                    continue
-            # Remove the hint entirely
-            tables[table_name].pop(hint_group, None)  # type: ignore[misc]
+    for table_name, hints in table_hints.items():
+        for hint in hints:
+            tables[table_name].pop(hint, None)  # type: ignore[misc]
 
     # Remove column-level hints
     for table_name, cols in col_hints.items():
-        for col_name, hint_groups in cols.items():
-            for hint_group in hint_groups:
-                tables[table_name]["columns"][col_name].pop(hint_group, None)  # type: ignore[misc]
+        for col_name, hints in cols.items():
+            for hint in hints:
+                tables[table_name]["columns"][col_name].pop(hint, None)  # type: ignore[misc]
 
     return tables
 

--- a/dlt/common/storages/schema_storage.py
+++ b/dlt/common/storages/schema_storage.py
@@ -84,11 +84,10 @@ class SchemaStorage(Mapping[str, Schema]):
                 self._load_import_schema(schema.name)
             except FileNotFoundError:
                 # save import schema only if it not exist
-                self._export_schema(
+                import_schema_hash = self._export_schema(
                     schema, self.config.import_schema_path, remove_processing_hints=True
                 )
-                # if import schema got saved then add own version hash as import version hash
-                schema._imported_version_hash = schema.version_hash
+                schema._imported_version_hash = import_schema_hash
                 return True
 
         return False
@@ -187,7 +186,7 @@ class SchemaStorage(Mapping[str, Schema]):
 
     def _export_schema(
         self, schema: Schema, export_path: str, remove_processing_hints: bool = False
-    ) -> None:
+    ) -> str:
         if self.config.external_schema_format == "json":
             exported_schema_s = schema.to_pretty_json(
                 remove_defaults=self.config.external_schema_format_remove_defaults,
@@ -217,6 +216,7 @@ class SchemaStorage(Mapping[str, Schema]):
             f" {stored_schema['version']}:{stored_schema['version_hash']} as"
             f" {self.config.external_schema_format}"
         )
+        return stored_schema["version_hash"]
 
     def _save_schema(self, schema: Schema) -> str:
         """Saves schema to schema store and bumps the version"""


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR attempts to resolve the root cause of the issue described in #2989, where the `max_table_nesting` is ignored during the first run of the pipeline in a situation where the import schema path is defined. The root cause consists in the following:

1. The `max_nesting` information is stored as part of the `x-normalizer` processing hints in the schema.
2. All processing hints are discarded when an import schema is being created for the first time.
3. The pipeline loads the schema from the import folder without processing hints, including the `max_nesting` setting.

**Approach:** Just preserve the `max_nesting` setting when creating an import schema for the first time, while discarding other processing hints.

**Possibly better approaches:** 
1. Ignore import schema when it is created for the first time or hasn't changed compared to when first created.
2. Since `max_nesting` is a user defined setting, we can put it outside the `x-normalizer` hint group as a normal table attribute. This way it won't be removed when the import schema is first created. This approach would involve a proper schema migration.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #2989 
