### PR TITLE
Docs: dataset access doesn't work in tutorial

### DIFF
--- a/docs/website/docs/tutorial/load-data-from-an-api.md
+++ b/docs/website/docs/tutorial/load-data-from-an-api.md
@@ -78,7 +78,7 @@ You can use dlt [datasets](../general-usage/dataset-access/dataset) to easily qu
 
 ```py
 # get the dataset
-dataset = pipeline.dataset("mydata")
+dataset = pipeline.dataset()
 
 # get the user relation
 table = dataset.users


### PR DESCRIPTION
This PR simply removes the wrong schema name from a `.dataset()` snippet in one of the tutorials in docs.

Resolves #3196 3196