### PR TITLE
Fix: 3490 better error message in schema contract application

### DIFF
--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -248,9 +248,9 @@ class Schema:
             if column_mode != "evolve" and not is_variant:
                 if existing_col and is_complete_column(existing_col):
                     error_msg = (
-                        f"Column `{column_name}` in table `{table_name}` already exists with"
-                        " different properties, but `columns` are frozen. Existing column:"
-                        f" {existing_col}. New column with different properties: {column}.\n"
+                        f"Can't evolve table column `{column_name}` in table `{table_name}` because"
+                        " `columns` are frozen. Existing column: {existing_col}. Incoming"
+                        " column: {column}."
                     )
                 else:
                     error_msg = (

--- a/tests/common/schema/test_schema_contract.py
+++ b/tests/common/schema/test_schema_contract.py
@@ -274,9 +274,7 @@ def test_check_adding_new_columns(base_settings) -> None:
         "name": "tables",
         "columns": {"column_3": {"name": "column_3", "data_type": "timestamp", "timezone": True}},
     }
-    assert_new_column(
-        table_update, "column_3", "exists with different properties, but `columns` are frozen"
-    )
+    assert_new_column(table_update, "column_3", "Can't evolve table column")
 
     #
     # check x-normalize evolve_once behaving as evolve override


### PR DESCRIPTION
This PR simply adjusts the error message thrown when the freeze mode on column level is violated with a complete column that already exists but has different properties. 

Resolves #3490 