### PR TITLE
feat: add row_filter to merge write disposition for partition-scoped operations

### DIFF
--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -266,6 +266,7 @@ class TWriteDispositionDict(TypedDict):
 
 class TMergeDispositionDict(TWriteDispositionDict):
     strategy: Optional[TLoaderMergeStrategy]
+    row_filter: Optional[str]
 
 
 class TDeleteInsertStrategyDict(TMergeDispositionDict):

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -172,10 +172,13 @@ class BigQueryMergeJob(SqlMergeFollowupJob):
         staging_root_table_name: str,
         key_clauses: Sequence[str],
         for_delete: bool,
+        row_filter: Optional[str] = None,
     ) -> List[str]:
+        row_filter_clause = f" AND ({row_filter})" if row_filter else ""
         sql: List[str] = [
             f"FROM {root_table_name} AS d WHERE EXISTS (SELECT 1 FROM {staging_root_table_name} AS"
             f" s WHERE {clause.format(d='d', s='s')})"
+            + row_filter_clause
             for clause in key_clauses
         ]
         return sql

--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -245,10 +245,19 @@ class ClickHouseMergeJob(SqlMergeFollowupJob):
         staging_root_table_name: str,
         key_clauses: Sequence[str],
         for_delete: bool,
+        row_filter: Optional[str] = None,
     ) -> List[str]:
         join_conditions = " OR ".join([c.format(d="d", s="s") for c in key_clauses])
+        # row_filter scopes destination rows; use subquery to avoid column ambiguity
+        if row_filter:
+            dest_ref = (
+                f"(SELECT * FROM {root_table_name} WHERE {row_filter}) AS d"
+            )
+        else:
+            dest_ref = f"{root_table_name} AS d"
         return [
-            f"FROM {root_table_name} AS d JOIN {staging_root_table_name} AS s ON {join_conditions}"
+            f"FROM {dest_ref} JOIN {staging_root_table_name} AS s ON"
+            f" {join_conditions}"
         ]
 
     @classmethod

--- a/dlt/destinations/impl/ducklake/ducklake.py
+++ b/dlt/destinations/impl/ducklake/ducklake.py
@@ -85,6 +85,7 @@ class DuckLakeMergeFollowupJob(SqlMergeFollowupJob):
         root_table_column_names: Sequence[str],
         hard_delete_col: Optional[str],
         deleted_cond: Optional[str],
+        row_filter: Optional[str] = None,
     ) -> List[str]:
         """Generate MERGE statement without DELETE clause + separate DELETE for hard deletes."""
         # Get MERGE statement from base class without DELETE clause (pass hard_delete_col=None)

--- a/dlt/destinations/impl/mssql/mssql.py
+++ b/dlt/destinations/impl/mssql/mssql.py
@@ -60,17 +60,20 @@ class MsSqlMergeJob(SqlMergeFollowupJob):
         staging_root_table_name: str,
         key_clauses: Sequence[str],
         for_delete: bool,
+        row_filter: Optional[str] = None,
     ) -> List[str]:
         """Generate sql clauses that may be used to select or delete rows in root table of destination dataset"""
+        row_filter_clause = f" AND ({row_filter})" if row_filter else ""
         if for_delete:
             # MS SQL doesn't support alias in DELETE FROM
             return [
                 f"FROM {root_table_name} WHERE EXISTS (SELECT 1 FROM"
                 f" {staging_root_table_name} WHERE"
                 f" {' OR '.join([c.format(d=root_table_name,s=staging_root_table_name) for c in key_clauses])})"
+                + row_filter_clause
             ]
         return SqlMergeFollowupJob.gen_key_table_clauses(
-            root_table_name, staging_root_table_name, key_clauses, for_delete
+            root_table_name, staging_root_table_name, key_clauses, for_delete, row_filter
         )
 
     @classmethod

--- a/dlt/destinations/impl/redshift/redshift.py
+++ b/dlt/destinations/impl/redshift/redshift.py
@@ -157,19 +157,22 @@ class RedshiftMergeJob(SqlMergeFollowupJob):
         staging_root_table_name: str,
         key_clauses: Sequence[str],
         for_delete: bool,
