### PR TITLE
handle _load_rows with None partition from DB2 driver

### DIFF
--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -199,6 +199,10 @@ class TableLoader:
                 # columns = [c[0] for c in result.cursor.description]
                 columns = list(result.keys())
                 for partition in result.partitions(size=self.chunk_size):
+                    # 🛠️ DB2 driver sometimes yields None instead of empty iterable
+                    if partition is None:
+                        logger.debug("Skipped None partition from DB2 driver.")
+                        continue
                     if self.backend == "sqlalchemy":
                         yield [dict(row._mapping) for row in partition]
                     elif self.backend == "pandas":


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

When running with db2 source using user defined query following this [doc](https://dlthub.com/docs/devel/dlt-ecosystem/verified-sources/sql_database/usage#write-custom-sql-queries), we got:
```
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:   File "/src/.venv/lib/python3.11/site-packages/dlt/extract/pipe_iterator.py", line 274, in _get_source_item
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:     pipe_item = next(gen)
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:                 ^^^^^^^^^
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:   File "/src/.venv/lib/python3.11/site-packages/dlt/sources/sql_database/helpers.py", line 342, in table_rows
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:     yield from loader.load_rows(backend_kwargs)
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:   File "/src/.venv/lib/python3.11/site-packages/dlt/sources/sql_database/helpers.py", line 191, in load_rows
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:     yield from self._load_rows(query, backend_kwargs)
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:   File "/src/.venv/lib/python3.11/site-packages/dlt/sources/sql_database/helpers.py", line 201, in _load_rows
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:     for partition in result.partitions(size=self.chunk_size):
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:   File "/src/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 1313, in partitions
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:     partition = getter(self, size)
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:                 ^^^^^^^^^^^^^^^^^^
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:   File "/src/.venv/lib/python3.11/site-packages/sqlalchemy/engine/result.py", line 718, in manyrows
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:     rows = [make_row(row) for row in rows]
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2025-10-21, 15:07:10 CEST] {pod.py:856} INFO - [base] logs: TypeError: 'NoneType' object is not iterable
```

**No such error if runs without user defined query.**


🧠 Explanation

currently DLT assumes result.partitions() always returns an iterable.
For DB2 (via ibm-db-sa), SQLAlchemy 2.x occasionally yields None for an empty final partition.

This causes: `TypeError: 'NoneType' object is not iterable`

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

- this fix is tested successfully in my side for db2
- this error doesn't occur for other sql databases (postgres, mssql, mysql, oracel)


<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
