### PR TITLE
feat(workspace): add ignore_file_found attribute to WorkspaceFileSelector

### DIFF
--- a/dlt/_workspace/deployment/file_selector.py
+++ b/dlt/_workspace/deployment/file_selector.py
@@ -4,7 +4,6 @@ from pathspec import PathSpec
 from pathspec.util import iter_tree_files
 
 from dlt._workspace._workspace_context import WorkspaceRunContext
-from dlt._workspace.cli import echo as fmt
 
 
 class BaseFileSelector(Iterable[Tuple[Path, Path]]):
@@ -32,6 +31,7 @@ class WorkspaceFileSelector(BaseFileSelector):
         self.root_path: Path = Path(context.run_dir).resolve()
         self.settings_dir: Path = Path(context.settings_dir).resolve()
         self.ignore_file: str = ignore_file
+        self.ignore_file_found: bool = False
         self.ignore_spec: PathSpec = self._build_pathspec(additional_excludes or [])
 
     def _build_pathspec(self, additional_excludes: List[str]) -> PathSpec:
@@ -43,12 +43,7 @@ class WorkspaceFileSelector(BaseFileSelector):
         if ignore_path.exists():
             with ignore_path.open("r", encoding="utf-8") as f:
                 patterns.extend(f.read().splitlines())
-        else:
-            fmt.secho(
-                f"⚠️ No {self.ignore_file} found. Only built-in excludes are active.\n"
-                f"   Consider adding a {self.ignore_file} to control what gets deployed.",
-                fg="yellow",
-            )
+            self.ignore_file_found = True
 
         # Add caller-provided excludes
         patterns.extend(additional_excludes)

--- a/tests/workspace/deployment/test_file_selector.py
+++ b/tests/workspace/deployment/test_file_selector.py
@@ -32,13 +32,18 @@ def test_file_selector_respects_gitignore(with_additional_exclude: bool) -> None
         assert files == expected_files
 
 
-def test_file_selector_warns_on_missing_ignore_file(capsys: pytest.CaptureFixture[str]) -> None:
-    """Warning is emitted when the configured ignore file does not exist."""
+def test_file_selector_ignore_file_not_found() -> None:
+    """ignore_file_found is False when the configured ignore file does not exist."""
     with isolated_workspace("default") as ctx:
-        WorkspaceFileSelector(ctx, ignore_file=".nonexistent_ignore")
-    captured = capsys.readouterr()
-    assert "No .nonexistent_ignore found" in captured.out
-    assert "Consider adding a .nonexistent_ignore" in captured.out
+        selector = WorkspaceFileSelector(ctx, ignore_file=".nonexistent_ignore")
+    assert selector.ignore_file_found is False
+
+
+def test_file_selector_ignore_file_found() -> None:
+    """ignore_file_found is True when the configured ignore file exists."""
+    with isolated_workspace("default") as ctx:
+        selector = WorkspaceFileSelector(ctx, ignore_file=".ignorefile")
+    assert selector.ignore_file_found is True
 
 
 def test_configuration_file_selector() -> None:


### PR DESCRIPTION
Add ignore_file_found attribute to WorkspaceFileSelector so consumers can check whether the configured ignore file (e.g. .gitignore) was found
