### PR TITLE
feat: `dlt.Schema.references` includes references with `_dlt_version`

### DIFF
--- a/dlt/common/schema/schema.py
+++ b/dlt/common/schema/schema.py
@@ -660,6 +660,19 @@ class Schema:
 
                 all_references.append(cast(TTableReferenceStandalone, top_level_ref))
 
+        # internal references with `_dlt_version` need to be extracted once
+        try:
+            version_table_hash_ref = utils.create_version_and_loads_hash_reference(
+                self.tables, naming=self.naming
+            )
+            version_table_schema_name_ref = utils.create_version_and_loads_schema_name_reference(
+                self.tables, naming=self.naming
+            )
+            all_references.append(cast(TTableReferenceStandalone, version_table_hash_ref))
+            all_references.append(cast(TTableReferenceStandalone, version_table_schema_name_ref))
+        except ValueError:
+            pass
+
         return all_references
 
     @property

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -57,6 +57,10 @@ C_DESCENDANT_ROOT_REF_LABEL = "_dlt_root"
 """Label of the implicit `TTableReference` between a descendant table and its root table"""
 C_ROOT_LOAD_REF_LABEL = "_dlt_load"
 """Label of the implicit `TTableReference` between a root table and the _dlt_loads table"""
+C_VERSION_SCHEMA_VERSION_LABEL = "_dlt_schema_version"
+"""Label of the implicit TTableReference between {LOAD_TABLE_NAME} and {VERSION_TABLE_NAME} for schema version."""
+C_VERSION_SCHEMA_NAME_LABEL = "_dlt_schema_name"
+"""Label of the implicit TTableReference between {LOAD_TABLE_NAME} and {VERSION_TABLE_NAME} for schema name."""
 
 TColumnProp = Literal[
     "name",

--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -25,6 +25,8 @@ from dlt.common.schema.typing import (
     C_CHILD_PARENT_REF_LABEL,
     C_DESCENDANT_ROOT_REF_LABEL,
     C_ROOT_LOAD_REF_LABEL,
+    C_VERSION_SCHEMA_NAME_LABEL,
+    C_VERSION_SCHEMA_VERSION_LABEL,
     SCHEMA_ENGINE_VERSION,
     LOADS_TABLE_NAME,
     SIMPLE_REGEX_PREFIX,
@@ -1116,7 +1118,7 @@ def create_version_and_loads_hash_reference(
         raise ValueError(f"Table `{load_table_name}` not found in tables: `{list(tables.keys())}`")
 
     return TTableReference(
-        label="_dlt_schema_version",
+        label=C_VERSION_SCHEMA_VERSION_LABEL,
         cardinality="one_to_many",
         table=version_table_name,
         columns=[naming.normalize_identifier("version_hash")],
@@ -1142,7 +1144,7 @@ def create_version_and_loads_schema_name_reference(
         raise ValueError(f"Table `{load_table_name}` not found in tables: `{list(tables.keys())}`")
 
     return TTableReference(
-        label="_dlt_schema_name",
+        label=C_VERSION_SCHEMA_NAME_LABEL,
         cardinality="many_to_many",
         table=version_table_name,
         columns=[naming.normalize_identifier("schema_name")],

--- a/tests/common/schema/test_references.py
+++ b/tests/common/schema/test_references.py
@@ -505,10 +505,26 @@ def test_references_parameterized_by_naming(schema: dlt.Schema, name_normalizer_
             "referenced_table": schema.naming.normalize_identifier("root_table1"),
             "referenced_columns": [schema.naming.normalize_identifier("_dlt_id")],
         },
+        {
+            "label": "_dlt_schema_version",
+            "cardinality": "one_to_many",
+            "table": schema.naming.normalize_identifier("_dlt_version"),
+            "columns": [schema.naming.normalize_identifier("version_hash")],
+            "referenced_table": schema.naming.normalize_identifier("_dlt_loads"),
+            "referenced_columns": [schema.naming.normalize_identifier("schema_version_hash")],
+        },
+        {
+            "label": "_dlt_schema_name",
+            "cardinality": "many_to_many",
+            "table": schema.naming.normalize_identifier("_dlt_version"),
+            "columns": [schema.naming.normalize_identifier("schema_name")],
+            "referenced_table": schema.naming.normalize_identifier("_dlt_loads"),
+            "referenced_columns": [schema.naming.normalize_identifier("schema_name")],
+        },
     ]
 
     assert isinstance(schema.references, list)
-    assert len(schema.references) == 8
+    assert len(schema.references) == 10
     assert isinstance(schema.references[0], dict)
     # check that keys are from TStandaloneTableReference
     # can't do `isinstance(..., TStandaloneTableReference)` on a `TypedDict`

--- a/tests/common/schema/test_schema.py
+++ b/tests/common/schema/test_schema.py
@@ -23,6 +23,8 @@ from dlt.common.schema.typing import (
     C_CHILD_PARENT_REF_LABEL,
     C_DESCENDANT_ROOT_REF_LABEL,
     C_ROOT_LOAD_REF_LABEL,
+    C_VERSION_SCHEMA_NAME_LABEL,
+    C_VERSION_SCHEMA_VERSION_LABEL,
     LOADS_TABLE_NAME,
     VERSION_TABLE_NAME,
     TColumnName,
@@ -885,10 +887,26 @@ def test_schema_references_property(naming: str) -> None:
             "referenced_table": "blocks",
             "referenced_columns": ["_dlt_id"],
         },
+        {
+            "label": "_dlt_schema_version",
+            "cardinality": "one_to_many",
+            "table": "_dlt_version",
+            "columns": ["version_hash"],
+            "referenced_table": "_dlt_loads",
+            "referenced_columns": ["schema_version_hash"],
+        },
+        {
+            "label": "_dlt_schema_name",
+            "cardinality": "many_to_many",
+            "table": "_dlt_version",
+            "columns": ["schema_name"],
+            "referenced_table": "_dlt_loads",
+            "referenced_columns": ["schema_name"],
+        },
     ]
 
     assert isinstance(schema.references, list)
-    assert len(schema.references) == 9
+    assert len(schema.references) == 11
     assert isinstance(schema.references[0], dict)
     # check that keys are from TStandaloneTableReference
     # can't do `isinstance(..., TStandaloneTableReference)` on a `TypedDict`
@@ -904,7 +922,13 @@ def test_schema_references_property(naming: str) -> None:
     )
     # `.references` should return parent-child, root-child, and load-root references
     assert set(ref["label"] for ref in schema.references) == set(
-        [C_CHILD_PARENT_REF_LABEL, C_DESCENDANT_ROOT_REF_LABEL, C_ROOT_LOAD_REF_LABEL]
+        [
+            C_CHILD_PARENT_REF_LABEL,
+            C_DESCENDANT_ROOT_REF_LABEL,
+            C_ROOT_LOAD_REF_LABEL,
+            C_VERSION_SCHEMA_VERSION_LABEL,
+            C_VERSION_SCHEMA_NAME_LABEL,
+        ]
     )
     # normalize table and column names in expected_references
     for reference in expected_references:

--- a/tests/helpers/test_mermaid.py
+++ b/tests/helpers/test_mermaid.py
@@ -460,6 +460,8 @@ erDiagram
     _dlt_pipeline_state }|--|| _dlt_loads : "_dlt_load"
     purchases__items }|--|| purchases : "_dlt_parent"
     purchases__items }|--|| purchases : "_dlt_root"
+    _dlt_version ||--|{ _dlt_loads : "_dlt_schema_version"
+    _dlt_version }|--|{ _dlt_loads : "_dlt_schema_name"
 """
     schema_dict = example_schema.to_dict(remove_processing_hints=remove_process_hints)
     mermaid_str = schema_to_mermaid(
@@ -532,6 +534,8 @@ erDiagram
     _dlt_pipeline_state }|--|| _dlt_loads : "_dlt_load"
     purchases__items }|--|| purchases : "_dlt_parent"
     purchases__items }|--|| purchases : "_dlt_root"
+    _dlt_version ||--|{ _dlt_loads : "_dlt_schema_version"
+    _dlt_version }|--|{ _dlt_loads : "_dlt_schema_name"
 """
 
     schema_dict = example_schema.to_dict()


### PR DESCRIPTION
what the title says! The utility function already existed, but it is now added to `dlt.Schema.references`. Tests were updated