### PR TITLE
feat(ducklake): add metadata_schema option to ATTACH statement

### DIFF
--- a/dlt/destinations/impl/ducklake/configuration.py
+++ b/dlt/destinations/impl/ducklake/configuration.py
@@ -35,15 +35,22 @@ def _get_ducklake_capabilities() -> DestinationCapabilitiesContext:
 @configspec(init=False)
 class DuckLakeCredentials(DuckDbBaseCredentials):
     ducklake_name: str = DEFAULT_DUCKLAKE_NAME
+    metadata_schema: Optional[str] = None
     catalog: ConnectionStringCredentials = None
     # NOTE: consider moving to DuckLakeClientConfiguration so bucket_url is not a secret
     storage: FilesystemConfiguration = None
 
-    __config_gen_annotations__: ClassVar[list[str]] = ["ducklake_name", "catalog", "storage"]
+    __config_gen_annotations__: ClassVar[list[str]] = [
+        "ducklake_name",
+        "metadata_schema",
+        "catalog",
+        "storage",
+    ]
 
     def __init__(
         self,
         ducklake_name: str = DEFAULT_DUCKLAKE_NAME,
+        metadata_schema: Optional[str] = None,
         catalog: Union[str, ConnectionStringCredentials] = None,
         storage: Union[str, FilesystemConfiguration] = None,
     ) -> None:
@@ -55,6 +62,9 @@ class DuckLakeCredentials(DuckDbBaseCredentials):
                 This value is mainly used as ATTACH name for the ducklake database and
                 as names for catalog and storage files if not configured explicitly.
                 If omitted, ducklake name is derived from destination name or pipeline name.
+            metadata_schema: str, optional
+                Metadata schema to use for SQL-based catalogs. If omitted, defaults to
+                `ducklake_name`.
             catalog: Either a connection string (for example,
                 "sqlite:///catalog.sqlite", "duckdb:///catalog.duckdb",
                 or "postgres://loader:loader@localhost:5432/dlt_data") or a
