### PR TITLE
Add DLT destination capabilities tags to documentation files

### DIFF
--- a/docs/website/docs/dlt-ecosystem/destinations/athena.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/athena.md
@@ -316,3 +316,4 @@ pipeline.run(partitioned_data)
 ```
 <!--@@@DLT_TUBA athena-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES athena-->

--- a/docs/website/docs/dlt-ecosystem/destinations/bigquery.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/bigquery.md
@@ -228,8 +228,8 @@ BigQuery supports the following [column hints](../../general-usage/schema#tables
 
 :::warning
 **Deprecation Notice:**
-Per-column `cluster` hints are deprecated and will be removed in a future release.  
-**To migrate, use the `cluster` argument of the `bigquery_adapter` instead.**  
+Per-column `cluster` hints are deprecated and will be removed in a future release.
+**To migrate, use the `cluster` argument of the `bigquery_adapter` instead.**
 See the [example below](#use-an-adapter-to-apply-hints-to-a-resource) for how to specify clustering columns with the adapter.
 :::
 
@@ -366,3 +366,4 @@ Refer to the [full API specification](../../api_reference/dlt/destinations/impl/
 
 <!--@@@DLT_TUBA bigquery-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES bigquery-->

--- a/docs/website/docs/dlt-ecosystem/destinations/clickhouse.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/clickhouse.md
@@ -259,3 +259,4 @@ This destination fully supports [dlt state sync](../../general-usage/state#synci
 
 <!--@@@DLT_TUBA clickhouse-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES clickhouse-->

--- a/docs/website/docs/dlt-ecosystem/destinations/databricks.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/databricks.md
@@ -628,3 +628,4 @@ If this workaround is necessary, validate your setup after each platform upgrade
 
 <!--@@@DLT_TUBA databricks-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES databricks-->

--- a/docs/website/docs/dlt-ecosystem/destinations/destination.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/destination.md
@@ -15,6 +15,7 @@ It will also allow you to simply get a path to the files of your normalized data
 ## Install `dlt` for reverse ETL
 
 To install `dlt` without additional dependencies:
+
 ```sh
 pip install dlt
 ```
@@ -40,9 +41,10 @@ pipeline.run([1, 2, 3], table_name="items")
 ```
 
 :::tip
+
 1. You can also remove the typing information (`TDataItems` and `TTableSchema`) from this example. Typing is generally useful to know the shape of the incoming objects, though.
 2. There are a few other ways to declare custom destination functions for your pipeline described below.
-:::
+   :::
 
 ### `@dlt.destination`, custom destination function, and signature
 
