### PR TITLE
Fix LanceDB SQL view creation when dataset name is not set

### DIFF
--- a/dlt/destinations/impl/lancedb/sql_client.py
+++ b/dlt/destinations/impl/lancedb/sql_client.py
@@ -124,9 +124,19 @@ class LanceDBSQLClient(DuckDbSqlClient):
 
     def create_view(self, table_name: str) -> None:
         lance_table_uri = get_lance_table_uri(self.lancedb_client, table_name)
+
+        # lancedb allows omitting the dataset_name, calling `make_qualified_table_name` will
+        # prepend the dataset_name even if it is None
+        if self.dataset_name:
+            view_name = self.make_qualified_table_name(table_name)
+        else:
+            view_name = self.capabilities.escape_identifier(
+                self.capabilities.casefold_identifier(table_name)
+            )
+
         create_view_sql = _prepare_create_view_statement(
             lance_table_uri=lance_table_uri,
-            view_name=self.make_qualified_table_name(table_name),
+            view_name=view_name,
         )
         try:
             self.open_connection().execute(create_view_sql)

--- a/tests/load/lancedb/test_pipeline.py
+++ b/tests/load/lancedb/test_pipeline.py
@@ -561,6 +561,10 @@ def test_empty_dataset_allowed() -> None:
     assert client.sentinel_table == "dltSentinelTable"  # type: ignore
     assert_table(pipe, "content", expected_items_count=3)
 
+    dataset = pipe.dataset()
+    rows = dataset.content.select("value").fetchall()
+    assert len(rows) == 3
+
 
 def test_lancedb_remove_nested_orphaned_records_with_chunks() -> None:
     @dlt.resource(


### PR DESCRIPTION
- Fix create_view in LanceDBSqlClient to handle the case where dataset_name is None. Previously, make_qualified_table_name was called unconditionally, which would prepend a None dataset prefix to the view name. Now, when no dataset name is configured, the table name is escaped and casefolded directly.
- Add a query assertion to the test_lancedb_pipeline_no_dataset_name test to verify that SQL reads via dataset.content.select(...) work correctly without a dataset name.

Fixes #3702 