### PR TITLE
fix: explicitly replace `postgresql` by `postgres` in `ATTACH`

### DIFF
--- a/dlt/destinations/impl/ducklake/sql_client.py
+++ b/dlt/destinations/impl/ducklake/sql_client.py
@@ -125,6 +125,10 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         if isinstance(catalog, DuckDbCredentials):
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:{catalog._conn_str()}'"
         elif catalog.drivername in ("postgres", "postgresql", "mysql"):
+            # `drivername="postgresql"` is supported by dlt / sqlalchemy, but it doesn't exist in duckdb.
+            if catalog.drivername == "postgresql":
+                catalog.drivername = "postgres"
+
             attach_statement = (
                 f"ATTACH IF NOT EXISTS 'ducklake:{catalog.drivername}:{catalog.to_url()}'"
             )

--- a/tests/load/ducklake/test_ducklake_client.py
+++ b/tests/load/ducklake/test_ducklake_client.py
@@ -195,7 +195,10 @@ def test_attach_statement_doesnt_use_postgresl() -> None:
 
     Make sure that the produced ATTACH statement doesn't use postgresql
     """
-    expected_attach_statement = "ATTACH IF NOT EXISTS 'ducklake:postgres:postgres://loader:loader@localhost:5432/dlt_data' AS foo (DATA_PATH './path/to/storage', METADATA_SCHEMA 'foo')"
+    expected_attach_statement = (
+        "ATTACH IF NOT EXISTS 'ducklake:postgres:postgres://loader:loader@localhost:5432/dlt_data'"
+        " AS foo (DATA_PATH './path/to/storage', METADATA_SCHEMA 'foo')"
+    )
     attach_statement = DuckLakeSqlClient.build_attach_statement(
         catalog=ConnectionStringCredentials("postgresql://loader:loader@localhost:5432/dlt_data"),
         catalog_name="foo",

--- a/tests/load/ducklake/test_ducklake_client.py
+++ b/tests/load/ducklake/test_ducklake_client.py
@@ -12,6 +12,7 @@ from dlt.destinations.impl.ducklake.configuration import (
     DuckLakeClientConfiguration,
 )
 
+from dlt.destinations.impl.ducklake.sql_client import DuckLakeSqlClient
 from tests.utils import TEST_STORAGE_ROOT
 
 
@@ -187,6 +188,22 @@ def test_default_ducklake_configuration() -> None:
         == "postgresql://loader:loader@localhost:5432/dlt_data"
     )
     assert credentials.storage_url == str(local_dir / "ducklake_catalog.files")
+
+
+def test_attach_statement_doesnt_use_postgresl() -> None:
+    """`drivername="postgresql"` is supported by dlt / sqlalchemy, but it doesn't exist in duckdb.
+
+    Make sure that the produced ATTACH statement doesn't use postgresql
+    """
+    expected_attach_statement = "ATTACH IF NOT EXISTS 'ducklake:postgres:postgres://loader:loader@localhost:5432/dlt_data' AS foo (DATA_PATH './path/to/storage', METADATA_SCHEMA 'foo')"
+    attach_statement = DuckLakeSqlClient.build_attach_statement(
+        catalog=ConnectionStringCredentials("postgresql://loader:loader@localhost:5432/dlt_data"),
+        catalog_name="foo",
+        storage_url="./path/to/storage",
+    )
+
+    assert expected_attach_statement == attach_statement
+    assert "postgresql" not in expected_attach_statement
 
 
 def test_ducklake_conn_pool_always_open() -> None:


### PR DESCRIPTION
In dlt / sqlalchemy, `postgresql` or `postgres` are interchangeable values for `drivername`. Though, we pass this value to duckdb and it doesn't handle `postgresql`.

```shell
Connection with `client_type=DuckLakeSqlClient` to `dataset_name=repro_dataset_20250929040657` failed. Please check if you configured the credentials at all and provided the right credentials values. You can be also denied access or your internet connection may be down. The actual reason given is: IO Error: Failed to attach DuckLake MetaData "__ducklake_metadata_lake_catalog" at path + "postgresql:postgresql://loader:loader@localhost:5432/dlt_data"Extension "/home/tjean/.duckdb/extensions/v1.3.2/linux_amd64/postgresql.duckdb_extension" not found.

Candidate extensions: "postgres", "postgres_scanner", "sqlite", "sqlite3", "parquet"
``` 

## Changes
- Explicitly convert `postgresql` to `postgres` when writing the ATTACH statement. It should be the only place where it's relevant
- Write a unit test