### PR TITLE
fix(ducklake): 3140 disambiguate config key and default values

### DIFF
--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -69,12 +69,15 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
         super().__init__(self.spec_name)
 
     @staticmethod
-    def _print_traces(
+    def _build_config_error_message(
         # spec_name: str, union_pos: int, union_count: int,
         spec_name: str,
         resolved_keys: List[str],
         traces: FieldLookupTraces,
     ) -> str:
+        """Takes in the configuration spec, the resolved key and the configuration resolution traces
+        to create a detailed exception / log message about failed configuration resolution.
+        """
         msg = ""
         for f, field_traces in traces.items():
             for idx, trace in enumerate(field_traces):
@@ -88,7 +91,7 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
                         msg += f" (Union {trace.union_pos} of {trace.union_count})"
                     msg += "\n"
                     msg += textwrap.indent(
-                        ConfigFieldMissingException._print_traces(
+                        ConfigFieldMissingException._build_config_error_message(
                             trace.spec_name, trace.resolved_fields_set, trace.traces
                         ),
                         "  ",
@@ -113,7 +116,7 @@ class ConfigFieldMissingException(KeyError, ConfigurationException):
             f"Missing {len(self.fields)} field(s) in configuration`{self.spec_name}`:"
             f" {', '.join(f'`{f}`' for f in self.fields)}\n"
         )
-        msg += self._print_traces(self.spec_name, self.resolved_fields_set, self.traces)
+        msg += self._build_config_error_message(self.spec_name, self.resolved_fields_set, self.traces)
 
         from dlt.common.configuration.container import Container
         from dlt.common.configuration.specs import PluggableRunContext

--- a/dlt/destinations/impl/ducklake/configuration.py
+++ b/dlt/destinations/impl/ducklake/configuration.py
@@ -1,7 +1,7 @@
 # from __future__ import annotations
 
 import dataclasses
-from typing import Any, ClassVar, Dict, Final, List, Optional, TYPE_CHECKING, Union
+from typing import ClassVar, Union
 
 from dlt.common.configuration import configspec
 from dlt.common.configuration.exceptions import ConfigFieldMissingException
@@ -18,6 +18,7 @@ from dlt.destinations.impl.duckdb.configuration import DuckDbConnectionPool, Duc
 from dlt.destinations.impl.duckdb.factory import _set_duckdb_raw_capabilities
 
 
+DEFAULT_DUCKLAKE_NAME = "ducklake"
 DUCKLAKE_STORAGE_PATTERN = "%s.files"
 
 
@@ -33,12 +34,12 @@ def _get_ducklake_capabilities() -> DestinationCapabilitiesContext:
 
 @configspec(init=False)
 class DuckLakeCredentials(DuckDbBaseCredentials):
-    ducklake_name: str = "ducklake"
-    catalog: ConnectionStringCredentials = None
+    ducklake_name: str
+    catalog: ConnectionStringCredentials
     # NOTE: consider moving to DuckLakeClientConfiguration so bucket_url is not a secret
-    storage: FilesystemConfiguration = None
+    storage: FilesystemConfiguration
 
-    __config_gen_annotations__: ClassVar[List[str]] = ["ducklake_name", "catalog", "storage"]
+    __config_gen_annotations__: ClassVar[list[str]] = ["ducklake_name", "catalog", "storage"]
 
     def __init__(
         self,

--- a/dlt/destinations/impl/ducklake/ducklake.py
+++ b/dlt/destinations/impl/ducklake/ducklake.py
@@ -92,9 +92,9 @@ class DuckLakeClient(DuckDbClient):
 
     A DuckLake has 3 components:
         - ducklake client: this is a `duckdb` instance with the `ducklake` extension
-        - catalog_database: this is an SQL database storing metadata. It can be a duckdb instance
+        - catalog: this is an SQL database storing metadata. It can be a duckdb instance
             (typically the ducklake client) or a remote database (sqlite, postgres, mysql)
-        - data_storage: this is a filesystem where data is stored in files
+        - storage: this is a filesystem where data is stored in files
 
     The dlt DuckLake destination gives access to the "ducklake client".
     You never have to manage the catalog and storage directly;

--- a/dlt/destinations/impl/ducklake/sql_client.py
+++ b/dlt/destinations/impl/ducklake/sql_client.py
@@ -13,12 +13,12 @@ from dlt.destinations.impl.ducklake.configuration import DuckLakeCredentials
 from dlt.destinations.sql_client import raise_open_connection_error
 
 
-class DucklakeDBApiCursorImpl(DuckDBDBApiCursorImpl):
+class DuckLakeDBApiCursorImpl(DuckDBDBApiCursorImpl):
     vector_size: ClassVar[int] = 700  # vector size for ducklake
 
 
 class DuckLakeSqlClient(DuckDbSqlClient):
-    cursor_impl: ClassVar[Type[DuckDBDBApiCursorImpl]] = DucklakeDBApiCursorImpl
+    cursor_impl: ClassVar[Type[DuckDBDBApiCursorImpl]] = DuckLakeDBApiCursorImpl
 
     def __init__(
         self,
@@ -57,7 +57,7 @@ class DuckLakeSqlClient(DuckDbSqlClient):
             # NOTE: database must be detached otherwise it is left in inconsistent state
             # TODO: perhaps move attach/detach to connection pool
             self._conn.execute(self.attach_statement)
-            self._conn.execute(f"USE {self.credentials.ducklake_name};")
+            self._conn.execute(f"USE {self.capabilities.escape_identifier(self.credentials.ducklake_name)};")
             # search path can only by set after database is attached
             try:
                 self._conn.execute(f"SET search_path = '{self.fully_qualified_dataset_name()}'")
@@ -112,7 +112,7 @@ class DuckLakeSqlClient(DuckDbSqlClient):
                 )
                 self._register_filesystem(fsspec_from_config(self.credentials.storage)[0], "gcs")
             else:
-                raise ValueError(f"Cannot create secret or register filesystem for `{protocol=:}`")
+                raise ValueError(f"Cannot create secret or register filesystem for `{protocol=}`")
 
     @staticmethod
     def build_attach_statement(

--- a/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
@@ -28,7 +28,7 @@ dlt init foo ducklake
 `dlt init` will create a sample `secrets.toml` for **postgres** catalog and **s3** bucket storage. For local automatic setup comment out catalog and storage entries:
 ```toml
 [destination.ducklake.credentials]
-catalog_name="lake_catalog"  # we recommend explicit catalog name
+ducklake_name="ducklake"  # we recommend explicit catalog name
 ```
 
 - Run a test pipeline that writes to a local DuckLake:
@@ -54,7 +54,7 @@ The console output will point you to where `sqlite` catalog database and data st
 - `lake_catalog.files` folder with `lake_schema` subfolder for the dataset.
 
 ## Configure Ducklake
-Pick your `catalog_name` as described above. This name is the used:
+Pick your `ducklake_name` as described above. This name is the used:
 - as attach name for the ducklake - each ducklake connection starts with **:memory:** connection to which we `ATTACH` the ducklake
 - to set default folder name of the local filesystem storage and database file name for `sqlite` and `duckdb` (if no explicit configuration is provided)
 - as **postgres** schema name where catalog tables will be created (if postgres configured)
@@ -82,7 +82,7 @@ Refer to [duckdb](duckdb.md) configuration for more options.
 [destination.ducklake.credentials]
 catalog="postgres://loader:pass@localhost:5432/dlt_data"
 ```
-`ducklake` will use postgres schema with the name of `catalog_name` config option and create required tables automatically.
+`ducklake` will use postgres schema with the name of `ducklake_name` config option and create required tables automatically.
 
 - 🧪 **mysql**: uses the same code path as for **postgres** but we never tested it
 
@@ -104,7 +104,7 @@ Make sure that you have Motherduck token in your environment. Hopefully situatio
 Example s3 configuration:
 ```toml
 [destination.ducklake.credentials]
-catalog_name="lake_catalog"
+ducklake_name="lakehouse"
 catalog="postgres://loader:pass@localhost:5432/dlt_data"
 
 [destination.ducklake.credentials.storage]
@@ -145,7 +145,7 @@ credentials = DuckLakeCredentials(
     catalog="postgresql://loader:pass@localhost:5432/dlt_data",
     storage="s3://dlt-ci-test-bucket/lake",
 )
-ducklake = dlt.destinations.ducklake(credentials=credentials)
+destination = dlt.destinations.ducklake(credentials=credentials)
 ```
 
 ```py

--- a/tests/load/ducklake/test_ducklake_client.py
+++ b/tests/load/ducklake/test_ducklake_client.py
@@ -12,6 +12,7 @@ from dlt.destinations.impl.ducklake.sql_client import DuckLakeSqlClient
 from dlt.destinations.impl.ducklake.configuration import (
     DuckLakeCredentials,
     DuckLakeClientConfiguration,
+    DEFAULT_DUCKLAKE_NAME,
 )
 
 from dlt.destinations.impl.ducklake.sql_client import DuckLakeSqlClient
@@ -57,7 +58,7 @@ def test_default_credentials() -> None:
     assert credentials.is_partial() is True
     assert credentials.is_resolved() is False
 
-    assert credentials.ducklake_name == "ducklake"
+    assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     assert credentials.catalog is None
     assert credentials.storage is None
 
@@ -66,6 +67,7 @@ def test_default_credentials() -> None:
     assert credentials.is_partial() is False
     assert credentials.is_resolved() is True
 
+    assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     assert credentials.catalog is not None
     assert credentials.catalog.drivername == "sqlite"
     assert credentials.storage is not None
@@ -88,7 +90,7 @@ def test_ducklake_configuration_default() -> None:
 
     assert credentials.is_partial() is False
     assert credentials.is_resolved() is True
-    assert credentials.ducklake_name == "ducklake"
+    assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     # default catalog location should point to _storage (local_dir)
     assert credentials.catalog.database == str(local_dir / "ducklake.sqlite")
     # sqlite is default catalog
@@ -113,7 +115,7 @@ def test_ducklake_configuration_duckdb_catalog() -> None:
     )
     credentials = configuration.credentials
 
-    assert credentials.ducklake_name == "ducklake"
+    assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     conn_str = credentials.catalog.to_native_representation()
     assert conn_str.endswith(str(local_dir / "ducklake.duckdb"))
 
@@ -144,7 +146,7 @@ def test_ducklake_configuration_destination_name() -> None:
     )
     credentials = configuration.credentials
     # no impact on locations
-    assert credentials.ducklake_name == "ducklake"
+    assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     conn_str = credentials.catalog.to_native_representation()
     assert conn_str.endswith(str(local_dir / "ducklake.sqlite"))
     assert credentials.storage_url == str(local_dir / "ducklake.files")
@@ -161,7 +163,7 @@ def test_ducklake_configuration_pipeline_name() -> None:
     )
     credentials = configuration.credentials
 
-    assert credentials.ducklake_name == "ducklake"
+    assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     # no impact on locations
     conn_str = credentials.catalog.to_native_representation()
     assert conn_str.endswith(str(local_dir / "ducklake.sqlite"))
@@ -208,7 +210,7 @@ def test_ducklake_configuration_catalog_credentials() -> None:
     )
     credentials = configuration.credentials
 
