### PR TITLE
fix: support explicit non-utf8 encoding in filesystem read_csv

### DIFF
--- a/dlt/sources/filesystem/readers.py
+++ b/dlt/sources/filesystem/readers.py
@@ -27,11 +27,21 @@ def _read_csv(
 
     # apply defaults to pandas kwargs
     kwargs = {**{"header": "infer", "chunksize": chunksize}, **pandas_kwargs}
+    # For some remote file systems (for example, sftp/paramiko), decoding may happen before
+    # pandas gets a chance to apply `encoding=...`. If encoding is explicitly provided,
+    # decode at file-open level and let pandas consume text directly.
+    open_mode = "rb"
+    open_kwargs = {}
+    if "encoding" in kwargs:
+        open_mode = "rt"
+        open_kwargs["encoding"] = kwargs.pop("encoding")
+        if "encoding_errors" in kwargs:
+            open_kwargs["errors"] = kwargs.pop("encoding_errors")
 
     for file_obj in items:
         # Here we use pandas chunksize to read the file in chunks and avoid loading the whole file
         # in memory.
-        with file_obj.open() as file:
+        with file_obj.open(mode=open_mode, **open_kwargs) as file:
             for df in pd.read_csv(file, **kwargs):
                 yield df.to_dict(orient="records")
 

--- a/tests/sources/filesystem/test_readers.py
+++ b/tests/sources/filesystem/test_readers.py
@@ -50,12 +50,14 @@ def _create_parquet_file(data: list[dict[str, Any]], tmp_path: pathlib.Path) -> 
     return FileItemDict(mapping=file_item, fsspec=_fsspec_client(tmp_path))
 
 
-def _create_csv_file(data: list[dict[str, Any]], tmp_path: pathlib.Path) -> FileItemDict:
+def _create_csv_file(
+    data: list[dict[str, Any]], tmp_path: pathlib.Path, encoding: str = "utf-8"
+) -> FileItemDict:
     file_name = "data.csv"
     full_file_path = tmp_path / file_name
 
     df = pd.DataFrame(data)
-    df.to_csv(full_file_path, index=False)
+    df.to_csv(full_file_path, index=False, encoding=encoding)
 
     file_item = FileItem(
         file_name=file_name,
@@ -125,6 +127,16 @@ def test_read_csv(tmp_path: pathlib.Path, data: list[dict[str, Any]]) -> None:
     assert isinstance(read_data, list)  # list of batches
     assert isinstance(read_data[0], list)  # batch of records
     assert isinstance(read_data[0][0], dict)  # record
+    assert read_data == [data]
+
+
+def test_read_csv_non_utf8_encoding(tmp_path: pathlib.Path, data: list[dict[str, Any]]) -> None:
+    file_ = _create_csv_file(data=data, tmp_path=tmp_path, encoding="utf-16")
+    iterator = _read_csv([file_], encoding="utf-16")
+    read_data = list(iterator)
+
+    assert isinstance(iterator, Iterator)
+    assert isinstance(read_data, list)
     assert read_data == [data]
 
 

--- a/tests/sources/filesystem/test_readers.py
+++ b/tests/sources/filesystem/test_readers.py
@@ -1,5 +1,6 @@
+import gzip
 import pathlib
-from typing import Any, Iterator
+from typing import Any, Dict, Iterator
 
 import pytest
 import pandas as pd
@@ -51,13 +52,21 @@ def _create_parquet_file(data: list[dict[str, Any]], tmp_path: pathlib.Path) -> 
 
 
 def _create_csv_file(
-    data: list[dict[str, Any]], tmp_path: pathlib.Path, encoding: str = "utf-8"
+    data: list[dict[str, Any]],
+    tmp_path: pathlib.Path,
+    encoding: str = "utf-8",
+    use_gzip: bool = False,
 ) -> FileItemDict:
-    file_name = "data.csv"
+    file_name = "data.csv.gz" if use_gzip else "data.csv"
     full_file_path = tmp_path / file_name
 
     df = pd.DataFrame(data)
-    df.to_csv(full_file_path, index=False, encoding=encoding)
+    if use_gzip:
+        csv_bytes = df.to_csv(index=False, encoding=encoding).encode(encoding)
+        with gzip.open(full_file_path, "wb") as gz:
+            gz.write(csv_bytes)
+    else:
+        df.to_csv(full_file_path, index=False, encoding=encoding)
 
     file_item = FileItem(
         file_name=file_name,
@@ -67,6 +76,8 @@ def _create_csv_file(
         modification_date=pendulum.DateTime(2025, 1, 1, 0, 0, 0, 0),
         size_in_bytes=111,
     )
+    if use_gzip:
+        file_item["encoding"] = "gzip"
     return FileItemDict(mapping=file_item, fsspec=_fsspec_client(tmp_path))
 
 
@@ -130,9 +141,28 @@ def test_read_csv(tmp_path: pathlib.Path, data: list[dict[str, Any]]) -> None:
     assert read_data == [data]
 
 
-def test_read_csv_non_utf8_encoding(tmp_path: pathlib.Path, data: list[dict[str, Any]]) -> None:
-    file_ = _create_csv_file(data=data, tmp_path=tmp_path, encoding="utf-16")
-    iterator = _read_csv([file_], encoding="utf-16")
+@pytest.mark.parametrize(
+    "encoding, use_gzip, extra_kwargs",
+    [
+        (
+            "utf-16",
+            False,
+            {},
+        ),
+        ("utf-16", True, {}),
+        ("utf-8", False, {"encoding_errors": "replace"}),
+    ],
+    ids=["utf16-plain", "utf16-gzip", "utf8-encoding-errors"],
+)
+def test_read_csv_non_utf8_encoding(
+    tmp_path: pathlib.Path,
+    data: list[dict[str, Any]],
+    encoding: str,
+    use_gzip: bool,
+    extra_kwargs: Dict[str, Any],
+) -> None:
+    file_ = _create_csv_file(data=data, tmp_path=tmp_path, encoding=encoding, use_gzip=use_gzip)
+    iterator = _read_csv([file_], encoding=encoding, **extra_kwargs)
     read_data = list(iterator)
 
     assert isinstance(iterator, Iterator)


### PR DESCRIPTION
## Summary
- update `_read_csv` to honor explicit `encoding` at file-open level
- keep existing behavior for default reads (`rb`) when no encoding is provided
- map `encoding_errors` to file-open `errors` when decoding at open-time
- add regression test for reading UTF-16 CSV via `_read_csv(..., encoding="utf-16")`

## Why
For some remote file systems (notably SFTP/paramiko stacks), decoding can happen before pandas applies `encoding=...`. Opening with explicit text encoding avoids premature UTF-8 decoding failures.

## Validation
- `uv run --group dev --group pipeline python -m pytest -q tests/sources/filesystem/test_readers.py -k "read_csv and not duckdb"`

Fixes #2945
