### PR TITLE
feat/Add install command for make test-load-local-p

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,4 +414,3 @@ test-e2e-dashboard-headed: ## Runs dashboard e2e tests with visible browser
 
 create-test-pipelines: ## Creates test pipelines for manual dashboard testing
 	uv run python tests/workspace/helpers/dashboard/example_pipelines.py
-	


### PR DESCRIPTION
This PR adds a convenience make install command to be able to run local load tests on duckdb and filesystem.
The make command changed is not used in CI at all

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 1 failed — [View all](https://hub.continue.dev/inbox/pr/dlt-hub/dlt/3645?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->