### PR TITLE
Fix: Mermaid doesn't handle incomplete columns

### DIFF
--- a/dlt/helpers/mermaid.py
+++ b/dlt/helpers/mermaid.py
@@ -62,7 +62,10 @@ def _to_mermaid_table(
 
 # TODO add scale & precision to `data_type`
 def _to_mermaid_column(column: TColumnSchema, hide_descriptions: bool = False) -> str:
-    mermaid_col = column.get("data_type", "unknown") + " " + column["name"]
+    # NOTE: incomplete columns (no data_type) currently arise from "seen-null-first" propagation
+    # (columns whose first observed values were all null). if that propagation is removed so that
+    # incomplete columns no longer reach the schema, this fallback should be revisited.
+    mermaid_col = column.get("data_type", "no_data_seen") + " " + column["name"]
     keys = []
     if column.get("primary_key"):
         keys.append("PK")

--- a/tests/helpers/test_mermaid.py
+++ b/tests/helpers/test_mermaid.py
@@ -313,7 +313,7 @@ EXPECTED_MERMAID_STR = """
         ),
         (
             {"name": "incomplete_col"},  # no data_type set yet
-            "unknown incomplete_col\n",
+            "no_data_seen incomplete_col\n",
         ),
     ],
 )


### PR DESCRIPTION
When a column is in the source but doesn't have data, it is set in the schema without data_type. Mermaid is not able to handle this becuase it directly tries to access `column["data_type"]`

PS: The mcp used in skills is consistently failing to use mermaid because of this.