### PR TITLE
repo: excluded zendesk-related tests

### DIFF
--- a/docs/docs_tools/examples/prepare_examples_tests.py
+++ b/docs/docs_tools/examples/prepare_examples_tests.py
@@ -17,6 +17,8 @@ SKIP_EXAMPLES: List[str] = [
     "backfill_in_chunks",
     "connector_x_arrow",
     "transformers",
+    "qdrant_zendesk",
+    "incremental_loading",
 ]
 # Examples will be skipped from forked subprocesses
 SKIP_FORK_EXAMPLES: List[str] = ["custom_destination_lancedb"]


### PR DESCRIPTION
We're currently experiencing issues with our CI Zendesk account. This causes systematic failures in our docs processing CI workflow ([example](https://github.com/dlt-hub/dlt/actions/runs/21372797610/job/61521451388?pr=3578#annotation:15:1163))

We have a custom process to generate test cases from docs examples. I added the two offending tests to the list for exclusion.

I expect this PR to succeed on the the docs processing CI now that Zendesk tests are excluded.