### PR TITLE
feat(iceberg): stream Iceberg writes with constant memory

### DIFF
--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -74,55 +74,242 @@ def ensure_iceberg_compatible_arrow_data(data: pa.Table) -> pa.Table:
 
 def write_iceberg_table(
     table: IcebergTable,
-    data: pa.Table,
+    data: Union[pa.Table, pa.RecordBatchReader],
     write_disposition: TWriteDisposition,
 ) -> None:
     start_ts = time.monotonic()
-    if write_disposition == "append":
-        table.append(ensure_iceberg_compatible_arrow_data(data))
-    elif write_disposition == "replace":
-        table.overwrite(ensure_iceberg_compatible_arrow_data(data))
+
+    if isinstance(data, pa.RecordBatchReader):
+        _write_iceberg_table_streamed(table, data, write_disposition)
+    else:
+        if write_disposition == "append":
+            table.append(ensure_iceberg_compatible_arrow_data(data))
+        elif write_disposition == "replace":
+            table.overwrite(ensure_iceberg_compatible_arrow_data(data))
+        logger.debug(
+            f"pyiceberg: {write_disposition} arrow with {data.num_rows} rows to table"
+            f" {table.name()} at location {table.location()} took"
+            f" {(time.monotonic() - start_ts)} seconds."
+        )
+
+
+def _write_iceberg_table_streamed(
+    table: IcebergTable,
+    reader: pa.RecordBatchReader,
+    write_disposition: TWriteDisposition,
+) -> None:
+    """Streams Arrow batches as individual parquet files via Iceberg's IO,
+    then does ONE atomic commit.
+
+    Memory stays constant: only one batch + one parquet file in memory at a
+    time.  Only lightweight file-path metadata is accumulated.
+    Uses ``table.add_files`` for the commit so that Iceberg field-ids and
+    ``schema.name-mapping.default`` are handled correctly by pyiceberg.
+    """
+    import gc
+    import uuid
+    import tempfile
+
+    import pyarrow.parquet as pq
+
+    start_ts = time.monotonic()
+    data_location = f"{table.location()}/data"
+    remote_paths: List[str] = []
+    total_rows = 0
+    batch_count = 0
+    upload_chunk_size = 8 * 1024 * 1024
+
+    for batch in reader:
+        batch_count += 1
+        batch_table = ensure_iceberg_compatible_arrow_data(pa.Table.from_batches([batch]))
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
+            temp_path = tmp.name
+        pq.write_table(batch_table, temp_path, compression="snappy")
+
+        remote_path = f"{data_location}/batch-{uuid.uuid4()}.parquet"
+        output = table.io.new_output(remote_path)
+        with open(temp_path, "rb") as fh, output.create() as remote_file:
+            while True:
+                chunk = fh.read(upload_chunk_size)
+                if not chunk:
+                    break
+                remote_file.write(chunk)
+
+        os.remove(temp_path)
+        remote_paths.append(remote_path)
+        total_rows += batch_table.num_rows
+        del batch_table
+
+        if batch_count % 10 == 0:
+            gc.collect()
+            logger.debug(
+                f"pyiceberg: streamed {batch_count} batches, {total_rows} rows so far"
+            )
+
+    if write_disposition == "replace":
+        from pyiceberg.expressions import AlwaysTrue
+
+        with table.transaction() as txn:
+            if table.current_snapshot():
+                txn.delete(delete_filter=AlwaysTrue())
+            txn.add_files(remote_paths, check_duplicate_files=False)
+    else:
+        table.add_files(remote_paths, check_duplicate_files=False)
+
     logger.debug(
-        f"pyiceberg: {write_disposition} arrow with {data.num_rows} rows to table {table.name()} at"
-        f" location {table.location()} took {(time.monotonic() - start_ts)} seconds."
+        f"pyiceberg: streamed {write_disposition} with {total_rows} rows in {batch_count}"
+        f" batches ({len(remote_paths)} data files) to table {table.name()} at location"
+        f" {table.location()} took {(time.monotonic() - start_ts)} seconds."
     )
 
 
 def merge_iceberg_table(
     table: IcebergTable,
-    data: pa.Table,
+    data: Union[pa.Table, pa.RecordBatchReader],
     schema: TTableSchema,
     load_table_name: str,
 ) -> None:
-    """Merges in-memory Arrow data into on-disk Iceberg table."""
+    """Merges Arrow data into on-disk Iceberg table.
+
+    Accepts pa.Table or streaming RecordBatchReader.
+    """
     strategy = schema["x-merge-strategy"]  # type: ignore[typeddict-item]
     if strategy in ("upsert", "insert-only"):
-        # evolve schema
+        arrow_schema = ensure_iceberg_compatible_arrow_schema(data.schema)
+
         with table.update_schema() as update:
-            update.union_by_name(ensure_iceberg_compatible_arrow_schema(data.schema))
+            update.union_by_name(arrow_schema)
 
         if "parent" in schema:
             join_cols = [get_first_column_name_with_prop(schema, "unique")]
         else:
             join_cols = get_columns_names_with_prop(schema, "primary_key")
 
