### PR TITLE
Making query_result_bucket optional

### DIFF
--- a/dlt/destinations/impl/athena/configuration.py
+++ b/dlt/destinations/impl/athena/configuration.py
@@ -36,6 +36,7 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
     db_location: Optional[str] = None
 
     __config_gen_annotations__: ClassVar[List[str]] = [
+        "query_result_bucket",
         "athena_work_group",
         "aws_data_catalog",
         "info_tables_query_threshold",

--- a/dlt/destinations/impl/athena/factory.py
+++ b/dlt/destinations/impl/athena/factory.py
@@ -195,7 +195,7 @@ class athena(Destination[AthenaClientConfiguration, "AthenaClient"]):
 
     def __init__(
         self,
-        query_result_bucket: str = None,
+        query_result_bucket: Optional[str] = None,
         credentials: Union[AwsCredentials, Dict[str, Any], Any] = None,
         athena_work_group: str = None,
         aws_data_catalog: str = DEFAULT_AWS_DATA_CATALOG,
@@ -209,7 +209,7 @@ class athena(Destination[AthenaClientConfiguration, "AthenaClient"]):
         All arguments provided here supersede other configuration sources such as environment variables and dlt config files.
 
         Args:
-            query_result_bucket (str, optional): S3 bucket to store query results in
+            query_result_bucket (Optional[str], optional): S3 bucket to store query results in. May be omitted when using Athena managed query results.
             credentials (Union[AwsCredentials, Dict[str, Any], Any], optional): AWS credentials to connect to the Athena database. Can be an instance of `AwsCredentials` or
                 a dict with AWS credentials
             athena_work_group (str, optional): Athena work group to use

--- a/docs/website/docs/dlt-ecosystem/destinations/athena.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/athena.md
@@ -46,7 +46,7 @@ pip install pyathena
 so pip does not fail on backtracking.
 :::
 
-To edit the `dlt` credentials file with your secret info, open `.dlt/secrets.toml`. You will need to provide a `bucket_url`, which holds the uploaded parquet files, a `query_result_bucket`, which Athena uses to write query results to, and credentials that have write and read access to these two buckets as well as the full Athena access AWS role.
+To edit the `dlt` credentials file with your secret info, open `.dlt/secrets.toml`. You will need to provide a `bucket_url`, which holds the uploaded parquet files, and credentials that have write and read access to the bucket as well as the full Athena access AWS role. You should also provide a `query_result_bucket`, which Athena uses to write query results to. If your Athena workgroup has [Managed Query Results](https://docs.aws.amazon.com/athena/latest/ug/querying-athena-managed-query-results.html) enabled, omit `query_result_bucket` (or leave it unset) — Athena will manage the results storage automatically.
 
 The TOML file looks like this:
 

--- a/tests/load/athena_iceberg/test_athena_configuration.py
+++ b/tests/load/athena_iceberg/test_athena_configuration.py
@@ -1,5 +1,10 @@
+from typing import cast
+
 from dlt.common.typing import StrAny
-from dlt.destinations.impl.athena.configuration import DEFAULT_AWS_DATA_CATALOG
+from dlt.destinations.impl.athena.configuration import (
+    AthenaClientConfiguration,
+    DEFAULT_AWS_DATA_CATALOG,
+)
 
 from tests.load.utils import S3_TABLES_CATALOG, cm_yield_client
 
@@ -40,3 +45,20 @@ def test_catalog_name() -> None:
         assert client.sql_client.catalog_name(quote=False) == DEFAULT_AWS_DATA_CATALOG
         with client.sql_client.with_staging_dataset():
             assert client.sql_client.catalog_name(quote=False) == "dummycatalog"
+
+
+def test_query_result_bucket_optional() -> None:
+    # query_result_bucket is Optional[str] so it should be resolved even when None.
+    # this enables users with Athena managed query results to omit it.
+    # see: https://github.com/dlt-hub/dlt/issues/3565
+    hints = AthenaClientConfiguration.get_resolvable_fields()
+    # None must be accepted as resolved for optional fields
+    assert AthenaClientConfiguration.is_field_resolved(None, hints["query_result_bucket"])
+    # query_result_bucket maps to pyathena's s3_staging_dir in to_connector_params().
+    # when None, pyathena omits OutputLocation from the StartQueryExecution request,
+    # which is required for workgroups with managed query results.
+    with cm_yield_client("athena", "dummy_dataset") as client:
+        athena_config = cast(AthenaClientConfiguration, client.config)
+        athena_config.query_result_bucket = None
+        connector_params = athena_config.to_connector_params()
+        assert connector_params["s3_staging_dir"] is None


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

This  PR makes `query_result_bucket` optional for the Athena destination. This parameter must be omitted or set to `None` when using Athena's managed results bucket.

This parameter also corresponds to PyAthena's [`s3_staging_dir`](https://laughingman7743.github.io/PyAthena/master/api/connection.html#pyathena.connect) parameter, which is optional.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #3565
- Closes #3565
- Resolves #3565

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
