### PR TITLE
feat: unify `dlt.Relation` API and create bound Ibis tables

### DIFF
--- a/dlt/common/libs/ibis.py
+++ b/dlt/common/libs/ibis.py
@@ -2,42 +2,35 @@ from __future__ import annotations
 
 import contextlib
 from typing import TYPE_CHECKING, Any, Union
-
-# ibis imports follow the convention used in the ibis source code
-import ibis
-import ibis.expr.datatypes as dt
-import ibis.expr.operations as ops
-import ibis.expr.schema as sch
-import ibis.expr.types as ir
-import sqlglot as sg
-from ibis.backends import _get_backend_names, NoUrl, NoExampleLoader
-from ibis.backends.sql import SQLBackend
-from ibis.formats import TypeMapper
+from typing_extensions import override
 
 import dlt
-from dlt.helpers.ibis import _get_ibis_to_sqlglot_compiler
+from dlt.helpers.ibis import create_ibis_backend, _get_ibis_to_sqlglot_compiler
 from dlt.common.schema import Schema as DltSchema
 from dlt.common.destination import TDestinationReferenceArg
-from dlt.common.schema.typing import TDataType
-from dlt.destinations.dataset.factory import dataset as dataset_factory
+from dlt.common.schema.typing import TDataType, TTableSchema
+from dlt.common.exceptions import MissingDependencyException
 
 if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
+    from ibis import BaseBackend
 
+try:
+    # ibis imports follow the convention used in the ibis source code
+    import ibis
+    import ibis.expr.datatypes as dt
+    import ibis.expr.operations as ops
+    import ibis.expr.schema as sch
+    import ibis.expr.types as ir
+    import sqlglot as sg
+    from ibis.backends import _get_backend_names, NoUrl, NoExampleLoader
+    from ibis.backends.sql import SQLBackend
+    from ibis.formats import TypeMapper
+except ImportError:
+    raise MissingDependencyException("dlt ibis helpers", ["ibis-framework"])
 
-# TODO move this as a destination capability; the destination should declare if it's compatible
-SUPPORTED_DESTINATIONS = (
-    "postgres",
-    "snowflake",
-    "filesystem",  # uses duckdb
-    "mssql",
-    "bigquery",
-    "redshift",  # uses postgres
-    "motherduck",  # uses duckdb
-)
-
-ALL_IBIS_BACKENDS = set(_get_backend_names())
+# TODO move `dlt.helpers.ibis` content to this module
 
 
 # TODO complete implementation and register to singledispatch `sch.infer.register`
@@ -46,7 +39,6 @@ class DltType(TypeMapper):
     def from_ibis(cls):
         raise NotImplementedError
 
-
     @classmethod
     def to_ibis(cls, typ: TDataType, nullable: bool | None = None) -> dt.DataType:
         nullable = True if nullable is None else bool(nullable)
@@ -54,19 +46,55 @@ class DltType(TypeMapper):
 
 
 # TODO support `database` kwarg (equiv. `dataset_name`) to enable DltBackend to access multiple database
-# NOTE this should support all SQLGlot dialects https://sqlglot.com/sqlglot/dialects.html#Dialect
+# NOTE most of the code below was derived from the Ibis BaseBackend and SQLBackend implementation
+class _DltBackend(SQLBackend, NoUrl, NoExampleLoader):
+    """Ibis backend that delegates execution to dlt's native SQL engine.
 
-class DltBackend(SQLBackend, NoUrl, NoExampleLoader):
+    To make Ibis expressions executable, they need to be bound to a table on the
+    backend (i.e., data that exists somewhere). By default, Ibis backends work by
+    creating and maintaining a connection to the backend.
+
+    This `DltBackend` is "lazier" and doesn't make a connection to the backend where
+    the data lives ("backend" in Ibis, "destination" in dlt). Instead, it uses dlt
+    metadata to register what table exists and create bound expressions.
+
+    For example, if you use Ibis with the Snowflake backend, you will get use Ibis'
+    implementation. If you use the DltBackend with a Snowflake destination, you will
+    use the dlt SQL client for Snowflake. The SQL query created should be the same
+    because dlt internally uses the `ibis -> sqlglot` compiler, but the actual
+    execution might differ. This is especially likely when calling `.execute()` or
+    other methods that return data in memory.
+    """
+
     name = "dlt"
     supports_temporary_tables = False
     supports_python_udfs = False
 
