### PR TITLE
chore/fixes pokemon table counts

### DIFF
--- a/tests/load/sources/rest_api/test_rest_api_source.py
+++ b/tests/load/sources/rest_api/test_rest_api_source.py
@@ -10,6 +10,7 @@ from tests.load.utils import (
     destinations_configs,
     DestinationTestConfiguration,
 )
+from tests.sources.rest_api.utils import POKEMON_EXPECTED_TABLE_COUNTS
 
 
 def _make_pipeline(destination_name: str):
@@ -54,10 +55,7 @@ def test_rest_api_source(destination_config: DestinationTestConfiguration) -> No
     table_counts = load_table_counts(pipeline)
 
     assert table_counts.keys() == {"pokemon_list", "berry", "location"}
-
-    assert table_counts["pokemon_list"] == 1302
-    assert table_counts["berry"] == 64
-    assert table_counts["location"] == 1070
+    assert table_counts.items() >= POKEMON_EXPECTED_TABLE_COUNTS.items()
 
 
 @pytest.mark.parametrize(

--- a/tests/sources/rest_api/test_rest_api_source.py
+++ b/tests/sources/rest_api/test_rest_api_source.py
@@ -8,6 +8,7 @@ from dlt.sources.helpers.rest_client.paginators import SinglePagePaginator
 from dlt.sources.rest_api import rest_api_source, rest_api
 
 from tests.common.configuration.utils import environment, toml_providers
+from tests.sources.rest_api.utils import POKEMON_EXPECTED_TABLE_COUNTS
 from tests.utils import ALL_DESTINATIONS
 from tests.pipeline.utils import assert_load_info, load_table_counts, load_tables_to_dicts
 
@@ -78,10 +79,7 @@ def test_rest_api_source(destination_name: str, invocation_type: str) -> None:
     table_counts = load_table_counts(pipeline)
 
     assert table_counts.keys() == {"pokemon_list", "berry", "location"}
-
-    assert table_counts["pokemon_list"] == 1302
-    assert table_counts["berry"] == 64
-    assert table_counts["location"] == 1070
+    assert table_counts.items() >= POKEMON_EXPECTED_TABLE_COUNTS.items()
 
 
 @pytest.mark.parametrize("destination_name", ALL_DESTINATIONS)

--- a/tests/sources/rest_api/utils.py
+++ b/tests/sources/rest_api/utils.py
@@ -1,0 +1,5 @@
+POKEMON_EXPECTED_TABLE_COUNTS = {
+    "pokemon_list": 1328,
+    "berry": 64,
+    "location": 1070,
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
adds pokemon table count as const for tests so it is easier to change it in the future. maybe we should switch to fruitshop or smth.

