### PR TITLE
Add fix for inmemory sqlite database and a test for that case

### DIFF
--- a/dlt/destinations/impl/sqlalchemy/configuration.py
+++ b/dlt/destinations/impl/sqlalchemy/configuration.py
@@ -53,6 +53,9 @@ class SqlalchemyCredentials(ConnectionStringCredentials):
         return engine_.connect()
 
     def return_conn(self, borrowed_conn: "Connection") -> None:
+        if getattr(self, "_conn_owner", None) is False:
+            borrowed_conn.close()
+            return
         # close the borrowed conn
         with self._conn_lock:
             borrowed_conn.close()

--- a/docs/website/docs/dlt-ecosystem/destinations/sqlalchemy.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/sqlalchemy.md
@@ -109,7 +109,7 @@ is stored in `/home/me/data/chess_data__games.db`
 ### In-memory databases
 In-memory databases require a persistent connection as the database is destroyed when the connection is closed.
 Normally, connections are opened and closed for each load job and in other stages during the pipeline run.
-To ensure the database persists throughout the pipeline run, you need to pass in an SQLAlchemy `Engine` object instead of credentials.
+To ensure the database persists throughout the pipeline run, you need to pass in an SQLAlchemy `Engine` object instead of credentials. This engine must be created with check_same_thread=False so worker threads can share the connection, and with StaticPool so all operations use the same in-memory database instance.
 This engine is not disposed of automatically by `dlt`. Example:
 
 ```py
@@ -117,7 +117,11 @@ import dlt
 import sqlalchemy as sa
 
 # Create the SQLite engine
-engine = sa.create_engine('sqlite:///:memory:')
+engine = sa.create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=sa.pool.StaticPool
+)
 
 # Configure the destination instance and create pipeline
 pipeline = dlt.pipeline('my_pipeline', destination=dlt.destinations.sqlalchemy(engine), dataset_name='main')

--- a/tests/load/sqlalchemy/test_sqlite_inmemory_pipeline.py
+++ b/tests/load/sqlalchemy/test_sqlite_inmemory_pipeline.py
@@ -1,0 +1,30 @@
+import dlt
+import sqlalchemy as sa
+
+from tests.pipeline.utils import assert_load_info
+from tests.load.utils import sequence_generator
+
+
+def test_inmemory_database() -> None:
+    engine = sa.create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sa.pool.StaticPool
+    )
+
+    generator_instance1 = sequence_generator()
+
+    @dlt.resource
+    def some_data():
+        yield from next(generator_instance1)
+
+    pipeline = dlt.pipeline(
+        pipeline_name="test_pipeline_sqlite_inmemory",
+        destination=dlt.destinations.sqlalchemy(engine),
+        dataset_name="main"
+    )
+    info = pipeline.run(
+        some_data(),
+        table_name="inmemory_table"
+    )
+    assert_load_info(info)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR fixes an attribute error that is raised when attempting to use a sqlite inmemory db. It also provides extra documentation of how to create a connection since more options are required in order to run a pipeline successfully.

There were two issues:

1. Atrribute error while trying to with _conn_lock when _conn_lock is always None if an engine is passed. This is fixed with the proper if guard when trying to return a connection
2. main.table does not exist if check_same_thread=False and poolclass=sa.pool.StaticPool args are not passed to the engine. This is only added to the documentation since its responsibility of the user to know that does params need to be passed.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #3407

<!--
Provide any additional context about the PR here.
-->

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
