### PR TITLE
fix: minor typos and redundant variable

### DIFF
--- a/dlt/helpers/ibis.py
+++ b/dlt/helpers/ibis.py
@@ -83,7 +83,7 @@ def create_ibis_backend(
             # also prevents empty duckdb files from being created
             client.sql_client.use_dataset()
         except Exception:
-            # close explicitly, wont be done by the conn pool
+            # close explicitly, won't be done by the conn pool
             client.sql_client.close_connection()
             raise
         con = ibis.duckdb.from_connection(conn)

--- a/dlt/pipeline/trace.py
+++ b/dlt/pipeline/trace.py
@@ -257,7 +257,6 @@ def end_trace_step(
             step_exception += "caused by: " + str(step_info.__context__)
         step_info = None
     else:
-        step_info = step_info
         exception_traces = None
         step_exception = None
 

--- a/tests/helpers/test_dbml.py
+++ b/tests/helpers/test_dbml.py
@@ -279,7 +279,7 @@ def assert_equal_dbml_columns(col1: Column, col2: Column) -> None:
     assert col1.comment == col2.comment
     assert col1.default == col2.default
     assert col1.properties == col2.properties
-    # we dont't compare `.table` because of circular references
+    # we don't compare `.table` because of circular references
     # between PyDBML `Column` and `Table` objects.
     # assert col1.table == col2.table
 

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -1128,7 +1128,7 @@ def test_ibis_expression_relation(populated_pipeline: Pipeline) -> None:
     )
 
     # selecting all columns (star schema expanded, columns aliased)
-    # TODO: fixe tests
+    # TODO: fix tests
     assert sql_from_expr(items_table) == (
         (
             'SELECT "items"."id" AS "id", "items"."decimal" AS "decimal", "items"."other_decimal"'


### PR DESCRIPTION
Fix some typos in comments in multiple files and remove redundant variable assignment.  