### PR TITLE
docs: Add realistic data masking example with multi-backend support

### DIFF
--- a/docs/website/docs/general-usage/customising-pipelines/pseudonymizing_columns.md
+++ b/docs/website/docs/general-usage/customising-pipelines/pseudonymizing_columns.md
@@ -57,3 +57,143 @@ pipeline = dlt.pipeline(pipeline_name='example', destination='bigquery', dataset
 load_info = pipeline.run(source_instance)
 ```
 
+## Masking columns in SQL database sources
+
+For more realistic use cases, especially when working with SQL database sources, you'll want a reusable function that can mask multiple columns and handle different backends. The example below shows a production-ready approach that:
+
+- Takes column names as parameters (reusable across different tables)
+- Supports multiple backends: `pyarrow`, `connectorx`, `pandas`, and `sqlalchemy`
+- Offers both masking (replacing with a mask string) and nullifying (setting to NULL) methods
+- Uses a closure pattern to capture the column configuration
+
+```py
+from enum import StrEnum
+import pyarrow as pa
+import pandas as pd
+import dlt
+from dlt.sources.sql_database import sql_table
+
+class MaskingMethod(StrEnum):
+    MASK = "mask"
+    NULLIFY = "nullify"
+
+def mask_columns(
+    columns: list[str],
+    method: MaskingMethod = MaskingMethod.MASK,
+    mask: str = "******",
+):
+    """Create a masking function for specified columns in a SQL Database table.
+    
+    This function returns a closure that can be used with add_map() to mask
+    sensitive data across different SQL database backends.
+    
+    All backends supported by the sql_database source are handled:
+    - pyarrow (Arrow tables)
+    - connectorx (Arrow tables)
+    - pandas (DataFrames)
+    - sqlalchemy (dict rows)
+    
+    Args:
+        columns: List of column names to mask
+        method: Either 'mask' (replace with mask string) or 'nullify' (set to NULL)
+        mask: String to use when masking (default: "******")
+    
+    Returns:
+        A function that can be passed to add_map()
+    
+    Example:
+        >>> table = sql_table(table="users")
+        >>> table.add_map(mask_columns(columns=["email", "phone"]))
+        >>> pipeline = dlt.pipeline(destination="duckdb")
+        >>> pipeline.run(table)
+    """
+    def mask_table_or_row(
+        table_or_row: pa.Table | pd.DataFrame | dict,
+    ) -> pa.Table | pd.DataFrame | dict:
+        # Handle PyArrow tables (pyarrow and connectorx backends)
+        if isinstance(table_or_row, pa.Table):
+            table = table_or_row
+            for col in table.schema.names:
+                if col in columns:
+                    if method == MaskingMethod.MASK:
+                        replace_with = pa.array([mask] * table.num_rows)
+                    elif method == MaskingMethod.NULLIFY:
+                        replace_with = pa.nulls(
+                            table.num_rows, type=table.schema.field(col).type
+                        )
+                    table = table.set_column(
+                        table.schema.get_field_index(col),
+                        col,
+                        replace_with,
+                    )
+            return table
+        
+        # Handle Pandas DataFrames (pandas backend)
+        if isinstance(table_or_row, pd.DataFrame):
+            table = table_or_row.copy()
+            for col in table.columns:
+                if col in columns:
+                    if method == MaskingMethod.MASK:
+                        table[col] = mask
+                    elif method == MaskingMethod.NULLIFY:
+                        table[col] = None
+            return table
+        
+        # Handle dict rows (sqlalchemy backend)
+        if isinstance(table_or_row, dict):
+            row = table_or_row.copy()
+            for col in row:
+                if col in columns:
+                    if method == MaskingMethod.MASK:
+                        row[col] = mask
+                    elif method == MaskingMethod.NULLIFY:
+                        row[col] = None
+            return row
+        
+        # Unsupported type
+        raise NotImplementedError(
+            f"Unsupported table type: {type(table_or_row)}. "
+            f"Supported backends: pyarrow, connectorx, pandas, sqlalchemy"
+        )
+    
+    return mask_table_or_row
+
+# Example usage with SQL database source
+table = sql_table(
+    table="customers",
+    backend="pandas"  # or "pyarrow", "connectorx", "sqlalchemy"
+)
+
+# Mask sensitive columns
+table.add_map(mask_columns(columns=["email", "phone", "ssn"]))
+
+# Or use nullify method
+# table.add_map(mask_columns(columns=["email"], method=MaskingMethod.NULLIFY))
+
+pipeline = dlt.pipeline(
+    pipeline_name="masked_data",
+    destination="duckdb",
+    dataset_name="analytics"
+)
+load_info = pipeline.run(table)
+```
+
+### Understanding closures in data masking
+
+The `mask_columns` function above uses a **closure** pattern - it returns an inner function (`mask_table_or_row`) that "remembers" the parameters (`columns`, `method`, `mask`) from its outer scope. This is a powerful pattern because:
+
+1. **Reusability**: You can create multiple masking functions with different configurations
+2. **Clean syntax**: `add_map(mask_columns(["email"]))` is more readable than passing parameters each time
+3. **Encapsulation**: The masking logic is self-contained and configurable
+
+```py
+# Create different masking functions for different needs
+mask_pii = mask_columns(columns=["ssn", "tax_id"], method=MaskingMethod.MASK)
+nullify_optional = mask_columns(columns=["middle_name"], method=MaskingMethod.NULLIFY)
+
+# Apply them to different tables
+customers_table.add_map(mask_pii)
+employees_table.add_map(mask_pii)
+contacts_table.add_map(nullify_optional)
+```
+


### PR DESCRIPTION
## Description

This PR addresses issue #2116 by adding a more realistic and production-ready data masking example to the documentation.

## Changes

- ✅ Added a reusable `mask_columns` function that takes column names as parameters
- ✅ Support for all SQL database backends: `pyarrow`, `connectorx`, `pandas`, and `sqlalchemy`
- ✅ Two masking methods: `MASK` (replace with mask string) and `NULLIFY` (set to NULL)
- ✅ Explanation of closure pattern for developers who may be unfamiliar with this concept
- ✅ Practical examples showing usage with SQL database sources

## Why this matters

The current example uses hardcoded column names, which isn't realistic for production use. The new example demonstrates:

1. **Reusability**: The function can be used across multiple tables with different column configurations
2. **Flexibility**: Supports different backends without code changes
3. **Educational**: Explains the closure pattern, helping non-professional developers understand this important software engineering concept

## Testing

The documentation has been updated with:
- Clear inline documentation
- Type hints for better IDE support
- Multiple usage examples
- Error handling for unsupported backends

Closes #2116

---

**Note**: As this is a documentation-only change, no code tests are needed. The examples follow the pattern from the original issue and have been tested manually.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fdlt-hub%2Fdlt%2Fpull%2F3630&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->