### PR TITLE
(fix) avoid leaking PUA markers in nested fields

### DIFF
--- a/dlt/common/json/__init__.py
+++ b/dlt/common/json/__init__.py
@@ -16,7 +16,7 @@ from dlt.common.exceptions import TypeErrorWithKnownTypes
 from dlt.common.pendulum import pendulum
 from dlt.common.arithmetics import Decimal
 from dlt.common.wei import Wei
-from dlt.common.utils import map_nested_values_in_place
+from dlt.common.utils import map_nested_values_in_place  # noqa: F401
 from dlt.common.libs.hexbytes import HexBytes
 
 TPuaDecoders = List[Callable[[Any], Any]]
@@ -180,10 +180,42 @@ def custom_pua_decode(obj: Any, decoders: TPuaDecoders = DECODERS) -> Any:
 
 
 def custom_pua_decode_nested(obj: Any, decoders: TPuaDecoders = DECODERS) -> Any:
+    """Decodes PUA markers in `obj`, recursing into dicts and lists in place."""
     if isinstance(obj, str):
-        return custom_pua_decode(obj, decoders)
-    elif isinstance(obj, (list, dict)):
-        return map_nested_values_in_place(custom_pua_decode, obj, decoders=decoders)
+        if len(obj) > 1:
+            c = ord(obj[0]) - PUA_START
+            if c >= 0 and c <= PUA_CHARACTER_MAX:
+                try:
+                    return decoders[c](obj[1:])
+                except Exception:
+                    return obj
+        return obj
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(v, str):
+                if len(v) > 1:
+                    c = ord(v[0]) - PUA_START
+                    if c >= 0 and c <= PUA_CHARACTER_MAX:
+                        try:
+                            obj[k] = decoders[c](v[1:])
+                        except Exception:
+                            pass
+            elif isinstance(v, (dict, list)):
+                custom_pua_decode_nested(v, decoders)
+        return obj
+    elif isinstance(obj, list):
+        for idx, v in enumerate(obj):
+            if isinstance(v, str):
+                if len(v) > 1:
+                    c = ord(v[0]) - PUA_START
+                    if c >= 0 and c <= PUA_CHARACTER_MAX:
+                        try:
+                            obj[idx] = decoders[c](v[1:])
+                        except Exception:
+                            pass
+            elif isinstance(v, (dict, list)):
+                custom_pua_decode_nested(v, decoders)
+        return obj
     return obj
 
 

--- a/dlt/normalize/items_normalizers/jsonl.py
+++ b/dlt/normalize/items_normalizers/jsonl.py
@@ -6,7 +6,7 @@ from dlt.common.data_types.typing import TDataType
 from dlt.common.destination.capabilities import adjust_column_schema_to_capabilities
 from dlt.common import logger
 from dlt.common.json import json
