### PR TITLE
3312: feat(snowflake) - add column_comment/description hint support

### DIFF
--- a/dlt/common/data_writers/escape.py
+++ b/dlt/common/data_writers/escape.py
@@ -152,6 +152,23 @@ def escape_snowflake_identifier(v: str) -> str:
     return escape_postgres_identifier(v)
 
 
+def escape_snowflake_literal(v: Any) -> Any:
+    """Escape string literals for Snowflake using standard SQL escaping.
+
+    Snowflake uses '' to escape single quotes (not backslash escaping).
+    """
+    if isinstance(v, str):
+        # Snowflake uses standard SQL escaping: ' -> ''
+        return "'" + v.replace("'", "''") + "'"
+    if isinstance(v, (datetime, date, time)):
+        return f"'{v.isoformat()}'"
+    if isinstance(v, (list, dict)):
+        return "'" + json.dumps(v).replace("'", "''") + "'"
+    if isinstance(v, bytes):
+        return f"X'{v.hex()}'"
+    return "NULL" if v is None else str(v)
+
+
 escape_databricks_identifier = escape_hive_identifier
 
 


### PR DESCRIPTION
## Summary

Add support for column comments in the Snowflake adapter, allowing users to set column descriptions that propagate to Snowflake.

- Add `escape_snowflake_literal()` function for proper SQL string escaping
- Add `COLUMN_COMMENT_HINT` constant (`x-snowflake-column-comment`) for Snowflake-specific hints
- Override `_get_column_def_sql()` to append `COMMENT` clause to column definitions
- Support both generic `description` field and Snowflake-specific hint for portability

This follows the exact pattern established by the Databricks adapter.

## Usage

```python
# Using generic description field (portable across destinations)
resource.apply_hints(columns={"my_column": {"description": "Column description"}})

# Using Snowflake-specific hint
from dlt.destinations.impl.snowflake.snowflake import COLUMN_COMMENT_HINT
resource.apply_hints(columns={"my_column": {COLUMN_COMMENT_HINT: "Snowflake-specific comment"}})
```

Generated SQL:
```sql
CREATE TABLE my_table (
    my_column VARCHAR COMMENT 'Column description'
)
```

## Test plan

- [x] Add `test_create_table_with_column_comments()` - tests both `description` and `COLUMN_COMMENT_HINT` fields
- [x] Add `test_column_comment_escaping()` - tests special character escaping (`'` → `''`)
- [x] Add `test_alter_table_with_column_comments()` - tests COMMENT in ALTER TABLE statements
- [x] `make format` passes
- [x] `make lint` passes (no new errors)

Fixes #3312