### PR TITLE
fix incorrect export

### DIFF
--- a/dlt/sources/helpers/requests/__init__.py
+++ b/dlt/sources/helpers/requests/__init__.py
@@ -65,6 +65,6 @@ __all__ = [
     "TooManyRedirects",
     "URLRequired",
     "ChunkedEncodingError",
-    "RetryErrorClient",
+    "Client",
     "RetryError",
 ]


### PR DESCRIPTION
### Description

It incorrectly exports Client as RetryErrorClient - see [c3ddbaa6e](https://github.com/dlt-hub/dlt/commit/c3ddbaa6e61c44a3809e625c802cb4c7632934a3#diff-70c5e7b1ec865abf88b585eec181a4de0122a4a41205fbaac06a00d38e1267dc)

As a result, pyright warns 

```
"Client" is not exported from module "dlt.sources.helpers.requests"
  Import from "dlt.sources.helpers.requests.retry" instead (Pyright reportPrivateImportUsage)
```
