### PR TITLE
fix: make `with_table_name` and other functions available through `dlt.pip…

### DIFF
--- a/dlt/pipeline/mark.py
+++ b/dlt/pipeline/mark.py
@@ -1,9 +1,18 @@
 """Module with mark functions that make data to be specially processed"""
 from dlt.extract import (
-    with_table_name,
-    with_hints,
-    with_file_import,
     make_hints,
     make_nested_hints,
+    with_file_import,
+    with_hints,
+    with_table_name,
     materialize_schema_item as materialize_table_schema,
 )
+
+__all__ = [
+    "with_table_name",
+    "with_hints",
+    "with_file_import",
+    "make_hints",
+    "make_nested_hints",
+    "materialize_table_schema",
+]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Functions such as `with_table_name` haven't been available for use by LSPs due to not being specified via `__all__` in`dlt.pipeline.mark` and therefore `dlt.mark`

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #... https://github.com/dlt-hub/dlt/issues/3319
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
