### PR TITLE
Restore sqlglot version differnt from 28.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "packaging>=21.1",
     "pluggy>=1.3.0",
     "win-precise-time>=1.4.2 ; os_name == 'nt' and python_version < '3.13'",
-    "sqlglot>=25.4.0,<28",
+    "sqlglot>=25.4.0,!=28.1",
     "pywin32>=306 ; sys_platform == 'win32'",
     "rich-argparse>=1.6.0",
 ]


### PR DESCRIPTION
This is a fix for the changes introduced in the sqlglot accidentally in https://github.com/dlt-hub/dlt/pull/3479
I wrote <28 while developing but this PR contains the correct fix that was already present in devel