### PR TITLE
fix: 3514 mermaid reference label

### DIFF
--- a/dlt/helpers/mermaid.py
+++ b/dlt/helpers/mermaid.py
@@ -114,12 +114,8 @@ def _to_mermaid_reference(ref: TTableReferenceStandalone) -> str:
     left_table = ref.get("table")
     right_table = ref.get("referenced_table")
     cardinality = ref.get("cardinality", "one_to_many")
-    label = ref.get("label", '""')
+    label = ref.get("label", "")
     arrow: str = _CARDINALITY_ARROW.get(cardinality).value
 
-    mermaid_reference = f"{left_table} {arrow} {right_table}"
-    if label:
-        mermaid_reference += f" : {label}"
-
-    mermaid_reference += "\n"
+    mermaid_reference = f'{left_table} {arrow} {right_table} : "{label}"\n'
     return mermaid_reference

--- a/tests/helpers/test_mermaid.py
+++ b/tests/helpers/test_mermaid.py
@@ -352,7 +352,7 @@ def test_to_and_from_dbml_table(table: TTableSchema, expected_mermaid_table: str
                 label="ordered",
                 cardinality="zero_to_many",
             ),
-            "customers |o--|{ orders : ordered\n",
+            'customers |o--|{ orders : "ordered"\n',
         ),
         (  # default label
             TTableReferenceStandalone(
@@ -372,7 +372,17 @@ def test_to_and_from_dbml_table(table: TTableSchema, expected_mermaid_table: str
                 referenced_table="orders",
                 label="ordered",
             ),
-            "customers ||--|{ orders : ordered\n",
+            'customers ||--|{ orders : "ordered"\n',
+        ),
+        (  # default cardinality
+            TTableReferenceStandalone(
+                table="customers",
+                columns=["id"],
+                referenced_columns=["customer_id"],
+                referenced_table="orders",
+                label="multi word label",
+            ),
+            'customers ||--|{ orders : "multi word label"\n',
         ),
     ],
 )
@@ -444,12 +454,12 @@ erDiagram
     bigint _dlt_list_idx
     text _dlt_id UK
 }
-    customers }|--|| _dlt_loads : _dlt_load
-    purchases }|--|| _dlt_loads : _dlt_load
+    customers }|--|| _dlt_loads : "_dlt_load"
+    purchases }|--|| _dlt_loads : "_dlt_load"
     purchases ||--|{ customers : ""
-    _dlt_pipeline_state }|--|| _dlt_loads : _dlt_load
-    purchases__items }|--|| purchases : _dlt_parent
-    purchases__items }|--|| purchases : _dlt_root
+    _dlt_pipeline_state }|--|| _dlt_loads : "_dlt_load"
+    purchases__items }|--|| purchases : "_dlt_parent"
+    purchases__items }|--|| purchases : "_dlt_root"
 """
     schema_dict = example_schema.to_dict(remove_processing_hints=remove_process_hints)
     mermaid_str = schema_to_mermaid(
@@ -488,8 +498,8 @@ erDiagram
     text _dlt_id UK
 }
     purchases ||--|{ customers : ""
-    purchases__items }|--|| purchases : _dlt_parent
-    purchases__items }|--|| purchases : _dlt_root
+    purchases__items }|--|| purchases : "_dlt_parent"
+    purchases__items }|--|| purchases : "_dlt_root"
 """
 
     schema_dict = example_schema.to_dict()
@@ -516,12 +526,12 @@ erDiagram
 }
     purchases__items{
 }
-    customers }|--|| _dlt_loads : _dlt_load
-    purchases }|--|| _dlt_loads : _dlt_load
+    customers }|--|| _dlt_loads : "_dlt_load"
+    purchases }|--|| _dlt_loads : "_dlt_load"
     purchases ||--|{ customers : ""
-    _dlt_pipeline_state }|--|| _dlt_loads : _dlt_load
-    purchases__items }|--|| purchases : _dlt_parent
-    purchases__items }|--|| purchases : _dlt_root
+    _dlt_pipeline_state }|--|| _dlt_loads : "_dlt_load"
+    purchases__items }|--|| purchases : "_dlt_parent"
+    purchases__items }|--|| purchases : "_dlt_root"
 """
 
     schema_dict = example_schema.to_dict()


### PR DESCRIPTION
fixes #3514 

Multi-word labels need to be enclosed in `"`. Test added