### PR TITLE
fix: set start_out_of_range flag when row equals start_value with ran…

### DIFF
--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -328,7 +328,7 @@ class JsonIncremental(IncrementalTransform):
 
             if self.range_start == "open" and processed_row_value == self.start_value:
                 # We only want greater than start_value
-                return None, False, False
+                return None, True, False
 
             # skip the record that is not a start_value or new_value: that record was already processed
             if self.start_value is None:

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -2302,6 +2302,29 @@ def test_out_of_range_flags(item_type: TestDataItemFormat) -> None:
 
 
 @pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
+def test_start_out_of_range_open_equals_start_value(item_type: TestDataItemFormat) -> None:
+    """start_out_of_range is set when row equals start_value with range_start='open'"""
+
+    @dlt.resource
+    def descending(
+        updated_at: dlt.sources.incremental[int] = dlt.sources.incremental(
+            "updated_at", initial_value=10, row_order="desc", range_start="open"
+        )
+    ) -> Any:
+        # descending from 12 down to 8, with value 10 == start_value
+        for i in [12, 11, 10, 9, 8]:
+            yield data_to_item_format(item_type, [{"updated_at": i}])
+            # 10 equals start_value and range_start="open" so it's out of range
+            if i <= 10:
+                assert updated_at.start_out_of_range is True
+
+    # early stopping should close the generator when row_order="desc"
+    data = list(descending)
+    # only 12 and 11 are > 10 (open range excludes 10)
+    assert data_item_length(data) == 2
+
+
+@pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
 def test_async_row_order_out_of_range(item_type: TestDataItemFormat) -> None:
     @dlt.resource
     async def descending(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->

### Description
`JsonIncremental.__call__()` returned `start_out_of_range=False` when a row's cursor value equaled `start_value` with `range_start="open"`. This delayed `can_close()` by one yield iteration for `row_order="desc"` pipelines.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->

### Related Issues
- Closes #3707