### PR TITLE
Added docs for chunksize and use_pyarrow for parquet reader

### DIFF
--- a/dlt/sources/filesystem/readers.py
+++ b/dlt/sources/filesystem/readers.py
@@ -71,9 +71,8 @@ def _read_parquet(
     Args:
         chunksize (int, optional): The number of records to process at once, defaults to 1000.
         use_pyarrow (bool, optional): When False (default) batches are converted to Python
-            lists for broad destination compatibility; when True, native ``pyarrow``
-            ``RecordBatch`` objects are yielded for zero-copy pipelines and manual schema
-            control.
+            lists of dictionaries for broad destination compatibility; when True, native `pyarrow`
+            `RecordBatch` objects are yielded for zero-copy pipelines.
 
     Returns:
         TDataItem: The file content

--- a/docs/website/docs/dlt-ecosystem/verified-sources/filesystem/basic.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/filesystem/basic.md
@@ -372,10 +372,10 @@ filesystem_pipe = filesystem(
 
 #### Available readers
 
-- `read_csv()` - processes CSV files using [Pandas](https://pandas.pydata.org/)
-- `read_jsonl()` - processes JSONL files chunk by chunk
-- `read_parquet()` - processes Parquet files using [PyArrow](https://arrow.apache.org/docs/python/) control memory usage with `chunksize` (defaults to 1000 rows per batch) and toggle `use_pyarrow` when you want the reader to emit native `pyarrow.RecordBatch` objects instead of Python lists.
-- `read_csv_duckdb()` - this transformer processes CSV files using DuckDB, which usually shows better performance than pandas.
+- `read_csv()` - processes CSV files using [Pandas](https://pandas.pydata.org/). Control batch size with `chunksize` (defaults to 10000 rows). Accepts additional `**pandas_kwargs` passed to `pd.read_csv()`.
+- `read_jsonl()` - processes JSONL files chunk by chunk. Control batch size with `chunksize` (defaults to 1000 lines per batch).
+- `read_parquet()` - processes Parquet files using [PyArrow](https://arrow.apache.org/docs/python/). Control memory usage with `chunksize` (defaults to 1000 rows per batch). Set `use_pyarrow=True` to yield native `pyarrow.RecordBatch` objects instead of Python dictionaries for zero-copy operations.
+- `read_csv_duckdb()` - processes CSV files using DuckDB, which usually shows better performance than Pandas. Control batch size with `chunk_size` (defaults to 5000 rows). Set `use_pyarrow=True` to yield Arrow format instead of JSON. Accepts additional `**duckdb_kwargs` passed to DuckDB's `read_csv()`.
 
 :::tip
 We advise that you give each resource a [specific name](../../../general-usage/resource#duplicate-and-rename-resources) before loading with `pipeline.run`. This will ensure that data goes to a table with the name you want and that each pipeline uses a [separate state for incremental loading.](../../../general-usage/state#read-and-write-pipeline-state-in-a-resource)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
- Documented the _read_parquet use_pyarrow behavior in both the docstring and the filesystem source docs.
- Clarified how enabling or disabling use_pyarrow affects output batches and added guidance on chunksize tuning.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context


<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
