### PR TITLE
Fix: type annotation failure in compute_columns_schema

### DIFF
--- a/dlt/common/libs/sqlglot.py
+++ b/dlt/common/libs/sqlglot.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Set, Any, Iterable, Literal
+from typing import Optional, Union, Set, Any, Iterable, Literal, cast
 
 from dlt.common.utils import without_none
 from dlt.common.exceptions import TerminalValueError
@@ -632,3 +632,14 @@ def build_typed_literal(
         return sge.Tuple(expressions=[_literal(v) for v in value])
     else:
         return _literal(value)
+
+
+def wrap_identifiers_in_columns(expression: sge.Query) -> sge.Query:
+    """Wrap bare Identifier nodes inside Alias with Column nodes"""
+
+    def transform(node: sge.Expression) -> sge.Expression:
+        if isinstance(node, sge.Alias) and isinstance(node.this, sge.Identifier):
+            return sge.Alias(this=sge.Column(this=node.this.copy()), alias=node.alias)
+        return node
+
+    return cast(sge.Query, expression.transform(transform))

--- a/tests/hub/test_transformations.py
+++ b/tests/hub/test_transformations.py
@@ -1,4 +1,5 @@
 import dlt
+from dlt.sources.rest_api import rest_api_resources
 
 
 def test_transformation_decorator() -> None:
@@ -12,3 +13,71 @@ def test_transformation_decorator() -> None:
     # get instance without license
     transformation = get_even_rows(dlt.dataset("duckdb", "mock_dataset"))
     assert transformation.name == "get_even_rows"
+
+
+def test_missing_columns_bug() -> None:
+    """Regression test: bare Identifier nodes were not properly type annotated in dlt.dataset.lineage.compute_columns_schema,
+    causing success_count and success_rate to have UNKNOWN type and be excluded as incomplete columns by dlt.
+    """
+    import dlthub.data_quality as dq
+
+    @dlt.source
+    def jaffleshop():
+        jaffle_rest_resources = rest_api_resources(
+            {
+                "client": {
+                    "base_url": "https://jaffle-shop.dlthub.com/api/v1",
+                    "paginator": {"type": "header_link"},
+                },
+                "resources": [
+                    "customers",
+                    "products",
+                    "orders",
+                ],
+                "resource_defaults": {
+                    "endpoint": {
+                        "params": {
+                            "start_date": "2017-01-01",
+                            "end_date": "2017-01-15",
+                        },
+                    },
+                },
+            }
+        )
+
+        return jaffle_rest_resources
+
+    @dlt.hub.transformation
+    def jaffle_checks(dataset: dlt.Dataset) -> dlt.Relation:
+        checks = {"orders": [dq.checks.is_unique("id"), dq.checks.case("subtotal > 0")]}
+        return dq.prepare_checks(dataset, checks=checks)
+
+    pipeline = dlt.pipeline("test_missing_columns", destination="duckdb")
+    pipeline.run([jaffleshop()])
+    pipeline.run(jaffle_checks(pipeline.dataset()))
+
+    expected_column_names = [
+        "table_name",
+        "check_qualified_name",
+        "row_count",
+        "success_count",  # was missing due to unqualified column
+        "success_rate",  # was missing due to unqualified column
+    ]
+
+    # direct query execution returns raw select output (no dlt columns)
+    query = dq.prepare_checks(
+        pipeline.dataset(),
+        checks={
+            "orders": [dq.checks.is_unique("id"), dq.checks.case("subtotal > 0")],
+        },
+    )
+    assert query.arrow().column_names == expected_column_names
+
+    # materialized table includes _dlt_load_id added by pipeline
+    with pipeline.sql_client() as client:
+        with client.execute_query(
+            f"SELECT * FROM {pipeline.pipeline_name}.{pipeline.dataset_name}.jaffle_checks"
+        ) as cursor:
+            df = cursor.df()
+            columns = list(df.columns)
+    assert columns == expected_column_names + ["_dlt_load_id"]

--- a/tests/hub/utils.py
+++ b/tests/hub/utils.py
@@ -12,7 +12,9 @@ from dlthub.common.license import (
 
 
 def issue_ephemeral_license() -> Iterator[LicenseContext]:
-    license_ = create_self_signed_license("dlthub.transformation dlthub.project dlthub.runner")
+    license_ = create_self_signed_license(
+        "dlthub.transformation dlthub.project dlthub.runner dlthub.data_quality"
+    )
     try:
         ctx = LicenseContext(decode_license(license_))
         Container()[LicenseContext] = ctx


### PR DESCRIPTION
This PR is an attempt to resolve the issue where sqlglot is not able to annotate the type of a column.

Root cause: In some cases, the `selects` of the `expression` passed to the `compute_columns_schema` in `dlt.dataset.lineage.py` include bare Identifiers. `qualify()` fails to qualify these bare Identifier nodes. Then `annotate_types()` fails downstream because it's working with unqualified columns.

Resolves #3345 