@@ -64,28 +66,31 @@ def my_destination(items: TDataItems, table: TTableSchema) -> None:
 ```
 
 ### Decorator arguments
-* The `batch_size` parameter on the destination decorator defines how many items per function call are batched together and sent as an array. If you set a batch size of `0`, instead of passing in actual data items, you will receive one call per load job with the path of the file as the items argument. You can then open and process that file in any way you like.
-* The `loader_file_format` parameter on the destination decorator defines the format in which files are stored in the load package before being sent to the destination function. This can be `jsonl` or `parquet`.
-* The `name` parameter on the destination decorator defines the name of the destination that gets created by the destination decorator.
-* The `naming_convention` parameter on the destination decorator defines the name of the destination that gets created by the destination decorator. This controls how table and column names are normalized. The default is `direct`, which will keep all names the same.
-* The `max_table_nesting` parameter on the destination decorator defines how deep the normalizer will go to normalize nested fields in your data to create subtables. This overwrites any settings on your `source` and is set to zero to not create any nested tables by default.
-* The `skip_dlt_columns_and_tables` parameter on the destination decorator defines whether internal tables and columns will be fed into the custom destination function. This is set to `True` by default.
-* The `max_parallel_load_jobs` parameter will define how many load jobs will run in parallel in threads. If you have a destination that only allows five connections at a time, you can set this value to 5, for example.
-* The `loader_parallelism_strategy` parameter will control how load jobs are parallelized. Set to `parallel`, the default, jobs will be parallelized no matter which table is being loaded to. `table-sequential` will parallelize loading but only ever have one load job per table at a time, `sequential` will run all load jobs sequentially on the main thread.
+
+- The `batch_size` parameter on the destination decorator defines how many items per function call are batched together and sent as an array. If you set a batch size of `0`, instead of passing in actual data items, you will receive one call per load job with the path of the file as the items argument. You can then open and process that file in any way you like.
+- The `loader_file_format` parameter on the destination decorator defines the format in which files are stored in the load package before being sent to the destination function. This can be `jsonl` or `parquet`.
+- The `name` parameter on the destination decorator defines the name of the destination that gets created by the destination decorator.
+- The `naming_convention` parameter on the destination decorator defines the name of the destination that gets created by the destination decorator. This controls how table and column names are normalized. The default is `direct`, which will keep all names the same.
+- The `max_table_nesting` parameter on the destination decorator defines how deep the normalizer will go to normalize nested fields in your data to create subtables. This overwrites any settings on your `source` and is set to zero to not create any nested tables by default.
+- The `skip_dlt_columns_and_tables` parameter on the destination decorator defines whether internal tables and columns will be fed into the custom destination function. This is set to `True` by default.
+- The `max_parallel_load_jobs` parameter will define how many load jobs will run in parallel in threads. If you have a destination that only allows five connections at a time, you can set this value to 5, for example.
+- The `loader_parallelism_strategy` parameter will control how load jobs are parallelized. Set to `parallel`, the default, jobs will be parallelized no matter which table is being loaded to. `table-sequential` will parallelize loading but only ever have one load job per table at a time, `sequential` will run all load jobs sequentially on the main thread.
 
 :::note
 Settings above ensure that the shape of the data you receive in the destination function is as close as possible to what you see in the data source.
 
-* The custom destination sets the `max_table_nesting` to 0 by default, which means no sub-tables will be generated during the normalization phase.
-* The custom destination also skips all internal tables and columns by default. If you need these, set `skip_dlt_columns_and_tables` to False.
-:::
+- The custom destination sets the `max_table_nesting` to 0 by default, which means no sub-tables will be generated during the normalization phase.
+- The custom destination also skips all internal tables and columns by default. If you need these, set `skip_dlt_columns_and_tables` to False.
+  :::
 
 ### Custom destination function
-* The `items` parameter on the custom destination function contains the items being sent into the destination function.
-* The `table` parameter contains the schema table the current call belongs to, including all table hints and columns. For example, the table name can be accessed with `table["name"]`.
-* You can also add config values and secrets to the function arguments, see below!
+
+- The `items` parameter on the custom destination function contains the items being sent into the destination function.
+- The `table` parameter contains the schema table the current call belongs to, including all table hints and columns. For example, the table name can be accessed with `table["name"]`.
+- You can also add config values and secrets to the function arguments, see below!
 
 ## Add configuration, credentials, and other secrets to the destination function
+
 The destination decorator supports settings and secrets variables. If you, for example, plan to connect to a service that requires an API secret or a login, you can do the following:
 
 ```py
@@ -106,6 +111,7 @@ Custom destinations follow the same configuration rules as [regular named destin
 ## Use the custom destination in `dlt` pipeline
 
 There are multiple ways to pass the custom destination function to the `dlt` pipeline:
+
 - Directly reference the destination function
 
   ```py
@@ -119,6 +125,7 @@ There are multiple ways to pass the custom destination function to the `dlt` pip
 
   Like for [regular destinations](../../general-usage/destination.md#pass-explicit-credentials), you are allowed to pass configuration and credentials
   explicitly to the destination function.
+
   ```py
   @dlt.destination(batch_size=10, loader_file_format="jsonl", name="my_destination")
   def my_destination(items: TDataItems, table: TTableSchema, api_key: str = dlt.secrets.value) -> None:
@@ -128,6 +135,7 @@ There are multiple ways to pass the custom destination function to the `dlt` pip
   ```
 
 - Directly via destination reference. In this case, don't use the decorator for the destination function.
+
   ```py
   # File my_destination.py
 
@@ -145,7 +153,9 @@ There are multiple ways to pass the custom destination function to the `dlt` pip
       )
   )
   ```
+
 - Via a fully qualified string to function location (this can be set in `config.toml` or through environment variables). The destination function should be located in another file.
+
   ```py
   # File my_pipeline.py
 