+    @classmethod
+    def from_dataset(cls, dataset: dlt.Dataset) -> _DltBackend:
+        """Create an Ibis `DltBackend` from a `dlt.Dataset`
+
+        This enables `dlt.Relation.to_ibis()` to create bound tables.
+        """
+        # NOTE it's essential to keep this lazy, no round-trip to destination
+        # sync with destination should be made through the dataset.
+        new_backend = cls()
+        new_backend._dataset = dataset
+        new_backend.compiler = _get_ibis_to_sqlglot_compiler(new_backend._dataset._destination)
+        return new_backend
+
+    def to_native_ibis(self, *, read_only: bool = False) -> BaseBackend:
+        return get_native_ibis_backend(self._dataset, read_only=read_only)
+
     @property
+    @override
     def version(self) -> str:
         import importlib.metadata
+
         return importlib.metadata.version("dlt")
 
     # NOTE can change signature
+    @override
     def do_connect(
         self,
         destination: TDestinationReferenceArg,
@@ -74,32 +102,20 @@ class DltBackend(SQLBackend, NoUrl, NoExampleLoader):
         schema: Union[DltSchema, str, None] = None,
         **config: Any,
     ) -> None:
-        self._dataset = dataset_factory(
+        self._dataset = dlt.dataset(
             destination=destination,
             dataset_name=dataset_name,
             schema=schema,
         )
         self.compiler = _get_ibis_to_sqlglot_compiler(self._dataset._destination)
 
-    @classmethod
-    def from_dataset(cls, dataset: dlt.Dataset) -> DltBackend:
-        new_backend = cls()
-        new_backend._dataset = dataset
-        new_backend.compiler = _get_ibis_to_sqlglot_compiler(new_backend._dataset._destination)
-        return new_backend
-
-    @classmethod
-    def from_pipeline(cls, pipeline: dlt.Pipeline) -> DltBackend:
-        new_backend = cls()
-        new_backend._dataset = pipeline.dataset()
-        new_backend.compiler = _get_ibis_to_sqlglot_compiler(new_backend._dataset._destination)
-        return new_backend
-
     @contextlib.contextmanager
+    @override
     def _safe_raw_sql(self, *args, **kwargs):
         yield self.raw_sql(*args, **kwargs)
 
-    def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
+    @override
+    def raw_sql(self, query: Union[str, sg.Expression], **kwargs: Any) -> Any:
         """Execute SQL string or SQLGlot expression using the dlt destination SQL client"""
         with contextlib.suppress(AttributeError):
             query = query.sql(dialect=self.name)
@@ -109,39 +125,51 @@ class DltBackend(SQLBackend, NoUrl, NoExampleLoader):
 
         return result
 
-    def _register_udfs(self, *args, **kwargs) -> None:
-        """Override SQLBackend method to avoid round-trip to Ibis SQL compiler"""
+    # required for marimo DataSources UI to work
+    @property
+    def current_database(self) -> str:
+        return self._dataset.dataset_name
 
+    # required for marimo DataSources UI to work
+    @override
     def list_tables(self, *args, **kwargs) -> list[str]:
         """Return the list of table names"""
         return list(self._dataset.schema.tables.keys())
 
+    # required for marimo DataSources UI to work
+    @override
     def get_schema(self, table_name: str, *args, **kwargs) -> sch.Schema:
         """Get the Ibis table schema"""
-        return sch.Schema(  
-            {
-                name: DltType.to_ibis(column["data_type"], column.get("nullable"))  # type: ignore
-                for name, column in self._dataset.schema.get_table(table_name)["columns"].items()  # type: ignore
-            }  # type: ignore
-        )
+        return _to_ibis_schema(self._dataset.table(table_name).schema)
 
-    def table(self, name: str) -> ir.Table:
+    # required for marimo DataSources UI to work
+    @override
+    def _get_schema_using_query(self, query: str):
+        """Required to subclass SQLBackend"""
+        return _to_ibis_schema(self._dataset(query).schema)
+
+    # required for marimo DataSources UI to work
+    @override
+    def table(
+        self, name: str, /, *, database: Union[tuple[str, str], str, None] = None
+    ) -> ir.Table:
         """Construct a table expression"""
         # TODO maybe there's a more straighforward way to retrieve catalog and db
         sql_client = self._dataset.sql_client
         catalog = sql_client.catalog_name()
-        database =  sql_client.capabilities.casefold_identifier(sql_client.dataset_name)
+        database = sql_client.capabilities.casefold_identifier(sql_client.dataset_name)
 
         table_schema = self.get_schema(name)
         return ops.DatabaseTable(
             name,
             schema=table_schema,
             source=self,
-            namespace=ops.Namespace(catalog=catalog, database=database)
+            namespace=ops.Namespace(catalog=catalog, database=database),
         ).to_expr()
 
     # TODO use the new dlt `model` format with INSERT statement
-    # for non-SQL (e.g., filesystem) use JobClient 
+    # for non-SQL (e.g., filesystem) use JobClient
+    @override
     def create_table(
         self,
         name: str,
@@ -155,10 +183,28 @@ class DltBackend(SQLBackend, NoUrl, NoExampleLoader):
     ) -> ir.Table:
         raise NotImplementedError
 
-    def _get_schema_using_query(self, *args, **kwargs):
-        """Required to subclass SQLBackend"""
-        raise NotImplementedError
-
+    @override
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         """Required to subclass SQLBackend"""
         raise NotImplementedError
+
+    @override
+    def _register_udfs(self, *args, **kwargs) -> None:
+        """Override SQLBackend method to avoid round-trip to Ibis SQL compiler"""
+
+
+def _to_ibis_schema(table_schema: TTableSchema) -> sch.Schema:
+    return sch.Schema(
+        {
+            name: DltType.to_ibis(column["data_type"], column.get("nullable"))
+            for name, column in table_schema["columns"].items()
+        }
+    )
+
+
+def get_native_ibis_backend(dataset: dlt.Dataset, *, read_only: bool = False) -> BaseBackend:
+    return create_ibis_backend(
+        destination=dataset._destination,
+        client=dataset.destination_client,
+        read_only=read_only,
+    )

--- a/dlt/common/libs/ibis.py
+++ b/dlt/common/libs/ibis.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any, Union
+
+# ibis imports follow the convention used in the ibis source code
+import ibis
+import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
+import ibis.expr.schema as sch
+import ibis.expr.types as ir
+import sqlglot as sg
+from ibis.backends import _get_backend_names, NoUrl, NoExampleLoader
+from ibis.backends.sql import SQLBackend
+from ibis.formats import TypeMapper
+
+import dlt
+from dlt.helpers.ibis import _get_ibis_to_sqlglot_compiler
+from dlt.common.schema import Schema as DltSchema
+from dlt.common.destination import TDestinationReferenceArg
+from dlt.common.schema.typing import TDataType
+from dlt.destinations.dataset.factory import dataset as dataset_factory
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import pyarrow as pa
+
+
+# TODO move this as a destination capability; the destination should declare if it's compatible
+SUPPORTED_DESTINATIONS = (
+    "postgres",
+    "snowflake",
+    "filesystem",  # uses duckdb
+    "mssql",
+    "bigquery",
+    "redshift",  # uses postgres
+    "motherduck",  # uses duckdb
+)
+
+ALL_IBIS_BACKENDS = set(_get_backend_names())
+
+
+# TODO complete implementation and register to singledispatch `sch.infer.register`
+class DltType(TypeMapper):
+    @classmethod
+    def from_ibis(cls):
+        raise NotImplementedError
+
+
+    @classmethod
+    def to_ibis(cls, typ: TDataType, nullable: bool | None = None) -> dt.DataType:
+        nullable = True if nullable is None else bool(nullable)
+        return ibis.dtype(dlt.helpers.ibis.DATA_TYPE_MAP[typ], nullable=nullable)
+
+
+# TODO support `database` kwarg (equiv. `dataset_name`) to enable DltBackend to access multiple database
+# NOTE this should support all SQLGlot dialects https://sqlglot.com/sqlglot/dialects.html#Dialect
+
+class DltBackend(SQLBackend, NoUrl, NoExampleLoader):
+    name = "dlt"
+    supports_temporary_tables = False
+    supports_python_udfs = False
+
+    @property
+    def version(self) -> str:
+        import importlib.metadata
+        return importlib.metadata.version("dlt")
+
+    # NOTE can change signature
+    def do_connect(
+        self,
+        destination: TDestinationReferenceArg,
+        dataset_name: str,
+        schema: Union[DltSchema, str, None] = None,
+        **config: Any,
+    ) -> None:
+        self._dataset = dataset_factory(
+            destination=destination,
+            dataset_name=dataset_name,
+            schema=schema,
+        )
+        self.compiler = _get_ibis_to_sqlglot_compiler(self._dataset._destination)
+
+    @classmethod
+    def from_dataset(cls, dataset: dlt.Dataset) -> DltBackend:
+        new_backend = cls()
+        new_backend._dataset = dataset
+        new_backend.compiler = _get_ibis_to_sqlglot_compiler(new_backend._dataset._destination)
+        return new_backend
+
+    @classmethod
+    def from_pipeline(cls, pipeline: dlt.Pipeline) -> DltBackend:
+        new_backend = cls()
+        new_backend._dataset = pipeline.dataset()
+        new_backend.compiler = _get_ibis_to_sqlglot_compiler(new_backend._dataset._destination)
+        return new_backend
+
+    @contextlib.contextmanager
+    def _safe_raw_sql(self, *args, **kwargs):
+        yield self.raw_sql(*args, **kwargs)
+
+    def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
+        """Execute SQL string or SQLGlot expression using the dlt destination SQL client"""
+        with contextlib.suppress(AttributeError):
+            query = query.sql(dialect=self.name)
+
+        with self._dataset.sql_client as client:
+            result = client.execute_sql(query)
+
+        return result
+
+    def _register_udfs(self, *args, **kwargs) -> None:
+        """Override SQLBackend method to avoid round-trip to Ibis SQL compiler"""
+
+    def list_tables(self, *args, **kwargs) -> list[str]:
+        """Return the list of table names"""
+        return list(self._dataset.schema.tables.keys())
+
+    def get_schema(self, table_name: str, *args, **kwargs) -> sch.Schema:
+        """Get the Ibis table schema"""
+        return sch.Schema(  
+            {
+                name: DltType.to_ibis(column["data_type"], column.get("nullable"))  # type: ignore
+                for name, column in self._dataset.schema.get_table(table_name)["columns"].items()  # type: ignore
+            }  # type: ignore
+        )
+
+    def table(self, name: str) -> ir.Table:
+        """Construct a table expression"""
+        # TODO maybe there's a more straighforward way to retrieve catalog and db
+        sql_client = self._dataset.sql_client
+        catalog = sql_client.catalog_name()
+        database =  sql_client.capabilities.casefold_identifier(sql_client.dataset_name)
+
+        table_schema = self.get_schema(name)
+        return ops.DatabaseTable(
+            name,
+            schema=table_schema,
+            source=self,
+            namespace=ops.Namespace(catalog=catalog, database=database)
+        ).to_expr()
+
+    # TODO use the new dlt `model` format with INSERT statement
+    # for non-SQL (e.g., filesystem) use JobClient 
+    def create_table(
+        self,
+        name: str,
+        /,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
+        *,
+        schema: sch.Schema | None = None,
+        database: str | None = None,
+        temp: bool = False,
+        overwrite: bool = False,
+    ) -> ir.Table:
+        raise NotImplementedError
+
+    def _get_schema_using_query(self, *args, **kwargs):
+        """Required to subclass SQLBackend"""
+        raise NotImplementedError
+
+    def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
+        """Required to subclass SQLBackend"""
+        raise NotImplementedError

--- a/tests/dataset/test_relation.py
+++ b/tests/dataset/test_relation.py
@@ -1,0 +1,52 @@
+import pytest
+from ibis import ir
+
+import dlt
+
+# TODO move destination-independent tests from `test_read_interfaces.py` to this module
+
+
+@pytest.fixture
+def dataset() -> dlt.Dataset:
+    @dlt.resource
+    def purchases():
+        yield from (
+            {"id": 1, "name": "alice", "city": "berlin"},
+            {"id": 2, "name": "bob", "city": "paris"},
+            {"id": 3, "name": "charlie", "city": "barcelona"},
+        )
+
+    pipeline = dlt.pipeline("_relation_to_ibis", destination="duckdb")
+    pipeline.run([purchases])
+    return pipeline.dataset()
+
+
+@pytest.fixture
+def purchases(dataset: dlt.Dataset) -> dlt.Relation:
+    purchases = dataset.table("purchases")
+    assert isinstance(purchases, dlt.Relation)
+    return purchases
+
+
+def test_sql_relation_to_ibis(dataset: dlt.Dataset) -> None:
+    purchases = dataset.query("SELECT * FROM purchases")
+    assert isinstance(purchases, dlt.Relation)
+
+    table = purchases.to_ibis()
+    assert isinstance(table, ir.Table)
+    # executes without error
+    table.execute()
+
+
+def test_base_relation_to_ibis(purchases: dlt.Relation) -> None:
+    table = purchases.to_ibis()
+    assert isinstance(table, ir.Table)
+    # executes without error
+    table.execute()
+
+
+def test_transformed_relation_to_ibis_(purchases: dlt.Relation) -> None:
+    table = purchases.where("id", "gt", 2).select("name").to_ibis()
+    assert isinstance(table, ir.Table)
+    # executes without error
+    table.execute()

--- a/tests/libs/test_ibis.py
+++ b/tests/libs/test_ibis.py
@@ -4,19 +4,19 @@ import ibis.expr.types as ir
 import pandas as pd
 
 import dlt
-from dlt.common.libs.ibis import DltBackend
+from dlt.common.libs.ibis import _DltBackend
 
 from tests.load.test_read_interfaces import populated_pipeline, configs
 from tests.utils import preserve_module_environ, autouse_module_test_storage, patch_module_home_dir
 
 
-duckdb_conf = [c for c in configs if c.destination_type=="duckdb" and c.file_format is None]
+duckdb_conf = [c for c in configs if c.destination_type == "duckdb" and c.file_format is None]
 
 
 @pytest.mark.no_load
 @pytest.mark.essential
 def test_instantiate_backend():
-    DltBackend()
+    _DltBackend()
 
 
 # TODO test for all destinations
@@ -29,12 +29,8 @@ def test_instantiate_backend():
     ids=lambda x: x.name,
 )
 def test_connect_to_backend(populated_pipeline: dlt.Pipeline):
