### PR TITLE
chore: add proper optional typehint to `dlt/extract/hints.py` module

### DIFF
--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -267,10 +267,9 @@ class DltResourceHints:
         return self._table_has_other_dynamic_hints
 
     @property
-    def write_disposition(self) -> Optional[TTableHintTemplate[TWriteDispositionConfig]]:
-        if self._hints is None or self._hints.get("write_disposition") is None:
-            return DEFAULT_WRITE_DISPOSITION
-        return self._hints.get("write_disposition")
+    def write_disposition(self) -> TTableHintTemplate[TWriteDispositionConfig]:
+        value = (self._hints or {}).get("write_disposition")
+        return value if value is not None else DEFAULT_WRITE_DISPOSITION
 
     @write_disposition.setter
     def write_disposition(self, value: TTableHintTemplate[TWriteDispositionConfig]) -> None:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
A lot of arguments in the `dlt.extract.hints.DltResourceHints.apply_hints` function are actually optional, but it's not wrapped with `typing.Optional`,
making some static linter, such as ruff/pyrefly, mark it as an error if we're providing a None value to it. 

Example usecase: I want to set incremental hints based on certain condition

```python
resource.apply_hints(incremental=incremental if condition is True else None,)
```

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes https://github.com/dlt-hub/dlt/issues/3330


<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