@@ -161,6 +171,7 @@ There are multiple ways to pass the custom destination function to the `dlt` pip
   ```
 
 ## Adjust batch size and retry policy for atomic loads
+
 The destination keeps a local record of how many `DataItems` were processed, so if you, for example, use the custom destination to push `DataItems` to a remote API, and this
 API becomes unavailable during the load resulting in a failed `dlt` pipeline run, you can repeat the run of your pipeline at a later moment and the custom destination will **restart from the whole batch that failed**. We are preventing any data from being lost, but you can still get duplicated data if you committed half of the batch, for example, to a database and then failed.
 **Keeping the batch atomicity is on you**. For this reason, it makes sense to choose a batch size that you can process in one transaction (say one API request or one database transaction) so that if this request or transaction fails repeatedly, you can repeat it at the next run without pushing duplicate data to your remote location. For systems that
@@ -176,6 +187,7 @@ However, it is fairly easy to back up and restore the pipeline directory, [see d
 :::
 
 ## Increase or decrease loading parallelism
+
 Calls to the destination function by default will be executed on multiple threads, so you need to make sure you are not using any non-thread-safe nonlocal or global variables from outside your destination function. If you need to have all calls executed from the same thread, you can set the `workers` [config variable of the load step](../../reference/performance.md#load) to 1.
 
 :::tip
@@ -191,15 +203,18 @@ For performance reasons, we recommend keeping the multithreaded approach and mak
 `@dlt.destination` does not support staging files in remote locations before being called at this time. If you need this feature, please let us know.
 
 ## Manage pipeline state for incremental loading
+
 Custom destinations do not have a general mechanism to restore pipeline state. This will impact data sources that rely on the state being kept, i.e., all incremental resources.
 If you wipe the pipeline directory (i.e., by deleting a folder or running on AWS Lambda or GitHub Actions where you get a clean runner), the progress of the incremental loading is lost. On the next run, you will re-acquire the data from the beginning.
 
 While we are working on a pluggable state storage, you can fix the problem above by:
+
 1. Not wiping the pipeline directory. For example, if you run your pipeline on an EC instance periodically, the state will be preserved.
 2. By doing a restore/backup of the pipeline directory before/after it runs. This is way easier than it sounds, and [here's a script you can reuse](https://gist.github.com/rudolfix/ee6e16d8671f26ac4b9ffc915ad24b6e).
 
 ## What's next
 
-* Check out our [Custom BigQuery Destination](../../examples/custom_destination_bigquery/) example.
-* Need help with building a custom destination? Ask your questions in our [Slack Community](https://dlthub.com/community) technical help channel.
+- Check out our [Custom BigQuery Destination](../../examples/custom_destination_bigquery/) example.
+- Need help with building a custom destination? Ask your questions in our [Slack Community](https://dlthub.com/community) technical help channel.
 
+<!--@@@DLT_DESTINATION_CAPABILITIES destination-->

--- a/docs/website/docs/dlt-ecosystem/destinations/dremio.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/dremio.md
@@ -124,3 +124,4 @@ This will result in `PARTITION BY ("foo","bar")` and `LOCALSORT BY ("baz")` clau
 
 <!--@@@DLT_TUBA dremio-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES dremio-->

--- a/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/duckdb.md
@@ -280,7 +280,7 @@ dest_ = dlt.destinations.duckdb(
     DuckDbCredentials("duck.db", extensions=["spatial"], local_config={"errors_as_json": True})
 )
 ```