-    backend1 = DltBackend.from_dataset(populated_pipeline.dataset())
-    backend2 = DltBackend.from_pipeline(populated_pipeline)
-
-    assert isinstance(backend1, DltBackend)
-    assert isinstance(backend2, DltBackend)
-    assert backend1 is not backend2
+    backend = _DltBackend.from_dataset(populated_pipeline.dataset())
+    assert isinstance(backend, _DltBackend)
 
 
 @pytest.mark.no_load
@@ -46,15 +42,15 @@ def test_connect_to_backend(populated_pipeline: dlt.Pipeline):
     ids=lambda x: x.name,
 )
 def test_list_tables(populated_pipeline: dlt.Pipeline):
-    backend = DltBackend.from_pipeline(populated_pipeline)
+    backend = _DltBackend.from_dataset(populated_pipeline.dataset())
     expected_table_names = [
-        '_dlt_version', 
-        '_dlt_loads',
-        'items',
-        'double_items',
+        "_dlt_version",
+        "_dlt_loads",
+        "items",
+        "double_items",
         "orderable_in_chain",
-        '_dlt_pipeline_state',
-        'items__children'
+        "_dlt_pipeline_state",
+        "items__children",
     ]
 
     assert backend.list_tables() == expected_table_names
@@ -69,7 +65,7 @@ def test_list_tables(populated_pipeline: dlt.Pipeline):
     ids=lambda x: x.name,
 )
 def test_get_schema(populated_pipeline: dlt.Pipeline):