+        row_filter: Optional[str] = None,
     ) -> List[str]:
         """Generate sql clauses that may be used to select or delete rows in root table of destination dataset
 
         A list of clauses may be returned for engines that do not support OR in subqueries. Like BigQuery
         """
+        row_filter_clause = f" AND ({row_filter})" if row_filter else ""
         if for_delete:
             return [
                 f"FROM {root_table_name} WHERE EXISTS (SELECT 1 FROM"
                 f" {staging_root_table_name} WHERE"
                 f" {' OR '.join([c.format(d=root_table_name,s=staging_root_table_name) for c in key_clauses])})"
+                + row_filter_clause
             ]
         return SqlMergeFollowupJob.gen_key_table_clauses(
-            root_table_name, staging_root_table_name, key_clauses, for_delete
+            root_table_name, staging_root_table_name, key_clauses, for_delete, row_filter
         )
 
 

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -41,10 +41,13 @@ class SnowflakeMergeJob(SqlMergeFollowupJob):
         staging_root_table_name: str,
         key_clauses: Sequence[str],
         for_delete: bool,
+        row_filter: Optional[str] = None,
     ) -> List[str]:
+        row_filter_clause = f" AND ({row_filter})" if row_filter else ""
         sql: List[str] = [
             f"FROM {root_table_name} AS d WHERE EXISTS (SELECT 1 FROM {staging_root_table_name} AS"
             f" s WHERE {clause.format(d='d', s='s')})"
+            + row_filter_clause
             for clause in key_clauses
         ]
         return sql

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -670,6 +670,9 @@ class DltResourceHints:
         if deduplicated := md_dict.get("deduplicated"):
             dict_["x-stage-data-deduplicated"] = deduplicated
 