-Code above install **spatial** (`dlt` only loads extension) and passes duckdb credentials to the destination constructor. Database file is **duck.db**, logging and error messages as `json` are enabled. 
+Code above install **spatial** (`dlt` only loads extension) and passes duckdb credentials to the destination constructor. Database file is **duck.db**, logging and error messages as `json` are enabled.
 
 ## Data access after loading
 After loading, it is available in **read/write** mode via `with pipeline.sql_client() as con:`, which is a wrapper over `DuckDBPyConnection`. See [duckdb docs](https://duckdb.org/docs/api/python/overview#persistent-storage) for details. If you want to **read** data, use [pipeline.dataset()](../../general-usage/dataset-access/dataset) instead of `sql_client`.
@@ -296,3 +296,4 @@ This destination fully supports [dlt state sync](../../general-usage/state#synci
 
 <!--@@@DLT_TUBA duckdb-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES duckdb-->

--- a/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
@@ -152,7 +152,7 @@ ducklake = dlt.destinations.ducklake(credentials=credentials)
 import dlt
 from dlt.sources.credentials import ConnectionStringCredentials
 
-# set catalog name using connection string credentials    
+# set catalog name using connection string credentials
 catalog_credentials = ConnectionStringCredentials()
 # use duckdb with the default name
 catalog_credentials.drivername = "duckdb"
@@ -215,7 +215,7 @@ with pipeline.sql_client() as client:
 All write dispositions are supported. `upsert` is supported on **duckdb 1.4.x** (without hard deletes for now)
 
 ## Data loading
-By default, Parquet files and the `COPY` command are used to move local files to the remote storage, 
+By default, Parquet files and the `COPY` command are used to move local files to the remote storage,
 
 The **INSERT** format is also supported and will execute large INSERT queries directly into the remote database. This method is significantly slower and may exceed the maximum query size, so it is not advised.
 
@@ -235,3 +235,5 @@ This destination fully supports [dlt state sync](../../general-usage/state#synci
 * Motherduck as catalog if possible.
 * support additional `ATTACH` options like `OVERRIDE_DATA_PATH`
 * implement callbacks that will be called on creation of :memory: database and `ATTACH` command so those can be fully customized.
+
+<!--@@@DLT_DESTINATION_CAPABILITIES ducklake-->

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -699,3 +699,5 @@ pipeline = dlt.pipeline(
 :::
 
 <!--@@@DLT_TUBA filesystem-->
+
+<!--@@@DLT_DESTINATION_CAPABILITIES filesystem-->

--- a/docs/website/docs/dlt-ecosystem/destinations/lancedb.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/lancedb.md
@@ -209,7 +209,7 @@ If you plan to use `merge` write disposition, remember to [enable load ids](../v
 
 ## Access loaded data
 
-You can access the data that got loaded in many ways. You can create lancedb client yourself, pass it to `dlt` pipeline 
+You can access the data that got loaded in many ways. You can create lancedb client yourself, pass it to `dlt` pipeline
 for loading and then use it for querying:
 ```py
 import dlt
@@ -369,3 +369,4 @@ The LanceDB destination supports syncing of the `dlt` state.
 
 <!--@@@DLT_TUBA lancedb-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES lancedb-->

--- a/docs/website/docs/dlt-ecosystem/destinations/motherduck.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/motherduck.md
@@ -69,7 +69,7 @@ python3 chess_pipeline.py
 ```
 
 ### DuckLake setup
-DuckLake can be used to manage and persist your MotherDuck databases on external object storage like S3. This is especially useful if you want more control over where your data is stored or if you’re integrating with your own cloud infrastructure. 
+DuckLake can be used to manage and persist your MotherDuck databases on external object storage like S3. This is especially useful if you want more control over where your data is stored or if you’re integrating with your own cloud infrastructure.
 The steps below show how to set up a DuckLake-managed database backed by S3.
 
 **1. Create the S3-Backed DuckLake Database**
@@ -149,3 +149,4 @@ before opening the connection.
 
 <!--@@@DLT_TUBA motherduck-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES motherduck-->

--- a/docs/website/docs/dlt-ecosystem/destinations/mssql.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/mssql.md
@@ -171,3 +171,4 @@ This destination [integrates with dbt](../transformations/dbt/dbt.md) via [dbt-s
 
 <!--@@@DLT_TUBA mssql-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES mssql-->

--- a/docs/website/docs/dlt-ecosystem/destinations/postgres.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/postgres.md
@@ -229,3 +229,4 @@ This destination fully supports [dlt state sync](../../general-usage/state#synci
 
 <!--@@@DLT_TUBA postgres-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES postgres-->

--- a/docs/website/docs/dlt-ecosystem/destinations/qdrant.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/qdrant.md
@@ -247,3 +247,4 @@ Qdrant destination supports syncing of the `dlt` state.
 
 <!--@@@DLT_TUBA qdrant-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES qdrant-->

--- a/docs/website/docs/dlt-ecosystem/destinations/redshift.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/redshift.md
@@ -163,3 +163,4 @@ Supported loader file formats for Redshift are `sql` and `insert_values` (defaul
 
 <!--@@@DLT_TUBA redshift-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES redshift-->

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -417,3 +417,4 @@ We enable Snowflake to identify that the connection is created by `dlt`. Snowfla
 
 <!--@@@DLT_TUBA snowflake-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES snowflake-->

--- a/docs/website/docs/dlt-ecosystem/destinations/sqlalchemy.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/sqlalchemy.md
@@ -140,7 +140,7 @@ Please report issues with particular dialects. We'll try to make them work.
 
 ### Trino limitations
 * Trino dialect does not case fold identifiers. Use `snake_case` naming convention only.
-* Trino does not support merge/scd2 write disposition (or you somehow create PRIMARY KEYs on engine tables) 
+* Trino does not support merge/scd2 write disposition (or you somehow create PRIMARY KEYs on engine tables)
 * We convert JSON and BINARY types are cast to STRING (dialect seems to have a conversion bug)
 * Trino does not support PRIMARY/UNIQUE constraints
 
@@ -255,3 +255,5 @@ create_primary_keys=true
 ```
 * `unique` hints are translated to `UNIQUE` constraints via SQLAlchemy.
 * `primary_key` hints are translated to `PRIMARY KEY` constraints via SQLAlchemy.
+
+<!--@@@DLT_DESTINATION_CAPABILITIES sqlalchemy-->

--- a/docs/website/docs/dlt-ecosystem/destinations/synapse.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/synapse.md
@@ -236,3 +236,4 @@ This destination fully supports [dlt state sync](../../general-usage/state#synci
 
 <!--@@@DLT_TUBA synapse-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES synapse-->

--- a/docs/website/docs/dlt-ecosystem/destinations/weaviate.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/weaviate.md
@@ -317,3 +317,4 @@ Weaviate destination supports syncing of the `dlt` state.
 
 <!--@@@DLT_TUBA weaviate-->
 
+<!--@@@DLT_DESTINATION_CAPABILITIES weaviate-->


### PR DESCRIPTION
This commit introduces the `<!--@@@DLT_DESTINATION_CAPABILITIES <destination>-->` tags to various destination documentation files as mentioned in [ticket-3128](https://github.com/dlt-hub/dlt/issues/3128) The following files were updated:
- athena.md
- bigquery.md
- clickhouse.md
- databricks.md
- destination.md
- dremio.md
- duckdb.md
- ducklake.md
- filesystem.md
- lancedb.md
- motherduck.md
- mssql.md
- postgres.md
- qdrant.md
- redshift.md
- snowflake.md
- sqlalchemy.md
- synapse.md
- weaviate.md

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #3128 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