-    assert credentials.ducklake_name == "ducklake"
+    assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     assert (
         credentials.catalog.to_native_representation()
         == "postgresql://loader:loader@localhost:5432/dlt_data"

--- a/tests/load/ducklake/test_ducklake_pipeline.py
+++ b/tests/load/ducklake/test_ducklake_pipeline.py
@@ -38,13 +38,13 @@ def test_all_catalogs(catalog: str) -> None:
     """
     if catalog is None:
         # use destination alias
-        catalog_name = "ducklake_catalog"
+        ducklake_name = "ducklake"
         destination: TDestinationReferenceArg = "ducklake"
     else:
         # pick random catalog name so we isolate via postgres schema
-        catalog_name = "catalog_" + uniq_id(4)
+        ducklake_name = "ducklake_" + uniq_id(4)
         destination = ducklake(
-            credentials=DuckLakeCredentials(catalog_name=catalog_name, catalog=catalog)
+            credentials=DuckLakeCredentials(ducklake_name=ducklake_name, catalog=catalog)
         )
     pipeline = dlt.pipeline(
         "destination_defaults", destination=destination, dataset_name="lake_schema", dev_mode=True
@@ -68,7 +68,7 @@ def test_all_catalogs(catalog: str) -> None:
     assert ds.table_foo["foo"].fetchall() == [(1,), (2,)]
 
     # test lake location
-    expected_location = pathlib.Path(TEST_STORAGE_ROOT, DUCKLAKE_STORAGE_PATTERN % catalog_name)
+    expected_location = pathlib.Path(TEST_STORAGE_ROOT, DUCKLAKE_STORAGE_PATTERN % ducklake_name)
     assert expected_location.exists()
     # test dataset in lake
     assert (expected_location / pipeline.dataset_name).exists()


### PR DESCRIPTION
- Follows #3140 
- Implements reviews from the end of PR #2709 

## Changes
The main change is changing configuration `catalog_name: ducklake_catalog` to `ducklake_name: ducklake`.

## Future todos
It would be nice to support a `:pipeline:` directive such that `ducklake_name` takes the value of the `dlt.Pipeline` by default. This would match the behavior for `duckdb` and `filesystem` destinations
