### PR TITLE
Fix: workspace package hash is dependent on file order

### DIFF
--- a/dlt/_workspace/deployment/package_builder.py
+++ b/dlt/_workspace/deployment/package_builder.py
@@ -52,9 +52,11 @@ class DeploymentPackageBuilder:
                     }
                 )
             # Create and add manifest with file metadata at the end
+            # NOTE: Sort files in manifest because os.scandir(), which the file selector's pathspec.util.iter_tree_files() relies on,
+            # yields files in a system-dependent order (https://peps.python.org/pep-0471/#os-scandir).
             manifest: TDeploymentManifest = {
                 "engine_version": DEPLOYMENT_ENGINE_VERSION,
-                "files": manifest_files,
+                "files": sorted(manifest_files, key=lambda x: x["relative_path"]),
             }
             manifest_yaml = yaml.dump(
                 manifest, allow_unicode=True, default_flow_style=False, sort_keys=False

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -132,11 +132,11 @@ def digest256_file_stream(stream: BinaryIO, chunk_size: int = 4096) -> str:
 
 
 def digest256_tar_stream(stream: BinaryIO, chunk_size: int = 8192) -> str:
-    """Returns a base64 encoded sha3_256 hash of tar archive contents (ignoring metadata)
+    """Returns a base64 encoded sha3_256 hash of tar archive contents.
 
     Hashes only filenames and file contents, ignoring timestamps and other metadata.
-    This ensures identical file contents produce identical hashes regardless of when
-    the tar was created.
+    Members are sorted by name before hashing, so tar member order doesn't affect
+    the hash.
 
     Note: This function operates entirely in-memory using tar.extractfile() which reads
     from the archive stream. No files are written to disk, preventing leakage of sensitive


### PR DESCRIPTION
This PR adjusts the package builder, so that the order of files in the manifest is sorted and doesn't affect the resulting hash. An appropriate test and comments are added.