### PR TITLE
Add docs for running streamlit/mcps in runtime

### DIFF
--- a/docs/website/docs/hub/runtime/overview.md
+++ b/docs/website/docs/hub/runtime/overview.md
@@ -293,7 +293,7 @@ The Runtime imports this object to start the server.
 
 Minimal example:
 
-```python
+```py
 from fastmcp import FastMCP
 
 mcp = FastMCP("simple-mcp")


### PR DESCRIPTION
This PR adds documentation about changes in the runtime to add support for mcp servers and streamlit apps. This PR depends on [this](https://github.com/dlt-hub/runtime/pull/228) other one.