### PR TITLE
feat: `Dataset.write()`

### DIFF
--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -1128,3 +1128,12 @@ class Schema:
         del state["naming"]
         del state["data_item_normalizer"]
         return state
+    
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Schema):
+            raise NotImplementedError(f"Equality between `dlt.Schema` object and {type(other).__name__} is not supported.")
+
+        return self.version_hash == other.version_hash
+    
+    def __hash__(self) -> int:
+        return hash(self.version_hash)

--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -1128,12 +1128,14 @@ class Schema:
         del state["naming"]
         del state["data_item_normalizer"]
         return state
-    
+
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Schema):
-            raise NotImplementedError(f"Equality between `dlt.Schema` object and {type(other).__name__} is not supported.")
+            raise NotImplementedError(
+                f"Equality between `dlt.Schema` object and {type(other).__name__} is not supported."
+            )
 
         return self.version_hash == other.version_hash
-    
+
     def __hash__(self) -> int:
         return hash(self.version_hash)

--- a/dlt/dataset/dataset.py
+++ b/dlt/dataset/dataset.py
@@ -15,8 +15,6 @@ from dlt.common.destination.client import JobClientBase, SupportsOpenTables, Wit
 from dlt.common.typing import Self, TDataItems
 from dlt.common.schema.typing import C_DLT_LOAD_ID, TWriteDisposition
 from dlt.common.pipeline import LoadInfo
-from dlt.extract.hints import TResourceHints
-from dlt.sources import DltResource
 from dlt.common.utils import simple_repr, without_none
 from dlt.destinations.sql_client import SqlClientBase, WithSqlClient
 from dlt.dataset import lineage
@@ -174,7 +172,7 @@ class Dataset:
         helpful if we want to run sql queries without extracting the data
         """
         return is_same_physical_destination(self, other)
-    
+
     # TODO explain users can inspect `_dlt_loads` table to differentiate data originating
     # from `pipeline.run()` or `dataset.write()`
     def get_write_pipeline(self) -> dlt.Pipeline:
@@ -489,7 +487,9 @@ def _get_dataset_schema_from_destination_using_dataset_name(
     return schema
 
 
-def _get_internal_pipeline(dataset_name: str, destination: AnyDestination) -> dlt.Pipeline:
+def _get_internal_pipeline(
+    dataset_name: str, destination: TDestinationReferenceArg
+) -> dlt.Pipeline:
     """Setup the internal pipeline used by `Dataset.write()`"""
     pipeline = dlt.pipeline(
         pipeline_name=_INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE.format(dataset_name=dataset_name),

--- a/dlt/dataset/dataset.py
+++ b/dlt/dataset/dataset.py
@@ -12,9 +12,11 @@ from dlt.common.libs.sqlglot import TSqlGlotDialect
 from dlt.common.json import json
 from dlt.common.destination.reference import AnyDestination, TDestinationReferenceArg, Destination
 from dlt.common.destination.client import JobClientBase, SupportsOpenTables, WithStateSync
-from dlt.common.schema import Schema
-from dlt.common.typing import Self
-from dlt.common.schema.typing import C_DLT_LOAD_ID
+from dlt.common.typing import Self, TDataItems
+from dlt.common.schema.typing import C_DLT_LOAD_ID, TWriteDisposition
+from dlt.common.pipeline import LoadInfo
+from dlt.extract.hints import TResourceHints
+from dlt.sources import DltResource
 from dlt.common.utils import simple_repr, without_none
 from dlt.destinations.sql_client import SqlClientBase, WithSqlClient
 from dlt.dataset import lineage
@@ -25,6 +27,9 @@ from dlt.common.destination.exceptions import SqlClientNotAvailable
 if TYPE_CHECKING:
     from ibis import ir
     from ibis import BaseBackend as IbisBackend
+
+
+_INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE = "_dlt_dataset_{dataset_name}"
 
 
 class Dataset:
@@ -169,6 +174,38 @@ class Dataset:
         helpful if we want to run sql queries without extracting the data
         """
         return is_same_physical_destination(self, other)
