### PR TITLE
Fix relative link levels in performance documentation

### DIFF
--- a/docs/website/docs/reference/performance.md
+++ b/docs/website/docs/reference/performance.md
@@ -46,7 +46,7 @@ You can change this setting in your `config.toml` as follows:
 
 ### Use the built-in requests wrapper or RESTClient for API calls
 
-Instead of using Python Requests directly, you can use the built-in [requests wrapper](../general-usage/http/requests) or [`RESTClient`](../general-usage/http/rest-client) for API calls. This will make your pipeline more resilient to intermittent network errors and other random glitches.
+Instead of using Python Requests directly, you can use the built-in [requests wrapper](../../general-usage/http/requests) or [`RESTClient`](../../general-usage/http/rest-client) for API calls. This will make your pipeline more resilient to intermittent network errors and other random glitches.
 
 
 ### Use built-in JSON parser


### PR DESCRIPTION
- Update relative links from ../general-usage/http/ to ../../general-usage/http/
- Based on directory structure analysis and working examples
- This is based on the latest upstream devel branch

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Fixed incorrect relative link levels in performance documentation.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context
## Problem  
Links were using `../general-usage/http/` (1 level up) instead of `../../general-usage/http/` (2 levels up) from the `/reference/` directory.

## Solution
Changed to `../../general-usage/http/` to match the directory structure and working examples in `/reference/explainers/`.

## Links Fixed
- RESTClient documentation link
- Requests wrapper documentation link
This is a clean PR with only the documentation fix, based on the latest upstream.
<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->



