### PR TITLE
docs: add missing page to index

### DIFF
--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -369,6 +369,7 @@ const sidebars = {
             'general-usage/dataset-access/dataset',
             'general-usage/dataset-access/ibis-backend',
             'general-usage/dataset-access/sql-client',
+            'general-usage/dataset-access/view-dlt-schema',
             'general-usage/destination-tables',
           ]
         },


### PR DESCRIPTION
Page was added to local `index.md`, but it was not added to `sidebar.js`