### PR TITLE
Fix: Section backrgound colors and top margins in dashboard

### DIFF
--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -185,8 +185,11 @@ def render_pipeline_home(
         )
         _pipeline_execution_exception = utils.build_exception_section(dlt_pipeline)
 
-    _stack = render_pipeline_header_row(
-        dlt_pipeline_name, dlt_profile_select, dlt_pipeline_select, _buttons
+    _stack = [ui.section_marker(strings.home_section_name)]
+    _stack.extend(
+        render_pipeline_header_row(
+            dlt_pipeline_name, dlt_profile_select, dlt_pipeline_select, _buttons
+        )
     )
 
     if _pipeline_execution_summary:
@@ -301,12 +304,15 @@ def section_info(
     Overview page of currently selected pipeline
     """
 
-    _result = ui.build_page_header(
-        dlt_pipeline,
-        strings.overview_title,
-        strings.overview_subtitle,
-        strings.overview_subtitle,
-        dlt_section_info_switch,
+    _result = [ui.section_marker(strings.overview_section_name)]
+    _result.extend(
+        ui.build_page_header(
+            dlt_pipeline,
+            strings.overview_title,
+            strings.overview_subtitle,
+            strings.overview_subtitle,
+            dlt_section_info_switch,
+        )
     )
 
     if dlt_pipeline and dlt_section_info_switch.value:
@@ -357,12 +363,15 @@ def section_schema(
     Show schema of the currently selected pipeline
     """
 
-    _result = ui.build_page_header(
-        dlt_pipeline,
-        strings.schema_title,
-        strings.schema_subtitle,
-        strings.schema_subtitle_long,
-        dlt_section_schema_switch,
+    _result = [ui.section_marker(strings.schema_section_name)]
+    _result.extend(
+        ui.build_page_header(
+            dlt_pipeline,
+            strings.schema_title,
+            strings.schema_subtitle,
+            strings.schema_subtitle_long,
+            dlt_section_schema_switch,
+        )
     )
 
     if dlt_pipeline and dlt_section_schema_switch.value and dlt_schema_table_list is None:
@@ -451,12 +460,15 @@ def section_browse_data_table_list(
     Show data of the currently selected pipeline
     """
 
-    _result = ui.build_page_header(
-        dlt_pipeline,
-        strings.browse_data_title,
-        strings.browse_data_subtitle,
-        strings.browse_data_subtitle_long,
-        dlt_section_browse_data_switch,
+    _result = [ui.section_marker(strings.browse_data_section_name)]
+    _result.extend(
+        ui.build_page_header(
+            dlt_pipeline,
+            strings.browse_data_title,
+            strings.browse_data_subtitle,
+            strings.browse_data_subtitle_long,
+            dlt_section_browse_data_switch,
+        )
     )
 
     dlt_query_editor: mo.ui.code_editor = None
@@ -693,12 +705,15 @@ def section_state(
     """
     Show state of the currently selected pipeline
     """
-    _result = ui.build_page_header(
-        dlt_pipeline,
-        strings.state_title,
-        strings.state_subtitle,
-        strings.state_subtitle,
-        dlt_section_state_switch,
+    _result = [ui.section_marker(strings.state_section_name)]
+    _result.extend(
+        ui.build_page_header(
+            dlt_pipeline,
+            strings.state_title,
+            strings.state_subtitle,
+            strings.state_subtitle,
+            dlt_section_state_switch,
+        )
     )
 
     if dlt_pipeline and dlt_section_state_switch.value:
@@ -722,12 +737,15 @@ def section_trace(
     Show last trace of the currently selected pipeline
     """
 
-    _result = ui.build_page_header(
-        dlt_pipeline,
-        strings.trace_title,
-        strings.trace_subtitle,
-        strings.trace_subtitle,
-        dlt_section_trace_switch,
+    _result = [ui.section_marker(strings.trace_section_name)]
+    _result.extend(
+        ui.build_page_header(
+            dlt_pipeline,
+            strings.trace_title,
+            strings.trace_subtitle,
+            strings.trace_subtitle,
+            dlt_section_trace_switch,
+        )
     )
 
     if dlt_pipeline and dlt_section_trace_switch.value:
@@ -833,12 +851,15 @@ def section_loads(
     Show loads of the currently selected pipeline
     """
 
-    _result = ui.build_page_header(
-        dlt_pipeline,
-        strings.loads_title,
-        strings.loads_subtitle,
-        strings.loads_subtitle_long,
-        dlt_section_loads_switch,
+    _result = [ui.section_marker(strings.loads_section_name)]
+    _result.extend(
+        ui.build_page_header(
+            dlt_pipeline,
+            strings.loads_title,
+            strings.loads_subtitle,
+            strings.loads_subtitle_long,
+            dlt_section_loads_switch,
+        )
     )
 
     if dlt_pipeline and dlt_section_loads_switch.value:
@@ -943,12 +964,15 @@ def section_ibis_backend(
     """
     Connects to ibis backend and makes it available in the datasources panel
     """
-    _result = ui.build_page_header(
-        dlt_pipeline,
-        strings.ibis_backend_title,
-        strings.ibis_backend_subtitle,
-        strings.ibis_backend_subtitle,
-        dlt_section_ibis_browser_switch,
+    _result = [ui.section_marker(strings.ibis_backend_section_name)]
+    _result.extend(
+        ui.build_page_header(
+            dlt_pipeline,
+            strings.ibis_backend_title,
+            strings.ibis_backend_subtitle,
+            strings.ibis_backend_subtitle,
+            dlt_section_ibis_browser_switch,
+        )
     )
 
     if dlt_pipeline and dlt_section_ibis_browser_switch.value:

--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard_styles.css
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard_styles.css
@@ -56,45 +56,24 @@
 
 /* add colors to cells */
 
-#App .marimo-cell .output-area{
+/* Default: all sections get purple border and background */
+#App .marimo-cell .output-area {
   border: 1px dashed var(--dlt-color-purple);
   background-color: var(--dlt-color-purple-background);
-
 }
 
-/**
-*
-* Note: The block below makes it easier to see which cells belong together in app mode.
-* If you start adding new cells, you might need to update (or clear) these styles.
-*
-*/
+/* All cells with section markers get margin-top */
+#App .marimo-cell .output-area:has(.section-marker) {
+  margin-top: 0.5rem;
+}
 
-/* data browser cells */
-#App .marimo-cell:nth-child(3) .output-area,
-#App .marimo-cell:nth-child(5) .output-area,
-#App .marimo-cell:nth-child(6) .output-area,
-#App .marimo-cell:nth-child(7) .output-area,
-#App .marimo-cell:nth-child(9) .output-area,
-#App .marimo-cell:nth-child(12) .output-area
- {
+/* Aqua sections - identified by section name in strings.py */
+#App .marimo-cell .output-area:has([data-section="home_section"]),
+#App .marimo-cell .output-area:has([data-section="schema_section"]),
+#App .marimo-cell .output-area:has([data-section="state_section"]),
+#App .marimo-cell .output-area:has([data-section="loads_section"]) {
   background-color: var(--dlt-color-aqua-background);
   border: 1px dashed var(--dlt-color-aqua);
-}
-
-#App .marimo-cell:nth-child(0) .output-area,
-#App .marimo-cell:nth-child(1) .output-area {
-  background-color: white;
-  border: none;
-}
-
-#App .marimo-cell:nth-child(3) .output-area,
-#App .marimo-cell:nth-child(4) .output-area,
-#App .marimo-cell:nth-child(5) .output-area,
-#App .marimo-cell:nth-child(8) .output-area,
-#App .marimo-cell:nth-child(9) .output-area,
-#App .marimo-cell:nth-child(10) .output-area,
-#App .marimo-cell:nth-child(12) .output-area {
-  margin-top: 0.5rem;
 }
 
 marimo-callout-output .border {

--- a/dlt/_workspace/helpers/dashboard/strings.py
+++ b/dlt/_workspace/helpers/dashboard/strings.py
@@ -46,6 +46,7 @@ This page will automatically refresh with your pipeline data once you have run a
 #
 # Home section
 #
+home_section_name = "home_section"
 home_quick_start_title = """
 ### Quick start: select one of your recently used pipelines:
 
@@ -95,6 +96,7 @@ view_load_packages_text = "Status of load packages from last execution"
 #
 # Overview section
 #
+overview_section_name = "overview_section"
 overview_title = "Pipeline Info"
 overview_subtitle = "Basic properties of the selected pipeline"
 overview_remote_state_title = "Remote state"
@@ -106,6 +108,7 @@ overview_remote_state_button = "Load and show remote state"
 #
 # Schema page
 #
+schema_section_name = "schema_section"
 schema_title = "Dataset Browser: Schema"
 schema_subtitle = "Browse the default schema of the selected pipeline"
 schema_subtitle_long = (
@@ -134,6 +137,7 @@ ui_limit_to_1000_rows = "Limit to 1000 rows"
 #
 # Browse data page
 #
+browse_data_section_name = "browse_data_section"
 browse_data_title = "Dataset Browser: Data and Source/Resource State"
 browse_data_subtitle = "Browse data from the current pipeline."
 browse_data_subtitle_long = (
@@ -171,6 +175,7 @@ browse_data_loading_spinner_text = "Loading data from destination..."
 #
 # State page
 #
+state_section_name = "state_section"
 state_title = "Pipeline State"
 state_subtitle = "A raw view of the currently stored pipeline state."
 
@@ -178,6 +183,7 @@ state_subtitle = "A raw view of the currently stored pipeline state."
 #
 # Last trace page
 #
+trace_section_name = "trace_section"
 trace_title = "Last Pipeline Run Trace"
 trace_subtitle = (
     "An overview of the last load trace from the most recent successful run of the selected"
@@ -211,6 +217,7 @@ trace_raw_trace_title = "Raw Trace"
 #
 # Loads page
 #
+loads_section_name = "loads_section"
 loads_title = "Pipeline Loads"
 loads_subtitle = (
     "View a list of all loads that have been executed on the destination dataset of the "
@@ -248,6 +255,7 @@ loads_details_error_text = "Error loading load details. "
 #
 # Ibis backend page
 #
+ibis_backend_section_name = "ibis_backend_section"
 ibis_backend_title = "Ibis Backend"
 ibis_backend_subtitle = (
     "Connect to the Ibis backend for the selected pipeline. This will make "

--- a/dlt/_workspace/helpers/dashboard/ui_elements.py
+++ b/dlt/_workspace/helpers/dashboard/ui_elements.py
@@ -76,3 +76,8 @@ def build_page_header(
             align="center",
         )
     ]
+
+
+def section_marker(section_name: str) -> mo.Html:
+    """Create an invisible marker element to identify sections for CSS styling."""
+    return mo.Html(f'<div class="section-marker" data-section="{section_name}" hidden"></div>')


### PR DESCRIPTION
The css uses hard-coded object numbers when deciding on the background color and top margin in the dashboard app. It currently looks the following way, because we added new things to the dashboard, but haven't adjusted the hard-coded cell numbers in the css style file:
<img width="573" height="614" alt="Screenshot 2025-11-27 at 15 11 36" src="https://github.com/user-attachments/assets/c79e8744-c0f5-4d4a-8bb2-00bfb9a49f0f" />

This PR makes the background color logic tied to section names, so we don't have to find the cell number and hard code it in css each time we add something. With this change, the dashboard looks the following way:

<img width="579" height="664" alt="Screenshot 2025-11-27 at 15 12 50" src="https://github.com/user-attachments/assets/df0929d7-e220-4779-9699-cfc308ffd431" />