-from dlt.common.json import custom_pua_decode, may_have_pua
+from dlt.common.json import custom_pua_decode_nested, may_have_pua
 from dlt.common.schema import utils
 from dlt.common.schema.typing import (
     TColumnSchema,
@@ -113,7 +113,7 @@ class JsonLItemsNormalizer(ItemsNormalizer):
                     # decode pua types
                     if may_have_pua:
                         for k, v in row.items():
-                            row[k] = custom_pua_decode(v)  # type: ignore
+                            row[k] = custom_pua_decode_nested(v)  # type: ignore
 
                     # coerce row of values into schema table, generating partial table with new columns if any
                     row, partial_table = self._coerce_row(table_name, parent_table, row)

--- a/dlt/normalize/items_normalizers/jsonl.py
+++ b/dlt/normalize/items_normalizers/jsonl.py
@@ -6,7 +6,13 @@ from dlt.common.data_types.typing import TDataType
 from dlt.common.destination.capabilities import adjust_column_schema_to_capabilities
 from dlt.common import logger
 from dlt.common.json import json
-from dlt.common.json import custom_pua_decode_nested, may_have_pua
+from dlt.common.json import (
+    DECODERS,
+    PUA_CHARACTER_MAX,
+    PUA_START,
+    custom_pua_decode_nested,
+    may_have_pua,
+)
 from dlt.common.schema import utils
 from dlt.common.schema.typing import (
     TColumnSchema,
@@ -110,10 +116,20 @@ class JsonLItemsNormalizer(ItemsNormalizer):
                             should_descend = False
                             continue
 
-                    # decode pua types
+                    # decode pua types: inline string check for the common
+                    # case (flat rows), delegate to recursive decoder for containers
                     if may_have_pua:
                         for k, v in row.items():
-                            row[k] = custom_pua_decode_nested(v)  # type: ignore
+                            if isinstance(v, str):
+                                if len(v) > 1:
+                                    c = ord(v[0]) - PUA_START
+                                    if c >= 0 and c <= PUA_CHARACTER_MAX:
+                                        try:
+                                            row[k] = DECODERS[c](v[1:])  # type: ignore[index]
+                                        except Exception:
+                                            pass
+                            elif isinstance(v, (dict, list)):
+                                custom_pua_decode_nested(v)
 
                     # coerce row of values into schema table, generating partial table with new columns if any
                     row, partial_table = self._coerce_row(table_name, parent_table, row)

--- a/tests/destinations/test_custom_destination.py
+++ b/tests/destinations/test_custom_destination.py
@@ -347,6 +347,7 @@ def test_destination_type_main_module_fallback() -> None:
 
 def test_custom_destination_cli_info() -> None:
     """Test that `dlt pipeline <name> info` works for all custom destination patterns."""
+
     # pattern 1: @dlt.destination decorator
     @dlt.destination
     def my_sink(items, table):

--- a/tests/pipeline/test_pipeline_extra.py
+++ b/tests/pipeline/test_pipeline_extra.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime
+from decimal import Decimal as PyDecimal
 import os
 import importlib.util
 from typing import Any, ClassVar, Dict, Iterator, List, Optional, Union
@@ -914,3 +916,50 @@ def test_pydantic_return_validated_models(return_models, yield_models, yield_lis
             assert all(t is dict for t in seen_inner if t)
         else:
             assert all(t is dict for t in seen_outer)
+
+
+def test_nested_pydantic_model_no_pua_markers() -> None:
+    """Nested Pydantic models with date/datetime/Decimal must not leak PUA markers.
+
+    Regression test for #3755.
+    """
+
+    class NestedModel(BaseModel):
+        date_field: date
+        timestamp_field: datetime
+        decimal_field: PyDecimal
+
+    class ParentModel(BaseModel):
+        nested: NestedModel
+
+    @dlt.resource(
+        table_name="items",
+        max_table_nesting=0,
+        columns=ParentModel,
+    )
+    def get_items():
+        yield [
+            {
+                "id": 1,
+                "nested": {
+                    "date_field": date(2026, 1, 1),
+                    "timestamp_field": datetime(2026, 1, 1, 12, 0, 0),
+                    "decimal_field": PyDecimal("123.45"),
+                },
+            },
+        ]
+
+    pipeline = dlt.pipeline(destination="duckdb")
+    info = pipeline.run(get_items)
+    assert_load_info(info)
+
+    with pipeline.sql_client() as client:
+        rows = client.execute_sql("SELECT nested FROM items")
+        nested_json = rows[0][0]
+        assert nested_json == json.dumps(
+            {
+                "date_field": "2026-01-01",
+                "timestamp_field": "2026-01-01T12:00:00",
+                "decimal_field": "123.45",
+            }
+        )

--- a/tests/workspace/helpers/dashboard/test_pipeline_operations.py
+++ b/tests/workspace/helpers/dashboard/test_pipeline_operations.py
@@ -113,8 +113,9 @@ def test_pipeline_details(pipeline, temp_pipelines_dir):
     elif pipeline.pipeline_name == LOAD_EXCEPTION_PIPELINE:
         assert details_dict["destination"] == "dummy (dlt.destinations.dummy)"
     elif pipeline.pipeline_name == CUSTOM_DESTINATION_PIPELINE:
-        assert details_dict["destination"] == (
-            "_dashboard_decorator_sink (tests.workspace.helpers.dashboard"
+        assert (
+            details_dict["destination"]
+            == "_dashboard_decorator_sink (tests.workspace.helpers.dashboard"
             ".example_pipelines.DashboardDecoratorSinkDestination)"
         )
     elif pipeline.pipeline_name == CUSTOM_DEST_CALLABLE_PIPELINE:


### PR DESCRIPTION
### Description

Some PUA markers leak in nested models when using Pydantic.
This should fix that.

Note that I'm not familiar with the codebase, Claude Opus 4.6 did most of the work.
That said, the test looks solid to me and it doesn't pass on `devel`, while it passes with the proposed fix.

### Related Issues

- Fixes #3755 

### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
