### PR TITLE
Add example to SQL docs: updated docs on how to filter rows using `query_adapter_callback`

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
@@ -284,6 +284,7 @@ source = sql_database(
     query_adapter_callback=query_adapter_callback,
     table_adapter_callback=table_adapter_callback,
 )
+```
 :::
 ## Configuring with TOML or environment variables
 You can set most of the arguments of `sql_database()` and `sql_table()` directly in the TOML files or as environment variables. `dlt` automatically injects these values into the pipeline script.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This PR adds a new section to the Advanced usage page of the sql_database source docs.

It demonstrates how to use `query_adapter_callback` and `table_adapter_callback` to:

- Filter rows for specific tables using SQL conditions
- Select only specific columns per table during schema reflection