### PR TITLE
fix: `dlt.Pipeline.__repr__`

### DIFF
--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -952,7 +952,9 @@ class Pipeline(SupportsPipeline):
     def __repr__(self) -> str:
         kwargs = {
             "pipeline_name": self.pipeline_name,
-            "destination": self._destination.destination_name if getattr(self, "_destination", None) else None,
+            "destination": (
+                self._destination.destination_name if getattr(self, "_destination", None) else None
+            ),
             "staging": self._staging.destination_name if getattr(self, "_staging", None) else None,
             "dataset_name": self.dataset_name,
             "default_schema_name": self.default_schema_name,

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -3868,6 +3868,7 @@ def test_nested_hints_primary_key() -> None:
     load_info = p.run(customers().add_map(_pushdown_customer_id))
     assert p.dataset().row_counts().fetchall() == row_count
 
+
 def test_pipeline_repr() -> None:
     sentinel = object()
     p = dlt.pipeline(pipeline_name="repr_pipeline", destination="duckdb")
@@ -3891,15 +3892,15 @@ def test_pipeline_repr() -> None:
     assert getattr(p, "is_active", sentinel) is not sentinel
     assert getattr(p, "pipelines_dir", sentinel) is not sentinel
     assert getattr(p, "working_dir", sentinel) is not sentinel
-    
-    
+
+
 def test_repr_after_loading_trace(tmp_path):
     pipeline_name = "foo"
     trace_path = tmp_path / pipeline_name / "trace.pickle"
     pipeline = dlt.pipeline(pipeline_name, destination="duckdb", pipelines_dir=tmp_path)
     pipeline.run([{"foo": "bar"}], table_name="temp")
     trace = pickle.load(trace_path.open("rb"))
-    
+
     # ensure calling `__repr__()` shouldn't cause any error
     trace.__repr__()
 


### PR DESCRIPTION
When loading a `trace.pickle` file, the current `__repr__` throws exceptions. This is because `dlt.Pipeline.__getstate__` removes some attributes from the object.