### PR TITLE
Fixed the mapping of timezone in sql timestamp datatype

### DIFF
--- a/dlt/sources/sql_database/schema_types.py
+++ b/dlt/sources/sql_database/schema_types.py
@@ -164,7 +164,7 @@ def sqla_col_to_column_schema(
     elif isinstance(sql_t, sqltypes.DateTime):
         col["data_type"] = "timestamp"
         # special handling for MSSQL
-        col["timezone"] = sql_t.timezone or sql_t.__visit_name__ in ("DATETIMEOFFSET")
+        col["timezone"] = sql_t.timezone or sql_t.__visit_name__ in ("DATETIMEOFFSET",)
     elif isinstance(sql_t, sqltypes.Date):
         col["data_type"] = "date"
     elif isinstance(sql_t, sqltypes.Time):

--- a/tests/sources/sql_database/test_schema_types.py
+++ b/tests/sources/sql_database/test_schema_types.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER
+from sqlalchemy.dialects.mssql import DATETIMEOFFSET, UNIQUEIDENTIFIER
+from sqlalchemy.dialects.oracle import DATE as OracleDATE
 from sqlalchemy.dialects.postgresql import UUID
 
 from dlt.sources.sql_database.schema_types import (
@@ -83,6 +84,25 @@ def test_default_table_adapter_sa2_generic_uuid() -> None:
     table = sa.Table("t", metadata, sa.Column("col", sa_uuid.Uuid()))
     default_table_adapter(table, included_columns=None)
     assert table.c.col.type.as_uuid is False
+
+
+@pytest.mark.parametrize(
+    "sql_type,expected_tz",
+    [
+        (sa.DateTime(timezone=False), False),
+        (sa.DateTime(timezone=True), True),
+        (OracleDATE(), False),
+        (DATETIMEOFFSET(), True),
+    ],
+    ids=["datetime_no_tz", "datetime_tz", "oracle_date", "mssql_datetimeoffset"],
+)
+def test_datetime_timezone_mapping(sql_type: sa.types.TypeEngine, expected_tz: bool) -> None:
+    """sqla_col_to_column_schema maps timezone correctly for DateTime types."""
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("col", sql_type))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full")
+    assert col_schema is not None
+    assert col_schema["timezone"] is expected_tz
 
 
 def test_get_table_references() -> None:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
The changes fixes the timezone to be set correctly incase of timestamp / datetime column datatype.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #3730 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
