### PR TITLE
Don't echo pypi token to console on library publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ clean-dist:
 
 publish-library: clean-dist build-library
 	ls -l dist/
-	@read -p "Enter PyPI API token: " PYPI_API_TOKEN; echo ; \
+	@read -sp "Enter PyPI API token: " PYPI_API_TOKEN; echo ; \
 	uv publish --token "$$PYPI_API_TOKEN"
 
 test-build-images: build-library


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
See title