@@ -68,6 +78,7 @@ class DuckLakeCredentials(DuckDbBaseCredentials):
 
         """
         self.ducklake_name = ducklake_name
+        self.metadata_schema = metadata_schema
         if isinstance(catalog, str):
             catalog = ConnectionStringCredentials(catalog)
         self.catalog = catalog
@@ -128,7 +139,6 @@ class DuckLakeClientConfiguration(WithLocalFiles, DestinationClientDwhWithStagin
     )
     credentials: DuckLakeCredentials = None
     create_indexes: bool = False  # does nothing but required
-    metadata_schema: Optional[str] = None
     override_data_path: bool = False
 
     def fingerprint(self) -> str:

--- a/dlt/destinations/impl/ducklake/configuration.py
+++ b/dlt/destinations/impl/ducklake/configuration.py
@@ -1,7 +1,7 @@
 # from __future__ import annotations
 
 import dataclasses
-from typing import ClassVar, Union
+from typing import ClassVar, Optional, Union
 
 from dlt.common.configuration import configspec
 from dlt.common.configuration.exceptions import ConfigFieldMissingException
@@ -128,6 +128,7 @@ class DuckLakeClientConfiguration(WithLocalFiles, DestinationClientDwhWithStagin
     )
     credentials: DuckLakeCredentials = None
     create_indexes: bool = False  # does nothing but required
+    metadata_schema: Optional[str] = None
     override_data_path: bool = False
 
     def fingerprint(self) -> str:

--- a/dlt/destinations/impl/ducklake/ducklake.py
+++ b/dlt/destinations/impl/ducklake/ducklake.py
@@ -174,6 +174,7 @@ class DuckLakeClient(DuckDbClient):
             staging_dataset_name=config.normalize_staging_dataset_name(schema),
             credentials=config.credentials,
             capabilities=capabilities,
+            metadata_schema=config.metadata_schema,
             override_data_path=config.override_data_path,
         )
 

--- a/dlt/destinations/impl/ducklake/ducklake.py
+++ b/dlt/destinations/impl/ducklake/ducklake.py
@@ -174,7 +174,6 @@ class DuckLakeClient(DuckDbClient):
             staging_dataset_name=config.normalize_staging_dataset_name(schema),
             credentials=config.credentials,
             capabilities=capabilities,
-            metadata_schema=config.metadata_schema,
             override_data_path=config.override_data_path,
         )
 

--- a/dlt/destinations/impl/ducklake/sql_client.py
+++ b/dlt/destinations/impl/ducklake/sql_client.py
@@ -26,13 +26,11 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         staging_dataset_name: str,
         credentials: DuckLakeCredentials,
         capabilities: DestinationCapabilitiesContext,
-        metadata_schema: Optional[str] = None,
         override_data_path: bool = False,
     ) -> None:
         super().__init__(dataset_name, staging_dataset_name, credentials, capabilities)
         self.credentials: DuckLakeCredentials = credentials
         self._attach_statement: str = None
-        self.metadata_schema = metadata_schema
         self.override_data_path = override_data_path
 
     def create_dataset(self) -> None:
@@ -166,7 +164,7 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         else:
             return self.build_attach_statement(
                 ducklake_name=self.credentials.ducklake_name,
-                metadata_schema=self.metadata_schema,
+                metadata_schema=self.credentials.metadata_schema,
                 catalog=self.credentials.catalog,
                 storage_url=self.credentials.storage_url,
                 override_data_path=self.override_data_path,

--- a/dlt/destinations/impl/ducklake/sql_client.py
+++ b/dlt/destinations/impl/ducklake/sql_client.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Type
+from typing import ClassVar, Optional, Type
 
 from duckdb import DuckDBPyConnection
 
@@ -26,11 +26,13 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         staging_dataset_name: str,
         credentials: DuckLakeCredentials,
         capabilities: DestinationCapabilitiesContext,
+        metadata_schema: Optional[str] = None,
         override_data_path: bool = False,
     ) -> None:
         super().__init__(dataset_name, staging_dataset_name, credentials, capabilities)
         self.credentials: DuckLakeCredentials = credentials
         self._attach_statement: str = None
+        self.metadata_schema = metadata_schema
         self.override_data_path = override_data_path
 
     def create_dataset(self) -> None:
@@ -122,11 +124,13 @@ class DuckLakeSqlClient(DuckDbSqlClient):
     def build_attach_statement(
         *,
         ducklake_name: str,
+        metadata_schema: Optional[str] = None,
         catalog: ConnectionStringCredentials,
         storage_url: str,
         override_data_path: bool = False,
     ) -> str:
         attach_params = ""
+        metadata_schema = metadata_schema or ducklake_name
         if isinstance(catalog, DuckDbCredentials):
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:{catalog._conn_str()}'"
         elif catalog.drivername in ("postgres", "postgresql", "mysql"):
@@ -136,13 +140,13 @@ class DuckLakeSqlClient(DuckDbSqlClient):
 
             db_url = catalog.to_url().render_as_string(hide_password=False)
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:{catalog.drivername}:{db_url}'"
-            attach_params = f", METADATA_SCHEMA '{ducklake_name}'"
+            attach_params = f", METADATA_SCHEMA '{metadata_schema}'"
         elif catalog.drivername == "md":
             logger.warning(
                 "Motherduck requires token present in the environment and will most probably crash."
             )
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:md:{catalog.database}'"
-            attach_params = f", METADATA_SCHEMA '{ducklake_name}'"
+            attach_params = f", METADATA_SCHEMA '{metadata_schema}'"
         elif catalog.drivername in ("sqlite", "duckdb"):
             # attach sqllite with multi-process access
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:{catalog.database}'"
@@ -162,6 +166,7 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         else:
             return self.build_attach_statement(
                 ducklake_name=self.credentials.ducklake_name,
+                metadata_schema=self.metadata_schema,
                 catalog=self.credentials.catalog,
                 storage_url=self.credentials.storage_url,
                 override_data_path=self.override_data_path,

--- a/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
@@ -129,15 +129,16 @@ ducklake_max_retry_count=100
 ### Metadata schema
 For SQL-based DuckLake catalogs, you can set `metadata_schema` to control the `METADATA_SCHEMA`
 option in the DuckLake `ATTACH` statement independently from `ducklake_name`. If omitted,
-`ducklake_name` is used.
+`ducklake_name` is used. This is useful when connecting to an existing PostgreSQL-backed
+DuckLake catalog that stores metadata in the `public` schema.
 
 ```toml
 [destination.ducklake.credentials]
-metadata_schema="ducklake_metadata"
+metadata_schema="public"
 ```
 
 Or via environment variable
-`DESTINATION__DUCKLAKE__CREDENTIALS__METADATA_SCHEMA=ducklake_metadata`, or in code:
+`DESTINATION__DUCKLAKE__CREDENTIALS__METADATA_SCHEMA=public`, or in code:
 ```py
 import dlt
 from dlt.destinations.impl.ducklake.configuration import DuckLakeCredentials
@@ -146,7 +147,7 @@ destination = dlt.destinations.ducklake(
     credentials=DuckLakeCredentials(
         catalog="postgresql://loader:loader@localhost:5432/dlt_data",
         storage="s3://bucket/data",
-        metadata_schema="ducklake_metadata",
+        metadata_schema="public",
     ),
 )
 ```

--- a/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
@@ -132,12 +132,12 @@ option in the DuckLake `ATTACH` statement independently from `ducklake_name`. If
 `ducklake_name` is used.
 
 ```toml
-[destination.ducklake]
+[destination.ducklake.credentials]
 metadata_schema="ducklake_metadata"
 ```
 
-Or via environment variable `DESTINATION__DUCKLAKE__METADATA_SCHEMA=ducklake_metadata`, or in
-code:
+Or via environment variable
+`DESTINATION__DUCKLAKE__CREDENTIALS__METADATA_SCHEMA=ducklake_metadata`, or in code:
 ```py
 import dlt
 from dlt.destinations.impl.ducklake.configuration import DuckLakeCredentials
@@ -146,8 +146,8 @@ destination = dlt.destinations.ducklake(
     credentials=DuckLakeCredentials(
         catalog="postgresql://loader:loader@localhost:5432/dlt_data",
         storage="s3://bucket/data",
+        metadata_schema="ducklake_metadata",
     ),
-    metadata_schema="ducklake_metadata",
 )
 ```
 

--- a/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
@@ -126,6 +126,31 @@ You can set additional connection options, pragmas and extensions - `ducklake` c
 ducklake_max_retry_count=100
 ```
 
+### Metadata schema
+For SQL-based DuckLake catalogs, you can set `metadata_schema` to control the `METADATA_SCHEMA`
+option in the DuckLake `ATTACH` statement independently from `ducklake_name`. If omitted,
+`ducklake_name` is used.
+
+```toml
+[destination.ducklake]
+metadata_schema="ducklake_metadata"
+```
+
+Or via environment variable `DESTINATION__DUCKLAKE__METADATA_SCHEMA=ducklake_metadata`, or in
+code:
+```py
+import dlt
+from dlt.destinations.impl.ducklake.configuration import DuckLakeCredentials
+
+destination = dlt.destinations.ducklake(
+    credentials=DuckLakeCredentials(
+        catalog="postgresql://loader:loader@localhost:5432/dlt_data",
+        storage="s3://bucket/data",
+    ),
+    metadata_schema="ducklake_metadata",
+)
+```
+
 ### Override data path
 DuckLake stores file paths in the catalog relative to a base `DATA_PATH` that is set at creation time. When `override_data_path` is set to `True`, the `DATA_PATH` provided in the current connection replaces the stored one for both reads and writes. The stored value in the catalog is not modified.
 

--- a/tests/load/ducklake/test_ducklake_client.py
+++ b/tests/load/ducklake/test_ducklake_client.py
@@ -230,10 +230,12 @@ def test_ducklake_configuration_catalog_credentials() -> None:
 
 def test_ducklake_metadata_schema_config() -> None:
     configuration = resolve_configuration(
-        DuckLakeClientConfiguration(metadata_schema="bar")._bind_dataset_name(dataset_name="foo")
+        DuckLakeClientConfiguration(
+            credentials=DuckLakeCredentials(metadata_schema="bar")
+        )._bind_dataset_name(dataset_name="foo")
     )
 
-    assert configuration.metadata_schema == "bar"
+    assert configuration.credentials.metadata_schema == "bar"
 
 
 def test_ducklake_attach_statement() -> None:

--- a/tests/load/ducklake/test_ducklake_client.py
+++ b/tests/load/ducklake/test_ducklake_client.py
@@ -228,6 +228,14 @@ def test_ducklake_configuration_catalog_credentials() -> None:
     assert credentials.storage_url == str(local_dir / "ducklake.files")
 
 
+def test_ducklake_metadata_schema_config() -> None:
+    configuration = resolve_configuration(
+        DuckLakeClientConfiguration(metadata_schema="bar")._bind_dataset_name(dataset_name="foo")
+    )
+
+    assert configuration.metadata_schema == "bar"
+
+
 def test_ducklake_attach_statement() -> None:
     """Low-level method to attach the ducklake catalog to the ducklake client.
 