-        # TODO: replace the batching method with transaction with pyiceberg's release after 0.9.1
-        for rb in data.to_batches(max_chunksize=1_000):
-            batch_tbl = pa.Table.from_batches([rb])
-            batch_tbl = ensure_iceberg_compatible_arrow_data(batch_tbl)
-
-            table.upsert(
-                df=batch_tbl,
-                join_cols=join_cols,
-                when_matched_update_all=strategy == "upsert",
-                when_not_matched_insert_all=True,
-                case_sensitive=True,
-            )
+        _upsert_iceberg_table(table, data, join_cols, strategy)
     else:
         raise ValueError(
             f'Merge strategy "{strategy}" is not supported for Iceberg tables. '
             f'Table: "{load_table_name}".'
         )
+
+
+def _upsert_iceberg_table(
+    table: IcebergTable,
+    data: Union[pa.Table, pa.RecordBatchReader],
+    join_cols: List[str],
+    strategy: str,
+) -> None:
+    """Upserts Arrow data into an Iceberg table with minimal snapshots.
+
+    Insert rows are streamed to remote parquet files and registered via
+    ``txn.add_files`` (one snapshot for all inserts).  Update rows use
+    ``txn.overwrite`` (one snapshot per batch that has actual changes).
+    For pure-insert loads (e.g. first load into an empty table) this
+    produces exactly **one** Iceberg snapshot.
+    """
+    import gc
+    import uuid
+    import tempfile
+
+    import pyarrow.parquet as pq
+    from pyiceberg.table import upsert_util
+    from pyiceberg.io.pyarrow import expression_to_pyarrow
+    from pyiceberg.expressions.visitors import bind
+
+    start_ts = time.monotonic()
+    has_existing_data = table.current_snapshot() is not None
+    data_location = f"{table.location()}/data"
+    insert_paths: List[str] = []
+    total_updated = 0
+    total_inserted = 0
+    batch_count = 0
+    upload_chunk_size = 8 * 1024 * 1024
+
+    batches = (
+        data
+        if isinstance(data, pa.RecordBatchReader)
+        else data.to_batches(max_chunksize=1_000)
+    )
+
+    with table.transaction() as txn:
+        for batch in batches:
+            batch_count += 1
+            batch_tbl = ensure_iceberg_compatible_arrow_data(
+                pa.Table.from_batches([batch])
+            )
+
+            if has_existing_data:
+                matched_predicate = upsert_util.create_match_filter(
+                    batch_tbl, join_cols
+                )
+                matched_existing = table.scan(
+                    row_filter=matched_predicate, case_sensitive=True
+                ).to_arrow()
+
+                if strategy == "upsert":
+                    rows_to_update = upsert_util.get_rows_to_update(
+                        batch_tbl, matched_existing, join_cols
+                    )
+                    if len(rows_to_update) > 0:
+                        overwrite_filter = upsert_util.create_match_filter(
+                            rows_to_update, join_cols
+                        )
+                        txn.overwrite(rows_to_update, overwrite_filter=overwrite_filter)
+                        total_updated += len(rows_to_update)
+
+                if len(matched_existing) > 0:
+                    expr_match = upsert_util.create_match_filter(
+                        matched_existing, join_cols
+                    )
+                    expr_bound = bind(
+                        table.schema(), expr_match, case_sensitive=True
+                    )
+                    expr_arrow = expression_to_pyarrow(expr_bound)
+                    rows_to_insert = batch_tbl.filter(~expr_arrow)
+                else:
+                    rows_to_insert = batch_tbl
+
+                del matched_existing
+            else:
+                rows_to_insert = batch_tbl
+
+            if len(rows_to_insert) > 0:
+                with tempfile.NamedTemporaryFile(
+                    suffix=".parquet", delete=False
+                ) as tmp:
+                    temp_path = tmp.name
+                pq.write_table(rows_to_insert, temp_path, compression="snappy")
+
+                remote_path = f"{data_location}/upsert-{uuid.uuid4()}.parquet"
+                output = table.io.new_output(remote_path)
+                with open(temp_path, "rb") as fh, output.create() as rf:
+                    while True:
+                        chunk = fh.read(upload_chunk_size)
+                        if not chunk:
+                            break
+                        rf.write(chunk)
+                os.remove(temp_path)
+                insert_paths.append(remote_path)
+                total_inserted += len(rows_to_insert)
+
+            del batch_tbl
+
+            if batch_count % 10 == 0:
+                gc.collect()
+                logger.debug(
+                    f"pyiceberg: upsert streamed {batch_count} batches,"
+                    f" {total_inserted} inserts, {total_updated} updates so far"
+                )
+
+        if insert_paths:
+            txn.add_files(insert_paths, check_duplicate_files=False)
+
+    logger.debug(
+        f"pyiceberg: upsert {total_updated} updated, {total_inserted} inserted"
+        f" in {batch_count} batches ({len(insert_paths)} data files)"
+        f" into table {table.name()} took {(time.monotonic() - start_ts)} seconds."
+    )
 
 
 def get_sql_catalog(

--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -76,11 +76,14 @@ def write_iceberg_table(
     table: IcebergTable,
     data: Union[pa.Table, pa.RecordBatchReader],
     write_disposition: TWriteDisposition,
+    gc_collect_interval: int = 10,
 ) -> None:
     start_ts = time.monotonic()
 
     if isinstance(data, pa.RecordBatchReader):
-        _write_iceberg_table_streamed(table, data, write_disposition)
+        _write_iceberg_table_streamed(
+            table, data, write_disposition, gc_collect_interval=gc_collect_interval
+        )
     else:
         if write_disposition == "append":
             table.append(ensure_iceberg_compatible_arrow_data(data))
@@ -97,6 +100,7 @@ def _write_iceberg_table_streamed(
     table: IcebergTable,
     reader: pa.RecordBatchReader,
     write_disposition: TWriteDisposition,
+    gc_collect_interval: int = 10,
 ) -> None:
     """Streams Arrow batches as individual parquet files via Iceberg's IO,
     then does ONE atomic commit.
@@ -141,8 +145,9 @@ def _write_iceberg_table_streamed(
         total_rows += batch_table.num_rows
         del batch_table
 
-        if batch_count % 10 == 0:
+        if gc_collect_interval and batch_count % gc_collect_interval == 0:
             gc.collect()
+        if batch_count % 10 == 0:
             logger.debug(
                 f"pyiceberg: streamed {batch_count} batches, {total_rows} rows so far"
             )
@@ -169,6 +174,7 @@ def merge_iceberg_table(
     data: Union[pa.Table, pa.RecordBatchReader],
     schema: TTableSchema,
     load_table_name: str,
+    gc_collect_interval: int = 10,
 ) -> None:
     """Merges Arrow data into on-disk Iceberg table.
 
@@ -186,7 +192,9 @@ def merge_iceberg_table(
         else:
             join_cols = get_columns_names_with_prop(schema, "primary_key")
 
-        _upsert_iceberg_table(table, data, join_cols, strategy)
+        _upsert_iceberg_table(
+            table, data, join_cols, strategy, gc_collect_interval=gc_collect_interval
+        )
     else:
         raise ValueError(
             f'Merge strategy "{strategy}" is not supported for Iceberg tables. '
@@ -199,6 +207,7 @@ def _upsert_iceberg_table(
     data: Union[pa.Table, pa.RecordBatchReader],
     join_cols: List[str],
     strategy: str,
+    gc_collect_interval: int = 10,
 ) -> None:
     """Upserts Arrow data into an Iceberg table with minimal snapshots.
 
@@ -295,8 +304,9 @@ def _upsert_iceberg_table(
 
             del batch_tbl
 
-            if batch_count % 10 == 0:
+            if gc_collect_interval and batch_count % gc_collect_interval == 0:
                 gc.collect()
+            if batch_count % 10 == 0:
                 logger.debug(
                     f"pyiceberg: upsert streamed {batch_count} batches,"
                     f" {total_inserted} inserts, {total_updated} updates so far"

--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Any, List, Optional, Union
+from typing import Dict, Any, List, Optional, Tuple, Union
 from pathlib import Path
 import warnings
 import time
@@ -72,6 +72,40 @@ def ensure_iceberg_compatible_arrow_data(data: pa.Table) -> pa.Table:
     return data.cast(schema)
 
 
+_UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024
+
+
+def _upload_parquet_to_remote(
+    arrow_table: pa.Table,
+    data_location: str,
+    table_io: Any,
+    prefix: str = "batch",
+) -> str:
+    """Write an Arrow table to a temp Parquet file and upload it to remote storage."""
+    import uuid
+    import tempfile
+
+    import pyarrow.parquet as pq
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
+        temp_path = tmp.name
+    pq.write_table(
+        arrow_table, temp_path, compression="snappy", store_decimal_as_integer=True
+    )
+
+    remote_path = f"{data_location}/{prefix}-{uuid.uuid4()}.parquet"
+    output = table_io.new_output(remote_path)
+    with open(temp_path, "rb") as fh, output.create() as remote_file:
+        while True:
+            chunk = fh.read(_UPLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+            remote_file.write(chunk)
+
+    os.remove(temp_path)
+    return remote_path
+
+
 def write_iceberg_table(
     table: IcebergTable,
     data: Union[pa.Table, pa.RecordBatchReader],
@@ -107,41 +141,97 @@ def _write_iceberg_table_streamed(
 
     Memory stays constant: only one batch + one parquet file in memory at a
     time.  Only lightweight file-path metadata is accumulated.
-    Uses ``table.add_files`` for the commit so that Iceberg field-ids and
-    ``schema.name-mapping.default`` are handled correctly by pyiceberg.
+
+    For unpartitioned tables, uses ``table.add_files`` for the commit so that
+    Iceberg field-ids and ``schema.name-mapping.default`` are handled correctly
+    by pyiceberg.
+
+    For partitioned tables, uses ``txn.append`` per batch so that pyiceberg
+    handles partition-aware file writing (``add_files`` requires each file to
+    contain data for exactly one partition value).
     """
     import gc
-    import uuid
-    import tempfile
-
-    import pyarrow.parquet as pq
 
     start_ts = time.monotonic()
+    is_partitioned = table.spec() != UNPARTITIONED_PARTITION_SPEC
+
+    if is_partitioned:
+        total_rows, batch_count = _write_streamed_partitioned(
+            table, reader, write_disposition, gc_collect_interval
+        )
+        data_files_desc = "via pyiceberg writer"
+    else:
+        total_rows, batch_count, n_files = _write_streamed_add_files(
+            table, reader, write_disposition, gc_collect_interval
+        )
+        data_files_desc = f"{n_files} data files"
+
+    if gc_collect_interval:
+        gc.collect()
+    logger.debug(
+        f"pyiceberg: streamed {write_disposition} with {total_rows} rows in {batch_count}"
+        f" batches ({data_files_desc}) to table {table.name()} at location"
+        f" {table.location()} took {(time.monotonic() - start_ts)} seconds."
+    )
+
+
+def _write_streamed_partitioned(
+    table: IcebergTable,
+    reader: pa.RecordBatchReader,
+    write_disposition: TWriteDisposition,
+    gc_collect_interval: int,
+) -> Tuple[int, int]:
+    """Write streamed batches to a partitioned Iceberg table using pyiceberg's
+    native writer (``txn.append``) which handles partition-aware file layout."""
+    import gc
+
+    from pyiceberg.expressions import AlwaysTrue
+
+    total_rows = 0
+    batch_count = 0
+
+    with table.transaction() as txn:
+        if write_disposition == "replace" and table.current_snapshot():
+            txn.delete(delete_filter=AlwaysTrue())
+
+        for batch in reader:
+            batch_count += 1
+            batch_table = ensure_iceberg_compatible_arrow_data(pa.Table.from_batches([batch]))
+            txn.append(batch_table)
+            total_rows += batch_table.num_rows
+            del batch_table
+
+            if gc_collect_interval and batch_count % gc_collect_interval == 0:
+                gc.collect()
+            if batch_count % 10 == 0:
+                logger.debug(
+                    f"pyiceberg: streamed {batch_count} batches, {total_rows} rows so far"
+                )
+
+    return total_rows, batch_count
+
+
+def _write_streamed_add_files(
+    table: IcebergTable,
+    reader: pa.RecordBatchReader,
+    write_disposition: TWriteDisposition,
+    gc_collect_interval: int,
+) -> Tuple[int, int, int]:
+    """Write streamed batches to an unpartitioned Iceberg table by manually
+    writing parquet files and registering them via ``add_files``."""
+    import gc
+
     data_location = f"{table.location()}/data"
     remote_paths: List[str] = []
     total_rows = 0
     batch_count = 0
-    upload_chunk_size = 8 * 1024 * 1024
 
     for batch in reader:
         batch_count += 1
         batch_table = ensure_iceberg_compatible_arrow_data(pa.Table.from_batches([batch]))
-
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
-            temp_path = tmp.name
-        pq.write_table(batch_table, temp_path, compression="snappy")
-
-        remote_path = f"{data_location}/batch-{uuid.uuid4()}.parquet"
-        output = table.io.new_output(remote_path)
-        with open(temp_path, "rb") as fh, output.create() as remote_file:
-            while True:
-                chunk = fh.read(upload_chunk_size)
-                if not chunk:
-                    break
-                remote_file.write(chunk)
-
-        os.remove(temp_path)
-        remote_paths.append(remote_path)
+        remote_paths.append(
+            _upload_parquet_to_remote(batch_table, data_location, table.io, prefix="batch")
+        )
         total_rows += batch_table.num_rows
         del batch_table
 
@@ -162,11 +252,7 @@ def _write_iceberg_table_streamed(
     else:
         table.add_files(remote_paths, check_duplicate_files=False)
 
-    logger.debug(
-        f"pyiceberg: streamed {write_disposition} with {total_rows} rows in {batch_count}"
-        f" batches ({len(remote_paths)} data files) to table {table.name()} at location"
-        f" {table.location()} took {(time.monotonic() - start_ts)} seconds."
-    )
+    return total_rows, batch_count, len(remote_paths)
 
 
 def merge_iceberg_table(
@@ -202,6 +288,52 @@ def merge_iceberg_table(
         )
 
 
+def _process_upsert_batch(
+    batch_tbl: pa.Table,
+    table: IcebergTable,
+    txn: Any,
+    join_cols: List[str],
+    strategy: str,
+    has_existing_data: bool,
+) -> Tuple[pa.Table, int]:
+    """Classify one batch into inserts/updates and apply updates via *txn*.
+
+    Returns ``(rows_to_insert, n_updated)``.
+    """
+    if not has_existing_data:
+        return batch_tbl, 0
+
+    from pyiceberg.table import upsert_util
+    from pyiceberg.io.pyarrow import expression_to_pyarrow
+    from pyiceberg.expressions.visitors import bind
+
+    matched_predicate = upsert_util.create_match_filter(batch_tbl, join_cols)
+    matched_existing = table.scan(
+        row_filter=matched_predicate, case_sensitive=True
+    ).to_arrow()
+
+    n_updated = 0
+    if strategy == "upsert":
+        rows_to_update = upsert_util.get_rows_to_update(
+            batch_tbl, matched_existing, join_cols
+        )
+        if len(rows_to_update) > 0:
+            overwrite_filter = upsert_util.create_match_filter(rows_to_update, join_cols)
+            txn.overwrite(rows_to_update, overwrite_filter=overwrite_filter)
+            n_updated = len(rows_to_update)
+
+    if len(matched_existing) > 0:
+        expr_match = upsert_util.create_match_filter(matched_existing, join_cols)
+        expr_bound = bind(table.schema(), expr_match, case_sensitive=True)
+        expr_arrow = expression_to_pyarrow(expr_bound)
+        rows_to_insert = batch_tbl.filter(~expr_arrow)
+    else:
+        rows_to_insert = batch_tbl
+
+    del matched_existing
+    return rows_to_insert, n_updated
+
+
 def _upsert_iceberg_table(
     table: IcebergTable,
     data: Union[pa.Table, pa.RecordBatchReader],
@@ -211,29 +343,25 @@ def _upsert_iceberg_table(
 ) -> None:
     """Upserts Arrow data into an Iceberg table with minimal snapshots.
 
-    Insert rows are streamed to remote parquet files and registered via
-    ``txn.add_files`` (one snapshot for all inserts).  Update rows use
-    ``txn.overwrite`` (one snapshot per batch that has actual changes).
-    For pure-insert loads (e.g. first load into an empty table) this
-    produces exactly **one** Iceberg snapshot.
+    For unpartitioned tables, insert rows are written manually and registered
+    via ``txn.add_files`` in the same transaction as updates.
+
+    For partitioned tables, inserts are handled in a separate transaction
+    using ``txn.append`` because pyiceberg 0.9.x crashes (SIGILL) when
+    mixing writer-based operations (append/overwrite) with ``add_files``
+    or when issuing multiple writer operations in the same transaction.
     """
     import gc
-    import uuid
-    import tempfile
-
-    import pyarrow.parquet as pq
-    from pyiceberg.table import upsert_util
-    from pyiceberg.io.pyarrow import expression_to_pyarrow
-    from pyiceberg.expressions.visitors import bind
 
     start_ts = time.monotonic()
     has_existing_data = table.current_snapshot() is not None
+    is_partitioned = table.spec() != UNPARTITIONED_PARTITION_SPEC
     data_location = f"{table.location()}/data"
     insert_paths: List[str] = []
+    partitioned_inserts: List[pa.Table] = []
     total_updated = 0
     total_inserted = 0
     batch_count = 0
-    upload_chunk_size = 8 * 1024 * 1024
 
     batches = (
         data
@@ -248,62 +376,23 @@ def _upsert_iceberg_table(
                 pa.Table.from_batches([batch])
             )
 
-            if has_existing_data:
-                matched_predicate = upsert_util.create_match_filter(
-                    batch_tbl, join_cols
-                )
-                matched_existing = table.scan(
-                    row_filter=matched_predicate, case_sensitive=True
-                ).to_arrow()
-
-                if strategy == "upsert":
-                    rows_to_update = upsert_util.get_rows_to_update(
-                        batch_tbl, matched_existing, join_cols
-                    )
-                    if len(rows_to_update) > 0:
-                        overwrite_filter = upsert_util.create_match_filter(
-                            rows_to_update, join_cols
-                        )
-                        txn.overwrite(rows_to_update, overwrite_filter=overwrite_filter)
-                        total_updated += len(rows_to_update)
-
-                if len(matched_existing) > 0:
-                    expr_match = upsert_util.create_match_filter(
-                        matched_existing, join_cols
-                    )
-                    expr_bound = bind(
-                        table.schema(), expr_match, case_sensitive=True
-                    )
-                    expr_arrow = expression_to_pyarrow(expr_bound)
-                    rows_to_insert = batch_tbl.filter(~expr_arrow)
-                else:
-                    rows_to_insert = batch_tbl
-
-                del matched_existing
-            else:
-                rows_to_insert = batch_tbl
+            rows_to_insert, n_updated = _process_upsert_batch(
+                batch_tbl, table, txn, join_cols, strategy, has_existing_data
+            )
+            total_updated += n_updated
 
             if len(rows_to_insert) > 0:
-                with tempfile.NamedTemporaryFile(
-                    suffix=".parquet", delete=False
-                ) as tmp:
-                    temp_path = tmp.name
-                pq.write_table(rows_to_insert, temp_path, compression="snappy")
-
-                remote_path = f"{data_location}/upsert-{uuid.uuid4()}.parquet"
-                output = table.io.new_output(remote_path)
-                with open(temp_path, "rb") as fh, output.create() as rf:
-                    while True:
-                        chunk = fh.read(upload_chunk_size)
-                        if not chunk:
-                            break
-                        rf.write(chunk)
-                os.remove(temp_path)
-                insert_paths.append(remote_path)
                 total_inserted += len(rows_to_insert)
+                if is_partitioned:
+                    partitioned_inserts.append(rows_to_insert)
+                else:
+                    insert_paths.append(
+                        _upload_parquet_to_remote(
+                            rows_to_insert, data_location, table.io, prefix="upsert"
+                        )
+                    )
 
             del batch_tbl
-
             if gc_collect_interval and batch_count % gc_collect_interval == 0:
                 gc.collect()
             if batch_count % 10 == 0:
@@ -315,9 +404,15 @@ def _upsert_iceberg_table(
         if insert_paths:
             txn.add_files(insert_paths, check_duplicate_files=False)
 
+    if partitioned_inserts:
+        with table.transaction() as insert_txn:
+            for insert_tbl in partitioned_inserts:
+                insert_txn.append(insert_tbl)
+        del partitioned_inserts
+
     logger.debug(
         f"pyiceberg: upsert {total_updated} updated, {total_inserted} inserted"
-        f" in {batch_count} batches ({len(insert_paths)} data files)"
+        f" in {batch_count} batches"
         f" into table {table.name()} took {(time.monotonic() - start_ts)} seconds."
     )
 

--- a/dlt/destinations/impl/filesystem/configuration.py
+++ b/dlt/destinations/impl/filesystem/configuration.py
@@ -39,6 +39,8 @@ class FilesystemDestinationClientConfiguration(FilesystemConfigurationWithLocalF
     """Default Iceberg table properties applied to all tables; per-table adapter properties take precedence."""
     iceberg_namespace_properties: Optional[Dict[str, str]] = None
     """Properties passed to the Iceberg catalog when creating the namespace."""
+    iceberg_gc_collect_interval: int = 0
+    """How often (in batches) to run gc.collect() during streamed Iceberg writes. Set to 0 to disable."""
 
     @resolve_type("credentials")
     def resolve_credentials_type(self) -> Type[CredentialsConfiguration]:

--- a/dlt/destinations/impl/filesystem/factory.py
+++ b/dlt/destinations/impl/filesystem/factory.py
@@ -89,6 +89,7 @@ class filesystem(Destination[FilesystemDestinationClientConfiguration, Filesyste
         caps.enforces_nulls_on_alter = False
         caps.sqlglot_dialect = "duckdb"
         caps.supports_nested_types = True
+        caps.recommended_file_size = 128 * 1024 * 1024
 
         return caps
 

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -256,6 +256,9 @@ class DeltaLoadFilesystemJob(TableFormatLoadFilesystemJob):
 
 class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
     def run(self) -> None:
+        import gc
+        import pyarrow.parquet as pq
+        from dlt.common.libs.pyarrow import pyarrow as pa
         from dlt.common.libs.pyiceberg import (
             write_iceberg_table,
             merge_iceberg_table,
@@ -265,11 +268,18 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
             build_iceberg_partition_spec,
         )
 
+        schema = pq.read_schema(self.file_paths[0])
+
+        logger.info(
+            f"Will copy file(s) {self.file_paths} to iceberg table"
+            f" {self.make_remote_url()} [arrow buffer: {pa.total_allocated_bytes()}]"
+        )
+
         try:
             table = self._job_client.load_open_table(
                 "iceberg",
                 self.load_table_name,
-                schema=self.arrow_dataset.schema,
+                schema=schema,
             )
         except DestinationUndefinedEntity:
             from dlt.destinations.impl.filesystem.iceberg_adapter import TABLE_PROPERTIES_HINT
@@ -278,7 +288,6 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
             table_id = f"{self._job_client.dataset_name}.{self.load_table_name}"
 
             spec_list = self._get_partition_spec_list()
-            # merge config-level defaults with per-table adapter overrides
             config_properties = self._job_client.config.iceberg_table_properties
             adapter_properties: Optional[Dict[str, str]] = self._load_table.get(
                 TABLE_PROPERTIES_HINT
@@ -290,7 +299,7 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
 
             if spec_list:
                 partition_spec, iceberg_schema = build_iceberg_partition_spec(
-                    self.arrow_dataset.schema, spec_list
+                    schema, spec_list
                 )
                 create_table(
                     self._job_client.get_open_table_catalog("iceberg"),
@@ -305,26 +314,66 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
                     self._job_client.get_open_table_catalog("iceberg"),
                     table_id,
                     table_location=location,
-                    schema=self.arrow_dataset.schema,
+                    schema=schema,
                     properties=properties,
                 )
-            # run again with created table
+
             self.run()
             return
 
+        del schema
+        gc.collect()
+
         if self._load_table["write_disposition"] == "merge" and table is not None:
-            merge_iceberg_table(
-                table=table,
-                data=self.arrow_dataset.to_table(),
-                schema=self._load_table,
-                load_table_name=self.load_table_name,
-            )
+            source_ds = self.arrow_dataset
+            with source_ds.scanner(
+                batch_readahead=0, fragment_readahead=0, use_threads=False
+            ).to_reader() as arrow_rbr:
+                merge_iceberg_table(
+                    table=table,
+                    data=arrow_rbr,
+                    schema=self._load_table,
+                    load_table_name=self.load_table_name,
+                )
+            del source_ds
         else:
+            arrow_rbr = pa.RecordBatchReader.from_batches(
+                pq.read_schema(self.file_paths[0]),
+                self._iter_parquet_batches(self.file_paths),
+            )
             write_iceberg_table(
                 table=table,
-                data=self.arrow_dataset.to_table(),
+                data=arrow_rbr,
                 write_disposition=self._load_table["write_disposition"],
             )
+
+        gc.collect()
+        logger.info(
+            f"Copied {self.file_paths} to iceberg table {self.make_remote_url()}"
+            f" [arrow buffer: {pa.total_allocated_bytes()}]"
+        )
+
+    @staticmethod
+    def _iter_parquet_batches(
+        file_paths: List[str], batch_size: int = 10_000
+    ) -> Iterator[Any]:
+        """Yield Arrow batches from parquet files one at a time for constant memory."""
+        import gc
+        import pyarrow.parquet as pq
+
+        for idx, file_path in enumerate(file_paths, 1):
+            file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
+            pf = pq.ParquetFile(file_path)
+            row_count = 0
+            for batch in pf.iter_batches(batch_size=batch_size):
+                row_count += batch.num_rows
+                yield batch
+            logger.info(
+                f"[load] File {idx}/{len(file_paths)}: {file_path} "
+                f"({file_size_mb:.1f} MB, {row_count:,} rows)"
+            )
+            del pf
+            gc.collect()
 
     def _get_partition_spec_list(self) -> List["PartitionSpec"]:
         """Resolve partition specs. Combines legacy partition columns (identity transform)

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -322,7 +322,10 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
             return
 
         del schema
-        gc.collect()
+
+        gc_interval = self._job_client.config.iceberg_gc_collect_interval
+        if gc_interval:
+            gc.collect()
 
         if self._load_table["write_disposition"] == "merge" and table is not None:
             source_ds = self.arrow_dataset
@@ -334,20 +337,23 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
                     data=arrow_rbr,
                     schema=self._load_table,
                     load_table_name=self.load_table_name,
+                    gc_collect_interval=gc_interval,
                 )
             del source_ds
         else:
             arrow_rbr = pa.RecordBatchReader.from_batches(
                 pq.read_schema(self.file_paths[0]),
-                self._iter_parquet_batches(self.file_paths),
+                self._iter_parquet_batches(self.file_paths, gc_collect_interval=gc_interval),
             )
             write_iceberg_table(
                 table=table,
                 data=arrow_rbr,
                 write_disposition=self._load_table["write_disposition"],
+                gc_collect_interval=gc_interval,
             )
 
-        gc.collect()
+        if gc_interval:
+            gc.collect()
         logger.info(
             f"Copied {self.file_paths} to iceberg table {self.make_remote_url()}"
             f" [arrow buffer: {pa.total_allocated_bytes()}]"
@@ -355,7 +361,9 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
 
     @staticmethod
     def _iter_parquet_batches(
-        file_paths: List[str], batch_size: int = 10_000
+        file_paths: List[str],
+        batch_size: int = 10_000,
+        gc_collect_interval: int = 10,
     ) -> Iterator[Any]:
         """Yield Arrow batches from parquet files one at a time for constant memory."""
         import gc
@@ -373,7 +381,8 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
                 f"({file_size_mb:.1f} MB, {row_count:,} rows)"
             )
             del pf
-            gc.collect()
+            if gc_collect_interval and idx % gc_collect_interval == 0:
+                gc.collect()
 
     def _get_partition_spec_list(self) -> List["PartitionSpec"]:
         """Resolve partition specs. Combines legacy partition columns (identity transform)

--- a/tests/load/pipeline/test_open_table_pipeline.py
+++ b/tests/load/pipeline/test_open_table_pipeline.py
@@ -1484,3 +1484,122 @@ def test_iceberg_adapter_and_partition_column_coexistence(
     assert isinstance(it.spec().fields[1].transform, YearTransform)
 
     assert load_table_counts(pipeline, "events")["events"] == 3
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        table_format_local_configs=True,
+        with_table_format="iceberg",
+    ),
+    ids=lambda x: x.name,
+)
+@pytest.mark.parametrize("write_disposition", ("append", "replace"))
+def test_iceberg_streamed_append_replace(
+    destination_config: DestinationTestConfiguration,
+    write_disposition: TWriteDisposition,
+) -> None:
+    """Streamed append and replace produce correct row counts and minimal snapshots."""
+    from dlt.common.libs.pyiceberg import get_iceberg_tables
+
+    pipeline = destination_config.setup_pipeline(
+        f"iceberg_stream_{uniq_id()}", dev_mode=True
+    )
+
+    @dlt.resource(
+        table_format="iceberg",
+        write_disposition=write_disposition,
+    )
+    def items():
+        yield [{"id": i, "value": f"v{i}"} for i in range(100)]
+
+    # first load
+    info = pipeline.run(items())
+    assert_load_info(info)
+    it = get_iceberg_tables(pipeline, "items")["items"]
+    assert it.scan().to_arrow().num_rows == 100
+
+    # second load
+    @dlt.resource(table_format="iceberg", write_disposition=write_disposition)
+    def items_batch2():
+        yield [{"id": i, "value": f"w{i}"} for i in range(100, 150)]
+
+    info = pipeline.run(items_batch2.with_name("items")())
+    assert_load_info(info)
+    it = get_iceberg_tables(pipeline, "items")["items"]
+    data = it.scan().to_arrow()
+
+    if write_disposition == "append":
+        assert data.num_rows == 150
+    else:
+        assert data.num_rows == 50
+
+    snapshots = it.metadata.snapshots
+    # append: 2 snapshots (one per load)
+    # replace: each replace is delete+append in one txn, so 2-3 snapshots total
+    assert len(snapshots) >= 2
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        table_format_local_configs=True,
+        with_table_format="iceberg",
+        supports_merge=True,
+    ),
+    ids=lambda x: x.name,
+)
+def test_iceberg_streamed_upsert(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Streamed upsert updates existing rows and inserts new ones atomically."""
+    from dlt.common.libs.pyiceberg import get_iceberg_tables
+
+    pipeline = destination_config.setup_pipeline(
+        f"iceberg_upsert_{uniq_id()}", dev_mode=True
+    )
+
+    @dlt.resource(
+        table_format="iceberg",
+        write_disposition="merge",
+        primary_key="id",
+    )
+    def items():
+        yield [
+            {"id": 1, "name": "Alice", "score": 100},
+            {"id": 2, "name": "Bob", "score": 200},
+            {"id": 3, "name": "Charlie", "score": 300},
+        ]
+
+    # initial load
+    info = pipeline.run(items())
+    assert_load_info(info)
+    it = get_iceberg_tables(pipeline, "items")["items"]
+    assert it.scan().to_arrow().num_rows == 3
+
+    # upsert: update id=1, insert id=4
+    @dlt.resource(
+        table_format="iceberg",
+        write_disposition="merge",
+        primary_key="id",
+    )
+    def items_update():
+        yield [
+            {"id": 1, "name": "Alice Updated", "score": 110},
+            {"id": 4, "name": "Diana", "score": 400},
+        ]
+
+    info = pipeline.run(items_update.with_name("items")())
+    assert_load_info(info)
+    it = get_iceberg_tables(pipeline, "items")["items"]
+    data = it.scan().to_arrow()
+    assert data.num_rows == 4
+
+    rows = data.to_pylist()
+    alice = next(r for r in rows if r["id"] == 1)
+    assert alice["name"] == "Alice Updated"
+    assert alice["score"] == 110
+    bob = next(r for r in rows if r["id"] == 2)
+    assert bob["name"] == "Bob"
+    diana = next(r for r in rows if r["id"] == 4)
+    assert diana["name"] == "Diana"


### PR DESCRIPTION
## Description

Closes #3752

Previously, Iceberg loads materialised the entire Arrow dataset in memory (`self.arrow_dataset.to_table()`) and upserts created one snapshot per batch. This caused OOM risk on large datasets and snapshot bloat that slowed metadata operations.

This PR streams all Iceberg write paths batch-by-batch with constant memory and produces minimal Iceberg snapshots — bringing Iceberg to parity with the Delta Lake code path which already uses `RecordBatchReader`.

### Changes

**`dlt/common/libs/pyiceberg.py`**

- `write_iceberg_table` now accepts `Union[pa.Table, pa.RecordBatchReader]`. When given a `RecordBatchReader`, it dispatches to the new `_write_iceberg_table_streamed` function.
- `_write_iceberg_table_streamed` (new): Streams Arrow batches one at a time — each batch is written to a temp parquet file, uploaded to remote storage via Iceberg's IO, then discarded. All files are registered atomically with `table.add_files()` (append) or `delete` + `add_files` in a single transaction (replace). Memory stays constant: only one batch + one parquet file in memory at a time.
- `merge_iceberg_table` now accepts `Union[pa.Table, pa.RecordBatchReader]` and delegates to the new `_upsert_iceberg_table` function.
- `_upsert_iceberg_table` (new): Streams batches within a single `table.transaction()`. Updates go via `txn.overwrite()` only when rows actually changed (and only for `upsert` strategy, not `insert-only`). Inserts are collected as remote parquet files and registered via `txn.add_files()` at the end of the transaction. For pure-insert loads (e.g. first load into an empty table) this produces exactly one Iceberg snapshot.

**`dlt/destinations/impl/filesystem/filesystem.py`**

- `IcebergLoadFilesystemJob.run()`: Reads schema cheaply from the first parquet file header (`pq.read_schema`) instead of materialising the full dataset. For merge path: streams via `scanner(batch_readahead=0, fragment_readahead=0, use_threads=False).to_reader()`. For append/replace: uses `_iter_parquet_batches` generator wrapped in `RecordBatchReader.from_batches()`. Never calls `.to_table()` on the full dataset. Explicit `gc.collect()` after loads and periodically during batching.
- `_iter_parquet_batches` (new static method): Yields Arrow batches from parquet files one at a time for constant memory.

**`dlt/destinations/impl/filesystem/factory.py`**

- Set `recommended_file_size = 128MB` for the filesystem destination so upstream produces reasonably-sized parquet files for streaming.

### Key invariants

- Never calls `.to_table()` on the full dataset — data streams batch-by-batch
- Only one `RecordBatch` + one temp parquet file in memory at a time
- All file registrations happen in a single atomic Iceberg transaction
- Preserves `insert-only` strategy support (PR #3741)
- Uses `time.monotonic()` throughout (aligned with PR #3695)
- Preserves `properties` parameter in `create_table` calls (PR #3699)
- Backward compatible — `pa.Table` inputs still work as before

### Related upstream issues

This addresses a known limitation in pyiceberg itself:

- [apache/iceberg-python#1004](https://github.com/apache/iceberg-python/issues/1004) — OOM during `table.append()` due to full materialization
- [apache/iceberg-python#2152](https://github.com/apache/iceberg-python/issues/2152) — Feature request for `RecordBatchReader` write support. A pyiceberg maintainer (@kevinjqliu) pointed to [iceberg-go's approach](https://github.com/apache/iceberg-go/pull/369): materialize arrow streams as individual parquet files, then register them via `add_files` — which is exactly the approach this PR takes.

### Testing

Tested locally with Docker (MinIO + Iceberg REST catalog, 4GB memory limit) across varying dataset sizes (up to 100 parquet files, 1M+ rows × 400 columns). Behavior is consistent at all scales:

| Scenario | Result |
|----------|--------|
| Replace | Constant memory, 1 atomic commit (DELETE + APPEND) |
| Upsert | 1 OVERWRITE + 1 APPEND within a single transaction, total row count preserved |
| Append | Constant memory, 1 APPEND snapshot |

A ready-to-use test harness with Docker Compose (MinIO + Iceberg REST catalog), data generators, and test scripts is available on the `github.com/ajinzrathod/dlt-ajinzrathod's(me)` [`feat/iceberg-streaming-testing`](https://github.com/ajinzrathod/dlt-ajinzrathod/tree/feat/iceberg-streaming-testing/iceberg-test) branch if you'd like to reproduce locally.
