### PR TITLE
feat:3162 add resource name to incremental extract duplicate checks logging.

### DIFF
--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -610,12 +610,11 @@ class Incremental(ItemTransform[TDataItem], BaseConfiguration, Generic[TCursorVa
     ) -> None:
         if initial_hash_count <= Incremental.duplicate_cursor_warning_threshold < final_hash_count:
             logger.warning(
-                f"Large number of records ({final_hash_count}) sharing the same value of "
-                f"cursor field '{self.cursor_path}'. This can happen if the cursor "
-                "field has a low resolution (e.g., only stores dates without times), "
-                "causing many records to share the same cursor value. "
-                "Consider using a cursor column with higher resolution to reduce "
-                "the deduplication state size."
+                f"Large number of records ({final_hash_count}) sharing the same value of cursor"
+                f" field '{self.cursor_path}' on resource {self.resource_name}. This can happen if"
+                " the cursor field has a low resolution (e.g., only stores dates without times),"
+                " causing many records to share the same cursor value. Consider using a cursor"
+                " column with higher resolution to reduce the deduplication state size."
             )
 
 


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Improve logging on incremental extract duplicate checks.

Issue #3162


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #3162 

<!--
Provide any additional context about the PR here.
-->
### Additional Context
When the threshold is reached the logging does not provide information on which resource it refers to. Depending on the checks the existing warning could appear thousands of times and it does not provide the clarity to debug which resources are in question. 
 This feature will add the resource name to the warnings and allows easier debugging both in the framework and in destination data.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
