### PR TITLE
cli: updated error in the dlt pipeline show command

### DIFF
--- a/dlt/helpers/dashboard/runner.py
+++ b/dlt/helpers/dashboard/runner.py
@@ -6,6 +6,17 @@ from typing import Any
 from pathlib import Path
 from dlt.common.exceptions import MissingDependencyException
 
+
+def _detect_dashboard_command() -> str:
+    command = sys.argv[1]
+    if command == "pipeline":
+        return f"dlt pipeline {sys.argv[2]} show"
+    elif command == "dashboard":
+        return "dlt dashboard"
+    else:
+        raise ValueError(f"Invalid command: {command}")
+
+
 # keep this, will raise if user tries to run dashboard without dependencies
 try:
     import marimo
@@ -13,7 +24,7 @@ try:
     import ibis
 except ModuleNotFoundError:
     raise MissingDependencyException(
-        "dlt dashboard or dlt pipeline [pipeline_name] show",
+        _detect_dashboard_command(),
         ['dlt["workspace"]'],
         "to install the dlt workspace extra.",
     )


### PR DESCRIPTION
When I run `dlt pipeline my_pipeline show` and I miss dependencies I get this message:

```
You must install additional dependencies to run `dlt pipeline dashboard`. If you use pip you may do the following:

pip install "dlt["workspace"]"

the dlt dashboard requires additional dependencies which you may install with the dlt workspace extra.
```

1. This may be confusing as it looks like command mismatch. The user runs `dlt pipeline my_pipeline show` but the error message refers to dlt pipeline dashboard.
2. The text after the pip command is redundant.

This PR updates error message in `dlt pipeline ... show` command:
- correctly reference the "show" command; 
- removed redundant text about additional dependencies