+    
+    # TODO explain users can inspect `_dlt_loads` table to differentiate data originating
+    # from `pipeline.run()` or `dataset.write()`
+    def get_write_pipeline(self) -> dlt.Pipeline:
+        """Get the internal pipeline used by `Dataset.write()`"""
+        return _get_internal_pipeline(self.dataset_name, destination=self._destination)
+
+    def write(
+        self,
+        data: TDataItems,
+        *,
+        table_name: str,
+        write_disposition: TWriteDisposition = "append",
+    ) -> LoadInfo:
+        """Write `data` to the specified table.
+
+        This method uses a full-on `dlt.Pipeline` internally. You can retrieve this pipeline
+        using `Dataset.get_write_pipeline()` for complete flexibility.
+        """
+        resource = _data_to_resource(
+            data,
+            schema=self.schema,
+            table_name=table_name,
+            dataset_name=self.dataset_name,
+            write_disposition=write_disposition,
+        )
+        internal_pipeline = _get_internal_pipeline(self.dataset_name, destination=self._destination)
+        # TODO should we try/except this run to gracefully handle failed writes?
+        info = internal_pipeline.run([resource], schema=self.schema)
+        # maybe update the dataset schema
+        self._schema = internal_pipeline.default_schema
+        return info
 
     def query(
         self,
@@ -387,7 +424,7 @@ class Dataset:
 def dataset(
     destination: TDestinationReferenceArg,
     dataset_name: str,
-    schema: Union[Schema, str, None] = None,
+    schema: Union[dlt.Schema, str, None] = None,
 ) -> Dataset:
     return Dataset(destination, dataset_name, schema)
 
@@ -451,3 +488,35 @@ def _get_dataset_schema_from_destination_using_dataset_name(
                 schema = dlt.Schema.from_stored_schema(json.loads(stored_schema.schema))
 
     return schema
+
+# TODO move this to `dlt.extract`. Maybe there's an existing function?
+def _data_to_resource(
+    data: TDataItems,
+    *,
+    schema: dlt.Schema,
+    table_name: str,
+    dataset_name: str,
+    write_disposition: TWriteDisposition,
+) -> DltResource:
+    """Create a resource from a `data` argument."""
+    table_schema = schema.tables.get(table_name)
+    hints: TResourceHints = (
+        table_schema
+        if table_schema  # type: ignore
+        else dlt.mark.make_hints(table_name=table_name, write_disposition=write_disposition)
+    )
+    return DltResource.from_data(data, name=table_name, section=dataset_name, hints=hints)
+
+
+def _get_internal_pipeline(dataset_name: str, destination: AnyDestination) -> dlt.Pipeline:
+    """Setup the internal pipeline used by `Dataset.write()`"""
+    pipeline = dlt.pipeline(
+        pipeline_name=_INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE.format(dataset_name=dataset_name),
+        dataset_name=dataset_name,
+        destination=destination,
+    )
+    # the internal write pipeline should be stateless; it is limited to the data passed
+    # it shouldn't persist state (e.g., incremntal cursor) and interfere with other `pipeline.run()`
+    pipeline.config.restore_from_destination = False
+
+    return pipeline

--- a/tests/dataset/test_dataset_write.py
+++ b/tests/dataset/test_dataset_write.py
@@ -1,7 +1,29 @@
 import duckdb
+import pytest
 
 import dlt
-from dlt.dataset.dataset import _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE, is_same_physical_destination
+from dlt.common.pipeline import LoadInfo
+from dlt.dataset.dataset import _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE, is_same_physical_destination, _get_internal_pipeline
+from dlt.destinations.exceptions import DatabaseUndefinedRelation
+
+from tests.utils import preserve_environ, patch_home_dir, autouse_test_storage
+
+
+def test_get_internal_pipeline():
+    dataset_name = "foo"
+    destination = dlt.destinations.duckdb(duckdb.connect())
+    dataset = dlt.dataset(destination, dataset_name)
+    expected_pipeline_name = _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE.format(dataset_name=dataset_name)
+
+    internal_pipeline = _get_internal_pipeline(dataset_name=dataset_name, destination=destination)
+    internal_dataset = internal_pipeline.dataset()
+
+    assert isinstance(internal_pipeline, dlt.Pipeline)
+    assert internal_pipeline.pipeline_name == expected_pipeline_name
+    assert internal_pipeline.dataset_name == dataset_name
+    assert internal_pipeline.destination == destination
+    assert is_same_physical_destination(dataset, internal_dataset)
+    assert dataset.schema == internal_dataset.schema
 
 
 def test_dataset_get_write_pipeline():
@@ -19,3 +41,25 @@ def test_dataset_get_write_pipeline():
     assert write_pipeline.destination == destination
     assert is_same_physical_destination(dataset, write_dataset)
     assert dataset.schema == write_dataset.schema
+
+
+def test_dataset_write():
+    dataset_name = "foo"
+    destination = dlt.destinations.duckdb(duckdb.connect())
+    dataset = dlt.dataset(destination, dataset_name)
+    table_name = "bar"
+    items = [{"id": 0, "value": "bingo"}, {"id": 1, "value": "bongo"}]
+
+    # TODO this is currently odd because the tables exists on the `Schema`
+    # used by the `Dataset` but the tables don't exist on the destination yet 
+    assert dataset.tables == ["_dlt_version", "_dlt_loads"]
+    with pytest.raises(DatabaseUndefinedRelation):
+        dataset.table("_dlt_version").fetchall()
+    with pytest.raises(DatabaseUndefinedRelation):
+        dataset.table("_dlt_loads").fetchall()
+
+    load_info = dataset.write(items, table_name=table_name)
+
+    assert isinstance(load_info, LoadInfo)
+    assert dataset.tables == ["bar", "_dlt_version", "_dlt_loads"]
+    assert dataset.table("bar").select("id", "value").fetchall() == [tuple(i.values()) for i in items]

--- a/tests/dataset/test_dataset_write.py
+++ b/tests/dataset/test_dataset_write.py
@@ -18,3 +18,4 @@ def test_dataset_get_write_pipeline():
     assert write_pipeline.dataset_name == dataset_name
     assert write_pipeline.destination == destination
     assert is_same_physical_destination(dataset, write_dataset)
+    assert dataset.schema == write_dataset.schema

--- a/tests/dataset/test_dataset_write.py
+++ b/tests/dataset/test_dataset_write.py
@@ -3,7 +3,11 @@ import pytest
 
 import dlt
 from dlt.common.pipeline import LoadInfo
-from dlt.dataset.dataset import _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE, is_same_physical_destination, _get_internal_pipeline
+from dlt.dataset.dataset import (
+    _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE,
+    is_same_physical_destination,
+    _get_internal_pipeline,
+)
 from dlt.destinations.exceptions import DatabaseUndefinedRelation
 
 from tests.utils import preserve_environ, patch_home_dir, autouse_test_storage
@@ -13,7 +17,9 @@ def test_get_internal_pipeline():
     dataset_name = "foo"
     destination = dlt.destinations.duckdb(duckdb.connect())
     dataset = dlt.dataset(destination, dataset_name)
-    expected_pipeline_name = _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE.format(dataset_name=dataset_name)
+    expected_pipeline_name = _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE.format(
+        dataset_name=dataset_name
+    )
 
     internal_pipeline = _get_internal_pipeline(dataset_name=dataset_name, destination=destination)
     internal_dataset = internal_pipeline.dataset()
@@ -30,7 +36,9 @@ def test_dataset_get_write_pipeline():
     dataset_name = "foo"
     destination = dlt.destinations.duckdb(duckdb.connect())
     dataset = dlt.dataset(destination, dataset_name)
-    expected_pipeline_name = _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE.format(dataset_name=dataset_name)
+    expected_pipeline_name = _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE.format(
+        dataset_name=dataset_name
+    )
 
     write_pipeline = dataset.get_write_pipeline()
     write_dataset = write_pipeline.dataset()
@@ -51,7 +59,7 @@ def test_dataset_write():
     items = [{"id": 0, "value": "bingo"}, {"id": 1, "value": "bongo"}]
 
     # TODO this is currently odd because the tables exists on the `Schema`
-    # used by the `Dataset` but the tables don't exist on the destination yet 
+    # used by the `Dataset` but the tables don't exist on the destination yet
     assert dataset.tables == ["_dlt_version", "_dlt_loads"]
     with pytest.raises(DatabaseUndefinedRelation):
         dataset.table("_dlt_version").fetchall()
@@ -62,4 +70,6 @@ def test_dataset_write():
 
     assert isinstance(load_info, LoadInfo)
     assert dataset.tables == ["bar", "_dlt_version", "_dlt_loads"]
-    assert dataset.table("bar").select("id", "value").fetchall() == [tuple(i.values()) for i in items]
+    assert dataset.table("bar").select("id", "value").fetchall() == [
+        tuple(i.values()) for i in items
+    ]

--- a/tests/dataset/test_dataset_write.py
+++ b/tests/dataset/test_dataset_write.py
@@ -1,0 +1,20 @@
+import duckdb
+
+import dlt
+from dlt.dataset.dataset import _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE, is_same_physical_destination
+
+
+def test_dataset_get_write_pipeline():
+    dataset_name = "foo"
+    destination = dlt.destinations.duckdb(duckdb.connect())
+    dataset = dlt.dataset(destination, dataset_name)
+    expected_pipeline_name = _INTERNAL_DATASET_PIPELINE_NAME_TEMPLATE.format(dataset_name=dataset_name)
+
+    write_pipeline = dataset.get_write_pipeline()
+    write_dataset = write_pipeline.dataset()
+
+    assert isinstance(write_pipeline, dlt.Pipeline)
+    assert write_pipeline.pipeline_name == expected_pipeline_name
+    assert write_pipeline.dataset_name == dataset_name
+    assert write_pipeline.destination == destination
+    assert is_same_physical_destination(dataset, write_dataset)


### PR DESCRIPTION
## Motivation
Users of `dlt.Dataset` want a simple way to write data back to the dataset.

Use cases:
- manually review data and push corrected records
- simple way to add records if you don't have access to the original `dlt.Pipeline` used to create the dataset

## Specs
- Look at `WritableDataset.save()` from `dlt-plus`
- Add `Dataset.write()` in `dlt` (this aligns with `pipeline.run()` operation)
  - Alternatives: `.write_to()`, `.load_into()`, `.load_table()`
- create an internal `dlt.Pipeline` named `_dlt_dataset_{dataset_name}`
- find a way for the internal pipeline to use the `dlt.Schema` from the `dlt.Dataset` instance; this way, this schema should evolve when `Dataset.load()` is used
- potential API
  ```python
  def load(
    self: dlt.Dataset,
    data: TDataItems,
    table_name: str,
    write_disposition: TWriteDisposition = "append",
    normalize: bool = False,
  ) -> LoadInfo: ...
  ```
  - `write_disposition` is useful to determine if we should append or modify existing records
  - `normalize` allows the user to decide to enable normalization (which might create more tables)
- can accept a `dlt.Relation` as input


## Out of scope
- `Dataset.load()` doesn't have to support 1-to-1 the `dlt.Pipeline.run()` method; if user needs full range of config, then they should create a pipeline