### PR TITLE
fix(dashboard): 3077 remove `pandas` deps

### DIFF
--- a/dlt/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/helpers/dashboard/dlt_dashboard.py
@@ -13,14 +13,10 @@ with app.setup:
 
     import marimo as mo
 
-    import pandas as pd
-
     import dlt
-    from dlt.common.json import json
+    import pyarrow
     from dlt.helpers.dashboard import strings, utils, ui_elements as ui
     from dlt.helpers.dashboard.config import DashboardConfiguration
-    from dlt.destinations.dataset.dataset import ReadableDBAPIDataset
-    from dlt.destinations.dataset.relation import ReadableDBAPIRelation
 
 
 @app.cell(hide_code=True)
@@ -848,7 +844,7 @@ def utils_caches_and_state(
     """
 
     # some state variables
-    dlt_get_last_query_result, dlt_set_last_query_result = mo.state(pd.DataFrame())
+    dlt_get_last_query_result, dlt_set_last_query_result = mo.state(pyarrow.table({}))
     # a cache of query results in the form of {query: row_count}
     dlt_get_query_cache, dlt_set_query_cache = mo.state(cast(Dict[str, int], {}))
 

--- a/dlt/helpers/dashboard/runner.py
+++ b/dlt/helpers/dashboard/runner.py
@@ -20,7 +20,7 @@ def _detect_dashboard_command() -> str:
 # keep this, will raise if user tries to run dashboard without dependencies
 try:
     import marimo
-    import pandas
+    import pyarrow
     import ibis
 except ModuleNotFoundError:
     raise MissingDependencyException(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,9 +179,9 @@ postgis = [
 ]
 workspace = [
     "duckdb>=0.9",
-    "ibis-framework[duckdb]>=10.5.0 ; python_version >= '3.10'",
+    "ibis-framework>=10.5.0 ; python_version >= '3.10'",
+    "duckdb",
     "pyarrow>=16.0.0",
-    "pandas>=2.1.4",
     "marimo>=0.14.5",
 ]
 dbml = [

--- a/tests/helpers/dashboard/test_utils.py
+++ b/tests/helpers/dashboard/test_utils.py
@@ -2,20 +2,13 @@ import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from this import d
 
-from ibis import pi
 import marimo as mo
+import pyarrow
 import pytest
-import pandas as pd
-
-from dlt.sources._single_file_templates.fruitshop_pipeline import (
-    fruitshop as fruitshop_source,
-)
-import pendulum
-
 
 import dlt
+from dlt.common import pendulum
 from dlt.helpers.dashboard.config import DashboardConfiguration
 from dlt.helpers.dashboard.utils import (
     PICKLE_TRACE_FILE,
@@ -346,10 +339,10 @@ def test_get_query_result(pipeline: dlt.Pipeline):
     )
 
     if pipeline.pipeline_name in PIPELINES_WITH_LOAD:
-        assert isinstance(result, pd.DataFrame)
+        assert isinstance(result, pyarrow.Table)
         assert len(result) == 1
         assert (
-            result.iloc[0]["count"] == 100
+            result[0][0].as_py() == 100
             if pipeline.pipeline_name == SUCCESS_PIPELINE_DUCKDB
             else 103
         )  #  merge does not work on filesystem
@@ -697,7 +690,7 @@ def test_integration_pipeline_workflow(pipeline, temp_pipelines_dir):
     )
     if pipeline.pipeline_name in PIPELINES_WITH_LOAD:
         assert len(query_result) == 13
-        assert query_result.iloc[0]["name"] == "simon"
+        assert query_result[0][0].as_py() == "simon"
         assert not error_message
         assert not traceback_string
     else:

--- a/uv.lock
+++ b/uv.lock
@@ -2204,9 +2204,8 @@ weaviate = [
 workspace = [
     { name = "duckdb", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "os_name == 'nt'" },
     { name = "duckdb", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "os_name != 'nt'" },
-    { name = "ibis-framework", extra = ["duckdb"], marker = "python_full_version >= '3.10'" },
+    { name = "ibis-framework", marker = "python_full_version >= '3.10'" },
     { name = "marimo" },
-    { name = "pandas" },
     { name = "pyarrow" },
 ]
 
@@ -2353,6 +2352,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
     { name = "duckdb", marker = "extra == 'ducklake'", specifier = ">=1.2.0" },
     { name = "duckdb", marker = "extra == 'motherduck'", specifier = ">=0.9" },
+    { name = "duckdb", marker = "extra == 'workspace'" },
     { name = "duckdb", marker = "extra == 'workspace'", specifier = ">=0.9" },
     { name = "fsspec", specifier = ">=2022.4.0" },
     { name = "gcsfs", marker = "extra == 'bigquery'", specifier = ">=2022.4.0" },
@@ -2367,7 +2367,7 @@ requires-dist = [
     { name = "grpcio", marker = "extra == 'gcp'", specifier = ">=1.50.0" },
     { name = "hexbytes", specifier = ">=0.2.2" },
     { name = "humanize", specifier = ">=4.4.0" },
-    { name = "ibis-framework", extras = ["duckdb"], marker = "python_full_version >= '3.10' and extra == 'workspace'", specifier = ">=10.5.0" },
+    { name = "ibis-framework", marker = "python_full_version >= '3.10' and extra == 'workspace'", specifier = ">=10.5.0" },
     { name = "jsonpath-ng", specifier = ">=1.5.3" },
     { name = "lancedb", marker = "python_full_version < '3.13' and extra == 'lancedb'", specifier = ">=0.22.0" },
     { name = "marimo", marker = "extra == 'workspace'", specifier = ">=0.14.5" },
@@ -2375,7 +2375,6 @@ requires-dist = [
     { name = "orjson", marker = "sys_platform != 'emscripten'", specifier = ">=3.10.1" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'", specifier = ">=3.6.7,!=3.9.11,!=3.9.12,!=3.9.13,!=3.9.14,!=3.10.1,<4" },
     { name = "packaging", specifier = ">=21.1" },
-    { name = "pandas", marker = "extra == 'workspace'", specifier = ">=2.1.4" },
     { name = "paramiko", marker = "extra == 'sftp'", specifier = ">=3.3.0" },
     { name = "pathvalidate", specifier = ">=2.5.2" },
     { name = "pendulum", specifier = ">=2.1.2" },


### PR DESCRIPTION
follows issue: #3077 

Remove `pandas` (which depends on `numpy`) as a dependency for the dlt Dashboard and `dlt[workspace]` dependency group.

marimo natively supports `pyarrow` for all dataframe features, which makes pandas redundant.

## Changes
- Remove `pandas` and replace with `pyarrow`
- Changed dependency `ibis-framework[duckdb]`  to `ibis-framework` and `duckdb` because the former implicitly depends on `pandas`. This is not required for the features we use.
- Update `uv.lock`
- Update tests
- Remove unused imports