-    backend = DltBackend.from_pipeline(populated_pipeline)
+    backend = _DltBackend.from_dataset(populated_pipeline.dataset())
     expected_schema = ibis.Schema(
         {
             "id": ibis.dtype("int64", nullable=True),
@@ -94,7 +90,7 @@ def test_get_schema(populated_pipeline: dlt.Pipeline):
     ids=lambda x: x.name,
 )
 def test_get_bound_table(populated_pipeline: dlt.Pipeline):
-    backend = DltBackend.from_pipeline(populated_pipeline)
+    backend = _DltBackend.from_dataset(populated_pipeline.dataset())
     expected_schema = ibis.Schema(
         {
             "id": ibis.dtype("int64", nullable=True),
@@ -120,7 +116,7 @@ def test_get_bound_table(populated_pipeline: dlt.Pipeline):
     ids=lambda x: x.name,
 )
 def test_execute_expression(populated_pipeline: dlt.Pipeline):
-    backend = DltBackend.from_pipeline(populated_pipeline)
+    backend = _DltBackend.from_dataset(populated_pipeline.dataset())
     expected_schema = ibis.Schema(
         {
             "_dlt_id": ibis.dtype("string", nullable=False),

--- a/tests/libs/test_ibis.py
+++ b/tests/libs/test_ibis.py
@@ -1,0 +1,157 @@
+import pytest
+import ibis
+import ibis.expr.types as ir
+import pandas as pd
+
+import dlt
+from dlt.common.libs.ibis import DltBackend
+
+from tests.load.test_read_interfaces import populated_pipeline, configs
+from tests.utils import preserve_module_environ, autouse_module_test_storage, patch_module_home_dir
+
+
+duckdb_conf = [c for c in configs if c.destination_type=="duckdb" and c.file_format is None]
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+def test_instantiate_backend():
+    DltBackend()
+
+
+# TODO test for all destinations
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_connect_to_backend(populated_pipeline: dlt.Pipeline):
+    backend1 = DltBackend.from_dataset(populated_pipeline.dataset())
+    backend2 = DltBackend.from_pipeline(populated_pipeline)
+
+    assert isinstance(backend1, DltBackend)
+    assert isinstance(backend2, DltBackend)
+    assert backend1 is not backend2
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_list_tables(populated_pipeline: dlt.Pipeline):
+    backend = DltBackend.from_pipeline(populated_pipeline)
+    expected_table_names = [
+        '_dlt_version', 
+        '_dlt_loads',
+        'items',
+        'double_items',
+        "orderable_in_chain",
+        '_dlt_pipeline_state',
+        'items__children'
+    ]
+
+    assert backend.list_tables() == expected_table_names
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_get_schema(populated_pipeline: dlt.Pipeline):
+    backend = DltBackend.from_pipeline(populated_pipeline)
+    expected_schema = ibis.Schema(
+        {
+            "id": ibis.dtype("int64", nullable=True),
+            "decimal": ibis.dtype("decimal", nullable=True),
+            "other_decimal": ibis.dtype("decimal", nullable=True),
+            "_dlt_load_id": ibis.dtype("string", nullable=False),
+            "_dlt_id": ibis.dtype("string", nullable=False),
+        }  # type: ignore
+    )
+
+    ibis_schema = backend.get_schema("items")
+
+    assert expected_schema.equals(ibis_schema)
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_get_bound_table(populated_pipeline: dlt.Pipeline):
+    backend = DltBackend.from_pipeline(populated_pipeline)
+    expected_schema = ibis.Schema(
+        {
+            "id": ibis.dtype("int64", nullable=True),
+            "decimal": ibis.dtype("decimal", nullable=True),
+            "other_decimal": ibis.dtype("decimal", nullable=True),
+            "_dlt_load_id": ibis.dtype("string", nullable=False),
+            "_dlt_id": ibis.dtype("string", nullable=False),
+        }
+    )
+
+    table = backend.table("items")
+
+    assert isinstance(table, ir.Table)
+    assert table.schema().equals(expected_schema)
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_execute_expression(populated_pipeline: dlt.Pipeline):
+    backend = DltBackend.from_pipeline(populated_pipeline)
+    expected_schema = ibis.Schema(
+        {
+            "_dlt_id": ibis.dtype("string", nullable=False),
+            "id": ibis.dtype("int64", nullable=True),
+        }
+    )
+
+    table = backend.table("items")
+    expr = table.select("_dlt_id", "id")
+    table2 = backend.execute(expr)
+
+    assert isinstance(table2, pd.DataFrame)
+    assert expr.schema().equals(expected_schema)
+    assert set(table2.columns) == set(expected_schema.names)
+
+
+@pytest.mark.no_load
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "populated_pipeline",
+    duckdb_conf,
+    indirect=True,
+    ids=lambda x: x.name,
+)
+def test_user_workflow(populated_pipeline: dlt.Pipeline):
+    expected_columns = ["_dlt_id", "id"]
+
+    dataset = populated_pipeline.dataset()
+    con = dataset.ibis()
+    table = con.table("items")
+    result = table.select("_dlt_id", "id").execute()
+
+    assert isinstance(result, pd.DataFrame)
+    assert set(result.columns) == set(expected_columns)


### PR DESCRIPTION
This continues the work started in #2498 (see previous review round)

## Summary
- Add a generic Ibis backend called `_DltBackend` that forwards Ibis expressions to the native destination SQL client provided by dlt
- Allows to create bound Ibis table, chain expressions and call `.execute()` or `.to_pyarrow()` directly on the Ibis object
- Simplifies the `dlt.Relation` object by removing the `.table(..., table_type=...)` kwarg

## Motivation
### Red / blue code
Reusing the language from [this blog about sync/async](https://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/), the `dlt.Dataset.table()` method introduces red and blue code. Based on `table_type=` kwarg, it returns a `dlt.Relation` or `ibis.Table` object, which are really different are currently hard to mix. 

Returning different types of objects based on a kwarg is generally something to avoid. This pattern also prevents Ibis users from all convenience methods available on `dlt.Relation` 

### Better ergonomics
I prefer using Ibis when interactively exploring datasets and writing transformations in a notebook. Currently, the ergonomics are poor because I need to:
1. get a `dlt.Dataset`
2. get an unbound ibis table via `.table(..., table_type="ibis")`
3. write queries on the Ibis table (here, it's native Ibis features)
4. pass the query to `dlt.Dataset` to create a new `dlt.Relation` 
5. execute the relation to see results

Step `4.` is the most awkward because you need to constantly add / delete `dataset(my_ibis_expr).df()` to view results. pattern

## Solution
### Red / blue code
The method `dlt.Dataset.table(...)` should always return a `dlt.Relation` and `dlt.Relation.to_ibis()` returns a native Ibis object to process further. This allows to deprecate `.table(..., table_type=...)`.

The method `.to_ibis()` is in line with other methods like `.to_pandas()`, `.to_pyarrow()`, `.to_sql()`,  `.to_sqlglot()`, etc. that we could provide on `dlt.Relation` (future work)

### Better ergonomics
Having a `_DltBackend` allows us to get bound Ibis tables while avoiding connecting to the destination (the main reason why we we're using unbound tables). Bound tables allow to:
1. get a `dlt.Dataset`
2. get a `dlt.Relation`
3. (optional) use `dlt.Relation` convenience methods (e.g., joining on references)
4. call `.to_ibis()` to get a native object
5. manipulate the ibis object and call `.to_pyarrow()` or `.execute()` to view results directly (this uses dlt's SQL client)

This feels much more familiar to Ibis users and ensures compatibility with the rest of the Ibis ecosystem. 

## TODO
- Update docs & educational content
- Add deprecation warnings for `.table(..., table_type=...)`
- Review marimo dashboard and features

## Future work
- Currently, `dlt.Dataset.ibis()` returns a native Ibis connection based on the specific dlt destination. By returning the `_DltBackend` instance, this could support a broader set of destinations (e.g., if we implement an SQL interface for LanceDB with an in-memory DuckDB)