### PR TITLE
feat(pipeline): context manager for pre/post operation on `pipeline.run()`

### DIFF
--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -782,8 +782,11 @@ class Pipeline(SupportsPipeline):
     ) -> LoadInfo:
         """Extracts, normalizes and loads data in a single pass.
 
-        Called from `run` within an active trace transaction. Override to wrap or
-        extend the extract-normalize-load cycle while staying in one trace.
+        Intended to be overriden in derived classes to extend the loading process
+        with additional load packages coming from "sidecar" data like data quarantine
+        or quality metrics.
+
+        Use ``dlt.pipeline(..., _impl_cls=MyPipeline)`` to activate the subclass.
         """
         self.extract(
             data,

--- a/dlt/pipeline/trace.py
+++ b/dlt/pipeline/trace.py
@@ -15,6 +15,7 @@ from dlt.common.configuration.utils import get_resolved_traces
 from dlt.common.configuration.container import Container
 from dlt.common.exceptions import ExceptionTrace, ResourceNameNotAvailable
 from dlt.common.logger import suppress_and_warn
+from dlt.common.runtime.tracking import SupportsTracking
 from dlt.common.runtime.exec_info import TExecutionContext, get_execution_context
 from dlt.common.pipeline import (
     ExtractInfo,
@@ -37,6 +38,8 @@ from dlt.pipeline.exceptions import PipelineStepFailed
 
 TRACE_ENGINE_VERSION = 1
 TRACE_FILE_NAME = "trace.pickle"
+# plug in your own tracking modules here
+TRACKING_MODULES: List[SupportsTracking] = None
 
 
 # @dataclasses.dataclass(init=True)
@@ -196,13 +199,6 @@ class PipelineTrace(SupportsHumanize, _PipelineTrace):
 
     def __str__(self) -> str:
         return self.asstr(verbosity=0)
-
-
-from dlt.common.runtime.tracking import SupportsTracking
-
-
-# plug in your own tracking modules here
-TRACKING_MODULES: List[SupportsTracking] = None
 
 
 def start_trace(step: TPipelineStep, pipeline: SupportsPipeline) -> PipelineTrace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "orjson>=3.10.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "orjson>=3.11.0 ; python_version > '3.13'",
     "tenacity>=8.0.2",
-    "jsonpath-ng>=1.5.3",
+    "jsonpath-ng>=1.5.3,<1.8",
     "fsspec>=2022.4.0",
     "packaging>=21.1",
     "pluggy>=1.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2374,7 +2374,7 @@ requires-dist = [
     { name = "humanize", specifier = ">=4.4.0" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10' and extra == 'lancedb'", specifier = ">=12.0.0" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10' and extra == 'workspace'", specifier = ">=12.0.0" },
-    { name = "jsonpath-ng", specifier = ">=1.5.3" },
+    { name = "jsonpath-ng", specifier = ">=1.5.3,<1.8" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.22.0" },
     { name = "marimo", marker = "extra == 'workspace'", specifier = ">=0.14.5" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'workspace'", specifier = ">=1.13.0" },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR enables and demonstrates customization of the run method: it injects additional data to be loaded in the same trace transaction in an idempotent (can be retried) way.

See the included test for PoC
