### PR TITLE
fix: fixed error in import of BaseOperator in airflow_helper.py (#2601)

### DIFF
--- a/dlt/helpers/airflow_helper.py
+++ b/dlt/helpers/airflow_helper.py
@@ -16,10 +16,10 @@ from dlt.common.exceptions import MissingDependencyException, ValueErrorWithKnow
 
 try:
     from airflow.configuration import conf
-    from airflow.models import TaskInstance
+    from airflow.models import TaskInstance, BaseOperator
     from airflow.utils.task_group import TaskGroup
     from airflow.operators.empty import EmptyOperator
-    from airflow.operators.python import BaseOperator, PythonOperator, get_current_context
+    from airflow.operators.python import PythonOperator, get_current_context
 except ModuleNotFoundError:
     raise MissingDependencyException("Airflow", ["apache-airflow>=2.5"])
 


### PR DESCRIPTION
### Description
fixed error in import of BaseOperator in airflow_helper.py

### Related Issues
- Fixes #2601 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

This is my first contribute to open source so please let me know if im wrong. 

airflow_helpers was causing this error: Traceback (most recent call last):
  File "/opt/airflow/dags/prod_dags/coachview.py", line 6, in <module>
    from dlt.helpers.airflow_helper import PipelineTasksGroup
  File "/home/airflow/.local/lib/python3.12/site-packages/dlt/helpers/airflow_helper.py", line 22, in <module>
    from airflow.operators.python import BaseOperator, PythonOperator, get_current_context
ImportError: cannot import name 'BaseOperator' from 'airflow.operators.python' (unknown location) 
<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
