### PR TITLE
flatten logic; improve typing

### DIFF
--- a/dlt/dataset/dataset.py
+++ b/dlt/dataset/dataset.py
@@ -488,5 +488,5 @@ def _get_latest_load_id(dataset: dlt.Dataset) -> Optional[str]:
         .select(dataset.schema.naming.normalize_identifier(C_DLT_LOADS_TABLE_LOAD_ID))
         .max()
     )
-    load_id: list[str] = query.fetchone()
-    return load_id[0] if load_id else None
+    load_id = query.fetchone()
+    return load_id[0] if load_id else None  # type: ignore[no-any-return]


### PR DESCRIPTION
Remove the dynamic methods `._wrap_iter()` and `._wrap()` from `dlt.Relation`. While convenient, they added confusing steps to the stack trace and muddied the typing. 

Now, the flattened methods `.df()`, `.arrow()`, etc. have explicit typing instead of `Any`.

There should be exactly no behavior change, hence no test update

edit: test failures seem unrelated 