### PR TITLE
ignore `__marimo__/` folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ secrets.toml
 *.wal
 logs/
 .continuerules
+# temporary directory used by marimo for layout, caching, HTML snapshots; see marimo docs
+**/__marimo__  
 
 # Byte-compiled / optimized / DLL files
 **/__pycache__/


### PR DESCRIPTION
Marimo produces temporary folders `__marimo__/` to store cached results, HTML snapshots, layout information, etc. As we use the tool more and more in docs, dashboard, widgets, etc., we don't want to accidentally commit those files.