### PR TITLE
fix: 3139 pass SQLAlchemy credentials to f-string

### DIFF
--- a/dlt/destinations/impl/ducklake/ducklake.py
+++ b/dlt/destinations/impl/ducklake/ducklake.py
@@ -46,9 +46,11 @@ ATTACH 'ducklake:{catalog_database}' (DATA_PATH '{data_storage}');
 
 adds the ducklake `Catalog` to your duckdb database
 """
+from __future__ import annotations
+
 import os
+import pathlib
 from packaging.version import Version
-import posixpath
 from typing import Iterable, List, Optional, Sequence
 
 import dlt
@@ -68,17 +70,19 @@ from dlt.destinations.insert_job_client import InsertValuesJobClient
 class DuckLakeCopyJob(DuckDbCopyJob):
     def __init__(self, file_path: str) -> None:
         super().__init__(file_path)
-        self._job_client: "DuckLakeClient" = None
+        self._job_client: DuckLakeClient = None
 
     def metrics(self) -> Optional[LoadJobMetrics]:
         """Generate remote url metrics which point to the table in storage"""
         m = super().metrics()
         # TODO: read location from catalog. ducklake supports customized table layouts
         return m._replace(
-            remote_url=posixpath.join(
-                self._job_client.config.credentials.storage.bucket_url,
-                self._job_client.sql_client.dataset_name,
-                self.load_table_name,
+            remote_url=str(
+                pathlib.Path().joinpath(
+                    self._job_client.config.credentials.storage.bucket_url,
+                    self._job_client.sql_client.dataset_name,
+                    self.load_table_name,
+                )
             )
         )
 

--- a/dlt/destinations/impl/ducklake/sql_client.py
+++ b/dlt/destinations/impl/ducklake/sql_client.py
@@ -1,10 +1,10 @@
 from typing import ClassVar, Type
+
 from duckdb import DuckDBPyConnection
 
 from dlt.common import logger
 from dlt.common.configuration.specs.connection_string_credentials import ConnectionStringCredentials
 from dlt.common.destination.capabilities import DestinationCapabilitiesContext
-
 from dlt.common.storages.configuration import FileSystemCredentials
 from dlt.common.storages.fsspec_filesystem import fsspec_from_config
 from dlt.destinations.impl.duckdb.configuration import DuckDbCredentials
@@ -129,9 +129,8 @@ class DuckLakeSqlClient(DuckDbSqlClient):
             if catalog.drivername == "postgresql":
                 catalog.drivername = "postgres"
 
-            attach_statement = (
-                f"ATTACH IF NOT EXISTS 'ducklake:{catalog.drivername}:{catalog.to_url()}'"
-            )
+            db_url = catalog.to_url().render_as_string(hide_password=False)
+            attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:{catalog.drivername}:{db_url}'"
             attach_params = f", METADATA_SCHEMA '{catalog_name}'"
         elif catalog.drivername == "md":
             logger.warning(

--- a/tests/load/ducklake/test_ducklake_client.py
+++ b/tests/load/ducklake/test_ducklake_client.py
@@ -211,7 +211,7 @@ def test_ducklake_attach_statement() -> None:
     assert expected_attach_statement == attach_statement
 
 
-def test_attach_statement_doesnt_use_postgresl() -> None:
+def test_attach_statement_doesnt_use_postgresql() -> None:
     """`drivername="postgresql"` is supported by dlt / sqlalchemy, but it doesn't exist in duckdb.
 
     Make sure that the produced ATTACH statement doesn't use postgresql

--- a/tests/load/ducklake/test_ducklake_pipeline.py
+++ b/tests/load/ducklake/test_ducklake_pipeline.py
@@ -5,7 +5,6 @@ import dlt
 from dlt.common.destination.reference import TDestinationReferenceArg
 
 from dlt.common.utils import uniq_id
-from dlt.destinations.exceptions import DestinationConnectionError
 from dlt.destinations.impl.ducklake.configuration import (
     DuckLakeCredentials,
     DUCKLAKE_STORAGE_PATTERN,


### PR DESCRIPTION
Solves issue #3139 

## Problem
When creating the `ATTACH` statement for the ducklake client, password value from SQLAlchemy would render as `***` instead of its value. This was not caught in our CI / tests because we use `sqlalchemy 1.4` and this behavior seems to be only in `sqlalchemy 2.0`

## Changes
- change `db_url = catalog.to_url()` -> `db_url = catalog.to_url().render_as_string(hide_password=False)`
- misc:
  - replaced `posixpath` with `pathlib` (posixpath is an internal module as its docstring mentions)
  - remove unused imports