### PR TITLE
feat(filesystem): add Hive partitioning support for filesystem destin…

### DIFF
--- a/dlt/destinations/impl/filesystem/configuration.py
+++ b/dlt/destinations/impl/filesystem/configuration.py
@@ -26,6 +26,17 @@ class FilesystemDestinationClientConfiguration(FilesystemConfigurationWithLocalF
     always_refresh_views: bool = False
     """Always refresh table scanner views by setting the newest table metadata or globbing table files"""
 
+    # Hive partition configuration
+    use_hive_partition: bool = False
+    """Enable Hive-style partitioning with format: {table_name}/partition_column=value/{file}
+    When enabled, files are organized in Hive partition format (e.g., users/loaded_at=2024-01-15/file.parquet)"""
+
+    hive_partition_column: str = "loaded_at"
+    """Column name to use for Hive partitioning (default: 'loaded_at')"""
+
+    hive_partition_date_format: str = "YYYY-MM-DD"
+    """Date format for Hive partition value (default: 'YYYY-MM-DD' which produces '2024-01-15')"""
+
     @resolve_type("credentials")
     def resolve_credentials_type(self) -> Type[CredentialsConfiguration]:
         return super().resolve_credentials_type()
@@ -38,3 +49,10 @@ class FilesystemDestinationClientConfiguration(FilesystemConfigurationWithLocalF
         )
         if unused_placeholders:
             logger.info(f"Found unused layout placeholders: {', '.join(unused_placeholders)}")
+
+        # Log Hive partition configuration
+        if self.use_hive_partition:
+            logger.info(
+                f"Hive partitioning enabled: column='{self.hive_partition_column}', "
+                f"date_format='{self.hive_partition_date_format}'"
+            )

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -134,6 +134,9 @@ class FilesystemLoadJob(RunnableLoadJob):
             current_datetime=self._job_client.config.current_datetime,
             load_package_timestamp=package_timestamp,
             extra_placeholders=self._job_client.config.extra_placeholders,
+            partition_column=self._job_client.config.hive_partition_column,
+            date_format=self._job_client.config.hive_partition_date_format,
+            use_hive_partition=self._job_client.config.use_hive_partition,
         )
         # pick local filesystem pathlib or posix for buckets
         pathlib = self._job_client.config.pathlib


### PR DESCRIPTION
 Key Changes:
  - Consolidated create_path() to support both standard and Hive-partitioned paths
  - Added configuration options: use_hive_partition, hive_partition_column, hive_partition_date_format
  - File structure: {table_name}/{partition_column}={date}/{file}.parquet
  - Default partition column: loaded_at (configurable)
  - Default date format: YYYY-MM-DD (configurable)
  - Backward compatible - standard paths work as before
 

  Configuration Example:
  ```python
  destination = dlt.destinations.filesystem(
      bucket_url="gs://bucket/dlt",
      use_hive_partition=True,
      hive_partition_column="extracted_at",
      hive_partition_date_format="YYYY/MM/DD",
  )

  Result:
  - Standard: balances/123.456.json
  - Hive partitioned: balances/loaded_at=2024-01-16/123.456.json
  Configuration Example:
  ```python
  destination = dlt.destinations.filesystem(
      bucket_url="gs://bucket/dlt",
      use_hive_partition=True,
      hive_partition_column="extracted_at",
      hive_partition_date_format="YYYY/MM/DD",
  )

  Result:
  - Standard: balances/123.456.json
  - Hive partitioned: balances/loaded_at=2024-01-16/123.456.json