### PR TITLE
Fix state file being ignored when pipline_name includes FILENAME_SEPA…

### DIFF
--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -784,7 +784,7 @@ class FilesystemClient(
             filename = os.path.splitext(os.path.basename(filepath))[0]
             fileparts = filename.rsplit(
                 FILENAME_SEPARATOR, maxsplit=2
-            )  # pipeline_name, load_id, version_hash
+            )  # name, load_id, version_hash
             if len(fileparts) != 3:
                 continue
             # Filters only if pipeline_name provided

--- a/tests/load/filesystem/test_filesystem_client.py
+++ b/tests/load/filesystem/test_filesystem_client.py
@@ -423,17 +423,26 @@ def test_get_storage_version_invalid(invalid_version_info: Union[str, Dict[str, 
             client.get_storage_versions()
 
 
-def test_list_dlt_table_files_with_separator_in_pipeline_name() -> None:
+@pytest.mark.parametrize("pipeline_name",
+    [
+        "my__pipeline",
+        "my_pipeline__long_name__with__underscores",
+        "__",
+        "____",
+        "__long_name__with__underscores__",
+    ],
+)
+def test_list_dlt_table_files_with_separator_in_pipeline_name(pipeline_name: str) -> None:
     filesystem_ = filesystem("random_location")
     client = _client_factory(filesystem_)
     client.initialize_storage()
 
     state_table_dir = client.get_table_dir(client.schema.state_table_name)
     client.fs_client.mkdirs(state_table_dir)
-    test_file = client.pathlib.join(state_table_dir, "my__pipeline__load123__hash123.jsonl")
+    test_file = client.pathlib.join(state_table_dir, f"{pipeline_name}__load123__hash123.jsonl")
     client.fs_client.touch(test_file)
 
     results = list(client._list_dlt_table_files(client.schema.state_table_name))
     assert len(results) == 1
     assert results[0][0] == test_file
-    assert results[0][1] == ["my__pipeline", "load123", "hash123"]
+    assert results[0][1] == [pipeline_name, "load123", "hash123"]


### PR DESCRIPTION
This PR fixes a bug where an existing `_dlt_pipeline_state` tables would be ignored if the `pipeline_name` contained the `FILE_SEPARATOR` (`__`).

Additionally a test for this is added

Resolves #3427 