### PR TITLE
feat(snowflake): Extend Snowflake query tags beyond load jobs

### DIFF
--- a/dlt/common/destination/client.py
+++ b/dlt/common/destination/client.py
@@ -621,7 +621,7 @@ class JobClientBase(ABC):
     def prepare_load_job_execution(  # noqa: B027, optional override
         self, job: RunnableLoadJob
     ) -> None:
-        """Prepare the connected job client for the execution of a load job (used for query tags in sql clients)"""
+        """Prepare the connected job client for a load job, including load-specific query-tag context when supported."""
         pass
 
     def should_truncate_table_before_load(self, table_name: str) -> bool:

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -165,7 +165,7 @@ class SnowflakeClientConfiguration(DestinationClientDwhWithStagingConfiguration)
     """Optional csv format configuration"""
 
     query_tag: Optional[str] = None
-    """A tag with placeholders to tag sessions executing jobs"""
+    """A template with placeholders used to tag Snowflake sessions for dlt operations."""
 
     create_indexes: bool = False
     """Whether UNIQUE or PRIMARY KEY constrains should be created"""

--- a/dlt/destinations/impl/snowflake/factory.py
+++ b/dlt/destinations/impl/snowflake/factory.py
@@ -188,7 +188,7 @@ class snowflake(Destination[SnowflakeClientConfiguration, "SnowflakeClient"]):
             stage_name (Optional[str], optional): Name of an existing stage to use for loading data. Default uses implicit stage per table
             keep_staged_files (bool, optional): Whether to delete or keep staged files after loading
             csv_format (Optional[CsvFormatConfiguration]): Optional csv format configuration
-            query_tag (Optional[str]): A tag with placeholders to tag sessions executing jobs
+            query_tag (Optional[str]): A template with placeholders used to tag Snowflake sessions for dlt operations
             create_indexes (bool, optional): Whether UNIQUE or PRIMARY KEY constrains should be created
             use_decfloat (bool, optional): Whether to use DECFLOAT type for unbound decimals. DECFLOAT stores
                 exact decimal values with up to 36 significant digits and a dynamic exponent.

