### PR TITLE
Feat/3447 - add DECFLOAT support for Snowflake

### DIFF
--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -173,8 +173,8 @@ class SnowflakeClientConfiguration(DestinationClientDwhWithStagingConfiguration)
     use_vectorized_scanner: bool = False
     """Whether to use or not use the vectorized scanner in COPY INTO"""
 
-    unbound_decimal_to_decfloat: bool = False
-    """Whether to convert unbound DECIMALs to DECFLOAT type"""
+    use_decfloat: bool = False
+    """Whether to use DECFLOAT type for unbound decimals instead of DECIMAL"""
 
     def fingerprint(self) -> str:
         """Returns a fingerprint of host part of a connection string"""

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -138,7 +138,7 @@ class SnowflakeClient(SqlJobClientWithStagingDataset, SupportsStagingDestination
         super().__init__(schema, config, sql_client)
         self.config: SnowflakeClientConfiguration = config
         self.sql_client: SnowflakeSqlClient = sql_client  # type: ignore
-        self.type_mapper = self.capabilities.get_type_mapper(config)
+        self.type_mapper = self.capabilities.get_type_mapper(config.use_decfloat)
         self.active_hints = SUPPORTED_HINTS if self.config.create_indexes else {}
 
     def create_load_job(

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -203,6 +203,53 @@ pipeline = dlt.pipeline(destination="snowflake")
 pipeline.run(events())
 ```
 
+### DECFLOAT type
+
+Snowflake's [DECFLOAT](https://docs.snowflake.com/en/sql-reference/data-types-numeric#decfloat) type stores exact decimal values with up to 36 significant digits and a dynamic base-10 exponent. Unlike the standard `DECIMAL(38,9)` type (which fixes the scale at 9), DECFLOAT preserves the exact number of significant digits regardless of where the decimal point falls.
+
+Enable DECFLOAT for unbound decimal columns:
+
+```py
+import dlt
+
+pipeline = dlt.pipeline(
+    destination=dlt.destinations.snowflake(use_decfloat=True),
+    pipeline_name="my_pipeline",
+)
+```
+
+Or via configuration:
+
+```toml
+[destination.snowflake]
+use_decfloat=true
+```
+
+When `use_decfloat` is enabled, decimal columns **without** explicit precision/scale are stored as `DECFLOAT`. Decimal columns **with** explicit precision/scale (e.g. `precision=10, scale=2`) continue to use `NUMBER(p,s)`.
+
+#### Retrieving DECFLOAT data without precision loss
+
+The Snowflake Python connector converts DECFLOAT values to Python `decimal.Decimal` objects during fetch. **Crucially**, it uses the current thread-local decimal context to create these objects. Python's default precision is 28 digits, but DECFLOAT supports up to 36. You **must** increase the decimal context precision before fetching to avoid silent truncation:
+
+```py
+import decimal
+
+# Set precision BEFORE fetching — the connector uses the active context
+with decimal.localcontext() as ctx:
+    ctx.prec = 38  # enough for DECFLOAT's 36 significant digits
+
+    rows = pipeline.dataset().my_table.select("amount").fetchall()
+    # rows[0][0] is a Decimal with full 36-digit precision
+```
+
+Without this, values with more than 28 significant digits are silently rounded at fetch time.
+
+#### Limitations
+
+- **Text-based formats only**: DECFLOAT works with `jsonl` and `csv` loader formats. Parquet staging does not work because Parquet's decimal type uses fixed precision/scale and cannot represent DECFLOAT's dynamic range. Values exceeding `DECIMAL(38,9)` will fail at the normalize step.
+- **No Arrow/DataFrame support**: The Snowflake connector does not recognize DECFLOAT when fetching via Arrow (`pipeline.dataset().table.df()` or `.arrow()`). The DECFLOAT column is returned as a raw dict `{'exponent': ..., 'significand': ...}` instead of a proper value. Use `fetchall()` or `fetchone()` instead.
+- **Python decimal context**: Always set `decimal.getcontext().prec` (or use `decimal.localcontext()`) to at least 38 before fetching DECFLOAT data with more than 28 significant digits.
+
 ## Supported file formats
 * [insert-values](../file-formats/insert-format.md) is used by default.
 * [Parquet](../file-formats/parquet.md) is supported.

--- a/tests/load/pipeline/test_snowflake_pipeline.py
+++ b/tests/load/pipeline/test_snowflake_pipeline.py
@@ -1,3 +1,4 @@
+import decimal
 from copy import deepcopy
 import os
 import pytest
@@ -6,6 +7,7 @@ from pytest_mock import MockerFixture
 
 import dlt
 from dlt.common import pendulum
+from dlt.common.destination import TLoaderFileFormat
 from dlt.common.utils import uniq_id
 from dlt.destinations.exceptions import DatabaseUndefinedRelation
 from dlt.load.exceptions import LoadClientJobFailed
@@ -505,3 +507,236 @@ def test_snowflake_merge_time(destination_config):
     merge_time = time.time() - start_time
     print(f"Merge operation completed in {merge_time:.2f} seconds")
     assert_load_info(merge_info)
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["snowflake"]),
+    ids=lambda x: x.name,
+)
+@pytest.mark.parametrize("loader_file_format", ["jsonl", "csv", "parquet"])
+def test_snowflake_decfloat_loading_and_schema(
+    destination_config: DestinationTestConfiguration,
+    loader_file_format: TLoaderFileFormat,
+) -> None:
+    """Load decimal data using DECFLOAT type and verify across file formats.
+
+    Text-based formats (jsonl, csv) work correctly: INFORMATION_SCHEMA shows DECFLOAT
+    and values round-trip through dataset().fetchall().
+
+    Parquet does NOT work: parquet maps unbound decimals to DECIMAL(38,9) which has only
+    29 integer digits. Values requiring DECFLOAT's full 36-digit range fail at normalize
+    because they overflow the fixed parquet precision.
+    """
+    snow_ = dlt.destinations.snowflake(use_decfloat=True)
+    pipeline = destination_config.setup_pipeline(
+        "test_decfloat_loading",
+        dataset_name="decfloat_test_" + uniq_id(),
+        destination=snow_,
+    )
+
+    # Use values that exceed 128-bit integer range (2^127-1 ≈ 1.7e38) when unscaled.
+    # "1e35" has 36 digits total and its significand exceeds 128-bit capacity, proving
+    # DECFLOAT handles what a fixed-precision 128-bit decimal cannot.
+    val_large = decimal.Decimal("123456789012345678901234567890123456")  # 36 integer digits
+    val_small = decimal.Decimal("0.123456789012345678901234567890123456")  # 36 fractional digits
+
+    @dlt.resource(
+        table_name="decfloat_data",
+        columns=[{"name": "amount", "data_type": "decimal"}],
+    )
+    def decimal_data():
+        yield [
+            {"amount": val_small},
+            {"amount": val_large},
+        ]
+
+    if loader_file_format == "parquet":
+        # Parquet uses fixed-precision DECIMAL(38,9) → 29 integer digits max.
+        # Values exceeding 128-bit range can't be represented in parquet at all, so
+        # the pipeline fails at normalize. Use jsonl or csv for DECFLOAT's full range.
+        with pytest.raises(PipelineStepFailed):
+            pipeline.run(decimal_data(), loader_file_format=loader_file_format)
+        return
+
+    info = pipeline.run(decimal_data(), loader_file_format=loader_file_format)
+    assert_load_info(info)
+
+    # verify the column type in Snowflake's INFORMATION_SCHEMA is DECFLOAT
+    with pipeline.sql_client() as client:
+        _, schema_name, table_names = client._get_information_schema_components("decfloat_data")
+        rows = client.execute_sql(
+            "SELECT data_type FROM INFORMATION_SCHEMA.COLUMNS"
+            f" WHERE table_schema = '{schema_name}'"
+            f" AND table_name = '{table_names[0]}'"
+            " AND column_name = 'AMOUNT'"
+        )
+        assert rows[0][0] == "DECFLOAT"
+
+    # verify data via dataset() fetchall with increased precision context
+    with decimal.localcontext(decimal.Context(prec=38)):
+        rows = pipeline.dataset().decfloat_data.select("amount").order_by("amount").fetchall()
+    assert len(rows) == 2
+    assert rows[0][0] == val_small
+    assert rows[1][0] == val_large
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["snowflake"]),
+    ids=lambda x: x.name,
+)
+def test_snowflake_decfloat_arrow_reading_not_supported(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """The arrow/df path does not correctly handle DECFLOAT columns.
+    The Snowflake connector logs 'unknown snowflake data type : DECFLOAT' and returns
+    a raw dict instead of Decimal. The DB-API path (fetchall()) works correctly."""
+    snow_ = dlt.destinations.snowflake(use_decfloat=True)
+    pipeline = destination_config.setup_pipeline(
+        "test_decfloat_arrow",
+        dataset_name="decfloat_arrow_" + uniq_id(),
+        destination=snow_,
+    )
+
+    @dlt.resource(
+        table_name="decfloat_arrow",
+        columns=[
+            {"name": "amount", "data_type": "decimal"},
+            {"name": "label", "data_type": "text"},
+        ],
+    )
+    def decimal_data():
+        yield [{"amount": decimal.Decimal("42.5"), "label": "test"}]
+
+    info = pipeline.run(decimal_data(), loader_file_format="jsonl")
+    assert_load_info(info)
+
+    # DB-API path via dataset() works correctly
+    rows = pipeline.dataset().decfloat_arrow.select("amount").fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == decimal.Decimal("42.5")
+
+    # arrow path: Snowflake connector doesn't recognize DECFLOAT and returns a raw
+    # structured dict {'exponent': ..., 'significand': ...} instead of a proper Decimal.
+    # Using .arrow() directly to surface the underlying issue without pandas wrapping.
+    table = pipeline.dataset().decfloat_arrow.arrow()
+    assert table is not None
+    val = table.column("amount").to_pylist()[0]
+    assert not isinstance(
+        val, decimal.Decimal
+    ), f"Expected raw dict from arrow path, got Decimal: {val}"
+    assert isinstance(val, dict)
+    assert "exponent" in val and "significand" in val
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["snowflake"]),
+    ids=lambda x: x.name,
+)
+def test_snowflake_decfloat_precision_preservation(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """DECFLOAT stores up to 36 significant digits. Standard DECIMAL(38,9) has only 29 integer
+    digits and 9 fractional, so it can't store a number with 36 significant digits without
+    truncation. This test loads such numbers and verifies exact round-trip.
+
+    Python's default decimal context has prec=28, but DECFLOAT supports 36 digits.
+    We must increase Python's precision context BEFORE fetching so the Snowflake connector
+    creates Decimal objects with full precision.
+    """
+    snow_ = dlt.destinations.snowflake(use_decfloat=True)
+    pipeline = destination_config.setup_pipeline(
+        "test_decfloat_precision",
+        dataset_name="decfloat_prec_" + uniq_id(),
+        destination=snow_,
+    )
+
+    # 36-digit significant figures: can't fit in DECIMAL(38,9) without precision loss
+    # large number: 30 integer digits + 6 fractional = 36 significant digits
+    large_val = decimal.Decimal("123456789012345678901234567890.123456")
+    # small number: 36 fractional significant digits
+    small_val = decimal.Decimal("0.123456789012345678901234567890123456")
+
+    @dlt.resource(
+        table_name="decfloat_precision",
+        columns=[{"name": "val", "data_type": "decimal"}],
+    )
+    def precision_data():
+        yield [
+            {"val": large_val},
+            {"val": small_val},
+        ]
+
+    info = pipeline.run(precision_data(), loader_file_format="jsonl")
+    assert_load_info(info)
+
+    # The Snowflake connector creates Decimal objects using the current thread-local decimal
+    # context, so we MUST set extended precision BEFORE the fetch call.
+    with decimal.localcontext() as ctx:
+        ctx.prec = 38  # enough for DECFLOAT's 36 significant digits
+
+        rows = pipeline.dataset().decfloat_precision.select("val").order_by("val").fetchall()
+        assert len(rows) == 2
+
+        retrieved_small = rows[0][0]
+        retrieved_large = rows[1][0]
+
+        # verify exact round-trip: the values should survive with full precision
+        assert (
+            retrieved_small == small_val
+        ), f"Small value precision loss: {retrieved_small} != {small_val}"
+        assert (
+            retrieved_large == large_val
+        ), f"Large value precision loss: {retrieved_large} != {large_val}"
+
+        # verify addition with extended precision works correctly
+        total = retrieved_small + retrieved_large
+        expected_total = small_val + large_val
+        assert total == expected_total
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["snowflake"]),
+    ids=lambda x: x.name,
+)
+def test_snowflake_decfloat_python_default_precision_warning(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Demonstrate that Python's default decimal precision (28) is insufficient for DECFLOAT's
+    36-digit range. The Snowflake connector creates Decimal objects using the current context
+    during fetch, so fetching with prec=28 already truncates the value."""
+    snow_ = dlt.destinations.snowflake(use_decfloat=True)
+    pipeline = destination_config.setup_pipeline(
+        "test_decfloat_default_prec",
+        dataset_name="decfloat_defprec_" + uniq_id(),
+        destination=snow_,
+    )
+
+    # 36 significant digits: exceeds Python's default prec=28
+    val_36_digits = decimal.Decimal("123456789012345678901234567890.123456")
+
+    @dlt.resource(
+        table_name="decfloat_defprec",
+        columns=[{"name": "val", "data_type": "decimal"}],
+    )
+    def precision_data():
+        yield [{"val": val_36_digits}]
+
+    info = pipeline.run(precision_data(), loader_file_format="jsonl")
+    assert_load_info(info)
+
+    # fetch with default Python precision (28): the connector truncates during fetch
+    rows = pipeline.dataset().decfloat_defprec.select("val").fetchall()
+    retrieved_default = rows[0][0]
+    # 36-digit number is already truncated to 28 significant digits at fetch time
+    assert retrieved_default != val_36_digits
+
+    # fetch with extended precision: the connector preserves all 36 digits
+    with decimal.localcontext() as ctx:
+        ctx.prec = 38
+        rows = pipeline.dataset().decfloat_defprec.select("val").fetchall()
+        retrieved_extended = rows[0][0]
+        assert retrieved_extended == val_36_digits


### PR DESCRIPTION
Implements #3447 . Properly works only on sqlalchemy backend (pyarrow doesn't support floating-point decimals and pandas has even bigger decimal problems)

To be done: 
- implementation: currently, this PR modifies the default behaviour when dlt type is decimal with both precision and scale being None. This is backwards incompatible, so instead of making this new logic the default, it should only work for some opt-in flag/config/...
- tests: add a test for oracle source and snowflake destination to ensure that a column with otherwise unsupported values will work. Oracle type should be `NUMBER()`, we should ensure that a `DECFLOAT` column on Snowflake gets created and that 2 values (one with 30 signs before the comma and another with 30 signs after) are transferred exactly, without loss of data