+        if row_filter := md_dict.get("row_filter"):
+            dict_["x-row-filter"] = row_filter
+
         if merge_strategy == "scd2":
             md_dict = cast(TScd2StrategyDict, md_dict)
             if "boundary_timestamp" in md_dict:

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -1872,3 +1872,256 @@ def test_replacing_merge_key(destination_config: DestinationTestConfiguration) -
     assert sorted(observed, key=lambda d: (d["email"], d["month_key"])) == sorted(
         expected, key=lambda d: (d["email"], d["month_key"])
     )
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, supports_merge=True),
+    ids=lambda x: x.name,
+)
+@pytest.mark.parametrize("merge_strategy", ("delete-insert", "upsert"))
+def test_row_filter(
+    destination_config: DestinationTestConfiguration,
+    merge_strategy: TLoaderMergeStrategy,
+) -> None:
+    skip_if_unsupported_merge_strategy(destination_config, merge_strategy)
+    table_name = "test_row_filter"
+
+    @dlt.resource(
+        name=table_name,
+        write_disposition={
+            "disposition": "merge",
+            "strategy": merge_strategy,
+        },
+        primary_key="id",
+    )
+    def data_resource(data):
+        yield data
+
+    p = destination_config.setup_pipeline("row_filter_test", dev_mode=True)
+
+    # insert records in two partitions, with id=1 appearing in both
+    initial_data = [
+        {"id": 1, "val": "a", "partition_date": "2024-01-15"},
+        {"id": 2, "val": "b", "partition_date": "2024-01-15"},
+        {"id": 3, "val": "c", "partition_date": "2024-01-16"},
+    ]
+    info = p.run(data_resource(initial_data), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(p, table_name)[table_name] == 3
+
+    # merge with row_filter scoped to partition 2024-01-15
+    # staging contains id=1 (update) and id=3 (same key as other partition)
+    data_resource.apply_hints(
+        write_disposition={
+            "disposition": "merge",
+            "strategy": merge_strategy,
+            "row_filter": "partition_date = '2024-01-15'",
+        },
+    )
+    update_data = [
+        {"id": 1, "val": "updated_a", "partition_date": "2024-01-15"},
+        {"id": 3, "val": "should_not_touch_other_partition", "partition_date": "2024-01-15"},
+    ]
+    info = p.run(data_resource(update_data), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    observed = [
+        {"id": row[0], "val": row[1], "partition_date": row[2]}
+        for row in select_data(p, f"SELECT id, val, partition_date FROM {table_name}")
+    ]
+    observed = sorted(observed, key=lambda d: (d["partition_date"], d["id"]))
+
+    # row_filter ensures only partition 2024-01-15 rows are affected
+    # id=3 in partition 2024-01-16 is NOT deleted/updated despite matching staging key
+    expected = [
+        {"id": 1, "val": "updated_a", "partition_date": "2024-01-15"},
+        {"id": 2, "val": "b", "partition_date": "2024-01-15"},
+        {"id": 3, "val": "should_not_touch_other_partition", "partition_date": "2024-01-15"},
+        {"id": 3, "val": "c", "partition_date": "2024-01-16"},
+    ]
+    assert observed == expected
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, supports_merge=True),
+    ids=lambda x: x.name,
+)
+def test_row_filter_apply_hints(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Test that row_filter can be set dynamically via apply_hints."""
+    table_name = "test_row_filter_dynamic"
+
+    @dlt.resource(
+        name=table_name,
+        write_disposition="merge",
+        primary_key="id",
+    )
+    def data_resource(data):
+        yield data
+
+    p = destination_config.setup_pipeline("row_filter_dynamic", dev_mode=True)
+
+    # initial load with two partitions
+    initial_data = [
+        {"id": 1, "val": "a", "part": "A"},
+        {"id": 2, "val": "b", "part": "A"},
+        {"id": 3, "val": "c", "part": "B"},
+    ]
+    info = p.run(data_resource(initial_data), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(p, table_name)[table_name] == 3
+
+    # dynamically apply row_filter for partition B only
+    data_resource.apply_hints(
+        write_disposition={
+            "disposition": "merge",
+            "row_filter": "part = 'B'",
+        },
+    )
+    update_data = [
+        {"id": 3, "val": "updated_c", "part": "B"},
+        {"id": 4, "val": "d", "part": "B"},
+    ]
+    info = p.run(data_resource(update_data), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    observed = [
+        {"id": row[0], "val": row[1]}
+        for row in select_data(p, f"SELECT id, val FROM {table_name}")
+    ]
+    observed = sorted(observed, key=lambda d: d["id"])
+    # partition A untouched (ids 1,2), partition B replaced (id 3 updated, id 4 added)
+    expected = [
+        {"id": 1, "val": "a"},
+        {"id": 2, "val": "b"},
+        {"id": 3, "val": "updated_c"},
+        {"id": 4, "val": "d"},
+    ]
+    assert observed == expected
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, supports_merge=True),
+    ids=lambda x: x.name,
+)
+def test_row_filter_nested_tables(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Test row_filter with nested child tables (exercises the temp table code path)."""
+    p = destination_config.setup_pipeline("row_filter_nested", dev_mode=True)
+
+    @dlt.resource(
+        table_name="parent",
+        write_disposition="merge",
+        primary_key="id",
+    )
+    def r(data):
+        yield data
+
+    # initial load: two partitions with child records
+    initial = [
+        {"id": 1, "part": "A", "child": [{"val": "c1"}]},
+        {"id": 2, "part": "A", "child": [{"val": "c2"}]},
+        {"id": 3, "part": "B", "child": [{"val": "c3"}, {"val": "c4"}]},
+    ]
+    info = p.run(r(initial), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(p, "parent")["parent"] == 3
+    assert load_table_counts(p, "parent__child")["parent__child"] == 4
+
+    # merge scoped to partition A only
+    r.apply_hints(
+        write_disposition={
+            "disposition": "merge",
+            "row_filter": "part = 'A'",
+        },
+    )
+    update = [
+        {"id": 1, "part": "A", "child": [{"val": "c1_updated"}]},
+    ]
+    info = p.run(r(update), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    # partition B (id=3) must be untouched: parent + 2 child rows
+    assert load_table_counts(p, "parent")["parent"] == 3
+    parent_rows = load_tables_to_dicts(p, "parent", exclude_system_cols=True)["parent"]
+    assert_records_as_set(
+        parent_rows,
+        [
+            {"id": 1, "part": "A"},
+            {"id": 2, "part": "A"},
+            {"id": 3, "part": "B"},
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, supports_merge=True),
+    ids=lambda x: x.name,
+)
+def test_row_filter_with_hard_delete(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Test row_filter + hard_delete with upsert strategy (exercises hard_delete branches
+    in _gen_upsert_update_insert_sql)."""
+    table_name = "test_row_filter_hard_del"
+
+    @dlt.resource(
+        name=table_name,
+        write_disposition={
+            "disposition": "merge",
+            "strategy": "upsert",
+            "row_filter": "part = 'A'",
+        },
+        primary_key="id",
+        columns={"deleted": {"hard_delete": True}},
+    )
+    def data_resource(data):
+        yield data
+
+    p = destination_config.setup_pipeline("row_filter_hard_del", dev_mode=True)
+
+    # initial load: no row_filter for first load (so both partitions load)
+    data_resource.apply_hints(
+        write_disposition={"disposition": "merge", "strategy": "upsert"},
+    )
+    initial = [
+        {"id": 1, "val": "a", "part": "A", "deleted": False},
+        {"id": 2, "val": "b", "part": "A", "deleted": False},
+        {"id": 3, "val": "c", "part": "B", "deleted": False},
+    ]
+    info = p.run(data_resource(initial), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(p, table_name)[table_name] == 3
+
+    # apply row_filter, hard-delete id=1 and update id=2, partition B untouched
+    data_resource.apply_hints(
+        write_disposition={
+            "disposition": "merge",
+            "strategy": "upsert",
+            "row_filter": "part = 'A'",
+        },
+    )
+    update = [
+        {"id": 1, "val": "a", "part": "A", "deleted": True},
+        {"id": 2, "val": "b_updated", "part": "A", "deleted": False},
+    ]
+    info = p.run(data_resource(update), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    observed = [
+        {"id": row[0], "val": row[1], "part": row[2]}
+        for row in select_data(p, f"SELECT id, val, part FROM {table_name}")
+    ]
+    observed = sorted(observed, key=lambda d: d["id"])
+    # id=1 hard-deleted, id=2 updated, id=3 (partition B) untouched
+    expected = [
+        {"id": 2, "val": "b_updated", "part": "A"},
+        {"id": 3, "val": "c", "part": "B"},
+    ]
+    assert observed == expected


### PR DESCRIPTION
### Description

Adds an optional `row_filter` field to `TMergeDispositionDict` — a raw SQL predicate that scopes DELETE/UPDATE operations to a subset of the destination table during merge. Equivalent to dbt's `incremental_predicates`.

**Usage:**
```python
@dlt.resource(
    write_disposition={
        "disposition": "merge",
        "strategy": "delete-insert",
        "row_filter": "partition_date = '2024-01-15'",
    },
    primary_key="id",
)
def my_resource():
    yield data
```

**Design:**
- Supports all 3 strategies: `delete-insert`, `upsert`, `scd2`
- For `upsert`: decomposed into DELETE + INSERT (instead of MERGE) to avoid column name ambiguity in MERGE ON clause
- Backward compatible: optional field, defaults to None
- Nested tables scoped transitively through root table temp table IDs

**Test coverage (DuckDB, all pass, no regressions):**
- delete-insert with cross-partition key protection
- upsert (decomposed DELETE+INSERT path)
- dynamic row_filter via `apply_hints`
- nested child tables (temp table code path)
- upsert + hard_delete combination
- scd2 retire + insert with partition scoping

**Not covered (need CI / external services):**
- SQLAlchemy `gen_merge_sql` and `gen_scd2_sql` with row_filter
- ClickHouse subquery path in `gen_key_table_clauses`
- BigQuery / Snowflake / Redshift / MSSQL overrides (identical pattern to base, tested via DuckDB)

### Related Issues

- Relates to #2039
- Relates to #2279
- Relates to #2957
- Relates to #3396
- Relates to #3655

### Additional Context

First-time contributor. This is a feature I need for partition-scoped merges in a Redshift pipeline at work. Happy to iterate on the implementation based on feedback.
