### PR TITLE
fix(dashboard): fix data quality checks component 

### DIFF
--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -615,25 +615,20 @@ def section_data_quality_raw_table(
     ):
         try:
             # Import constants from data_quality module (using private names to avoid conflicts)
+            from dlthub import data_quality as dq
             from dlthub.data_quality.storage import (
-                DLT_CHECKS_RESULTS_TABLE_NAME as _DLT_CHECKS_RESULTS_TABLE_NAME,
+                DLT_CHECKS_TABLE_NAME as _DLT_CHECKS_RESULTS_TABLE_NAME,
                 DLT_DATA_QUALITY_SCHEMA_NAME as _DLT_DATA_QUALITY_SCHEMA_NAME,
             )
 
             _error_message: str = None
             with mo.status.spinner(title="Loading raw data quality checks table..."):
                 try:
-                    # Build query to select all columns including _dlt_load_id
-                    _raw_dataset = dlt_pipeline.dataset(schema=_DLT_DATA_QUALITY_SCHEMA_NAME)
-                    _raw_sql_query = (
-                        _raw_dataset.table(_DLT_CHECKS_RESULTS_TABLE_NAME)
-                        .limit(1000)
-                        .to_sql(pretty=True, _raw_query=True)
-                    )
+                    _raw_sql_query = dq.read_check(dlt_pipeline.dataset())
 
                     # Execute query
                     _raw_query_result, _error_message, _traceback_string = utils.get_query_result(
-                        dlt_pipeline, _raw_sql_query
+                        dlt_pipeline, _raw_sql_query.to_sql()
                     )
                     dlt_set_last_query_result(_raw_query_result)
                 except Exception as exc:


### PR DESCRIPTION
The latest `dlthub` release included changes to data quality checks. This silently broke code in `dlt`.

This shows some of the challenges of developing and testing across repos.


I believe moving forward with [composable widgets PR](https://github.com/dlt-hub/dlt/pull/3613) will allow us to better tests marimo components and maintain separation of concerns between `dlthub` and `dlt`


NOTE this works as intended only when `dlthub` is installed from [this PR](https://github.com/dlt-hub/dlthub/pull/408).

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 1 failed — [View all](https://hub.continue.dev/inbox/pr/dlt-hub/dlt/3647?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->