@@ -278,6 +286,21 @@ def test_ducklake_attach_statement_with_override_data_path() -> None:
         storage_url="/path/to/storage",
         override_data_path=True,
     )
+    assert expected_attach_statement == attach_statement
+
+
+def test_ducklake_attach_statement_with_metadata_schema() -> None:
+    expected_attach_statement = (
+        "ATTACH IF NOT EXISTS 'ducklake:postgres:postgres://loader:loader@localhost:5432/dlt_data'"
+        " AS foo (DATA_PATH '/path/to/storage', METADATA_SCHEMA 'bar')"
+    )
+    attach_statement = DuckLakeSqlClient.build_attach_statement(
+        catalog=ConnectionStringCredentials("postgres://loader:loader@localhost:5432/dlt_data"),
+        ducklake_name="foo",
+        metadata_schema="bar",
+        storage_url="/path/to/storage",
+    )
+
     assert expected_attach_statement == attach_statement
 
 


### PR DESCRIPTION
### Description

Add `metadata_schema: Optional[str]` option to `DuckLakeCredentials`. When set, the generated DuckLake `ATTACH` statement uses the provided value for `METADATA_SCHEMA`, allowing the metadata schema to be configured independently from `ducklake_name`.

If omitted, `ducklake_name` is used as the default metadata schema to preserve the current behavior.

### Related Issues

- Closes #3764

### Additional Context

Configurable via Python API or environment variable `DESTINATION__DUCKLAKE__CREDENTIALS__METADATA_SCHEMA`.

```py
import dlt
from dlt.destinations.impl.ducklake.configuration import DuckLakeCredentials

destination = dlt.destinations.ducklake(
    credentials=DuckLakeCredentials(
        catalog="postgresql://loader:loader@localhost:5432/dlt_data",
        storage="s3://bucket/data",
        metadata_schema="public",
    ),
)
```

Test: `uv run --extra ducklake pytest tests/load/ducklake/test_ducklake_client.py -v -k metadata_schema`