### PR TITLE
repo(ci): disable docker container autorestart

### DIFF
--- a/tests/load/clickhouse/docker-compose.yml
+++ b/tests/load/clickhouse/docker-compose.yml
@@ -1,7 +1,8 @@
----
 services:
   clickhouse:
     image: clickhouse/clickhouse-server
+    container_name: dlt_test_clickhouse
+    restart: on-failure
     ports:
       - "9000:9000"
       - "8123:8123"

--- a/tests/load/dremio/docker-compose.yml
+++ b/tests/load/dremio/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   dremio:
     image: dremio/dremio-oss:25.0
+    container_name: dlt_test_dremio
+    restart: on-failure
     ports:
       - "9047:9047"
       - "31010:31010"
@@ -10,6 +12,7 @@ services:
       - dremio
   minio:
     image: minio/minio
+    container_name: dlt_test_dremio-minio-bucket
     command: server /data --console-address ":9001"
     environment:
       - MINIO_ROOT_USER=minioadmin

--- a/tests/load/filesystem_sftp/docker-compose.yml
+++ b/tests/load/filesystem_sftp/docker-compose.yml
@@ -4,6 +4,8 @@ services:
       context: bootstrap
       dockerfile: Dockerfile
     image: sftpserver:latest
+    container_name: dlt_test_filesystem-sftp
+    restart: on-failure
     networks:
       - sftpserver
     ports:

--- a/tests/load/postgres/docker-compose.yml
+++ b/tests/load/postgres/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     build:
       context: postgres
       dockerfile: Dockerfile
-    container_name: dlt_postgres_db
+    container_name: dlt_test_postgres
+    restart: on-failure
     volumes:
       - db_home:/var/lib/postgresql/data
     ports:

--- a/tests/load/sources/sql_database/docker-compose.yml
+++ b/tests/load/sources/sql_database/docker-compose.yml
@@ -2,7 +2,8 @@ services:
   mssql:
     image: mcr.microsoft.com/mssql/server:2022-latest
     platform: linux/amd64
-    container_name: mssql_ct
+    container_name: dlt_test_mssql
+    restart: on-failure
     environment:
       - ACCEPT_EULA=Y
       - MSSQL_SA_PASSWORD=Strong!Passw0rd

--- a/tests/load/sqlalchemy/docker-compose.yml
+++ b/tests/load/sqlalchemy/docker-compose.yml
@@ -1,11 +1,8 @@
-# Use root/example as user/password credentials
-version: '3.1'
-
 services:
-
   db:
     image: mysql:8
-    restart: always
+    container_name: dlt_test_mysql
+    restart: on-failure
     command: --sql-mode="STRICT_ALL_TABLES,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION" --innodb-strict-mode
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/tests/load/weaviate/docker-compose.yml
+++ b/tests/load/weaviate/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     - --scheme
     - http
     image: semitechnologies/weaviate:1.21.1
+    container_name: dlt_test_weaviate
+    restart: on-failure
     ports:
     - 8080:8080
     environment:
@@ -26,5 +28,7 @@ services:
       NEIGHBOR_OCCURRENCE_IGNORE_PERCENTILE: 5
       ENABLE_COMPOUND_SPLITTING: 'false'
     image: semitechnologies/contextionary:en0.16.0-v1.2.1
+    container_name: dlt_test_weaviate-contextionary
+    restart: on-failure
     ports:
     - 9999:9999


### PR DESCRIPTION
`dlt` uses several containers in its test setup. Most define the policy `restart: unless-stopped` in their docker-compose.

This means these containers are started when booting the developer's machine and run most of the time in the background. This has a noticeable impact on CPU during intensive usage. The developer is required to manually spin down containers each time via `docker container stop $(docker ps -q -a)` 

## Changes
- set policy `restart: "on-failure"` which doesn't start containers on boot.
- remove the `version:` field; this has been deprecated and ignored for some time
- set `container_name` with a `dlt_test_` prefix to facilitate container management and prevent spawning duplicate containers

## Future steps
- some docker compose use docker networks and named volumes; those can be harder to cleanup. Would be useful to minimize resource usage of dev machines or provide cleanup scripts