--- a/dlt/destinations/impl/snowflake/sql_client.py
+++ b/dlt/destinations/impl/snowflake/sql_client.py
@@ -12,7 +12,7 @@ from dlt.destinations.exceptions import (
 from dlt.destinations.sql_client import (
     DBApiCursorImpl,
     SqlClientBase,
-    TJobQueryTags,
+    TQueryTags,
     raise_database_error,
     raise_open_connection_error,
 )
@@ -141,7 +141,7 @@ class SnowflakeSqlClient(SqlClientBase[snowflake_lib.SnowflakeConnection], DBTra
         self._conn.rollback()
         self._conn.autocommit(True)
 
-    def set_query_tags(self, tags: TJobQueryTags) -> None:
+    def set_query_tags(self, tags: Optional[TQueryTags]) -> None:
         super().set_query_tags(tags)
         if self.query_tag:
             self._tag_session()

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -1,4 +1,3 @@
-from dlt.common.storages.load_package import load_package_state, CurrentLoadPackageStateNotAvailable
 import os
 from abc import abstractmethod
 import base64
@@ -45,7 +44,7 @@ from dlt.common.schema.utils import (
 )
 from dlt.common.utils import read_dialect_and_sql
 from dlt.common.storages import FileStorage
-from dlt.common.storages.load_package import LoadJobInfo, ParsedLoadJobFileName
+from dlt.common.storages.load_package import LoadJobInfo, ParsedLoadJobFileName, load_package_state, CurrentLoadPackageStateNotAvailable
 from dlt.common.schema import TColumnSchema, Schema, TTableSchemaColumns, TSchemaTables
 from dlt.common.schema import TColumnHint
 from dlt.common.destination.client import (

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -1,3 +1,4 @@
+from dlt.common.storages.load_package import load_package_state, CurrentLoadPackageStateNotAvailable
 import os
 from abc import abstractmethod
 import base64
@@ -920,19 +921,31 @@ WHERE """
     ) -> None:
         from dlt.common.pipeline import current_pipeline
 
+        if not load_id:
+            try:
+                load_id = load_package_state()["load_id"]
+            except CurrentLoadPackageStateNotAvailable:
+                load_id = ""
+
         pipeline = current_pipeline()
         pipeline_name = pipeline.pipeline_name if pipeline else ""
-        table_name = table["name"] if table else ""
+        if table:
+            table_name = table["name"] if table else ""
+            resource = (
+                get_inherited_table_hint(
+                    self.schema.tables, table_name, "resource", allow_none=True
+                )
+                or ""
+            )
+        else:
+            table_name = ""
+            resource = ""
+
         self.sql_client.set_query_tags(
             {
                 "operation": operation,
                 "source": self.schema.name,
-                "resource": (
-                    get_inherited_table_hint(
-                        self.schema.tables, table_name, "resource", allow_none=True
-                    )
-                    or ""
-                ),
+                "resource": resource,
                 "table": table_name,
                 "load_id": load_id,
                 "pipeline_name": pipeline_name,

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -290,6 +290,7 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
                 self.sql_client.drop_dataset()
 
     def initialize_storage(self, truncate_tables: Iterable[str] = None) -> None:
+        self._set_query_tags(operation="prepare_storage")
         if not self.is_storage_initialized():
             self.sql_client.create_dataset()
         elif truncate_tables:
@@ -303,6 +304,7 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
         only_tables: Iterable[str] = None,
         expected_update: TSchemaTables = None,
     ) -> Optional[TSchemaTables]:
+        self._set_query_tags(operation="update_stored_schema")
         super().update_stored_schema(only_tables, expected_update)
         applied_update: TSchemaTables = {}
         schema_info = self.get_stored_schema_by_hash(self.schema.stored_version_hash)
@@ -329,6 +331,7 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
             tables: Names of tables to drop.
             delete_schema: If True, also delete all versions of the current schema from storage
         """
+        self._set_query_tags(operation="drop_tables")
         with self.maybe_ddl_transaction():
             self.sql_client.drop_tables(*tables)
             if delete_schema:
@@ -411,6 +414,7 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
         return None
 
     def complete_load(self, load_id: str) -> None:
+        self._set_query_tags(operation="complete_load", load_id=load_id)
         name = self.sql_client.make_qualified_table_name(self.schema.loads_table_name)
         now_ts = pendulum.now()
         self.sql_client.execute_sql(
@@ -529,6 +533,7 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
         pass
 
     def get_stored_schema(self, schema_name: str = None) -> StorageSchemaInfo:
+        self._set_query_tags(operation="get_stored_schema")
         name = self.sql_client.make_qualified_table_name(self.schema.version_table_name)
         c_schema_name, c_inserted_at = self._norm_and_escape_columns("schema_name", "inserted_at")
         if not schema_name:
@@ -545,6 +550,7 @@ class SqlJobClientBase(WithSqlClient, JobClientBase, WithStateSync):
             return self._row_to_schema_info(query, schema_name)
 
     def get_stored_state(self, pipeline_name: str) -> StateInfo:
+        self._set_query_tags(operation="get_stored_state")
         state_table = self.sql_client.make_qualified_table_name(self.schema.state_table_name)
         loads_table = self.sql_client.make_qualified_table_name(self.schema.loads_table_name)
         c_load_id, c_dlt_load_id, c_pipeline_name, c_status = self._norm_and_escape_columns(
@@ -907,24 +913,27 @@ WHERE """
         return loaded_tables
 
     def prepare_load_job_execution(self, job: RunnableLoadJob) -> None:
-        self._set_query_tags_for_job(load_id=job._load_id, table=job._load_table)
+        self._set_query_tags(operation="load", load_id=job._load_id, table=job._load_table)
 
-    def _set_query_tags_for_job(self, load_id: str, table: PreparedTableSchema) -> None:
-        """Sets query tags in sql_client for a job in package `load_id`, starting for a particular `table`"""
+    def _set_query_tags(
+        self, operation: str, *, load_id: str = "", table: Optional[PreparedTableSchema] = None
+    ) -> None:
         from dlt.common.pipeline import current_pipeline
 
         pipeline = current_pipeline()
         pipeline_name = pipeline.pipeline_name if pipeline else ""
+        table_name = table["name"] if table else ""
         self.sql_client.set_query_tags(
             {
+                "operation": operation,
                 "source": self.schema.name,
                 "resource": (
                     get_inherited_table_hint(
-                        self.schema.tables, table["name"], "resource", allow_none=True
+                        self.schema.tables, table_name, "resource", allow_none=True
                     )
                     or ""
                 ),
-                "table": table["name"],
+                "table": table_name,
                 "load_id": load_id,
                 "pipeline_name": pipeline_name,
             }

--- a/dlt/destinations/sql_client.py
+++ b/dlt/destinations/sql_client.py
@@ -19,6 +19,7 @@ from typing import (
     Generator,
     cast,
 )
+from typing_extensions import NotRequired
 
 from dlt.common.destination.exceptions import DestinationUndefinedEntity
 from dlt.common.typing import TFun, TypedDict, Self
@@ -50,7 +51,8 @@ class TQueryTags(TypedDict):
     table: str
     load_id: str
     pipeline_name: str
-    operation: str
+    operation: NotRequired[str]
+
 
 # compatibility export, query tags are no longer job scoped
 TJobQueryTags = TQueryTags

--- a/dlt/destinations/sql_client.py
+++ b/dlt/destinations/sql_client.py
@@ -42,14 +42,18 @@ from dlt.destinations.typing import (
 from dlt.common.destination.dataset import DBApiCursor
 
 
-class TJobQueryTags(TypedDict):
-    """Applied to sql client when a job using it starts. Using to tag queries"""
+class TQueryTags(TypedDict):
+    """Query-tag values applied to a SQL client session for a dlt operation."""
 
     source: str
     resource: str
     table: str
     load_id: str
     pipeline_name: str
+    operation: str
+
+# compatibility export, query tags are no longer job scoped
+TJobQueryTags = TQueryTags
 
 
 class SqlClientBase(ABC, Generic[TNativeConn]):
@@ -75,7 +79,7 @@ class SqlClientBase(ABC, Generic[TNativeConn]):
         self.staging_dataset_name = staging_dataset_name
         self.database_name = database_name
         self.capabilities = capabilities
-        self._query_tags: TJobQueryTags = None
+        self._query_tags: Optional[TQueryTags] = None
 
     @abstractmethod
     def open_connection(self) -> TNativeConn:
@@ -291,8 +295,8 @@ SELECT 1
         """Checks if staging dataset is currently active"""
         return self.dataset_name == self.staging_dataset_name
 
-    def set_query_tags(self, tags: TJobQueryTags) -> None:
-        """Sets current schema (source), resource, load_id and table name when a job starts"""
+    def set_query_tags(self, tags: Optional[TQueryTags]) -> None:
+        """Sets the query-tag payload for the current SQL client session."""
         self._query_tags = tags
 
     def _ensure_native_conn(self) -> None:

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -507,25 +507,27 @@ You'll need these settings when [importing external files](../../general-usage/r
 
 ### Query tagging
 
-`dlt` [tags sessions](https://docs.snowflake.com/en/sql-reference/parameters#query-tag) that execute loading jobs with the following job properties:
+`dlt` [tags sessions](https://docs.snowflake.com/en/sql-reference/parameters#query-tag) used for Snowflake operations with the following properties:
+* **operation** - high-level dlt operation currently using the session
 * **source** - name of the source (identical with the name of the `dlt` schema)
 * **resource** - name of the resource (if known, else empty string)
-* **table** - name of the table loaded by the job
-* **load_id** - load id of the job
+* **table** - name of the table involved in the operation (if known, else empty string)
+* **load_id** - load id associated with the operation (if known, else empty string)
 * **pipeline_name** - name of the active pipeline (or empty string if not found)
 
 You can define a query tag by defining a query tag placeholder in Snowflake credentials:
 
 ```toml
 [destination.snowflake]
-query_tag='{{"source":"{source}", "resource":"{resource}", "table": "{table}", "load_id":"{load_id}", "pipeline_name":"{pipeline_name}"}}'
+query_tag='{{"operation":"{operation}", "source":"{source}", "resource":"{resource}", "table": "{table}", "load_id":"{load_id}", "pipeline_name":"{pipeline_name}"}}'
 ```
 which contains Python named formatters corresponding to tag names i.e., `{source}` will assume the name of the dlt source.
 
 :::note
 1. Query tagging is off by default. The `query_tag` configuration field is `None` by default and must be set to enable tagging.
-2. Only sessions associated with a job are tagged. Sessions that migrate schemas remain untagged.
-3. Jobs processing table chains (i.e., SQL merge jobs) will use the top-level table as **table**.
+2. `dlt` sets query tags for major Snowflake operations such as storage preparation, schema and state reads, schema updates, load jobs, and load completion.
+3. Fields such as **resource**, **table**, and **load_id** may be empty for operations where that context does not apply.
+4. Jobs processing table chains (i.e., SQL merge jobs) will use the top-level table as **table**.
 :::
 
 ### dbt support

--- a/tests/load/pipeline/test_snowflake_pipeline.py
+++ b/tests/load/pipeline/test_snowflake_pipeline.py
@@ -96,21 +96,90 @@ def test_snowflake_query_tagging(
     info = pipeline.run([1, 2, 3], table_name="digits", **destination_config.run_kwargs)
     assert_load_info(info)
 
-    operations = {call.args[1]["operation"] for call in set_query_tags_spy.call_args_list}
-    assert {"prepare_storage", "update_stored_schema", "load", "complete_load"} <= operations
+    expected_load_id = info.loads_ids[0]
+    expected_pipeline_name = pipeline.pipeline_name
+    expected_source = pipeline.default_schema.name
+    expected_resource = pipeline.default_schema.get_table("digits")["resource"]
+
+    tag_calls = [call.args[1] for call in set_query_tags_spy.call_args_list]
+    load_tags = [
+        call for call in tag_calls if call["operation"] == "load" and call["table"] == "digits"
+    ]
+    assert load_tags
+    assert load_tags[0] == {
+        "operation": "load",
+        "source": expected_source,
+        "resource": expected_resource,
+        "table": "digits",
+        "load_id": expected_load_id,
+        "pipeline_name": expected_pipeline_name,
+    }
+
+    complete_load_tags = [call for call in tag_calls if call["operation"] == "complete_load"]
+    assert complete_load_tags
+    assert complete_load_tags[0] == {
+        "operation": "complete_load",
+        "source": expected_source,
+        "resource": "",
+        "table": "",
+        "load_id": expected_load_id,
+        "pipeline_name": expected_pipeline_name,
+    }
+
+    operations = {call["operation"] for call in tag_calls}
+    assert operations == {
+        "complete_load",
+        "get_stored_state",
+        "load",
+        "prepare_storage",
+        "update_stored_schema",
+    }
 
     set_query_tags_spy.reset_mock()
     pipeline._schema_storage.clear_storage()
     pipeline.sync_destination()
 
-    operations = {call.args[1]["operation"] for call in set_query_tags_spy.call_args_list}
-    assert {"get_stored_state", "get_stored_schema"} <= operations
+    sync_tag_calls = [call.args[1] for call in set_query_tags_spy.call_args_list]
+    operations = {call["operation"] for call in sync_tag_calls}
+    assert operations == {"get_stored_state", "get_stored_schema"}
+    for operation in ("get_stored_state", "get_stored_schema"):
+        operation_tags = [call for call in sync_tag_calls if call["operation"] == operation]
+        assert operation_tags
+        assert operation_tags[0] == {
+            "operation": operation,
+            "source": expected_source,
+            "resource": "",
+            "table": "",
+            "load_id": "",
+            "pipeline_name": expected_pipeline_name,
+        }
 
     set_query_tags_spy.reset_mock()
-    info = pipeline.run([1,2,3], table_name="digits", refresh="drop_sources", **destination_config.run_kwargs)
+    info = pipeline.run(
+        [1, 2, 3], table_name="digits", refresh="drop_sources", **destination_config.run_kwargs
+    )
     assert_load_info(info)
-    operations = {call.args[1]["operation"] for call in set_query_tags_spy.call_args_list}
-    assert {"drop_tables"} <= operations
+    refresh_load_id = info.loads_ids[0]
+    refresh_tag_calls = [call.args[1] for call in set_query_tags_spy.call_args_list]
+    operations = {call["operation"] for call in refresh_tag_calls}
+    assert operations == {
+        "complete_load",
+        "drop_tables",
+        "load",
+        "prepare_storage",
+        "update_stored_schema",
+    }
+    drop_table_tags = [call for call in refresh_tag_calls if call["operation"] == "drop_tables"]
+    assert drop_table_tags
+    assert drop_table_tags[0] == {
+        "operation": "drop_tables",
+        "source": expected_source,
+        "resource": "",
+        "table": "",
+        "load_id": refresh_load_id,
+        "pipeline_name": expected_pipeline_name,
+    }
+
 
 # do not remove - it allows us to filter tests by destination
 @pytest.mark.parametrize(

--- a/tests/load/pipeline/test_snowflake_pipeline.py
+++ b/tests/load/pipeline/test_snowflake_pipeline.py
@@ -91,12 +91,26 @@ def test_snowflake_query_tagging(
     from dlt.destinations.impl.snowflake.sql_client import SnowflakeSqlClient
 
     os.environ["DESTINATION__SNOWFLAKE__QUERY_TAG"] = QUERY_TAG
-    tag_query_spy = mocker.spy(SnowflakeSqlClient, "_tag_session")
-    pipeline = destination_config.setup_pipeline("test_snowflake_case_sensitive_identifiers")
+    set_query_tags_spy = mocker.spy(SnowflakeSqlClient, "set_query_tags")
+    pipeline = destination_config.setup_pipeline("test_snowflake_query_tagging")
     info = pipeline.run([1, 2, 3], table_name="digits", **destination_config.run_kwargs)
     assert_load_info(info)
-    assert tag_query_spy.call_count == 2
 
+    operations = {call.args[1]["operation"] for call in set_query_tags_spy.call_args_list}
+    assert {"prepare_storage", "update_stored_schema", "load", "complete_load"} <= operations
+
+    set_query_tags_spy.reset_mock()
+    pipeline._schema_storage.clear_storage()
+    pipeline.sync_destination()
+
+    operations = {call.args[1]["operation"] for call in set_query_tags_spy.call_args_list}
+    assert {"get_stored_state", "get_stored_schema"} <= operations
+
+    set_query_tags_spy.reset_mock()
+    info = pipeline.run([1,2,3], table_name="digits", refresh="drop_sources", **destination_config.run_kwargs)
+    assert_load_info(info)
+    operations = {call.args[1]["operation"] for call in set_query_tags_spy.call_args_list}
+    assert {"drop_tables"} <= operations
 
 # do not remove - it allows us to filter tests by destination
 @pytest.mark.parametrize(

--- a/tests/load/snowflake/test_snowflake_client.py
+++ b/tests/load/snowflake/test_snowflake_client.py
@@ -95,10 +95,10 @@ def test_query_tag(client: SnowflakeClient, mocker: MockerFixture):
     client.sql_client.query_tag = None
     execute_sql_spy.reset_mock()
     client.sql_client.set_query_tags(QUERY_TAGS_DICT)
-    execute_sql_spy.assert_not_called
+    execute_sql_spy.assert_not_called()
     execute_sql_spy.reset_mock()
     client.sql_client.set_query_tags(None)
-    execute_sql_spy.assert_not_called
+    execute_sql_spy.assert_not_called()
 
 
 def test_session_autocommit() -> None:

--- a/tests/load/snowflake/test_snowflake_client.py
+++ b/tests/load/snowflake/test_snowflake_client.py
@@ -12,7 +12,7 @@ from dlt.common.schema.schema import Schema
 from dlt.destinations.impl.snowflake.snowflake import SUPPORTED_HINTS, SnowflakeClient
 from dlt.destinations.job_client_impl import SqlJobClientBase
 
-from dlt.destinations.sql_client import TJobQueryTags
+from dlt.destinations.sql_client import TQueryTags
 
 from tests.cases import TABLE_UPDATE
 from tests.load.utils import yield_client_with_storage, cm_yield_client, empty_schema
@@ -22,10 +22,11 @@ from tests.load.utils import yield_client_with_storage, cm_yield_client, empty_s
 pytestmark = pytest.mark.essential
 
 QUERY_TAG = (
-    '{{"source":"{source}", "resource":"{resource}", "table": "{table}", "load_id":"{load_id}",'
-    ' "pipeline_name":"{pipeline_name}"}}'
+    '{{"operation":"{operation}", "source":"{source}", "resource":"{resource}", "table": "{table}",'
+    ' "load_id":"{load_id}", "pipeline_name":"{pipeline_name}"}}'
 )
-QUERY_TAGS_DICT: TJobQueryTags = {
+QUERY_TAGS_DICT: TQueryTags = {
+    "operation": "load",
     "source": "test_source",
     "resource": "test_resource",
     "table": "test_table",
@@ -81,15 +82,13 @@ def test_query_tag(client: SnowflakeClient, mocker: MockerFixture):
     client.sql_client.set_query_tags(None)
     execute_sql_spy.assert_called_once_with(sql="ALTER SESSION UNSET QUERY_TAG")
     execute_sql_spy.reset_mock()
-    client.sql_client.set_query_tags({})  # type: ignore[typeddict-item]
-    execute_sql_spy.assert_called_once_with(sql="ALTER SESSION UNSET QUERY_TAG")
-    execute_sql_spy.reset_mock()
     # set query tags
     client.sql_client.set_query_tags(QUERY_TAGS_DICT)
     execute_sql_spy.assert_called_once_with(
         sql=(
-            'ALTER SESSION SET QUERY_TAG = \'{"source":"test_source", "resource":"test_resource",'
-            ' "table": "test_table", "load_id":"1109291083091", "pipeline_name":"test_pipeline"}\''
+            'ALTER SESSION SET QUERY_TAG = \'{"operation":"load", "source":"test_source",'
+            ' "resource":"test_resource", "table": "test_table", "load_id":"1109291083091",'
+            ' "pipeline_name":"test_pipeline"}\''
         )
     )
     # remove query tag from config


### PR DESCRIPTION
- Expand Snowflake query tagging from load jobs to broader dlt operations, including storage setup, schema/state reads, schema updates, load execution, load completion, and table drops
- Generalize query tag payloads by renaming TJobQueryTags to TQueryTags, adding an operation field, and keeping a compatibility export for existing imports
- Update docs
- Update tests

Closes #3717 