### PR TITLE
fix(typing): add None to Container._Instance typing

### DIFF
--- a/dlt/common/configuration/container.py
+++ b/dlt/common/configuration/container.py
@@ -29,7 +29,7 @@ class Container:
 
     """
 
-    _INSTANCE: ClassVar["Container"] = None
+    _INSTANCE: ClassVar[Optional["Container"]] = None
     _LOCK: ClassVar[threading.Lock] = threading.Lock()
     _MAIN_THREAD_ID: ClassVar[int] = threading.get_ident()
     """A main thread id to which get item will fallback for contexts without default"""


### PR DESCRIPTION
Existing type annotations are incorrect and prevent type checker resolution

## Problem
When using the latest versions of the type checker `ty` (`>= 0.0.1a21`), most symbols in `dlt` can't be resolved. For example, this code

```python
# repro.py
import dlt

def create_pipeline() -> dlt.destinations.duckdb:
    return dlt.destinations.duckdb()
```

Then run

```shell
ty check repro.py
``` 

Output
```shell
error[invalid-type-form]: Variable of type `Never` is not allowed in a type expression
 --> repro.py:3:26
  |
1 | import dlt
2 |
3 | def create_pipeline() -> dlt.destinations.duckdb:
  |                          ^^^^^^^^^^^^^^^^^^^^^^^
4 |     return dlt.destinations.duckdb()
  |
help: The variable may have been inferred as `Never` because its definition was inferred as being unreachable
info: rule `invalid-type-form` is enabled by default

Found 1 diagnostic
``` 

Note that this `Never` block error happens for **a lot** of dlt classes useful for type annotations.

## Why that happens
This is the result of the `assert` statement at the bottom of `dlt/__init__.py`. Given our incorrect annotations of `Container._INSTANCE`, this `assert` is False-y all the time and indicates `dlt.__init__.py` should never probably resolve. This trigger a `Never` type block for anything dowsntream. (can't be reach)

```python
# verify that no injection context was created
from dlt.common.configuration.container import Container as _Container

assert (
    _Container._INSTANCE is None
), "Injection container should not be initialized during initial import"
# create injection container
_Container()
``` 

## Solution
Correctly annotate that the class variable `Container._INSTANCE` can be `Container` or `None`. Running `ty check repro.py` succeeds with this change.

This one line changes removes 87 typing errors when running `ty check dlt/`

## Reference
- Related discussion on the `ty` repo: https://github.com/issues/created?q=is%3Aissue+archived%3Afalse+author%3A%40me+sort%3Aupdated-desc&issue=astral-sh%7Cty%7C1709