### PR TITLE
Fix race condition in LimitItem 

### DIFF
--- a/dlt/extract/items_transform.py
+++ b/dlt/extract/items_transform.py
@@ -199,6 +199,10 @@ class LimitItem(ItemTransform[TDataItem, Dict[str, Any]]):
         if item is None:
             return None
 
+        # do not return any late arriving items
+        if self.exhausted:
+            return None
+
         if self.count_rows:
             self.count += count_rows_in_items(item)
         else:
@@ -219,9 +223,6 @@ class LimitItem(ItemTransform[TDataItem, Dict[str, Any]]):
             # otherwise never return anything
             if self.max_items != 0:
                 return item
-
-        # do not return any late arriving items
-        if self.exhausted:
             return None
 
         return item


### PR DESCRIPTION
This PR fixes race condition in LimitItem.

Say it's parallelized  and `max_items=1` and:

1. Item A arrives:
- `self.count` becomes 1.
- `(self.count >= self.max_items)` is True.
- `self.exhausted` set to True.
- `self.gen.close()` is called.
- Returns Item A.
2. Item B arrives:
- The generator didn't stop fast enough, so `__call__` runs again.
- self.count becomes 2.
- (self.count >= self.max_items) is True.
- self.exhausted set to True.
- `return item` returns Item B.

Can be tested with:

```bash
for i in {1..100}; do pytest tests/extract/test_sources.py::test_limit_edge_cases[10] || break; done
```