### PR TITLE
override local marimo theme for dashboard, fix to 'light'

### DIFF
--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -1,3 +1,7 @@
+# /// script
+# [tool.marimo.display]
+# theme = "light"
+# ///
 # flake8: noqa: F841
 # mypy: disable-error-code=no-untyped-def
 


### PR DESCRIPTION
closes #3002 

dashboard always renders in light-theme like this