### PR TITLE
fix/3141 - process Oracle "table not found" exception

### DIFF
--- a/dlt/destinations/impl/sqlalchemy/db_api_client.py
+++ b/dlt/destinations/impl/sqlalchemy/db_api_client.py
@@ -453,6 +453,11 @@ class SqlalchemyClient(SqlClientBase[Connection]):
             return DatabaseTransientException(e)
         elif isinstance(e, sa.exc.IntegrityError):
             return DatabaseTerminalException(e)
+        elif isinstance(e, sa.exc.DatabaseError):
+            if "oracle" in msg:
+                if "00942" in msg and "does not exist" in msg:  # ORA-00942
+                    return DatabaseUndefinedRelation(e)
+            return DatabaseTransientException(e)
         elif isinstance(e, sa.exc.SQLAlchemyError):
             return DatabaseTransientException(e)
         else:


### PR DESCRIPTION
- Resolves #3141 

As seen from the issue and reproduced with `oracledb` driver, `SqlalchemyClient._make_database_exception` doesn't recognise `ORA-00942 table does not exist` to be rethrown as `DatabaseUndefinedRelation`, which is the expected behaviour for first runs when dlt tables don't exist on destination dataset. The reason is that `oracledb` internally doesn't raise neither `sa.exc.ProgrammingError` nor `sa.exc.OperationalError`, but instead raises the superclass generic `sa.exc.DatabaseError`. In this PR, I've added the logic to process only this case individually and raise `DatabaseUndefinedRelation`, otherwise de-facto resort to default logic in the next elif branch - raise generic `DatabaseTransientException`

Tested manually on local Oracle instance