### PR TITLE
Enable CI run for the runtime branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: dlt
 
 on:
   pull_request:
-    branches: [ master, devel ]
+    branches: [ master, devel, runtime ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This PR enables the main CI flow to run for PRs against the runtime branch.