### PR TITLE
feat: add `dlt.hub.data_quality` entrypoint

### DIFF
--- a/dlt/hub/__init__.py
+++ b/dlt/hub/__init__.py
@@ -2,10 +2,10 @@
 
 __found__ = False
 try:
-    from dlthub import transformation, runner
+    from dlthub import transformation, runner, data_quality
     from . import current
 
     __found__ = True
-    __all__ = ["transformation", "current", "runner"]
+    __all__ = ("transformation", "current", "runner", "data_quality")
 except ImportError:
     pass

--- a/tests/hub/test_data_quality.py
+++ b/tests/hub/test_data_quality.py
@@ -1,0 +1,25 @@
+import pytest
+
+import dlt
+
+
+def test_direct_module_import():
+    """It's currently not possible to import the module directly"""
+    with pytest.raises(ModuleNotFoundError):
+        import dlt.hub.data_quality  # type: ignore[import-not-found]
+
+
+def test_from_module_import():
+    """Can import the registered `dlthub` submodule from `dlt.hub`."""
+    from dlt.hub import data_quality
+
+
+def test_data_quality_entrypoints():
+    import dlthub.data_quality as dq
+
+    # access a single check
+    assert dlt.hub.data_quality is dq
+    assert dlt.hub.data_quality.checks is dq.checks
+    assert dlt.hub.data_quality.checks.is_not_null is dq.checks.is_not_null
+    assert dlt.hub.data_quality.CheckSuite is dq.CheckSuite
+    assert dlt.hub.data_quality.prepare_checks is dq.prepare_checks


### PR DESCRIPTION
This gives access to the `dlthub.data_quality` module. 

CI won't succeed until `dlthub >= 1.18.0`, which adds `dlthub.data_quality` is released. 
