### PR TITLE
Issue 3592 make --non-interactive flag always accept confirmations

### DIFF
--- a/dlt/_workspace/cli/_dlt.py
+++ b/dlt/_workspace/cli/_dlt.py
@@ -68,10 +68,9 @@ class NonInteractiveAction(argparse.Action):
         values: Any,
         option_string: str = None,
     ) -> None:
-        fmt.ALWAYS_CHOOSE_DEFAULT = True
+        fmt.ALWAYS_CHOOSE_VALUE = True
         fmt.note(
-            "Non interactive mode. Default choices are automatically made for confirmations and"
-            " prompts."
+            "Non interactive mode. Confirmations are automatically accepted."
         )
 
 

--- a/tests/workspace/cli/conftest.py
+++ b/tests/workspace/cli/conftest.py
@@ -6,6 +6,14 @@ from dlt._workspace._workspace_context import WorkspaceRunContext
 
 from tests.workspace.utils import isolated_workspace
 
+# Import fixtures from utils to make them available to all tests
+from tests.workspace.cli.utils import (  # noqa: F401
+    _cached_init_repo,
+    cloned_init_repo,
+    repo_dir,
+    auto_echo_default_choice,
+)
+
 
 @pytest.fixture(autouse=True)
 def auto_isolated_workspace(

--- a/tests/workspace/cli/test_non_interactive.py
+++ b/tests/workspace/cli/test_non_interactive.py
@@ -1,0 +1,136 @@
+import io
+import os
+import contextlib
+from subprocess import CalledProcessError
+
+import dlt
+from dlt.common.runners.venv import Venv
+
+from dlt._workspace.cli import echo, _init_command, _pipeline_command
+
+from tests.workspace.cli.utils import (
+    repo_dir,
+    cloned_init_repo,
+    _cached_init_repo,
+)
+
+
+def test_non_interactive_drop_command(repo_dir: str) -> None:
+    """Test that --non-interactive flag makes drop command proceed without prompts."""
+    # init_command will use auto_echo_default_choice from the fixture
+    _init_command.init_command("chess", "duckdb", repo_dir)
+
+    # clean up any existing pipeline
+    try:
+        pipeline = dlt.attach(pipeline_name="chess_pipeline")
+        pipeline.drop()
+    except Exception:
+        pass
+
+    # run the pipeline
+    os.environ.pop("DESTINATION__DUCKDB__CREDENTIALS", None)
+    venv = Venv.restore_current()
+    try:
+        venv.run_script("chess_pipeline.py")
+    except CalledProcessError as cpe:
+        print(cpe.stdout)
+        print(cpe.stderr)
+        raise
+
+    # verify the resource exists before drop
+    pipeline = dlt.attach(pipeline_name="chess_pipeline")
+    assert "players_games" in pipeline.default_schema.tables
+
+    # test drop command with non-interactive mode (simulates --non-interactive flag)
+    # We use echo.always_choose to set ALWAYS_CHOOSE_VALUE = True
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        with echo.always_choose(False, True):
+            _pipeline_command.pipeline_command(
+                "drop", "chess_pipeline", None, 0, resources=["players_games"]
+            )
+        _out = buf.getvalue()
+
+        # verify the command output shows it will drop the resource
+        assert "Selected resource(s): ['players_games']" in _out
+
+    # verify the command actually executed (resource was dropped)
+    pipeline = dlt.attach(pipeline_name="chess_pipeline")
+    assert "players_games" not in pipeline.default_schema.tables
+
+
+def test_non_interactive_sync_command(repo_dir: str) -> None:
+    """Test that --non-interactive flag makes sync command proceed without prompts."""
+    _init_command.init_command("chess", "duckdb", repo_dir)
+
+    # clean up any existing pipeline
+    try:
+        pipeline = dlt.attach(pipeline_name="chess_pipeline")
+        pipeline.drop()
+    except Exception:
+        pass
+
+    # run the pipeline
+    os.environ.pop("DESTINATION__DUCKDB__CREDENTIALS", None)
+    venv = Venv.restore_current()
+    try:
+        venv.run_script("chess_pipeline.py")
+    except CalledProcessError as cpe:
+        print(cpe.stdout)
+        print(cpe.stderr)
+        raise
+
+    # test sync command with non-interactive mode
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        with echo.always_choose(False, True):
+            _pipeline_command.pipeline_command("sync", "chess_pipeline", None, 0)
+        _out = buf.getvalue()
+
+        # verify sync was executed
+        assert "Dropping local state" in _out
+        assert "Restoring from destination" in _out
+
+    # after sync there's no trace
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        _pipeline_command.pipeline_command("info", "chess_pipeline", None, 0)
+        _out = buf.getvalue()
+        assert "Pipeline does not have last run trace." in _out
+
+
+def test_non_interactive_drop_pending_packages(repo_dir: str) -> None:
+    """Test that --non-interactive flag makes drop-pending-packages command proceed."""
+    _init_command.init_command("chess", "dummy", repo_dir)
+    os.environ["EXCEPTION_PROB"] = "1.0"
+
+    # clean up any existing pipeline
+    try:
+        pipeline = dlt.attach(pipeline_name="chess_pipeline")
+        pipeline.drop()
+    except Exception:
+        pass
+
+    # run pipeline with exception to create pending packages
+    venv = Venv.restore_current()
+    try:
+        venv.run_script("chess_pipeline.py")
+    except CalledProcessError:
+        pass  # expected to fail
+
+    # verify there are pending packages
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        _pipeline_command.pipeline_command("info", "chess_pipeline", None, 1)
+        _out = buf.getvalue()
+        assert "extracted packages ready to be normalized" in _out or "normalized packages ready to be loaded" in _out
+
+    # test drop-pending-packages with non-interactive mode
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        with echo.always_choose(False, True):
+            _pipeline_command.pipeline_command("drop-pending-packages", "chess_pipeline", None, 1)
+        _out = buf.getvalue()
+
+        assert "Pending packages deleted" in _out
+
+    # verify packages were deleted
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        _pipeline_command.pipeline_command("drop-pending-packages", "chess_pipeline", None, 1)
+        _out = buf.getvalue()
+        assert "No pending packages found" in _out

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ overrides = [{ name = "docstring-parser", marker = "sys_platform == 'never'" }]
 [[package]]
 name = "about-time"
 version = "4.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/3f/ccb16bdc53ebb81c1bf837c1ee4b5b0b69584fd2e4a802a2a79936691c0a/about-time-4.2.1.tar.gz", hash = "sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece", size = 15380, upload-time = "2022-12-21T04:15:54.991Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/cd/7ee00d6aa023b1d0551da0da5fee3bc23c3eeea632fbfc5126d1fec52b7e/about_time-4.2.1-py3-none-any.whl", hash = "sha256:8bbf4c75fe13cbd3d72f49a03b02c5c7dca32169b6d49117c257e7eb3eaee341", size = 13295, upload-time = "2022-12-21T04:15:53.613Z" },
@@ -55,7 +55,7 @@ wheels = [
 [[package]]
 name = "adbc-driver-manager"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -65,7 +65,7 @@ resolution-markers = [
     "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/2a/00fe4974b7d134c8d0691a87f09460d949e607e1ef65a022c665e8bde64f/adbc_driver_manager-1.8.0.tar.gz", hash = "sha256:88ca0f4d8c02fc6859629acaf0504620da17a39549e64d4098a3497f7f1eb2d0", size = 203568, upload-time = "2025-09-12T12:31:24.233Z" }
 wheels = [
@@ -107,7 +107,7 @@ wheels = [
 [[package]]
 name = "adbc-driver-manager"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -141,7 +141,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/b4/09a85ca2bb2ba53d6577745a0aae0766393b69d0ae1e645ff4d34bee6866/adbc_driver_manager-1.9.0.tar.gz", hash = "sha256:d6687acf57f92e469e78d53df6baf70ab62f8886ba8f2e0b25613aecd1807ae9", size = 205762, upload-time = "2025-11-07T01:46:55.953Z" }
 wheels = [
@@ -183,7 +183,7 @@ wheels = [
 [[package]]
 name = "adlfs"
 version = "2024.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "azure-core" },
@@ -200,7 +200,7 @@ wheels = [
 [[package]]
 name = "agate"
 version = "1.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "babel" },
     { name = "isodate" },
@@ -217,7 +217,7 @@ wheels = [
 [[package]]
 name = "aiobotocore"
 version = "2.22.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aioitertools" },
@@ -235,7 +235,7 @@ wheels = [
 [[package]]
 name = "aiofile"
 version = "3.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "caio", marker = "python_full_version >= '3.10'" },
 ]
@@ -247,7 +247,7 @@ wheels = [
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
@@ -256,13 +256,13 @@ wheels = [
 [[package]]
 name = "aiohttp"
 version = "3.12.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
@@ -360,9 +360,9 @@ wheels = [
 [[package]]
 name = "aioitertools"
 version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/de/38491a84ab323b47c7f86e94d2830e748780525f7a10c8600b67ead7e9ea/aioitertools-0.12.0.tar.gz", hash = "sha256:c2a9055b4fbb7705f561b9d86053e8af5d10cc845d22c32008c43490b2d8dd6b", size = 19369, upload-time = "2024-09-02T03:33:40.349Z" }
 wheels = [
@@ -372,7 +372,7 @@ wheels = [
 [[package]]
 name = "aiosignal"
 version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "frozenlist" },
 ]
@@ -384,13 +384,13 @@ wheels = [
 [[package]]
 name = "alembic"
 version = "1.16.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/89/bfb4fe86e3fc3972d35431af7bedbc60fa606e8b17196704a1747f7aa4c3/alembic-1.16.1.tar.gz", hash = "sha256:43d37ba24b3d17bc1eb1024fe0f51cd1dc95aeb5464594a02c6bb9ca9864bfa4", size = 1955006, upload-time = "2025-05-21T23:11:05.991Z" }
 wheels = [
@@ -400,7 +400,7 @@ wheels = [
 [[package]]
 name = "alive-progress"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "about-time" },
     { name = "grapheme" },
@@ -413,7 +413,7 @@ wheels = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -422,7 +422,7 @@ wheels = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -431,7 +431,7 @@ wheels = [
 [[package]]
 name = "ansicon"
 version = "1.89.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/e2/1c866404ddbd280efedff4a9f15abfe943cb83cde6e895022370f3a61f85/ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1", size = 67312, upload-time = "2019-04-29T20:23:57.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/f9/f1c10e223c7b56a38109a3f2eb4e7fe9a757ea3ed3a166754fb30f65e466/ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec", size = 63675, upload-time = "2019-04-29T20:23:53.83Z" },
@@ -440,13 +440,13 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "sniffio" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
@@ -456,7 +456,7 @@ wheels = [
 [[package]]
 name = "apache-airflow"
 version = "2.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "alembic", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-compat", marker = "python_full_version < '3.13'" },
@@ -470,8 +470,8 @@ dependencies = [
     { name = "apache-airflow-providers-sqlite", marker = "python_full_version < '3.13'" },
     { name = "argcomplete", marker = "python_full_version < '3.13'" },
     { name = "asgiref", marker = "python_full_version < '3.13'" },
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "blinker", marker = "python_full_version < '3.13'" },
     { name = "colorlog", marker = "python_full_version < '3.13'" },
     { name = "configupdater", marker = "python_full_version < '3.13'" },
@@ -537,7 +537,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-common-compat"
 version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -549,7 +549,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-common-io"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -561,7 +561,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-common-sql"
 version = "1.27.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "methodtools", marker = "python_full_version < '3.13'" },
@@ -576,7 +576,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-fab"
 version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-compat", marker = "python_full_version < '3.13'" },
@@ -594,7 +594,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-ftp"
 version = "3.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -606,7 +606,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-http"
 version = "5.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "aiohttp", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
@@ -622,7 +622,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-imap"
 version = "3.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -634,7 +634,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-smtp"
 version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-compat", marker = "python_full_version < '3.13'" },
@@ -647,7 +647,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-sqlite"
 version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-sql", marker = "python_full_version < '3.13'" },
@@ -660,7 +660,7 @@ wheels = [
 [[package]]
 name = "apispec"
 version = "6.8.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "packaging", marker = "python_full_version < '3.13'" },
 ]
@@ -677,7 +677,7 @@ yaml = [
 [[package]]
 name = "appdirs"
 version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
@@ -686,7 +686,7 @@ wheels = [
 [[package]]
 name = "argcomplete"
 version = "3.6.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/16/0f/861e168fc813c56a78b35f3c30d91c6757d1fd185af1110f1aec784b35d0/argcomplete-3.6.2.tar.gz", hash = "sha256:d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf", size = 73403, upload-time = "2025-04-03T04:57:03.52Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/da/e42d7a9d8dd33fa775f467e4028a47936da2f01e4b0e561f9ba0d74cb0ca/argcomplete-3.6.2-py3-none-any.whl", hash = "sha256:65b3133a29ad53fb42c48cf5114752c7ab66c1c38544fdf6460f450c09b42591", size = 43708, upload-time = "2025-04-03T04:57:01.591Z" },
@@ -695,10 +695,10 @@ wheels = [
 [[package]]
 name = "arro3-core"
 version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/e7/d84370ea85be641a8c57f4f8296e8465d30e46938cc9480d384a3ee0084c/arro3_core-0.8.0.tar.gz", hash = "sha256:b75d8281b87a87d3b66836bab89951ae06421970e5f880717723a93e38743f40", size = 93557, upload-time = "2026-02-23T15:12:20.622Z" }
 wheels = [
@@ -784,10 +784,10 @@ wheels = [
 [[package]]
 name = "asgiref"
 version = "3.8.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/38/b3395cc9ad1b56d2ddac9970bc8f4141312dbaec28bc7c218b0dfafd0f42/asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590", size = 35186, upload-time = "2024-03-22T14:39:36.863Z" }
 wheels = [
@@ -797,7 +797,7 @@ wheels = [
 [[package]]
 name = "asn1crypto"
 version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
@@ -806,7 +806,7 @@ wheels = [
 [[package]]
 name = "astatine"
 version = "0.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "asttokens" },
     { name = "domdf-python-tools" },
@@ -819,7 +819,7 @@ wheels = [
 [[package]]
 name = "asttokens"
 version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978, upload-time = "2024-11-30T04:30:14.439Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918, upload-time = "2024-11-30T04:30:10.946Z" },
@@ -828,7 +828,7 @@ wheels = [
 [[package]]
 name = "async-timeout"
 version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
@@ -837,7 +837,7 @@ wheels = [
 [[package]]
 name = "atpublic"
 version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/40/e686038a07af08e8462a71dc9201867ffdde408b4d93be90a4ad0fbc83ef/atpublic-6.0.1.tar.gz", hash = "sha256:718932844f5bdfdf5d80ad4c64e13964f22274b4f8937d54a8d3811d6bc5dc05", size = 17520, upload-time = "2025-05-07T03:11:30.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/37/66f9fcdd6a56ab3da53291c7501890246c39bc7b5891e27cd956efe127ca/atpublic-6.0.1-py3-none-any.whl", hash = "sha256:f9a23902faf5ca1fdc6436b3712d79452f71abc61a810d22be1f31b40a8004c5", size = 6421, upload-time = "2025-05-07T03:11:29.398Z" },
@@ -846,7 +846,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "25.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -863,7 +863,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "25.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -904,7 +904,7 @@ wheels = [
 [[package]]
 name = "authlib"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -924,7 +924,7 @@ wheels = [
 [[package]]
 name = "authlib"
 version = "1.6.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -968,12 +968,12 @@ wheels = [
 [[package]]
 name = "azure-core"
 version = "1.34.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "requests" },
     { name = "six" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/29/ff7a519a315e41c85bab92a7478c6acd1cf0b14353139a08caee4c691f77/azure_core-1.34.0.tar.gz", hash = "sha256:bdb544989f246a0ad1c85d72eeb45f2f835afdcbc5b45e43f0dbde7461c81ece", size = 297999, upload-time = "2025-05-01T23:17:27.59Z" }
 wheels = [
@@ -983,7 +983,7 @@ wheels = [
 [[package]]
 name = "azure-datalake-store"
 version = "0.0.53"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cffi" },
     { name = "msal" },
@@ -997,14 +997,14 @@ wheels = [
 [[package]]
 name = "azure-identity"
 version = "1.23.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "cryptography" },
     { name = "msal" },
     { name = "msal-extensions" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/52/458c1be17a5d3796570ae2ed3c6b7b55b134b22d5ef8132b4f97046a9051/azure_identity-1.23.0.tar.gz", hash = "sha256:d9cdcad39adb49d4bb2953a217f62aec1f65bbb3c63c9076da2be2a47e53dde4", size = 265280, upload-time = "2025-05-14T00:18:30.408Z" }
 wheels = [
@@ -1014,13 +1014,13 @@ wheels = [
 [[package]]
 name = "azure-storage-blob"
 version = "12.25.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "cryptography" },
     { name = "isodate" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/f764536c25cc3829d36857167f03933ce9aee2262293179075439f3cd3ad/azure_storage_blob-12.25.1.tar.gz", hash = "sha256:4f294ddc9bc47909ac66b8934bd26b50d2000278b10ad82cc109764fdc6e0e3b", size = 570541, upload-time = "2025-03-27T17:13:05.424Z" }
 wheels = [
@@ -1030,7 +1030,7 @@ wheels = [
 [[package]]
 name = "babel"
 version = "2.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
@@ -1039,7 +1039,7 @@ wheels = [
 [[package]]
 name = "backports-tarfile"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
@@ -1048,7 +1048,7 @@ wheels = [
 [[package]]
 name = "bandit"
 version = "1.8.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
@@ -1063,7 +1063,7 @@ wheels = [
 [[package]]
 name = "bcrypt"
 version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", hash = "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18", size = 25697, upload-time = "2025-02-28T01:24:09.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/2c/3d44e853d1fe969d229bd58d39ae6902b3d924af0e2b5a60d17d4b809ded/bcrypt-4.3.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281", size = 483719, upload-time = "2025-02-28T01:22:34.539Z" },
@@ -1121,7 +1121,7 @@ wheels = [
 [[package]]
 name = "beartype"
 version = "0.22.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
@@ -1130,11 +1130,11 @@ wheels = [
 [[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "soupsieve" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
 wheels = [
@@ -1144,7 +1144,7 @@ wheels = [
 [[package]]
 name = "black"
 version = "23.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "mypy-extensions" },
@@ -1152,8 +1152,8 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/c3/257adbdbf2cc60bf844b5c0e3791a9d49e4fb4f7bcd8a2e875824ca0b7bc/black-23.9.1.tar.gz", hash = "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d", size = 589529, upload-time = "2023-09-11T00:39:01.74Z" }
 wheels = [
@@ -1177,16 +1177,16 @@ wheels = [
 
 [package.optional-dependencies]
 jupyter = [
-    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "ipython", version = "9.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "ipython", version = "9.5.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tokenize-rt" },
 ]
 
 [[package]]
 name = "blessed"
 version = "1.21.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "jinxed", marker = "sys_platform == 'win32'" },
     { name = "wcwidth" },
@@ -1199,7 +1199,7 @@ wheels = [
 [[package]]
 name = "blinker"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
@@ -1208,7 +1208,7 @@ wheels = [
 [[package]]
 name = "boto3"
 version = "1.37.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
@@ -1222,12 +1222,12 @@ wheels = [
 [[package]]
 name = "boto3-stubs"
 version = "1.38.28"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/dc/c4b318bdf66ff4973d3cbf0f218e47bdf558b94d921c8ff27d401e8ca4f9/boto3_stubs-1.38.28.tar.gz", hash = "sha256:fae8e009ea4d810b77e49d88247183b5d8d153bf268ebde8b4abdf58a701802f", size = 99065, upload-time = "2025-06-02T19:42:51.659Z" }
 wheels = [
@@ -1257,7 +1257,7 @@ sts = [
 [[package]]
 name = "botocore"
 version = "1.37.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
@@ -1271,7 +1271,7 @@ wheels = [
 [[package]]
 name = "botocore-stubs"
 version = "1.38.28"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "types-awscrt" },
 ]
@@ -1283,7 +1283,7 @@ wheels = [
 [[package]]
 name = "cachelib"
 version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/69/0b5c1259e12fbcf5c2abe5934b5c0c1294ec0f845e2b4b2a51a91d79a4fb/cachelib-0.13.0.tar.gz", hash = "sha256:209d8996e3c57595bee274ff97116d1d73c4980b2fd9a34c7846cd07fd2e1a48", size = 34418, upload-time = "2024-04-13T14:18:27.782Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/42/960fc9896ddeb301716fdd554bab7941c35fb90a1dc7260b77df3366f87f/cachelib-0.13.0-py3-none-any.whl", hash = "sha256:8c8019e53b6302967d4e8329a504acf75e7bc46130291d30188a6e4e58162516", size = 20914, upload-time = "2024-04-13T14:18:26.361Z" },
@@ -1292,7 +1292,7 @@ wheels = [
 [[package]]
 name = "cachetools"
 version = "5.5.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
@@ -1301,7 +1301,7 @@ wheels = [
 [[package]]
 name = "caio"
 version = "0.9.25"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
@@ -1330,7 +1330,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2025.1.31"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload-time = "2025-01-31T02:16:47.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload-time = "2025-01-31T02:16:45.015Z" },
@@ -1339,7 +1339,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pycparser" },
 ]
@@ -1408,7 +1408,7 @@ wheels = [
 [[package]]
 name = "chardet"
 version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
@@ -1417,7 +1417,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload-time = "2025-05-02T08:34:42.01Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/28/9901804da60055b406e1a1c5ba7aac1276fb77f1dde635aabfc7fd84b8ab/charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941", size = 201818, upload-time = "2025-05-02T08:31:46.725Z" },
@@ -1491,7 +1491,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -1503,7 +1503,7 @@ wheels = [
 [[package]]
 name = "clickclick"
 version = "20.10.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "click", marker = "python_full_version < '3.13'" },
     { name = "pyyaml", marker = "python_full_version < '3.13'" },
@@ -1516,7 +1516,7 @@ wheels = [
 [[package]]
 name = "clickhouse-connect"
 version = "0.8.17"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "lz4" },
@@ -1592,12 +1592,12 @@ wheels = [
 
 [package.optional-dependencies]
 arrow = [
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 numpy = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 pandas = [
     { name = "pandas", marker = "python_full_version >= '3.10'" },
@@ -1606,7 +1606,7 @@ pandas = [
 [[package]]
 name = "clickhouse-driver"
 version = "0.2.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pytz" },
     { name = "tzlocal" },
@@ -1684,7 +1684,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -1693,7 +1693,7 @@ wheels = [
 [[package]]
 name = "coloredlogs"
 version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "humanfriendly" },
 ]
@@ -1705,7 +1705,7 @@ wheels = [
 [[package]]
 name = "colorlog"
 version = "6.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "colorama", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
 ]
@@ -1717,7 +1717,7 @@ wheels = [
 [[package]]
 name = "configupdater"
 version = "3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/603bd8a65e040b23d25b5843836297b0f4e430f509d8ed2ef8f072fb4127/ConfigUpdater-3.2.tar.gz", hash = "sha256:9fdac53831c1b062929bf398b649b87ca30e7f1a735f3fbf482072804106306b", size = 140603, upload-time = "2023-11-27T17:16:45.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/f0/b59cb7613d9d0f866b6ff247c5953ad78363c27ff5d684a2a98899ab8220/ConfigUpdater-3.2-py2.py3-none-any.whl", hash = "sha256:0f65a041627d7693840b4dd743581db4c441c97195298a29d075f91b79539df2", size = 34688, upload-time = "2023-11-27T17:16:43.53Z" },
@@ -1726,7 +1726,7 @@ wheels = [
 [[package]]
 name = "connectorx"
 version = "0.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -1757,7 +1757,7 @@ wheels = [
 [[package]]
 name = "connectorx"
 version = "0.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -1816,7 +1816,7 @@ wheels = [
 [[package]]
 name = "connexion"
 version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "clickclick", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -1842,7 +1842,7 @@ flask = [
 [[package]]
 name = "cron-descriptor"
 version = "1.4.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/83/70bd410dc6965e33a5460b7da84cf0c5a7330a68d6d5d4c3dfdb72ca117e/cron_descriptor-1.4.5.tar.gz", hash = "sha256:f51ce4ffc1d1f2816939add8524f206c376a42c87a5fca3091ce26725b3b1bca", size = 30666, upload-time = "2024-08-24T18:16:48.654Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/20/2cfe598ead23a715a00beb716477cfddd3e5948cf203c372d02221e5b0c6/cron_descriptor-1.4.5-py3-none-any.whl", hash = "sha256:736b3ae9d1a99bc3dbfc5b55b5e6e7c12031e7ba5de716625772f8b02dcd6013", size = 50370, upload-time = "2024-08-24T18:16:46.783Z" },
@@ -1851,7 +1851,7 @@ wheels = [
 [[package]]
 name = "croniter"
 version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "python-dateutil", marker = "python_full_version < '3.13'" },
     { name = "pytz", marker = "python_full_version < '3.13'" },
@@ -1864,7 +1864,7 @@ wheels = [
 [[package]]
 name = "cryptography"
 version = "41.0.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cffi" },
 ]
@@ -1893,14 +1893,14 @@ wheels = [
 [[package]]
 name = "cyclopts"
 version = "4.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "docstring-parser", marker = "python_full_version >= '3.10' and sys_platform == 'never'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
     { name = "rich-rst", marker = "python_full_version >= '3.10'" },
     { name = "tomli", marker = "python_full_version == '3.10.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/d2/f37df900b163f51b4faacdb01bf4895c198906d67c5b2a85c2522de85459/cyclopts-4.5.4.tar.gz", hash = "sha256:eed4d6c76d4391aa796d8fcaabd50e5aad7793261792beb19285f62c5c456c8b", size = 162438, upload-time = "2026-02-20T00:58:46.161Z" }
 wheels = [
@@ -1910,7 +1910,7 @@ wheels = [
 [[package]]
 name = "databricks-sdk"
 version = "0.73.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
@@ -1924,7 +1924,7 @@ wheels = [
 [[package]]
 name = "databricks-sql-connector"
 version = "4.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "lz4" },
     { name = "oauthlib" },
@@ -1944,7 +1944,7 @@ wheels = [
 [[package]]
 name = "datasets"
 version = "4.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -1960,10 +1960,10 @@ dependencies = [
     { name = "httpx", marker = "python_full_version < '3.10'" },
     { name = "huggingface-hub", marker = "python_full_version < '3.10'" },
     { name = "multiprocess", marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
     { name = "packaging", marker = "python_full_version < '3.10'" },
     { name = "pandas", marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyyaml", marker = "python_full_version < '3.10'" },
     { name = "requests", marker = "python_full_version < '3.10'" },
     { name = "tqdm", marker = "python_full_version < '3.10'" },
@@ -1977,7 +1977,7 @@ wheels = [
 [[package]]
 name = "datasets"
 version = "4.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -2017,12 +2017,12 @@ dependencies = [
     { name = "httpx", marker = "python_full_version >= '3.10'" },
     { name = "huggingface-hub", marker = "python_full_version >= '3.10'" },
     { name = "multiprocess", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyyaml", marker = "python_full_version >= '3.10'" },
     { name = "requests", marker = "python_full_version >= '3.10'" },
     { name = "tqdm", marker = "python_full_version >= '3.10'" },
@@ -2036,15 +2036,15 @@ wheels = [
 [[package]]
 name = "db-dtypes"
 version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/c8/83fd7a11ef8d960da6c58d1a36b430b0a1818ae7a1da6efe887d96c35f40/db_dtypes-1.4.3.tar.gz", hash = "sha256:d3cb08c32939d24e05501f17694be8c1c54cfb4620d61fb56fb311e8c3d8885e", size = 33379, upload-time = "2025-05-12T13:54:21.736Z" }
 wheels = [
@@ -2054,7 +2054,7 @@ wheels = [
 [[package]]
 name = "dbc"
 version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/53/d9cbbbd55ea9cf3028f11870f1f25cc3d920836f0090de02632088f883b2/dbc-0.1.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:9469e30a81b2350901259d6a6b53d1cb579692f534a5d077d294a83a7606f397", size = 3511476, upload-time = "2025-10-27T19:35:51.847Z" },
     { url = "https://files.pythonhosted.org/packages/2a/f6/8d0db43cd40506c458bf8533b705ccb04f2c6fe731d74cb8c853f540820c/dbc-0.1.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:d627f64b1ada1abdc20c583e778ca7f8c3a2aa738e77fa49bfa70cff41808d19", size = 3854094, upload-time = "2025-10-27T19:35:53.871Z" },
@@ -2066,15 +2066,15 @@ wheels = [
 [[package]]
 name = "dbt-athena-community"
 version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["athena", "glue", "lakeformation", "sts"] },
     { name = "dbt-core" },
     { name = "mmh3" },
     { name = "pyathena" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/26/b6ba74236e7524ca7eee12621765b7870c3fbe078b2d60b5464566b03c58/dbt-athena-community-1.7.2.tar.gz", hash = "sha256:3e705315de100be0ffa79f6618ac2f6e388940cb601b7b00d5989583cce1dcef", size = 89012, upload-time = "2024-02-06T09:32:43.066Z" }
@@ -2085,7 +2085,7 @@ wheels = [
 [[package]]
 name = "dbt-bigquery"
 version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "dbt-core" },
     { name = "google-api-core" },
@@ -2101,7 +2101,7 @@ wheels = [
 [[package]]
 name = "dbt-core"
 version = "1.7.19"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "agate" },
     { name = "cffi" },
@@ -2116,9 +2116,9 @@ dependencies = [
     { name = "logbook" },
     { name = "mashumaro", extra = ["msgpack"] },
     { name = "minimal-snowplow-tracker" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pathspec" },
     { name = "protobuf" },
@@ -2126,8 +2126,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlparse" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/66/32e97ff2dd9560a1b7e2b88a4fbaacc5bc1d0f668fede072c0a4c7f6c9a0/dbt_core-1.7.19.tar.gz", hash = "sha256:39f868f050be4f66f7791a6aad550b59b4f096cf79859e8efa2794fae5a7e318", size = 916539, upload-time = "2024-12-02T18:23:00.55Z" }
@@ -2138,7 +2138,7 @@ wheels = [
 [[package]]
 name = "dbt-duckdb"
 version = "1.7.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "dbt-core" },
     { name = "duckdb" },
@@ -2151,7 +2151,7 @@ wheels = [
 [[package]]
 name = "dbt-extractor"
 version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/d0/4ee14955ad0214da695b3c15dc0acf2ab54c9d263242f36073c999cb699a/dbt_extractor-0.5.1.tar.gz", hash = "sha256:cd5d95576a8dea4190240aaf9936a37fd74b4b7913ca69a3c368fc4472bb7e13", size = 266278, upload-time = "2023-11-28T17:25:19.934Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/1f/ca6d66d67464df1ea8e814d09b1100d15672ae4ce7f0dff41f67956e5f7f/dbt_extractor-0.5.1-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3b91e6106b967d908b34f83929d3f50ee2b498876a1be9c055fe060ed728c556", size = 865677, upload-time = "2023-11-28T17:24:52.457Z" },
@@ -2174,11 +2174,11 @@ wheels = [
 [[package]]
 name = "dbt-fabric"
 version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "azure-identity", marker = "python_full_version < '3.13'" },
     { name = "dbt-core", marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/f7/b94cc6672d50d0cef9f3910c49fd4a1ceebe26874fbd2b0ec95f39cd17cc/dbt-fabric-1.7.4.tar.gz", hash = "sha256:6f17f0ba683c2944c8f846589dca4b54106579af32ac5acafe701d1becc2496f", size = 25820, upload-time = "2024-02-02T21:00:42.189Z" }
 wheels = [
@@ -2188,7 +2188,7 @@ wheels = [
 [[package]]
 name = "dbt-postgres"
 version = "1.7.19"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "agate" },
     { name = "dbt-core" },
@@ -2202,7 +2202,7 @@ wheels = [
 [[package]]
 name = "dbt-redshift"
 version = "1.7.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "agate" },
     { name = "dbt-core" },
@@ -2217,19 +2217,19 @@ wheels = [
 [[package]]
 name = "dbt-semantic-interfaces"
 version = "0.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "importlib-metadata" },
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "more-itertools" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/38/e889ad15d281093e53a7ec1e692a387a92dc056fff56b8c2961634b1968b/dbt_semantic_interfaces-0.4.4.tar.gz", hash = "sha256:3b8126deb964c03d14e8af1cb4bdfb9f20c53dfcef28fa3a0bc158a8312e4070", size = 75128, upload-time = "2024-02-26T19:34:34.962Z" }
 wheels = [
@@ -2239,7 +2239,7 @@ wheels = [
 [[package]]
 name = "dbt-snowflake"
 version = "1.7.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "agate" },
     { name = "dbt-core" },
@@ -2253,12 +2253,12 @@ wheels = [
 [[package]]
 name = "dbt-sqlserver"
 version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "azure-identity", marker = "python_full_version < '3.13'" },
     { name = "dbt-core", marker = "python_full_version < '3.13'" },
     { name = "dbt-fabric", marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/97/d7244c6ab1ce380ec8ce453ecebe4692325028c7c2fe9863c5fbb163ca04/dbt-sqlserver-1.7.4.tar.gz", hash = "sha256:b9e85771a1c00e8f4aadefb37b00d02b3d49bc93ad7c52782fd9cae9db31dd98", size = 13386, upload-time = "2024-03-04T14:46:41.247Z" }
 wheels = [
@@ -2268,7 +2268,7 @@ wheels = [
 [[package]]
 name = "decopatch"
 version = "1.4.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "makefun" },
 ]
@@ -2280,7 +2280,7 @@ wheels = [
 [[package]]
 name = "decorator"
 version = "5.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
@@ -2289,7 +2289,7 @@ wheels = [
 [[package]]
 name = "deltalake"
 version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -2315,7 +2315,7 @@ wheels = [
 [[package]]
 name = "deltalake"
 version = "1.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -2365,7 +2365,7 @@ wheels = [
 [[package]]
 name = "deprecated"
 version = "1.2.18"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
@@ -2377,7 +2377,7 @@ wheels = [
 [[package]]
 name = "deprecation"
 version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -2389,7 +2389,7 @@ wheels = [
 [[package]]
 name = "diff-cover"
 version = "9.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "jinja2" },
@@ -2404,7 +2404,7 @@ wheels = [
 [[package]]
 name = "dill"
 version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/80/630b4b88364e9a8c8c5797f4602d0f76ef820909ee32f0bacb9f90654042/dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0", size = 186976, upload-time = "2025-04-16T00:41:48.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049", size = 119668, upload-time = "2025-04-16T00:41:47.671Z" },
@@ -2421,8 +2421,8 @@ dependencies = [
     { name = "giturlparse" },
     { name = "humanize" },
     { name = "jsonpath-ng" },
-    { name = "orjson", version = "3.10.18", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version >= '3.11' and python_full_version < '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
-    { name = "orjson", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.11' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
+    { name = "orjson", version = "3.10.18", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version >= '3.11' and python_full_version < '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
+    { name = "orjson", version = "3.11.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14' or (python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.11' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
     { name = "packaging" },
     { name = "pathvalidate" },
     { name = "pendulum" },
@@ -2436,12 +2436,12 @@ dependencies = [
     { name = "semver" },
     { name = "setuptools" },
     { name = "simplejson" },
-    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "sqlglot", version = "28.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sqlglot", version = "28.10.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
     { name = "tenacity" },
     { name = "tomlkit" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tzdata" },
     { name = "win-precise-time", marker = "python_full_version < '3.13' and os_name == 'nt'" },
 ]
@@ -2449,8 +2449,8 @@ dependencies = [
 [package.optional-dependencies]
 athena = [
     { name = "botocore" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyathena" },
     { name = "s3fs" },
 ]
@@ -2462,8 +2462,8 @@ bigquery = [
     { name = "gcsfs" },
     { name = "google-cloud-bigquery" },
     { name = "grpcio" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 cli = [
     { name = "cron-descriptor" },
@@ -2475,8 +2475,8 @@ clickhouse = [
     { name = "clickhouse-connect" },
     { name = "clickhouse-driver" },
     { name = "gcsfs" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "s3fs" },
 ]
 databricks = [
@@ -2487,29 +2487,29 @@ dbml = [
     { name = "pydbml" },
 ]
 deltalake = [
-    { name = "deltalake", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "deltalake", version = "1.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "deltalake", version = "1.2.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "deltalake", version = "1.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 dremio = [
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 duckdb = [
     { name = "duckdb" },
 ]
 ducklake = [
     { name = "duckdb" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 fabric = [
     { name = "adlfs" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 filesystem = [
     { name = "botocore" },
@@ -2526,8 +2526,8 @@ gs = [
 ]
 hf = [
     { name = "huggingface-hub" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 http = [
     { name = "aiohttp" },
@@ -2540,24 +2540,24 @@ lancedb = [
     { name = "duckdb" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10'" },
     { name = "lancedb" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 motherduck = [
     { name = "duckdb" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 mssql = [
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 oracle = [
     { name = "oracledb" },
 ]
 parquet = [
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 postgis = [
     { name = "psycopg2-binary" },
@@ -2566,8 +2566,8 @@ postgres = [
     { name = "psycopg2-binary" },
 ]
 pyiceberg = [
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyiceberg" },
     { name = "pyiceberg-core" },
     { name = "sqlalchemy" },
@@ -2597,10 +2597,10 @@ sqlalchemy = [
 ]
 synapse = [
     { name = "adlfs" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 weaviate = [
     { name = "weaviate-client" },
@@ -2609,19 +2609,19 @@ workspace = [
     { name = "duckdb" },
     { name = "fastmcp", marker = "python_full_version >= '3.10'" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10'" },
-    { name = "marimo", version = "0.14.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "marimo", version = "0.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "marimo", version = "0.14.10", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "marimo", version = "0.20.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mowidgets", marker = "python_full_version >= '3.11'" },
     { name = "pathspec" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydbml" },
 ]
 
 [package.dev-dependencies]
 adbc = [
-    { name = "adbc-driver-manager", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "adbc-driver-manager", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "adbc-driver-manager", version = "1.8.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "adbc-driver-manager", version = "1.9.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "dbc" },
 ]
 airflow = [
@@ -2629,8 +2629,8 @@ airflow = [
 ]
 dashboard-tests = [
     { name = "playwright" },
-    { name = "pytest-playwright", version = "0.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest-playwright", version = "0.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-playwright", version = "0.7.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-playwright", version = "0.7.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 dbt = [
     { name = "dbt-athena-community" },
@@ -2653,8 +2653,8 @@ dev = [
     { name = "flake8-print" },
     { name = "flake8-tidy-imports" },
     { name = "graphviz" },
-    { name = "griffe", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "griffe", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "griffe", version = "1.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "griffe", version = "1.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pip" },
@@ -2699,18 +2699,18 @@ pipeline = [
     { name = "alive-progress" },
     { name = "cffi" },
     { name = "cryptography" },
-    { name = "datasets", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "datasets", version = "4.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "datasets", version = "4.5.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "datasets", version = "4.6.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "enlighten" },
     { name = "greenlet" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "regex" },
-    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "shapely", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "shapely", version = "2.1.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sqlalchemy" },
     { name = "tqdm" },
 ]
@@ -2721,8 +2721,8 @@ sentry-sdk = [
     { name = "sentry-sdk" },
 ]
 sources = [
-    { name = "connectorx", version = "0.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "connectorx", version = "0.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "connectorx", version = "0.3.3", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "connectorx", version = "0.4.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mimesis" },
     { name = "openpyxl" },
     { name = "pymysql" },
@@ -2942,9 +2942,9 @@ sources = [
 [[package]]
 name = "dlt-runtime"
 version = "0.21.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "cron-descriptor", marker = "python_full_version >= '3.10'" },
     { name = "httpx", marker = "python_full_version >= '3.10'" },
     { name = "pathspec", marker = "python_full_version >= '3.10'" },
@@ -2959,11 +2959,11 @@ wheels = [
 [[package]]
 name = "dlthub"
 version = "0.22.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "python-jose", marker = "python_full_version >= '3.10'" },
     { name = "ruamel-yaml", marker = "python_full_version >= '3.10'" },
-    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/af/fe84689f8742a7a3dc3e538faf5bc001a70168a34c6375e17eb15d2ce3e1/dlthub-0.22.0.tar.gz", hash = "sha256:cede29e2d0340b48e6ec3d287b9573340707273509f4f697b23d7f4981d86b9d", size = 169355, upload-time = "2026-02-17T15:15:56.941Z" }
 wheels = [
@@ -2973,7 +2973,7 @@ wheels = [
 [[package]]
 name = "dnspython"
 version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
@@ -2982,7 +2982,7 @@ wheels = [
 [[package]]
 name = "docstring-parser"
 version = "0.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
@@ -2991,7 +2991,7 @@ wheels = [
 [[package]]
 name = "docstring-parser-fork"
 version = "0.0.14"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/bf/27f9cab2f0cd1d17a4420572088bbc19f36d726fbcf165edf226a8926dbc/docstring_parser_fork-0.0.14.tar.gz", hash = "sha256:a2743a63d8d36c09650594f7b4ab5b2758fee8629dcf794d1b221b23179baa5c", size = 34551, upload-time = "2025-09-07T17:27:38.272Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/50/98b146aea0f1cd7531d25f12bea69fa9ce8d1662124f93fb30dc4511b65e/docstring_parser_fork-0.0.14-py3-none-any.whl", hash = "sha256:4c544f234ef2cc2749a3df32b70c437d77888b1099143a1ad5454452c574b9af", size = 43063, upload-time = "2025-09-07T17:27:37.012Z" },
@@ -3000,7 +3000,7 @@ wheels = [
 [[package]]
 name = "docutils"
 version = "0.21.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
@@ -3009,11 +3009,11 @@ wheels = [
 [[package]]
 name = "domdf-python-tools"
 version = "3.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "natsort" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/8b/ab2d8a292bba8fe3135cacc8bfd3576710a14b8f2d0a8cde19130d5c9d21/domdf_python_tools-3.10.0.tar.gz", hash = "sha256:2ae308d2f4f1e9145f5f4ba57f840fbfd1c2983ee26e4824347789649d3ae298", size = 100458, upload-time = "2025-02-12T17:34:05.747Z" }
 wheels = [
@@ -3023,7 +3023,7 @@ wheels = [
 [[package]]
 name = "duckdb"
 version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7f/da/17c3eb5458af69d54dedc8d18e4a32ceaa8ce4d4c699d45d6d8287e790c3/duckdb-1.4.3.tar.gz", hash = "sha256:fea43e03604c713e25a25211ada87d30cd2a044d8f27afab5deba26ac49e5268", size = 18478418, upload-time = "2025-12-09T10:59:22.945Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/3a/ea8e237e1ba40203dea4ed6a8798ea51e66a4c4f34605697025e5fa06fdd/duckdb-1.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:efa7f1191c59e34b688fcd4e588c1b903a4e4e1f4804945902cf0b20e08a9001", size = 29016021, upload-time = "2025-12-09T10:57:46.847Z" },
@@ -3071,7 +3071,7 @@ wheels = [
 [[package]]
 name = "ecdsa"
 version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "six", marker = "python_full_version >= '3.10'" },
 ]
@@ -3083,7 +3083,7 @@ wheels = [
 [[package]]
 name = "email-validator"
 version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "dnspython" },
     { name = "idna" },
@@ -3096,7 +3096,7 @@ wheels = [
 [[package]]
 name = "enlighten"
 version = "1.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "blessed" },
     { name = "prefixed" },
@@ -3109,7 +3109,7 @@ wheels = [
 [[package]]
 name = "et-xmlfile"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
@@ -3118,7 +3118,7 @@ wheels = [
 [[package]]
 name = "eval-type-backport"
 version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/ea/8b0ac4469d4c347c6a385ff09dc3c048c2d021696664e26c7ee6791631b5/eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1", size = 9079, upload-time = "2024-12-21T20:09:46.005Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/31/55cd413eaccd39125368be33c46de24a1f639f2e12349b0361b4678f3915/eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a", size = 5830, upload-time = "2024-12-21T20:09:44.175Z" },
@@ -3127,10 +3127,10 @@ wheels = [
 [[package]]
 name = "exceptiongroup"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3140,7 +3140,7 @@ wheels = [
 [[package]]
 name = "execnet"
 version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
@@ -3149,7 +3149,7 @@ wheels = [
 [[package]]
 name = "executing"
 version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
@@ -3158,18 +3158,18 @@ wheels = [
 [[package]]
 name = "fastembed"
 version = "0.7.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "loguru" },
     { name = "mmh3" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "onnxruntime", version = "1.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "onnxruntime", version = "1.22.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pillow", version = "10.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "11.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "onnxruntime", version = "1.19.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "onnxruntime", version = "1.22.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pillow", version = "10.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pillow", version = "11.2.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "py-rust-stemmers" },
     { name = "requests" },
     { name = "tokenizers" },
@@ -3183,9 +3183,9 @@ wheels = [
 [[package]]
 name = "fastmcp"
 version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "authlib", version = "1.6.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "authlib", version = "1.6.8", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "cyclopts", marker = "python_full_version >= '3.10'" },
     { name = "exceptiongroup", marker = "python_full_version >= '3.10'" },
     { name = "httpx", marker = "python_full_version >= '3.10'" },
@@ -3197,12 +3197,12 @@ dependencies = [
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "platformdirs", marker = "python_full_version >= '3.10'" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"], marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, extra = ["email"], marker = "python_full_version >= '3.10'" },
     { name = "pyperclip", marker = "python_full_version >= '3.10'" },
     { name = "python-dotenv", marker = "python_full_version >= '3.10'" },
     { name = "pyyaml", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "watchfiles", marker = "python_full_version >= '3.10'" },
     { name = "websockets", marker = "python_full_version >= '3.10'" },
 ]
@@ -3214,7 +3214,7 @@ wheels = [
 [[package]]
 name = "filelock"
 version = "3.18.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
@@ -3223,7 +3223,7 @@ wheels = [
 [[package]]
 name = "flake8"
 version = "7.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "mccabe" },
     { name = "pycodestyle" },
@@ -3237,10 +3237,10 @@ wheels = [
 [[package]]
 name = "flake8-bugbear"
 version = "22.12.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "flake8" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/b5/83a89114a82a2764ddfe27451df6b69c46513f88a3f66206514265b6f447/flake8-bugbear-22.12.6.tar.gz", hash = "sha256:4cdb2c06e229971104443ae293e75e64c6107798229202fbe4f4091427a30ac0", size = 44094, upload-time = "2022-12-06T19:07:02.569Z" }
@@ -3251,7 +3251,7 @@ wheels = [
 [[package]]
 name = "flake8-builtins"
 version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "flake8" },
 ]
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "flake8-helper"
 version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "flake8" },
 ]
@@ -3286,7 +3286,7 @@ wheels = [
 [[package]]
 name = "flake8-print"
 version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "flake8" },
     { name = "pycodestyle" },
@@ -3299,7 +3299,7 @@ wheels = [
 [[package]]
 name = "flake8-tidy-imports"
 version = "4.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "flake8" },
 ]
@@ -3311,7 +3311,7 @@ wheels = [
 [[package]]
 name = "flask"
 version = "2.2.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "click", marker = "python_full_version < '3.13'" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
@@ -3327,7 +3327,7 @@ wheels = [
 [[package]]
 name = "flask-appbuilder"
 version = "4.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "apispec", extra = ["yaml"], marker = "python_full_version < '3.13'" },
     { name = "click", marker = "python_full_version < '3.13'" },
@@ -3336,8 +3336,8 @@ dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "flask-babel", marker = "python_full_version < '3.13'" },
     { name = "flask-jwt-extended", marker = "python_full_version < '3.13'" },
-    { name = "flask-limiter", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "flask-limiter", version = "3.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "flask-limiter", version = "3.11.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "flask-limiter", version = "3.12", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "flask-login", marker = "python_full_version < '3.13'" },
     { name = "flask-sqlalchemy", marker = "python_full_version < '3.13'" },
     { name = "flask-wtf", marker = "python_full_version < '3.13'" },
@@ -3360,7 +3360,7 @@ wheels = [
 [[package]]
 name = "flask-babel"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "babel", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -3375,7 +3375,7 @@ wheels = [
 [[package]]
 name = "flask-caching"
 version = "2.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cachelib", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -3388,7 +3388,7 @@ wheels = [
 [[package]]
 name = "flask-jwt-extended"
 version = "4.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "pyjwt", marker = "python_full_version < '3.13'" },
@@ -3402,7 +3402,7 @@ wheels = [
 [[package]]
 name = "flask-limiter"
 version = "3.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -3413,10 +3413,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.10'" },
-    { name = "limits", version = "4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "limits", version = "4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ordered-set", marker = "python_full_version < '3.10'" },
     { name = "rich", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/a4/02f67783825a4207d4ae7de4c8be45596c3fba5b65ace77fd6dc3878020d/flask_limiter-3.11.0.tar.gz", hash = "sha256:57b037fb8be423ef7ebac4fbb279fbfdc42d9aa5378467ab6798d6ce3d912117", size = 303361, upload-time = "2025-03-11T20:37:59.839Z" }
 wheels = [
@@ -3426,7 +3426,7 @@ wheels = [
 [[package]]
 name = "flask-limiter"
 version = "3.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -3449,7 +3449,7 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "flask", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "limits", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "limits", version = "5.2.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "ordered-set", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "rich", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
@@ -3461,7 +3461,7 @@ wheels = [
 [[package]]
 name = "flask-login"
 version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "werkzeug", marker = "python_full_version < '3.13'" },
@@ -3474,7 +3474,7 @@ wheels = [
 [[package]]
 name = "flask-session"
 version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cachelib", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -3487,7 +3487,7 @@ wheels = [
 [[package]]
 name = "flask-sqlalchemy"
 version = "2.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
@@ -3500,7 +3500,7 @@ wheels = [
 [[package]]
 name = "flask-wtf"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "itsdangerous", marker = "python_full_version < '3.13'" },
@@ -3514,7 +3514,7 @@ wheels = [
 [[package]]
 name = "flatbuffers"
 version = "25.2.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/30/eb5dce7994fc71a2f685d98ec33cc660c0a5887db5610137e60d8cbc4489/flatbuffers-25.2.10.tar.gz", hash = "sha256:97e451377a41262f8d9bd4295cc836133415cc03d8cb966410a4af92eb00d26e", size = 22170, upload-time = "2025-02-11T04:26:46.257Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/25/155f9f080d5e4bc0082edfda032ea2bc2b8fab3f4d25d46c1e9dd22a1a89/flatbuffers-25.2.10-py2.py3-none-any.whl", hash = "sha256:ebba5f4d5ea615af3f7fd70fc310636fbb2bbd1f566ac0a23d98dd412de50051", size = 30953, upload-time = "2025-02-11T04:26:44.484Z" },
@@ -3523,7 +3523,7 @@ wheels = [
 [[package]]
 name = "frozenlist"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/f4/d744cba2da59b5c1d88823cf9e8a6c74e4659e2b27604ed973be2a0bf5ab/frozenlist-1.6.0.tar.gz", hash = "sha256:b99655c32c1c8e06d111e7f41c06c29a5318cb1835df23a45518e02a47c63b68", size = 42831, upload-time = "2025-04-17T22:38:53.099Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/03/22e4eb297981d48468c3d9982ab6076b10895106d3039302a943bb60fd70/frozenlist-1.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e6e558ea1e47fd6fa8ac9ccdad403e5dd5ecc6ed8dda94343056fa4277d5c65e", size = 160584, upload-time = "2025-04-17T22:35:48.163Z" },
@@ -3634,7 +3634,7 @@ wheels = [
 [[package]]
 name = "fsspec"
 version = "2025.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
@@ -3648,7 +3648,7 @@ http = [
 [[package]]
 name = "gcsfs"
 version = "2025.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "decorator" },
@@ -3666,7 +3666,7 @@ wheels = [
 [[package]]
 name = "gitdb"
 version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "smmap" },
 ]
@@ -3678,7 +3678,7 @@ wheels = [
 [[package]]
 name = "gitpython"
 version = "3.1.44"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
@@ -3690,7 +3690,7 @@ wheels = [
 [[package]]
 name = "giturlparse"
 version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/5f/543dc54c82842376139748226e5aa61eb95093992f63dd495af9c6b4f076/giturlparse-0.12.0.tar.gz", hash = "sha256:c0fff7c21acc435491b1779566e038757a205c1ffdcb47e4f81ea52ad8c3859a", size = 14907, upload-time = "2023-09-24T07:22:36.795Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/94/c6ff3388b8e3225a014e55aed957188639aa0966443e0408d38f0c9614a7/giturlparse-0.12.0-py2.py3-none-any.whl", hash = "sha256:412b74f2855f1da2fefa89fd8dde62df48476077a72fc19b62039554d27360eb", size = 15752, upload-time = "2023-09-24T07:22:35.465Z" },
@@ -3699,7 +3699,7 @@ wheels = [
 [[package]]
 name = "google-api-core"
 version = "2.11.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
@@ -3720,7 +3720,7 @@ grpc = [
 [[package]]
 name = "google-api-python-client"
 version = "2.170.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -3736,7 +3736,7 @@ wheels = [
 [[package]]
 name = "google-auth"
 version = "2.40.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "pyasn1-modules" },
@@ -3750,7 +3750,7 @@ wheels = [
 [[package]]
 name = "google-auth-httplib2"
 version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "httplib2" },
@@ -3763,7 +3763,7 @@ wheels = [
 [[package]]
 name = "google-auth-oauthlib"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "requests-oauthlib" },
@@ -3776,7 +3776,7 @@ wheels = [
 [[package]]
 name = "google-cloud-bigquery"
 version = "3.19.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
@@ -3794,7 +3794,7 @@ wheels = [
 [[package]]
 name = "google-cloud-bigquery-storage"
 version = "2.32.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"], marker = "python_full_version >= '3.10'" },
     { name = "google-auth", marker = "python_full_version >= '3.10'" },
@@ -3809,7 +3809,7 @@ wheels = [
 [[package]]
 name = "google-cloud-core"
 version = "2.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -3822,7 +3822,7 @@ wheels = [
 [[package]]
 name = "google-cloud-dataproc"
 version = "5.18.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
@@ -3838,7 +3838,7 @@ wheels = [
 [[package]]
 name = "google-cloud-storage"
 version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -3855,7 +3855,7 @@ wheels = [
 [[package]]
 name = "google-crc32c"
 version = "1.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/ae/87802e6d9f9d69adfaedfcfd599266bf386a54d0be058b532d04c794f76d/google_crc32c-1.7.1.tar.gz", hash = "sha256:2bff2305f98846f3e825dbeec9ee406f89da7962accdb29356e4eadc251bd472", size = 14495, upload-time = "2025-03-26T14:29:13.32Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/69/b1b05cf415df0d86691d6a8b4b7e60ab3a6fb6efb783ee5cd3ed1382bfd3/google_crc32c-1.7.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:b07d48faf8292b4db7c3d64ab86f950c2e94e93a11fd47271c28ba458e4a0d76", size = 30467, upload-time = "2025-03-26T14:31:11.92Z" },
@@ -3896,7 +3896,7 @@ wheels = [
 [[package]]
 name = "google-re2"
 version = "1.1.20240702"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/34/ea9bfa2afbb6847b7bc7f90ab927dd31fcd7f478062a8a10045059367de1/google_re2-1.1.20240702.tar.gz", hash = "sha256:8788db69f6c93cb229df62c74b2d9aa8e64bf754e9495700f85812afa32efd2b", size = 11626, upload-time = "2024-07-01T14:09:10.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/9b/0fb72635a75405bce9e15fb94f994e59883a2757adda43978fc8eb6dad3e/google_re2-1.1.20240702-1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:46e7ed614ffaafccae017542d68e9bbf664c8c1e5ca37046adee640bbee4846e", size = 464159, upload-time = "2024-07-01T14:07:46.575Z" },
@@ -3944,7 +3944,7 @@ wheels = [
 [[package]]
 name = "google-resumable-media"
 version = "2.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-crc32c" },
 ]
@@ -3956,7 +3956,7 @@ wheels = [
 [[package]]
 name = "googleapis-common-protos"
 version = "1.70.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -3973,13 +3973,13 @@ grpc = [
 [[package]]
 name = "grapheme"
 version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e7/bbaab0d2a33e07c8278910c1d0d8d4f3781293dfbc70b5c38197159046bf/grapheme-0.6.0.tar.gz", hash = "sha256:44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca", size = 207306, upload-time = "2020-03-07T17:13:55.492Z" }
 
 [[package]]
 name = "graphviz"
 version = "0.21"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
@@ -3988,7 +3988,7 @@ wheels = [
 [[package]]
 name = "greenlet"
 version = "3.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/c1/a82edae11d46c0d83481aacaa1e578fea21d94a1ef400afd734d47ad95ad/greenlet-3.2.2.tar.gz", hash = "sha256:ad053d34421a2debba45aa3cc39acf454acbcd025b3fc1a9f8a0dee237abd485", size = 185797, upload-time = "2025-05-09T19:47:35.066Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/66/910217271189cc3f32f670040235f4bf026ded8ca07270667d69c06e7324/greenlet-3.2.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c49e9f7c6f625507ed83a7485366b46cbe325717c60837f7244fc99ba16ba9d6", size = 267395, upload-time = "2025-05-09T14:50:45.357Z" },
@@ -4050,7 +4050,7 @@ wheels = [
 [[package]]
 name = "griffe"
 version = "1.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4070,7 +4070,7 @@ wheels = [
 [[package]]
 name = "griffe"
 version = "1.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4114,7 +4114,7 @@ wheels = [
 [[package]]
 name = "grpc-google-iam-v1"
 version = "0.14.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "googleapis-common-protos", extra = ["grpc"] },
     { name = "grpcio" },
@@ -4128,7 +4128,7 @@ wheels = [
 [[package]]
 name = "grpcio"
 version = "1.72.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/45/ff8c80a5a2e7e520d9c4d3c41484a11d33508253f6f4dd06d2c4b4158999/grpcio-1.72.1.tar.gz", hash = "sha256:87f62c94a40947cec1a0f91f95f5ba0aa8f799f23a1d42ae5be667b6b27b959c", size = 12584286, upload-time = "2025-06-02T10:14:11.595Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/a8/a468586ef3db8cd90f507c0e5655c50cdf136e936f674effddacd5e6f83b/grpcio-1.72.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:ce2706ff37be7a6de68fbc4c3f8dde247cab48cc70fee5fedfbc9cd923b4ee5a", size = 5210592, upload-time = "2025-06-02T10:08:34.416Z" },
@@ -4186,7 +4186,7 @@ wheels = [
 [[package]]
 name = "grpcio-status"
 version = "1.62.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
@@ -4200,7 +4200,7 @@ wheels = [
 [[package]]
 name = "gunicorn"
 version = "23.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "packaging", marker = "python_full_version < '3.13'" },
 ]
@@ -4212,7 +4212,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -4221,7 +4221,7 @@ wheels = [
 [[package]]
 name = "h2"
 version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
@@ -4234,7 +4234,7 @@ wheels = [
 [[package]]
 name = "hf-xet"
 version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/cb/9bb543bd987ffa1ee48202cc96a756951b734b79a542335c566148ade36c/hf_xet-1.3.2.tar.gz", hash = "sha256:e130ee08984783d12717444e538587fa2119385e5bd8fc2bb9f930419b73a7af", size = 643646, upload-time = "2026-02-27T17:26:08.051Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/75/462285971954269432aad2e7938c5c7ff9ec7d60129cec542ab37121e3d6/hf_xet-1.3.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:335a8f36c55fd35a92d0062f4e9201b4015057e62747b7e7001ffb203c0ee1d2", size = 3761019, upload-time = "2026-02-27T17:25:49.441Z" },
@@ -4266,7 +4266,7 @@ wheels = [
 [[package]]
 name = "hpack"
 version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
@@ -4275,7 +4275,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -4288,7 +4288,7 @@ wheels = [
 [[package]]
 name = "httplib2"
 version = "0.22.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
@@ -4300,7 +4300,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -4320,7 +4320,7 @@ http2 = [
 [[package]]
 name = "httpx-sse"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6e/fa/66bd985dd0b7c109a3bcb89272ee0bfb7e2b4d06309ad7b38ff866734b2a/httpx_sse-0.4.1.tar.gz", hash = "sha256:8f44d34414bc7b21bf3602713005c5df4917884f76072479b21f68befa4ea26e", size = 12998, upload-time = "2025-06-24T13:21:05.71Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/0a/6269e3473b09aed2dab8aa1a600c70f31f00ae1349bee30658f7e358a159/httpx_sse-0.4.1-py3-none-any.whl", hash = "sha256:cba42174344c3a5b06f255ce65b350880f962d99ead85e776f23c6618a377a37", size = 8054, upload-time = "2025-06-24T13:21:04.772Z" },
@@ -4329,7 +4329,7 @@ wheels = [
 [[package]]
 name = "huggingface-hub"
 version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
@@ -4339,8 +4339,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tqdm" },
     { name = "typer" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/76/b5efb3033d8499b17f9386beaf60f64c461798e1ee16d10bc9c0077beba5/huggingface_hub-1.5.0.tar.gz", hash = "sha256:f281838db29265880fb543de7a23b0f81d3504675de82044307ea3c6c62f799d", size = 695872, upload-time = "2026-02-26T15:35:32.745Z" }
 wheels = [
@@ -4350,7 +4350,7 @@ wheels = [
 [[package]]
 name = "humanfriendly"
 version = "10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
@@ -4362,7 +4362,7 @@ wheels = [
 [[package]]
 name = "humanize"
 version = "4.12.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/d1/bbc4d251187a43f69844f7fd8941426549bbe4723e8ff0a7441796b0789f/humanize-4.12.3.tar.gz", hash = "sha256:8430be3a615106fdfceb0b2c1b41c4c98c6b0fc5cc59663a5539b111dd325fb0", size = 80514, upload-time = "2025-04-30T11:51:07.98Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1e/62a2ec3104394a2975a2629eec89276ede9dbe717092f6966fcf963e1bf0/humanize-4.12.3-py3-none-any.whl", hash = "sha256:2cbf6370af06568fa6d2da77c86edb7886f3160ecd19ee1ffef07979efc597f6", size = 128487, upload-time = "2025-04-30T11:51:06.468Z" },
@@ -4371,7 +4371,7 @@ wheels = [
 [[package]]
 name = "hyperframe"
 version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
@@ -4380,14 +4380,14 @@ wheels = [
 [[package]]
 name = "ibis-framework"
 version = "12.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "atpublic", marker = "python_full_version >= '3.10'" },
     { name = "parsy", marker = "python_full_version >= '3.10'" },
     { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
-    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "toolz", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tzdata", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/8e/2e7ad9bdeaf45350da7beeb67a0d4317d400dac882825eb7c3bd4d3c6ae1/ibis_framework-12.0.0.tar.gz", hash = "sha256:238624f2c14fdab8382ca2f4f667c3cdb81e29844cd5f8db8a325d0743767c61", size = 1351369, upload-time = "2026-02-07T14:31:13.171Z" }
@@ -4400,72 +4400,72 @@ bigquery = [
     { name = "db-dtypes", marker = "python_full_version >= '3.10'" },
     { name = "google-cloud-bigquery", marker = "python_full_version >= '3.10'" },
     { name = "google-cloud-bigquery-storage", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
     { name = "pandas-gbq", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "pydata-google-auth", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 clickhouse = [
     { name = "clickhouse-connect", extra = ["arrow", "numpy", "pandas"], marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 databricks = [
     { name = "databricks-sql-connector", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 duckdb = [
     { name = "duckdb", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 mssql = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "pandas", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "rich", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 postgres = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
     { name = "psycopg", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 snowflake = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
     { name = "snowflake-connector-python", marker = "python_full_version >= '3.10'" },
@@ -4474,7 +4474,7 @@ snowflake = [
 [[package]]
 name = "idna"
 version = "3.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
@@ -4483,7 +4483,7 @@ wheels = [
 [[package]]
 name = "importlib-metadata"
 version = "6.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "zipp" },
 ]
@@ -4495,7 +4495,7 @@ wheels = [
 [[package]]
 name = "inflection"
 version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091, upload-time = "2020-08-22T08:16:29.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454, upload-time = "2020-08-22T08:16:27.816Z" },
@@ -4504,7 +4504,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
@@ -4513,7 +4513,7 @@ wheels = [
 [[package]]
 name = "ipython"
 version = "8.18.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4533,7 +4533,7 @@ dependencies = [
     { name = "pygments", marker = "python_full_version < '3.10'" },
     { name = "stack-data", marker = "python_full_version < '3.10'" },
     { name = "traitlets", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/b9/3ba6c45a6df813c09a48bac313c22ff83efa26cbb55011218d925a46e2ad/ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27", size = 5486330, upload-time = "2023-11-27T09:58:34.596Z" }
 wheels = [
@@ -4543,7 +4543,7 @@ wheels = [
 [[package]]
 name = "ipython"
 version = "8.37.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4563,7 +4563,7 @@ dependencies = [
     { name = "pygments", marker = "python_full_version == '3.10.*'" },
     { name = "stack-data", marker = "python_full_version == '3.10.*'" },
     { name = "traitlets", marker = "python_full_version == '3.10.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -4573,7 +4573,7 @@ wheels = [
 [[package]]
 name = "ipython"
 version = "9.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4611,7 +4611,7 @@ dependencies = [
     { name = "pygments", marker = "python_full_version >= '3.11'" },
     { name = "stack-data", marker = "python_full_version >= '3.11'" },
     { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/71/a86262bf5a68bf211bcc71fe302af7e05f18a2852fdc610a854d20d085e6/ipython-9.5.0.tar.gz", hash = "sha256:129c44b941fe6d9b82d36fc7a7c18127ddb1d6f02f78f867f402e2e3adde3113", size = 4389137, upload-time = "2025-08-29T12:15:21.519Z" }
 wheels = [
@@ -4621,7 +4621,7 @@ wheels = [
 [[package]]
 name = "ipython-pygments-lexers"
 version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
@@ -4633,7 +4633,7 @@ wheels = [
 [[package]]
 name = "isodate"
 version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -4645,7 +4645,7 @@ wheels = [
 [[package]]
 name = "isort"
 version = "5.13.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
@@ -4654,7 +4654,7 @@ wheels = [
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
@@ -4663,7 +4663,7 @@ wheels = [
 [[package]]
 name = "jaraco-classes"
 version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -4675,7 +4675,7 @@ wheels = [
 [[package]]
 name = "jaraco-context"
 version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
@@ -4687,7 +4687,7 @@ wheels = [
 [[package]]
 name = "jaraco-functools"
 version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -4699,7 +4699,7 @@ wheels = [
 [[package]]
 name = "jedi"
 version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "parso" },
 ]
@@ -4711,7 +4711,7 @@ wheels = [
 [[package]]
 name = "jeepney"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
@@ -4720,7 +4720,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -4732,7 +4732,7 @@ wheels = [
 [[package]]
 name = "jinxed"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "ansicon", marker = "sys_platform == 'win32'" },
 ]
@@ -4744,7 +4744,7 @@ wheels = [
 [[package]]
 name = "jmespath"
 version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
@@ -4753,7 +4753,7 @@ wheels = [
 [[package]]
 name = "jsonpath-ng"
 version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "ply" },
 ]
@@ -4765,7 +4765,7 @@ wheels = [
 [[package]]
 name = "jsonref"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
@@ -4774,10 +4774,10 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.24.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "jsonschema-specifications" },
     { name = "referencing" },
     { name = "rpds-py" },
@@ -4790,7 +4790,7 @@ wheels = [
 [[package]]
 name = "jsonschema-path"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pathable", marker = "python_full_version >= '3.10'" },
     { name = "pyyaml", marker = "python_full_version >= '3.10'" },
@@ -4804,7 +4804,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -4816,7 +4816,7 @@ wheels = [
 [[package]]
 name = "keyring"
 version = "25.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "jaraco-classes" },
@@ -4834,7 +4834,7 @@ wheels = [
 [[package]]
 name = "lance-namespace"
 version = "0.4.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
@@ -4846,13 +4846,13 @@ wheels = [
 [[package]]
 name = "lance-namespace-urllib3-client"
 version = "0.4.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-dateutil" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/a9/4e527c2f05704565618b239b0965f829d1a194837f01234af3f8e2f33d92/lance_namespace_urllib3_client-0.4.5.tar.gz", hash = "sha256:184deda8cf8700926d994618187053c644eb1f2866a4479e7b80843cacc92b1c", size = 159726, upload-time = "2026-01-07T19:20:24.025Z" }
@@ -4863,19 +4863,19 @@ wheels = [
 [[package]]
 name = "lancedb"
 version = "0.26.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "deprecation" },
     { name = "lance-namespace" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "overrides", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tqdm" },
 ]
 wheels = [
@@ -4890,7 +4890,7 @@ wheels = [
 [[package]]
 name = "lazy-object-proxy"
 version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/f9/1f56571ed82fb324f293661690635cf42c41deb8a70a6c9e6edc3e9bb3c8/lazy_object_proxy-1.11.0.tar.gz", hash = "sha256:18874411864c9fbbbaa47f9fc1dd7aea754c86cfde21278ef427639d1dd78e9c", size = 44736, upload-time = "2025-04-16T16:53:48.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/c8/457f1555f066f5bacc44337141294153dc993b5e9132272ab54a64ee98a2/lazy_object_proxy-1.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:132bc8a34f2f2d662a851acfd1b93df769992ed1b81e2b1fda7db3e73b0d5a18", size = 28045, upload-time = "2025-04-16T16:53:32.314Z" },
@@ -4911,7 +4911,7 @@ wheels = [
 [[package]]
 name = "leather"
 version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ed/6e/48a05e2f7f62a616d675cfee182643f2dd8023bf7429aa326f4bebd629c8/leather-0.4.0.tar.gz", hash = "sha256:f964bec2086f3153a6c16e707f20cb718f811f57af116075f4c0f4805c608b95", size = 43877, upload-time = "2024-02-23T22:03:36.657Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/30/9ec597c962c5249ebd5c580386e4b5f2884cd943af42634291ee3b406415/leather-0.4.0-py2.py3-none-any.whl", hash = "sha256:18290bc93749ae39039af5e31e871fcfad74d26c4c3ea28ea4f681f4571b3a2b", size = 30256, upload-time = "2024-02-23T22:03:34.75Z" },
@@ -4920,7 +4920,7 @@ wheels = [
 [[package]]
 name = "librt"
 version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/5f/63f5fa395c7a8a93558c0904ba8f1c8d1b997ca6a3de61bc7659970d66bf/librt-0.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:81fd938344fecb9373ba1b155968c8a329491d2ce38e7ddb76f30ffb938f12dc", size = 65697, upload-time = "2026-02-17T16:11:06.903Z" },
@@ -5017,7 +5017,7 @@ wheels = [
 [[package]]
 name = "limits"
 version = "4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -5029,7 +5029,7 @@ resolution-markers = [
 dependencies = [
     { name = "deprecated", marker = "python_full_version < '3.10'" },
     { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/54/f73e4810332f500b46b3fbf01d3258e0cbf1508d1be8d2438a1e174208c3/limits-4.2.tar.gz", hash = "sha256:d602ceae5d6b71063d5f9338904e32d569efaa84a7dd0399cde7ca6ff1a8fc9b", size = 85710, upload-time = "2025-03-11T18:55:13.637Z" }
 wheels = [
@@ -5039,7 +5039,7 @@ wheels = [
 [[package]]
 name = "limits"
 version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -5063,7 +5063,7 @@ resolution-markers = [
 dependencies = [
     { name = "deprecated", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "packaging", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/93/1d0d9feedbf58220be4160f5f3fbe51f52449d0699f896b32ce731756e30/limits-5.2.0.tar.gz", hash = "sha256:b6b659774f17befef2dd30a76dcd2bdecf3852e73b6627143d44ab4deda94b48", size = 95048, upload-time = "2025-05-16T19:40:20.741Z" }
 wheels = [
@@ -5073,7 +5073,7 @@ wheels = [
 [[package]]
 name = "linkify-it-py"
 version = "2.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "uc-micro-py", marker = "python_full_version < '3.13'" },
 ]
@@ -5085,7 +5085,7 @@ wheels = [
 [[package]]
 name = "lockfile"
 version = "0.12.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/17/47/72cb04a58a35ec495f96984dddb48232b551aafb95bde614605b754fe6f7/lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799", size = 20874, upload-time = "2015-11-25T18:29:58.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa", size = 13564, upload-time = "2015-11-25T18:29:51.462Z" },
@@ -5094,13 +5094,13 @@ wheels = [
 [[package]]
 name = "logbook"
 version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2f/d9/16ac346f7c0102835814cc9e5b684aaadea101560bb932a2403bd26b2320/Logbook-1.5.3.tar.gz", hash = "sha256:66f454ada0f56eae43066f604a222b09893f98c1adc18df169710761b8f32fe8", size = 85783, upload-time = "2019-10-16T18:00:26.666Z" }
 
 [[package]]
 name = "loguru"
 version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "win32-setctime", marker = "sys_platform == 'win32'" },
@@ -5113,7 +5113,7 @@ wheels = [
 [[package]]
 name = "loro"
 version = "1.10.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/27/ea6f3298fc87ea5f2d60ebfbca088e7d9b2ceb3993f67c83bfb81778ec01/loro-1.10.3.tar.gz", hash = "sha256:68184ab1c2ab94af6ad4aaba416d22f579cabee0b26cbb09a1f67858207bbce8", size = 68833, upload-time = "2025-12-09T10:14:06.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/af/517956be7153d3450263f35ca70b1d7845b404e197045274db07b869e26f/loro-1.10.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:7e7e3461439c57efaadfd364a5a504a849653cf408c97086033004dffb3f2857", size = 3258650, upload-time = "2025-12-09T10:11:29.657Z" },
@@ -5247,7 +5247,7 @@ wheels = [
 [[package]]
 name = "lxml"
 version = "5.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/3d/14e82fc7c8fb1b7761f7e748fd47e2ec8276d137b6acfe5a4bb73853e08f/lxml-5.4.0.tar.gz", hash = "sha256:d12832e1dbea4be280b22fd0ea7c9b87f0d8fc51ba06e92dc62d52f804f78ebd", size = 3679479, upload-time = "2025-04-23T01:50:29.322Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/1f/a3b6b74a451ceb84b471caa75c934d2430a4d84395d38ef201d539f38cd1/lxml-5.4.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e7bc6df34d42322c5289e37e9971d6ed114e3776b45fa879f734bded9d1fea9c", size = 8076838, upload-time = "2025-04-23T01:44:29.325Z" },
@@ -5346,7 +5346,7 @@ wheels = [
 [[package]]
 name = "lz4"
 version = "4.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c6/5a/945f5086326d569f14c84ac6f7fcc3229f0b9b1e8cc536b951fd53dfb9e1/lz4-4.4.4.tar.gz", hash = "sha256:070fd0627ec4393011251a094e08ed9fdcc78cb4e7ab28f507638eee4e39abda", size = 171884, upload-time = "2025-04-01T22:55:58.62Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/80/4054e99cda2e003097f59aeb3ad470128f3298db5065174a84564d2d6983/lz4-4.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f170abb8416c4efca48e76cac2c86c3185efdf841aecbe5c190121c42828ced0", size = 220896, upload-time = "2025-04-01T22:55:13.577Z" },
@@ -5394,7 +5394,7 @@ wheels = [
 [[package]]
 name = "makefun"
 version = "1.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/cf/6780ab8bc3b84a1cce3e4400aed3d64b6db7d5e227a2f75b6ded5674701a/makefun-1.16.0.tar.gz", hash = "sha256:e14601831570bff1f6d7e68828bcd30d2f5856f24bad5de0ccb22921ceebc947", size = 73565, upload-time = "2025-05-09T15:00:42.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/c0/4bc973defd1270b89ccaae04cef0d5fa3ea85b59b108ad2c08aeea9afb76/makefun-1.16.0-py2.py3-none-any.whl", hash = "sha256:43baa4c3e7ae2b17de9ceac20b669e9a67ceeadff31581007cca20a07bbe42c4", size = 22923, upload-time = "2025-05-09T15:00:41.042Z" },
@@ -5403,7 +5403,7 @@ wheels = [
 [[package]]
 name = "mako"
 version = "1.3.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -5415,7 +5415,7 @@ wheels = [
 [[package]]
 name = "marimo"
 version = "0.14.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -5436,7 +5436,7 @@ dependencies = [
     { name = "itsdangerous", marker = "python_full_version < '3.11'" },
     { name = "jedi", marker = "python_full_version < '3.11'" },
     { name = "markdown", marker = "python_full_version < '3.11'" },
-    { name = "narwhals", version = "1.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "narwhals", version = "1.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.11'" },
     { name = "packaging", marker = "python_full_version < '3.11'" },
     { name = "psutil", marker = "python_full_version < '3.11'" },
     { name = "pygments", marker = "python_full_version < '3.11'" },
@@ -5444,10 +5444,10 @@ dependencies = [
     { name = "pyyaml", marker = "python_full_version < '3.11'" },
     { name = "starlette", marker = "python_full_version < '3.11'" },
     { name = "tomlkit", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "uvicorn", version = "0.34.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "uvicorn", version = "0.34.3", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "websockets", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/93/d646fccda297843c41fa088e831212a425036e1cf7ea1c1fca41d7f7ad56/marimo-0.14.10.tar.gz", hash = "sha256:195247aabaccb7559532daa0313b7f47647ba78b98e151fe2b85df1f67bff79e", size = 29134153, upload-time = "2025-07-03T00:54:02.37Z" }
@@ -5458,7 +5458,7 @@ wheels = [
 [[package]]
 name = "marimo"
 version = "0.20.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -5493,7 +5493,7 @@ dependencies = [
     { name = "loro", marker = "python_full_version >= '3.11'" },
     { name = "markdown", marker = "python_full_version >= '3.11'" },
     { name = "msgspec", marker = "python_full_version >= '3.11'" },
-    { name = "narwhals", version = "2.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", version = "2.17.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging", marker = "python_full_version >= '3.11'" },
     { name = "psutil", marker = "python_full_version >= '3.11'" },
     { name = "pygments", marker = "python_full_version >= '3.11'" },
@@ -5501,7 +5501,7 @@ dependencies = [
     { name = "pyyaml", marker = "python_full_version >= '3.11'" },
     { name = "starlette", marker = "python_full_version >= '3.11'" },
     { name = "tomlkit", marker = "python_full_version >= '3.11'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "websockets", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/be/84a28265e1698dbac439de8a1d428a18e07c4dd23fa72df72e8b4922e3ff/marimo-0.20.2.tar.gz", hash = "sha256:cdab009b65d58d571640ab8bb2ede68ab3b755c8f99f06b934a23f3b8aba3f34", size = 38237601, upload-time = "2026-02-22T20:19:42.198Z" }
@@ -5512,7 +5512,7 @@ wheels = [
 [[package]]
 name = "markdown"
 version = "3.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
 ]
@@ -5524,7 +5524,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -5536,7 +5536,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357, upload-time = "2024-10-18T15:20:51.44Z" },
@@ -5604,7 +5604,7 @@ wheels = [
 [[package]]
 name = "marshmallow"
 version = "3.26.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "packaging", marker = "python_full_version < '3.13'" },
 ]
@@ -5616,7 +5616,7 @@ wheels = [
 [[package]]
 name = "marshmallow-oneofschema"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "marshmallow", marker = "python_full_version < '3.13'" },
 ]
@@ -5628,7 +5628,7 @@ wheels = [
 [[package]]
 name = "marshmallow-sqlalchemy"
 version = "0.28.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "marshmallow", marker = "python_full_version < '3.13'" },
     { name = "packaging", marker = "python_full_version < '3.13'" },
@@ -5642,10 +5642,10 @@ wheels = [
 [[package]]
 name = "mashumaro"
 version = "3.14"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/47/0a450b281bef2d7e97ec02c8e1168d821e283f58e02e6c403b2bb4d73c1c/mashumaro-3.14.tar.gz", hash = "sha256:5ef6f2b963892cbe9a4ceb3441dfbea37f8c3412523f25d42e9b3a7186555f1d", size = 166160, upload-time = "2024-10-23T21:48:40.164Z" }
 wheels = [
@@ -5660,7 +5660,7 @@ msgpack = [
 [[package]]
 name = "matplotlib-inline"
 version = "0.1.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
@@ -5672,7 +5672,7 @@ wheels = [
 [[package]]
 name = "mccabe"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
@@ -5681,22 +5681,22 @@ wheels = [
 [[package]]
 name = "mcp"
 version = "1.26.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
     { name = "httpx", marker = "python_full_version >= '3.10'" },
     { name = "httpx-sse", marker = "python_full_version >= '3.10'" },
     { name = "jsonschema", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydantic-settings", marker = "python_full_version >= '3.10'" },
     { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.10'" },
     { name = "python-multipart", marker = "python_full_version >= '3.10'" },
     { name = "pywin32", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
     { name = "sse-starlette", marker = "python_full_version >= '3.10'" },
     { name = "starlette", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
@@ -5706,7 +5706,7 @@ wheels = [
 [[package]]
 name = "mdit-py-plugins"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "markdown-it-py", marker = "python_full_version < '3.13'" },
 ]
@@ -5718,7 +5718,7 @@ wheels = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -5727,7 +5727,7 @@ wheels = [
 [[package]]
 name = "methodtools"
 version = "0.4.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "wirerope", marker = "python_full_version < '3.13'" },
 ]
@@ -5739,7 +5739,7 @@ wheels = [
 [[package]]
 name = "mimesis"
 version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/08/182b081de5fc7a148360c0da5d482f65e593e6e739fd5ab0e488e6b26adb/mimesis-7.1.0.tar.gz", hash = "sha256:c83b55d35536d7e9b9700a596b7ccfb639a740e3e1fb5e08062e8ab2a67dcb37", size = 4332255, upload-time = "2023-04-06T21:11:42Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/76/9cb8ef05ee9b07489fd3323f932acfb0e6fff753a3c368f25baa08635a53/mimesis-7.1.0-py3-none-any.whl", hash = "sha256:da65bea6d6d5d5d87d5c008e6b23ef5f96a49cce436d9f8708dabb5152da0290", size = 4371099, upload-time = "2023-04-06T21:11:39.831Z" },
@@ -5748,7 +5748,7 @@ wheels = [
 [[package]]
 name = "minimal-snowplow-tracker"
 version = "0.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "requests" },
     { name = "six" },
@@ -5758,7 +5758,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/e4/9f/004f810169a48ed5c
 [[package]]
 name = "mmh3"
 version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/96/aa247e82878b123468f0079ce2ac77e948315bab91ce45d2934a62e0af95/mmh3-4.1.0.tar.gz", hash = "sha256:a1cf25348b9acd229dda464a094d6170f47d2850a1fcb762a3b6172d2ce6ca4a", size = 26357, upload-time = "2024-01-09T06:46:04.536Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/5a/8609dc74421858f7e94a89dc69221ab9b2c14d0d63a139b46ec190eedc44/mmh3-4.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:be5ac76a8b0cd8095784e51e4c1c9c318c19edcd1709a06eb14979c8d850c31a", size = 39433, upload-time = "2024-01-09T06:44:25.903Z" },
@@ -5830,7 +5830,7 @@ wheels = [
 [[package]]
 name = "more-itertools"
 version = "10.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload-time = "2025-04-22T14:17:41.838Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload-time = "2025-04-22T14:17:40.49Z" },
@@ -5839,9 +5839,9 @@ wheels = [
 [[package]]
 name = "mowidgets"
 version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "marimo", version = "0.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "marimo", version = "0.20.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fb/f4f2f25e9df46e5bb5342201d6851b7b7449f69aa7673612c8ae5d152f8c/mowidgets-0.2.1.tar.gz", hash = "sha256:d3e154e1c27c8c97f31500cda13bcd32bc508df8de2801c3daae56dbb61f2332", size = 9793, upload-time = "2026-01-15T00:00:59.919Z" }
 wheels = [
@@ -5851,7 +5851,7 @@ wheels = [
 [[package]]
 name = "mpmath"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
@@ -5860,7 +5860,7 @@ wheels = [
 [[package]]
 name = "msal"
 version = "1.32.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -5874,7 +5874,7 @@ wheels = [
 [[package]]
 name = "msal-extensions"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "msal" },
 ]
@@ -5886,7 +5886,7 @@ wheels = [
 [[package]]
 name = "msgpack"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/d0/7555686ae7ff5731205df1012ede15dd9d927f6227ea151e901c7406af4f/msgpack-1.1.0.tar.gz", hash = "sha256:dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e", size = 167260, upload-time = "2024-09-10T04:25:52.197Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/f9/a892a6038c861fa849b11a2bb0502c07bc698ab6ea53359e5771397d883b/msgpack-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7ad442d527a7e358a469faf43fda45aaf4ac3249c8310a82f0ccff9164e5dccd", size = 150428, upload-time = "2024-09-10T04:25:43.089Z" },
@@ -5949,7 +5949,7 @@ wheels = [
 [[package]]
 name = "msgspec"
 version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/9c/bfbd12955a49180cbd234c5d29ec6f74fe641698f0cd9df154a854fc8a15/msgspec-0.20.0.tar.gz", hash = "sha256:692349e588fde322875f8d3025ac01689fead5901e7fb18d6870a44519d62a29", size = 317862, upload-time = "2025-11-24T03:56:28.934Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/5e/151883ba2047cca9db8ed2f86186b054ad200bc231352df15b0c1dd75b1f/msgspec-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:23a6ec2a3b5038c233b04740a545856a068bc5cb8db184ff493a58e08c994fbf", size = 195191, upload-time = "2025-11-24T03:55:08.549Z" },
@@ -6013,10 +6013,10 @@ wheels = [
 [[package]]
 name = "multidict"
 version = "6.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/2f/a3470242707058fe856fe59241eee5635d79087100b7042a867368863a27/multidict-6.4.4.tar.gz", hash = "sha256:69ee9e6ba214b5245031b76233dd95408a0fd57fdb019ddcc1ead4790932a8e8", size = 90183, upload-time = "2025-05-19T14:16:37.381Z" }
 wheels = [
@@ -6128,7 +6128,7 @@ wheels = [
 [[package]]
 name = "multiprocess"
 version = "0.70.18"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "dill" },
 ]
@@ -6154,14 +6154,14 @@ wheels = [
 [[package]]
 name = "mypy"
 version = "1.19.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
 wheels = [
@@ -6207,10 +6207,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-athena"
 version = "1.38.28"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/52/93a49eb0269da549337e6691c99d62d742928bacfaafcdd641ac6625a1f2/mypy_boto3_athena-1.38.28.tar.gz", hash = "sha256:5d7e74a59a4c778374848290d3c462665830954495912ec226ce270a4a4eae4d", size = 36553, upload-time = "2025-06-02T19:42:08.879Z" }
 wheels = [
@@ -6220,10 +6220,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-glue"
 version = "1.38.22"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/97/a479bc9405da1d6ae4d2bc88965e76e4d3c8c1c83188eb03c7a49d902826/mypy_boto3_glue-1.38.22.tar.gz", hash = "sha256:a9c529fafaaa9845d39c3204b3fb6cbbb633fa747faf6a084a2b2a381ef12a2b", size = 122519, upload-time = "2025-05-22T19:27:07.452Z" }
 wheels = [
@@ -6233,10 +6233,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-lakeformation"
 version = "1.38.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/51/1f87495c7f48037151a721ab4ba9c27c15b76eb8205e61be5c745eaebe81/mypy_boto3_lakeformation-1.38.0.tar.gz", hash = "sha256:0932699d6fa98cd02be94f753fc03425d12317301cdf534629be347f16238524", size = 34956, upload-time = "2025-04-22T21:27:53.038Z" }
 wheels = [
@@ -6246,10 +6246,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-s3"
 version = "1.38.39"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a7/cc2a5b095401b4d937ece53819ab9323572a82a6bbdc5a699b815fabe76b/mypy_boto3_s3-1.38.39.tar.gz", hash = "sha256:b272d1c9b359017ea7c5d79b4610ba93e91f557ad01da0d6e302bd7b7804f73b", size = 74169, upload-time = "2025-06-18T22:35:04.391Z" }
 wheels = [
@@ -6259,10 +6259,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-s3tables"
 version = "1.38.42"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/8c/c8d129f32737d09d2c23db5110a43164085b47c843460a5c89c748bf3f3f/mypy_boto3_s3tables-1.38.42.tar.gz", hash = "sha256:b3b24401f0e5e21f6c8ab35560a76a72e78983cf59f0b1adf6b7d07d9a6dabe5", size = 19731, upload-time = "2025-06-23T19:28:16.273Z" }
 wheels = [
@@ -6272,10 +6272,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-sts"
 version = "1.38.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/24/638ceabff74e07855b59c3bb863b0c11e69ff7ec8fa8678ff6db9ee38318/mypy_boto3_sts-1.38.0.tar.gz", hash = "sha256:143a96f06bd17ec4bbb120e04b65e646cb4345e2d0d4c3c596f8aa0458d12707", size = 16561, upload-time = "2025-04-22T21:35:39.729Z" }
 wheels = [
@@ -6285,7 +6285,7 @@ wheels = [
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
@@ -6294,7 +6294,7 @@ wheels = [
 [[package]]
 name = "narwhals"
 version = "1.41.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6317,7 +6317,7 @@ wheels = [
 [[package]]
 name = "narwhals"
 version = "2.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6352,7 +6352,7 @@ wheels = [
 [[package]]
 name = "natsort"
 version = "8.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
@@ -6361,7 +6361,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6378,7 +6378,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6395,7 +6395,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6430,7 +6430,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "1.26.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6493,7 +6493,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.2.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.13.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.13.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6569,7 +6569,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6656,7 +6656,7 @@ wheels = [
 [[package]]
 name = "oauthlib"
 version = "3.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352, upload-time = "2022-10-17T20:04:27.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688, upload-time = "2022-10-17T20:04:24.037Z" },
@@ -6665,7 +6665,7 @@ wheels = [
 [[package]]
 name = "onnxruntime"
 version = "1.19.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6677,7 +6677,7 @@ resolution-markers = [
 dependencies = [
     { name = "coloredlogs", marker = "python_full_version < '3.10'" },
     { name = "flatbuffers", marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
     { name = "packaging", marker = "python_full_version < '3.10'" },
     { name = "protobuf", marker = "python_full_version < '3.10'" },
     { name = "sympy", marker = "python_full_version < '3.10'" },
@@ -6708,7 +6708,7 @@ wheels = [
 [[package]]
 name = "onnxruntime"
 version = "1.22.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6744,9 +6744,9 @@ resolution-markers = [
 dependencies = [
     { name = "coloredlogs", marker = "python_full_version >= '3.10'" },
     { name = "flatbuffers", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "protobuf", marker = "python_full_version >= '3.10'" },
     { name = "sympy", marker = "python_full_version >= '3.10'" },
@@ -6775,9 +6775,9 @@ wheels = [
 [[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
@@ -6787,7 +6787,7 @@ wheels = [
 [[package]]
 name = "openpyxl"
 version = "3.1.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "et-xmlfile" },
 ]
@@ -6799,7 +6799,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-api"
 version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "importlib-metadata" },
@@ -6812,7 +6812,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp"
 version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version < '3.13'" },
@@ -6825,7 +6825,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "opentelemetry-proto", marker = "python_full_version < '3.13'" },
 ]
@@ -6837,7 +6837,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
@@ -6855,7 +6855,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
@@ -6873,7 +6873,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-proto"
 version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "protobuf", marker = "python_full_version < '3.13'" },
 ]
@@ -6885,12 +6885,12 @@ wheels = [
 [[package]]
 name = "opentelemetry-sdk"
 version = "1.27.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-semantic-conventions", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/9a/82a6ac0f06590f3d72241a587cb8b0b751bd98728e896cc4cbd4847248e6/opentelemetry_sdk-1.27.0.tar.gz", hash = "sha256:d525017dea0ccce9ba4e0245100ec46ecdc043f2d7b8315d56b19aff0904fa6f", size = 145019, upload-time = "2024-08-28T21:35:46.708Z" }
 wheels = [
@@ -6900,7 +6900,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.48b0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-api", marker = "python_full_version < '3.13'" },
@@ -6913,11 +6913,11 @@ wheels = [
 [[package]]
 name = "oracledb"
 version = "3.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/9d/4e86cd410294ebbb1f90a609aaae61c5fa064a5c10e501de3f4c67664e6c/oracledb-3.4.1.tar.gz", hash = "sha256:f5920df5ac9446579e8409607bba31dc2d23a2286a5b0ea17cb0d78d419392a6", size = 852693, upload-time = "2025-11-12T03:21:36.157Z" }
 wheels = [
@@ -6956,7 +6956,7 @@ wheels = [
 [[package]]
 name = "ordered-set"
 version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/ca/bfac8bc689799bcca4157e0e0ced07e70ce125193fc2e166d2e685b7e2fe/ordered-set-4.1.0.tar.gz", hash = "sha256:694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8", size = 12826, upload-time = "2022-01-26T14:38:56.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/55/af02708f230eb77084a299d7b08175cff006dea4f2721074b92cdb0296c0/ordered_set-4.1.0-py3-none-any.whl", hash = "sha256:046e1132c71fcf3330438a539928932caf51ddbc582496833e23de611de14562", size = 7634, upload-time = "2022-01-26T14:38:48.677Z" },
@@ -6965,7 +6965,7 @@ wheels = [
 [[package]]
 name = "orjson"
 version = "3.10.18"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.13.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.13.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -7053,7 +7053,7 @@ wheels = [
 [[package]]
 name = "orjson"
 version = "3.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -7143,7 +7143,7 @@ wheels = [
 [[package]]
 name = "overrides"
 version = "7.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
@@ -7152,7 +7152,7 @@ wheels = [
 [[package]]
 name = "packaging"
 version = "24.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
@@ -7161,11 +7161,11 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -7218,19 +7218,19 @@ wheels = [
 [[package]]
 name = "pandas-gbq"
 version = "0.29.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "db-dtypes", marker = "python_full_version >= '3.10'" },
     { name = "google-api-core", marker = "python_full_version >= '3.10'" },
     { name = "google-auth", marker = "python_full_version >= '3.10'" },
     { name = "google-auth-oauthlib", marker = "python_full_version >= '3.10'" },
     { name = "google-cloud-bigquery", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydata-google-auth", marker = "python_full_version >= '3.10'" },
     { name = "setuptools", marker = "python_full_version >= '3.10'" },
 ]
@@ -7242,7 +7242,7 @@ wheels = [
 [[package]]
 name = "paramiko"
 version = "3.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "bcrypt" },
     { name = "cryptography" },
@@ -7256,7 +7256,7 @@ wheels = [
 [[package]]
 name = "parsedatetime"
 version = "2.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a8/20/cb587f6672dbe585d101f590c3871d16e7aec5a576a1694997a3777312ac/parsedatetime-2.6.tar.gz", hash = "sha256:4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455", size = 60114, upload-time = "2020-05-31T23:50:57.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/a4/3dd804926a42537bf69fb3ebb9fd72a50ba84f807d95df5ae016606c976c/parsedatetime-2.6-py3-none-any.whl", hash = "sha256:cb96edd7016872f58479e35879294258c71437195760746faffedb692aef000b", size = 42548, upload-time = "2020-05-31T23:50:56.315Z" },
@@ -7265,7 +7265,7 @@ wheels = [
 [[package]]
 name = "parso"
 version = "0.8.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609, upload-time = "2024-04-05T09:43:55.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650, upload-time = "2024-04-05T09:43:53.299Z" },
@@ -7274,7 +7274,7 @@ wheels = [
 [[package]]
 name = "parsy"
 version = "2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/ea/e0853951be3b3e0ca41f962971816065b671ac88e257b99abcd0879198ce/parsy-2.1.tar.gz", hash = "sha256:fd5dd18d7b0b61f8275ee88665f430a20c02cf5a82d88557f35330530186d7ac", size = 45252, upload-time = "2023-02-22T15:26:55.628Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/05/1c84e2ebd1eb2817d92ae05a917e60e57b1c83f7b89e63c31df2cd6fcb70/parsy-2.1-py3-none-any.whl", hash = "sha256:8f18e7b11985e7802e7e3ecbd8291c6ca243d29820b1186e4c84605db4efffa0", size = 9111, upload-time = "2023-02-22T15:26:53.793Z" },
@@ -7283,7 +7283,7 @@ wheels = [
 [[package]]
 name = "pathable"
 version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
@@ -7292,7 +7292,7 @@ wheels = [
 [[package]]
 name = "pathspec"
 version = "0.11.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a0/2a/bd167cdf116d4f3539caaa4c332752aac0b3a0cc0174cdb302ee68933e81/pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3", size = 47032, upload-time = "2023-07-29T01:05:04.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/2a/9b1be29146139ef459188f5e420a66e835dda921208db600b7037093891f/pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20", size = 29603, upload-time = "2023-07-29T01:05:02.656Z" },
@@ -7301,7 +7301,7 @@ wheels = [
 [[package]]
 name = "pathvalidate"
 version = "3.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/87/c7a2f51cc62df0495acb0ed2533a7c74cc895e569a1b020ee5f6e9fa4e21/pathvalidate-3.2.3.tar.gz", hash = "sha256:59b5b9278e30382d6d213497623043ebe63f10e29055be4419a9c04c721739cb", size = 61717, upload-time = "2025-01-03T14:06:42.789Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/14/c5a0e1a947909810fc4c043b84cac472b70e438148d34f5393be1bac663f/pathvalidate-3.2.3-py3-none-any.whl", hash = "sha256:5eaf0562e345d4b6d0c0239d0f690c3bd84d2a9a3c4c73b99ea667401b27bee1", size = 24130, upload-time = "2025-01-03T14:06:39.568Z" },
@@ -7310,7 +7310,7 @@ wheels = [
 [[package]]
 name = "pbr"
 version = "6.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "setuptools" },
 ]
@@ -7322,7 +7322,7 @@ wheels = [
 [[package]]
 name = "pendulum"
 version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "python-dateutil" },
     { name = "tzdata" },
@@ -7397,7 +7397,7 @@ wheels = [
 [[package]]
 name = "pexpect"
 version = "4.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "ptyprocess", marker = "python_full_version < '3.10' or sys_platform != 'emscripten'" },
 ]
@@ -7409,7 +7409,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "10.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -7494,7 +7494,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "11.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -7614,7 +7614,7 @@ wheels = [
 [[package]]
 name = "pip"
 version = "25.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/59/de/241caa0ca606f2ec5fe0c1f4261b0465df78d786a38da693864a116c37f4/pip-25.1.1.tar.gz", hash = "sha256:3de45d411d308d5054c2168185d8da7f9a2cd753dbac8acbfa88a8909ecd9077", size = 1940155, upload-time = "2025-05-02T15:14:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/a2/d40fb2460e883eca5199c62cfc2463fd261f760556ae6290f88488c362c0/pip-25.1.1-py3-none-any.whl", hash = "sha256:2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af", size = 1825227, upload-time = "2025-05-02T15:13:59.102Z" },
@@ -7623,7 +7623,7 @@ wheels = [
 [[package]]
 name = "pipdeptree"
 version = "2.9.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/b2/2508e11f44e0e7b136555175f21c121f20642d43ab2a09797b178e968834/pipdeptree-2.9.6.tar.gz", hash = "sha256:f815caf165e89c576ce659b866c7a82ae4590420c2d020a92d32e45097f8bc73", size = 30858, upload-time = "2023-07-14T22:34:19.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/2c/63ad89d8e01d471b91c0ad4d69ed45f5221f70f3ece6c097beecb7c67f7a/pipdeptree-2.9.6-py3-none-any.whl", hash = "sha256:de93f990d21224297c9f03e057da5a3dc65ff732a0147945dd9421671f13626b", size = 19768, upload-time = "2023-07-14T22:34:17.109Z" },
@@ -7632,7 +7632,7 @@ wheels = [
 [[package]]
 name = "platformdirs"
 version = "4.3.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
@@ -7641,7 +7641,7 @@ wheels = [
 [[package]]
 name = "playwright"
 version = "1.58.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
@@ -7660,7 +7660,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -7669,7 +7669,7 @@ wheels = [
 [[package]]
 name = "ply"
 version = "3.11"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
@@ -7678,7 +7678,7 @@ wheels = [
 [[package]]
 name = "portalocker"
 version = "2.10.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
@@ -7690,7 +7690,7 @@ wheels = [
 [[package]]
 name = "prefixed"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/48/ae/296470eca349da35bdec573e54320afa2b5b099c582e5d97be8bccac247e/prefixed-0.9.0.tar.gz", hash = "sha256:164403fa9ebc83280bbc4705f4b243a28837e164310b4e65c38ccab1ebafeeb3", size = 99277, upload-time = "2024-09-02T18:56:25.248Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/61/d9957a0ed189ac8a89075c59c97588fb1c77e51d8d44a26f5cdf001d260c/prefixed-0.9.0-py2.py3-none-any.whl", hash = "sha256:3cdb74bfc4cf0aba28f3574662b13afdcac27c463dcbef320fe5d03f4c5fbca8", size = 13509, upload-time = "2024-09-02T18:56:23.47Z" },
@@ -7699,7 +7699,7 @@ wheels = [
 [[package]]
 name = "prison"
 version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "six", marker = "python_full_version < '3.13'" },
 ]
@@ -7711,7 +7711,7 @@ wheels = [
 [[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -7723,7 +7723,7 @@ wheels = [
 [[package]]
 name = "propcache"
 version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/07/c8/fdc6686a986feae3541ea23dcaa661bd93972d3940460646c6bb96e21c40/propcache-0.3.1.tar.gz", hash = "sha256:40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf", size = 43651, upload-time = "2025-03-26T03:06:12.05Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/56/e27c136101addf877c8291dbda1b3b86ae848f3837ce758510a0d806c92f/propcache-0.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f27785888d2fdd918bc36de8b8739f2d6c791399552333721b58193f68ea3e98", size = 80224, upload-time = "2025-03-26T03:03:35.81Z" },
@@ -7828,7 +7828,7 @@ wheels = [
 [[package]]
 name = "proto-plus"
 version = "1.26.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -7840,7 +7840,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "4.25.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/01/34c8d2b6354906d728703cb9d546a0e534de479e25f1b581e4094c4a85cc/protobuf-4.25.8.tar.gz", hash = "sha256:6135cf8affe1fc6f76cced2641e4ea8d3e59518d1f24ae41ba97bcad82d397cd", size = 380920, upload-time = "2025-05-28T14:22:25.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/ff/05f34305fe6b85bbfbecbc559d423a5985605cad5eda4f47eae9e9c9c5c5/protobuf-4.25.8-cp310-abi3-win32.whl", hash = "sha256:504435d831565f7cfac9f0714440028907f1975e4bed228e58e72ecfff58a1e0", size = 392745, upload-time = "2025-05-28T14:22:10.524Z" },
@@ -7856,7 +7856,7 @@ wheels = [
 [[package]]
 name = "psutil"
 version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003, upload-time = "2025-02-13T21:54:07.946Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051, upload-time = "2025-02-13T21:54:12.36Z" },
@@ -7871,9 +7871,9 @@ wheels = [
 [[package]]
 name = "psycopg"
 version = "3.2.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "tzdata", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/4a/93a6ab570a8d1a4ad171a1f4256e205ce48d828781312c0bbaff36380ecb/psycopg-3.2.9.tar.gz", hash = "sha256:2fbb46fcd17bc81f993f28c47f1ebea38d66ae97cc2dbc3cad73b37cefbff700", size = 158122, upload-time = "2025-05-13T16:11:15.533Z" }
@@ -7884,7 +7884,7 @@ wheels = [
 [[package]]
 name = "psycopg2-binary"
 version = "2.9.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/bdc8274dc0585090b4e3432267d7be4dfbfd8971c0fa59167c711105a6bf/psycopg2-binary-2.9.10.tar.gz", hash = "sha256:4b3df0e6990aa98acda57d983942eff13d824135fe2250e6522edaa782a06de2", size = 385764, upload-time = "2024-10-16T11:24:58.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/81/331257dbf2801cdb82105306042f7a1637cc752f65f2bb688188e0de5f0b/psycopg2_binary-2.9.10-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:0ea8e3d0ae83564f2fc554955d327fa081d065c8ca5cc6d2abb643e2c9c1200f", size = 3043397, upload-time = "2024-10-16T11:18:58.647Z" },
@@ -7950,7 +7950,7 @@ wheels = [
 [[package]]
 name = "ptyprocess"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
@@ -7959,7 +7959,7 @@ wheels = [
 [[package]]
 name = "pure-eval"
 version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
@@ -7968,7 +7968,7 @@ wheels = [
 [[package]]
 name = "py"
 version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
@@ -7977,10 +7977,10 @@ wheels = [
 [[package]]
 name = "py-key-value-aio"
 version = "0.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "beartype", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
@@ -8002,7 +8002,7 @@ memory = [
 [[package]]
 name = "py-rust-stemmers"
 version = "0.1.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/63/4fbc14810c32d2a884e2e94e406a7d5bf8eee53e1103f558433817230342/py_rust_stemmers-0.1.5.tar.gz", hash = "sha256:e9c310cfb5c2470d7c7c8a0484725965e7cab8b1237e106a0863d5741da3e1f7", size = 9388, upload-time = "2025-02-19T13:56:28.708Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/28/2247e06de9896ac5d0fe9c6c16e611fd39549cb3197e25f12ca4437f12e7/py_rust_stemmers-0.1.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bfbd9034ae00419ff2154e33b8f5b4c4d99d1f9271f31ed059e5c7e9fa005844", size = 286084, upload-time = "2025-02-19T13:54:52.061Z" },
@@ -8064,7 +8064,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "21.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8122,7 +8122,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "23.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8211,7 +8211,7 @@ wheels = [
 [[package]]
 name = "pyarrow-hotfix"
 version = "0.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d2/ed/c3e8677f7abf3981838c2af7b5ac03e3589b3ef94fcb31d575426abae904/pyarrow_hotfix-0.7.tar.gz", hash = "sha256:59399cd58bdd978b2e42816a4183a55c6472d4e33d183351b6069f11ed42661d", size = 9910, upload-time = "2025-04-25T10:17:06.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/c3/94ade4906a2f88bc935772f59c934013b4205e773bcb4239db114a6da136/pyarrow_hotfix-0.7-py3-none-any.whl", hash = "sha256:3236f3b5f1260f0e2ac070a55c1a7b339c4bb7267839bd2015e283234e758100", size = 7923, upload-time = "2025-04-25T10:17:05.224Z" },
@@ -8220,7 +8220,7 @@ wheels = [
 [[package]]
 name = "pyasn1"
 version = "0.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
@@ -8229,7 +8229,7 @@ wheels = [
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -8241,7 +8241,7 @@ wheels = [
 [[package]]
 name = "pyathena"
 version = "3.0.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
@@ -8256,7 +8256,7 @@ wheels = [
 [[package]]
 name = "pycodestyle"
 version = "2.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/aa/210b2c9aedd8c1cbeea31a50e42050ad56187754b34eb214c46709445801/pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521", size = 39232, upload-time = "2024-08-04T20:26:54.576Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/d8/a211b3f85e99a0daa2ddec96c949cac6824bd305b040571b82a03dd62636/pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3", size = 31284, upload-time = "2024-08-04T20:26:53.173Z" },
@@ -8265,7 +8265,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "2.22"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
@@ -8274,7 +8274,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.11.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8285,9 +8285,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "annotated-types", marker = "python_full_version < '3.10'" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-inspection", version = "0.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-inspection", version = "0.4.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/86/8ce9040065e8f924d642c58e4a344e33163a07f6b57f836d0d734e0ad3fb/pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a", size = 787102, upload-time = "2025-05-22T21:18:08.761Z" }
 wheels = [
@@ -8297,7 +8297,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.12.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8332,9 +8332,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "annotated-types", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -8349,7 +8349,7 @@ email = [
 [[package]]
 name = "pydantic-core"
 version = "2.33.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8359,7 +8359,7 @@ resolution-markers = [
     "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -8466,7 +8466,7 @@ wheels = [
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8500,7 +8500,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -8629,11 +8629,11 @@ wheels = [
 [[package]]
 name = "pydantic-settings"
 version = "2.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-dotenv", marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180", size = 188394, upload-time = "2025-09-24T14:19:11.764Z" }
 wheels = [
@@ -8643,7 +8643,7 @@ wheels = [
 [[package]]
 name = "pydata-google-auth"
 version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "google-auth", marker = "python_full_version >= '3.10'" },
     { name = "google-auth-oauthlib", marker = "python_full_version >= '3.10'" },
@@ -8657,7 +8657,7 @@ wheels = [
 [[package]]
 name = "pydbml"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
@@ -8669,7 +8669,7 @@ wheels = [
 [[package]]
 name = "pydoclint"
 version = "0.6.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "docstring-parser-fork" },
@@ -8683,10 +8683,10 @@ wheels = [
 [[package]]
 name = "pyee"
 version = "13.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
 wheels = [
@@ -8696,7 +8696,7 @@ wheels = [
 [[package]]
 name = "pyflakes"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/f9/669d8c9c86613c9d568757c7f5824bd3197d7b1c6c27553bc5618a27cce2/pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f", size = 63788, upload-time = "2024-01-05T00:28:47.703Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/d7/f1b7db88d8e4417c5d47adad627a93547f44bdc9028372dbd2313f34a855/pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a", size = 62725, upload-time = "2024-01-05T00:28:45.903Z" },
@@ -8705,7 +8705,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.19.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
@@ -8714,14 +8714,14 @@ wheels = [
 [[package]]
 name = "pyiceberg"
 version = "0.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
     { name = "fsspec" },
     { name = "mmh3" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyparsing" },
     { name = "requests" },
     { name = "rich" },
@@ -8764,7 +8764,7 @@ wheels = [
 [[package]]
 name = "pyiceberg-core"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c8/85/d3ec2e229d4e1bad3b9c4092889cae102eaf0d4ed62ce0e2de2b6e32cc4d/pyiceberg_core-0.7.0.tar.gz", hash = "sha256:8166883ace30a388d2f659634bec87731cad7bc52341c997fcdd4e13780e4345", size = 504657, upload-time = "2025-10-10T16:30:16.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/35/2942dcaf19ca1becc7f9a9001d0cf98168634732a33efbb06a6f382c36b1/pyiceberg_core-0.7.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:99e23463c30c4180329719fe1f120e779b20616a36bbdd42042b70063a13bd39", size = 56895735, upload-time = "2025-10-10T16:30:00.949Z" },
@@ -8777,7 +8777,7 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.10.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
@@ -8791,7 +8791,7 @@ crypto = [
 [[package]]
 name = "pymdown-extensions"
 version = "10.15"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
@@ -8804,7 +8804,7 @@ wheels = [
 [[package]]
 name = "pymysql"
 version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/ce59b5e5ed4ce8512f879ff1fa5ab699d211ae2495f1adaa5fbba2a1eada/pymysql-1.1.1.tar.gz", hash = "sha256:e127611aaf2b417403c60bf4dc570124aeb4a57f5f37b8e95ae399a42f904cd0", size = 47678, upload-time = "2024-05-21T11:03:43.722Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/94/e4181a1f6286f545507528c78016e00065ea913276888db2262507693ce5/PyMySQL-1.1.1-py3-none-any.whl", hash = "sha256:4de15da4c61dc132f4fb9ab763063e693d521a80fd0e87943b9a453dd4c19d6c", size = 44972, upload-time = "2024-05-21T11:03:41.216Z" },
@@ -8813,7 +8813,7 @@ wheels = [
 [[package]]
 name = "pynacl"
 version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cffi" },
 ]
@@ -8833,7 +8833,7 @@ wheels = [
 [[package]]
 name = "pyodbc"
 version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8891,7 +8891,7 @@ wheels = [
 [[package]]
 name = "pyodbc"
 version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8943,11 +8943,11 @@ wheels = [
 [[package]]
 name = "pyopenssl"
 version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/8c/cd89ad05804f8e3c17dea8f178c3f40eeab5694c30e0c9f5bcd49f576fc3/pyopenssl-25.1.0.tar.gz", hash = "sha256:8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b", size = 179937, upload-time = "2025-05-17T16:28:31.31Z" }
 wheels = [
@@ -8957,7 +8957,7 @@ wheels = [
 [[package]]
 name = "pyparsing"
 version = "3.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608, upload-time = "2025-03-25T05:01:28.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120, upload-time = "2025-03-25T05:01:24.908Z" },
@@ -8966,7 +8966,7 @@ wheels = [
 [[package]]
 name = "pyperclip"
 version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
@@ -8975,7 +8975,7 @@ wheels = [
 [[package]]
 name = "pyreadline3"
 version = "3.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
@@ -8984,7 +8984,7 @@ wheels = [
 [[package]]
 name = "pytest"
 version = "7.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -9001,7 +9001,7 @@ wheels = [
 [[package]]
 name = "pytest-asyncio"
 version = "0.23.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -9013,7 +9013,7 @@ wheels = [
 [[package]]
 name = "pytest-base-url"
 version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "requests" },
@@ -9026,7 +9026,7 @@ wheels = [
 [[package]]
 name = "pytest-cases"
 version = "3.8.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "decopatch" },
     { name = "makefun" },
@@ -9040,7 +9040,7 @@ wheels = [
 [[package]]
 name = "pytest-console-scripts"
 version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "pytest" },
@@ -9053,7 +9053,7 @@ wheels = [
 [[package]]
 name = "pytest-forked"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "py" },
     { name = "pytest" },
@@ -9066,7 +9066,7 @@ wheels = [
 [[package]]
 name = "pytest-mock"
 version = "3.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -9078,7 +9078,7 @@ wheels = [
 [[package]]
 name = "pytest-order"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -9090,7 +9090,7 @@ wheels = [
 [[package]]
 name = "pytest-playwright"
 version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -9113,7 +9113,7 @@ wheels = [
 [[package]]
 name = "pytest-playwright"
 version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -9160,7 +9160,7 @@ wheels = [
 [[package]]
 name = "pytest-timeout"
 version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -9172,7 +9172,7 @@ wheels = [
 [[package]]
 name = "pytest-xdist"
 version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest" },
@@ -9185,7 +9185,7 @@ wheels = [
 [[package]]
 name = "python-daemon"
 version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "lockfile", marker = "python_full_version < '3.13'" },
 ]
@@ -9197,7 +9197,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -9209,7 +9209,7 @@ wheels = [
 [[package]]
 name = "python-dotenv"
 version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
@@ -9218,7 +9218,7 @@ wheels = [
 [[package]]
 name = "python-jose"
 version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "ecdsa", marker = "python_full_version >= '3.10'" },
     { name = "pyasn1", marker = "python_full_version >= '3.10'" },
@@ -9232,7 +9232,7 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.20"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
@@ -9241,7 +9241,7 @@ wheels = [
 [[package]]
 name = "python-nvd3"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "jinja2", marker = "python_full_version < '3.13'" },
     { name = "python-slugify", marker = "python_full_version < '3.13'" },
@@ -9251,7 +9251,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/54/e7/2a0bf4d9209d23a91
 [[package]]
 name = "python-slugify"
 version = "8.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "text-unidecode" },
 ]
@@ -9263,7 +9263,7 @@ wheels = [
 [[package]]
 name = "pytimeparse"
 version = "1.1.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/5d/231f5f33c81e09682708fb323f9e4041408d8223e2f0fb9742843328778f/pytimeparse-1.1.8.tar.gz", hash = "sha256:e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a", size = 9403, upload-time = "2018-05-18T17:40:42.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/b4/afd75551a3b910abd1d922dbd45e49e5deeb4d47dc50209ce489ba9844dd/pytimeparse-1.1.8-py2.py3-none-any.whl", hash = "sha256:04b7be6cc8bd9f5647a6325444926c3ac34ee6bc7e69da4367ba282f076036bd", size = 9969, upload-time = "2018-05-18T17:40:41.28Z" },
@@ -9272,7 +9272,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
@@ -9281,7 +9281,7 @@ wheels = [
 [[package]]
 name = "pywin32"
 version = "310"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/da/a5f38fffbba2fb99aa4aa905480ac4b8e83ca486659ac8c95bce47fb5276/pywin32-310-cp310-cp310-win32.whl", hash = "sha256:6dd97011efc8bf51d6793a82292419eba2c71cf8e7250cfac03bba284454abc1", size = 8848240, upload-time = "2025-03-17T00:55:46.783Z" },
     { url = "https://files.pythonhosted.org/packages/aa/fe/d873a773324fa565619ba555a82c9dabd677301720f3660a731a5d07e49a/pywin32-310-cp310-cp310-win_amd64.whl", hash = "sha256:c3e78706e4229b915a0821941a84e7ef420bf2b77e08c9dae3c76fd03fd2ae3d", size = 9601854, upload-time = "2025-03-17T00:55:48.783Z" },
@@ -9302,7 +9302,7 @@ wheels = [
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
@@ -9311,7 +9311,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
@@ -9364,17 +9364,17 @@ wheels = [
 [[package]]
 name = "qdrant-client"
 version = "1.14.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "httpx", extra = ["http2"] },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "portalocker" },
     { name = "protobuf" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/56/3f355f931c239c260b4fe3bd6433ec6c9e6185cd5ae0970fe89d0ca6daee/qdrant_client-1.14.3.tar.gz", hash = "sha256:bb899e3e065b79c04f5e47053d59176150c0a5dabc09d7f476c8ce8e52f4d281", size = 286766, upload-time = "2025-06-16T11:13:47.838Z" }
@@ -9390,7 +9390,7 @@ fastembed = [
 [[package]]
 name = "redshift-connector"
 version = "2.0.917"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
@@ -9409,13 +9409,13 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.36.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "rpds-py" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
@@ -9425,7 +9425,7 @@ wheels = [
 [[package]]
 name = "regex"
 version = "2024.11.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz", hash = "sha256:7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519", size = 399494, upload-time = "2024-11-06T20:12:31.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/3c/4651f6b130c6842a8f3df82461a8950f923925db8b6961063e82744bddcc/regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ff590880083d60acc0433f9c3f713c51f7ac6ebb9adf889c79a261ecf541aa91", size = 482674, upload-time = "2024-11-06T20:08:57.575Z" },
@@ -9510,7 +9510,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.32.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -9525,7 +9525,7 @@ wheels = [
 [[package]]
 name = "requests-mock"
 version = "1.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "requests" },
 ]
@@ -9537,7 +9537,7 @@ wheels = [
 [[package]]
 name = "requests-oauthlib"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
@@ -9550,7 +9550,7 @@ wheels = [
 [[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "requests", marker = "python_full_version < '3.13'" },
 ]
@@ -9562,7 +9562,7 @@ wheels = [
 [[package]]
 name = "requirements-parser"
 version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -9574,7 +9574,7 @@ wheels = [
 [[package]]
 name = "rfc3339-validator"
 version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "six", marker = "python_full_version < '3.13'" },
 ]
@@ -9586,12 +9586,12 @@ wheels = [
 [[package]]
 name = "rich"
 version = "13.9.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
@@ -9601,7 +9601,7 @@ wheels = [
 [[package]]
 name = "rich-argparse"
 version = "1.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "rich" },
 ]
@@ -9613,7 +9613,7 @@ wheels = [
 [[package]]
 name = "rich-rst"
 version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "docutils", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
@@ -9626,7 +9626,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/a6/60184b7fc00dd3ca80ac635dd5b8577d444c57e8e8742cecabfacb829921/rpds_py-0.25.1.tar.gz", hash = "sha256:8960b6dac09b62dac26e75d7e2c4a22efb835d827a7278c34f72b2b84fa160e3", size = 27304, upload-time = "2025-05-21T12:46:12.502Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/09/e1158988e50905b7f8306487a576b52d32aa9a87f79f7ab24ee8db8b6c05/rpds_py-0.25.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:f4ad628b5174d5315761b67f212774a32f5bad5e61396d38108bd801c0a8f5d9", size = 373140, upload-time = "2025-05-21T12:42:38.834Z" },
@@ -9750,7 +9750,7 @@ wheels = [
 [[package]]
 name = "rsa"
 version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -9762,7 +9762,7 @@ wheels = [
 [[package]]
 name = "ruamel-yaml"
 version = "0.18.16"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "ruamel-yaml-clib", marker = "python_full_version >= '3.10' and python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
 ]
@@ -9774,7 +9774,7 @@ wheels = [
 [[package]]
 name = "ruamel-yaml-clib"
 version = "0.2.15"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/5a/4ab767cd42dcd65b83c323e1620d7c01ee60a52f4032fb7b61501f45f5c2/ruamel_yaml_clib-0.2.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:88eea8baf72f0ccf232c22124d122a7f26e8a24110a0273d9bcddcb0f7e1fa03", size = 147454, upload-time = "2025-11-16T16:13:02.54Z" },
@@ -9842,7 +9842,7 @@ wheels = [
 [[package]]
 name = "ruff"
 version = "0.3.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/6a/5cdb9e5ae04210ddc5b7b6cf31aeca50654de595e73e59961ce1a662656c/ruff-0.3.7.tar.gz", hash = "sha256:d5c1aebee5162c2226784800ae031f660c350e7a3402c4d1f8ea4e97e232e3ba", size = 2164419, upload-time = "2024-04-12T03:54:39.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/59/8416cddfcc65b710d79374358a81632f2c4810326e8391d5a3c23f1cc422/ruff-0.3.7-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0e8377cccb2f07abd25e84fc5b2cbe48eeb0fea9f1719cad7caedb061d70e5ce", size = 16845547, upload-time = "2024-04-12T03:53:41.335Z" },
@@ -9866,7 +9866,7 @@ wheels = [
 [[package]]
 name = "s3fs"
 version = "2025.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "aiobotocore" },
     { name = "aiohttp" },
@@ -9880,7 +9880,7 @@ wheels = [
 [[package]]
 name = "s3transfer"
 version = "0.11.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "botocore" },
 ]
@@ -9892,7 +9892,7 @@ wheels = [
 [[package]]
 name = "scramp"
 version = "1.4.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "asn1crypto" },
 ]
@@ -9904,7 +9904,7 @@ wheels = [
 [[package]]
 name = "secretstorage"
 version = "3.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cryptography", marker = "os_name != 'nt' and sys_platform != 'emscripten'" },
     { name = "jeepney", marker = "os_name != 'nt' and sys_platform != 'emscripten'" },
@@ -9917,7 +9917,7 @@ wheels = [
 [[package]]
 name = "semver"
 version = "3.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
@@ -9926,7 +9926,7 @@ wheels = [
 [[package]]
 name = "sentry-sdk"
 version = "2.29.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
@@ -9939,7 +9939,7 @@ wheels = [
 [[package]]
 name = "setproctitle"
 version = "1.3.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/af/56efe21c53ac81ac87e000b15e60b3d8104224b4313b6eacac3597bd183d/setproctitle-1.3.6.tar.gz", hash = "sha256:c9f32b96c700bb384f33f7cf07954bb609d35dd82752cef57fb2ee0968409169", size = 26889, upload-time = "2025-04-29T13:35:00.184Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/db/8214810cae49e2e474ea741aaa7d6111486f27377e864f0eb6d297c9be56/setproctitle-1.3.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ebcf34b69df4ca0eabaaaf4a3d890f637f355fed00ba806f7ebdd2d040658c26", size = 17412, upload-time = "2025-04-29T13:32:38.795Z" },
@@ -10027,7 +10027,7 @@ wheels = [
 [[package]]
 name = "setuptools"
 version = "80.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
@@ -10036,7 +10036,7 @@ wheels = [
 [[package]]
 name = "shapely"
 version = "2.0.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10046,7 +10046,7 @@ resolution-markers = [
     "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/c0/a911d1fd765d07a2b6769ce155219a281bfbe311584ebe97340d75c5bdb1/shapely-2.0.7.tar.gz", hash = "sha256:28fe2997aab9a9dc026dc6a355d04e85841546b2a5d232ed953e3321ab958ee5", size = 283413, upload-time = "2025-01-31T01:10:20.787Z" }
 wheels = [
@@ -10085,7 +10085,7 @@ wheels = [
 [[package]]
 name = "shapely"
 version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10119,9 +10119,9 @@ resolution-markers = [
     "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/3c/2da625233f4e605155926566c0e7ea8dda361877f48e8b1655e53456f252/shapely-2.1.1.tar.gz", hash = "sha256:500621967f2ffe9642454808009044c21e5b35db89ce69f8a2042c2ffd0e2772", size = 315422, upload-time = "2025-05-19T11:04:41.265Z" }
 wheels = [
@@ -10170,7 +10170,7 @@ wheels = [
 [[package]]
 name = "shellingham"
 version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
@@ -10179,7 +10179,7 @@ wheels = [
 [[package]]
 name = "simplejson"
 version = "3.19.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c0/5c/61e2afbe62bbe2e328d4d1f426f6e39052b73eddca23b5ba524026561250/simplejson-3.19.1.tar.gz", hash = "sha256:6277f60848a7d8319d27d2be767a7546bc965535b28070e310b3a9af90604a4c", size = 85207, upload-time = "2023-04-06T20:38:16.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/90/d37e7e026b1f460577f8480581a25494987ae2a31fd61305c30aa62342e1/simplejson-3.19.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:66d780047c31ff316ee305c3f7550f352d87257c756413632303fc59fef19eac", size = 94834, upload-time = "2023-04-06T20:36:34.537Z" },
@@ -10227,7 +10227,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -10236,7 +10236,7 @@ wheels = [
 [[package]]
 name = "smmap"
 version = "5.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
@@ -10245,7 +10245,7 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
@@ -10254,7 +10254,7 @@ wheels = [
 [[package]]
 name = "snowflake-connector-python"
 version = "3.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "asn1crypto" },
     { name = "boto3" },
@@ -10273,8 +10273,8 @@ dependencies = [
     { name = "requests" },
     { name = "sortedcontainers" },
     { name = "tomlkit" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/ff/7c1b2cbb5a43b21abebfa58c83926266e9f5ea05123e795753da6ce84f96/snowflake_connector_python-3.15.0.tar.gz", hash = "sha256:1ef52e2fb3ecc295139737d3d759f85d962ef7278c6990c3bd9c17fcb82508d6", size = 774355, upload-time = "2025-04-28T23:15:36.681Z" }
@@ -10313,7 +10313,7 @@ secure-local-storage = [
 [[package]]
 name = "sortedcontainers"
 version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
@@ -10322,7 +10322,7 @@ wheels = [
 [[package]]
 name = "soupsieve"
 version = "2.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
@@ -10331,7 +10331,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy"
 version = "1.4.54"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
 ]
@@ -10366,7 +10366,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy-jsonfield"
 version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
 ]
@@ -10378,7 +10378,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy-utils"
 version = "0.41.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
 ]
@@ -10390,7 +10390,7 @@ wheels = [
 [[package]]
 name = "sqlfluff"
 version = "2.3.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "appdirs" },
     { name = "chardet" },
@@ -10405,8 +10405,8 @@ dependencies = [
     { name = "tblib" },
     { name = "toml", marker = "python_full_version < '3.11'" },
     { name = "tqdm" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/4d/62bbe63bfaff220af7a23fbc165763aefe4d62e818b26f5fd52f44cc4a43/sqlfluff-2.3.5.tar.gz", hash = "sha256:fd77ef5a41ebfa798235a5b28bcfa71f7521e9336159a08b40b545953e84c3c3", size = 697029, upload-time = "2023-10-27T19:32:09.91Z" }
 wheels = [
@@ -10416,7 +10416,7 @@ wheels = [
 [[package]]
 name = "sqlglot"
 version = "28.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10457,7 +10457,7 @@ wheels = [
 [[package]]
 name = "sqlglot"
 version = "28.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10474,7 +10474,7 @@ wheels = [
 [[package]]
 name = "sqlparse"
 version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
@@ -10483,7 +10483,7 @@ wheels = [
 [[package]]
 name = "sse-starlette"
 version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
 ]
@@ -10495,7 +10495,7 @@ wheels = [
 [[package]]
 name = "stack-data"
 version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "asttokens" },
     { name = "executing" },
@@ -10509,10 +10509,10 @@ wheels = [
 [[package]]
 name = "starlette"
 version = "0.47.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/d0/0332bd8a25779a0e2082b0e179805ad39afad642938b371ae0882e7f880d/starlette-0.47.0.tar.gz", hash = "sha256:1f64887e94a447fed5f23309fb6890ef23349b7e478faa7b24a851cd4eb844af", size = 2582856, upload-time = "2025-05-29T15:45:27.628Z" }
 wheels = [
@@ -10522,7 +10522,7 @@ wheels = [
 [[package]]
 name = "stevedore"
 version = "5.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "pbr" },
 ]
@@ -10534,7 +10534,7 @@ wheels = [
 [[package]]
 name = "strictyaml"
 version = "1.7.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "python-dateutil" },
 ]
@@ -10546,7 +10546,7 @@ wheels = [
 [[package]]
 name = "sympy"
 version = "1.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "mpmath" },
 ]
@@ -10558,7 +10558,7 @@ wheels = [
 [[package]]
 name = "tabulate"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
@@ -10567,7 +10567,7 @@ wheels = [
 [[package]]
 name = "tblib"
 version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/95/4b3044ec4bf248186769629bbfb495a458deb6e4c1f9eff7f298ae1e336e/tblib-3.1.0.tar.gz", hash = "sha256:06404c2c9f07f66fee2d7d6ad43accc46f9c3361714d9b8426e7f47e595cd652", size = 30766, upload-time = "2025-03-31T12:58:27.473Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl", hash = "sha256:670bb4582578134b3d81a84afa1b016128b429f3d48e6cbbaecc9d15675e984e", size = 12552, upload-time = "2025-03-31T12:58:26.142Z" },
@@ -10576,7 +10576,7 @@ wheels = [
 [[package]]
 name = "tenacity"
 version = "8.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a3/4d/6a19536c50b849338fcbe9290d562b52cbdcf30d8963d3588a68a4107df1/tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78", size = 47309, upload-time = "2024-07-05T07:25:31.836Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/3f/8ba87d9e287b9d385a02a7114ddcef61b26f86411e121c9003eb509a1773/tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687", size = 28165, upload-time = "2024-07-05T07:25:29.591Z" },
@@ -10585,7 +10585,7 @@ wheels = [
 [[package]]
 name = "termcolor"
 version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/6c/3d75c196ac07ac8749600b60b03f4f6094d54e132c4d94ebac6ee0e0add0/termcolor-3.1.0.tar.gz", hash = "sha256:6a6dd7fbee581909eeec6a756cff1d7f7c376063b14e4a298dc4980309e55970", size = 14324, upload-time = "2025-04-30T11:37:53.791Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl", hash = "sha256:591dd26b5c2ce03b9e43f391264626557873ce1d379019786f99b0c2bee140aa", size = 7684, upload-time = "2025-04-30T11:37:52.382Z" },
@@ -10594,7 +10594,7 @@ wheels = [
 [[package]]
 name = "text-unidecode"
 version = "1.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
@@ -10603,7 +10603,7 @@ wheels = [
 [[package]]
 name = "thrift"
 version = "0.20.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -10612,7 +10612,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3c/2d/8946864f716ac82dc
 [[package]]
 name = "tokenize-rt"
 version = "6.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/ed/8f07e893132d5051d86a553e749d5c89b2a4776eb3a579b72ed61f8559ca/tokenize_rt-6.2.0.tar.gz", hash = "sha256:8439c042b330c553fdbe1758e4a05c0ed460dbbbb24a606f11f0dee75da4cad6", size = 5476, upload-time = "2025-05-23T23:48:00.035Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/f0/3fe8c6e69135a845f4106f2ff8b6805638d4e85c264e70114e8126689587/tokenize_rt-6.2.0-py2.py3-none-any.whl", hash = "sha256:a152bf4f249c847a66497a4a95f63376ed68ac6abf092a2f7cfb29d044ecff44", size = 6004, upload-time = "2025-05-23T23:47:58.812Z" },
@@ -10621,7 +10621,7 @@ wheels = [
 [[package]]
 name = "tokenizers"
 version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
@@ -10646,7 +10646,7 @@ wheels = [
 [[package]]
 name = "toml"
 version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
@@ -10655,7 +10655,7 @@ wheels = [
 [[package]]
 name = "tomli"
 version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
@@ -10694,7 +10694,7 @@ wheels = [
 [[package]]
 name = "tomlkit"
 version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/07/d34a911a98e64b07f862da4b10028de0c1ac2222ab848eaf5dd1877c4b1b/tomlkit-0.12.1.tar.gz", hash = "sha256:38e1ff8edb991273ec9f6181244a6a391ac30e9f5098e7535640ea6be97a7c86", size = 190535, upload-time = "2023-07-27T14:50:22.643Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/6d/808775ed618e51edaa7bbe6759e22e1c7eafe359af6e084700c6d39d3455/tomlkit-0.12.1-py3-none-any.whl", hash = "sha256:712cbd236609acc6a3e2e97253dfc52d4c2082982a88f61b640ecf0817eab899", size = 37335, upload-time = "2023-07-27T14:50:21.12Z" },
@@ -10703,7 +10703,7 @@ wheels = [
 [[package]]
 name = "toolz"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/0b/d80dfa675bf592f636d1ea0b835eab4ec8df6e9415d8cfd766df54456123/toolz-1.0.0.tar.gz", hash = "sha256:2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02", size = 66790, upload-time = "2024-10-04T16:17:04.001Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl", hash = "sha256:292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236", size = 56383, upload-time = "2024-10-04T16:17:01.533Z" },
@@ -10712,7 +10712,7 @@ wheels = [
 [[package]]
 name = "tqdm"
 version = "4.67.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -10724,7 +10724,7 @@ wheels = [
 [[package]]
 name = "traitlets"
 version = "5.14.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
@@ -10733,7 +10733,7 @@ wheels = [
 [[package]]
 name = "typer"
 version = "0.23.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "click" },
@@ -10748,7 +10748,7 @@ wheels = [
 [[package]]
 name = "types-awscrt"
 version = "0.27.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/36/6c/583522cfb3c330e92e726af517a91c13247e555e021791a60f1b03c6ff16/types_awscrt-0.27.2.tar.gz", hash = "sha256:acd04f57119eb15626ab0ba9157fc24672421de56e7bd7b9f61681fedee44e91", size = 16304, upload-time = "2025-05-16T03:10:08.712Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/82/1ee2e5c9d28deac086ab3a6ff07c8bc393ef013a083f546c623699881715/types_awscrt-0.27.2-py3-none-any.whl", hash = "sha256:49a045f25bbd5ad2865f314512afced933aed35ddbafc252e2268efa8a787e4e", size = 37761, upload-time = "2025-05-16T03:10:07.466Z" },
@@ -10757,7 +10757,7 @@ wheels = [
 [[package]]
 name = "types-cachetools"
 version = "6.0.0.20250525"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/d0/55ff0eeda141436c1bd2142cd026906870c661b3f7755070d6da7ea7210f/types_cachetools-6.0.0.20250525.tar.gz", hash = "sha256:baf06f234cac3aeb44c07893447ba03ecdb6c0742ba2607e28a35d38e6821b02", size = 8925, upload-time = "2025-05-25T03:13:53.498Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8c/4ab0a17ece30fe608270b89cf066387051862899fff9f54ab12511fc7fdd/types_cachetools-6.0.0.20250525-py3-none-any.whl", hash = "sha256:1de8f0fe4bdcb187a48d2026c1e3672830f67943ad2bf3486abe031b632f1252", size = 8938, upload-time = "2025-05-25T03:13:52.406Z" },
@@ -10766,7 +10766,7 @@ wheels = [
 [[package]]
 name = "types-click"
 version = "7.1.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/ff/0e6a56108d45c80c61cdd4743312d0304d8192482aea4cce96c554aaa90d/types-click-7.1.8.tar.gz", hash = "sha256:b6604968be6401dc516311ca50708a0a28baa7a0cb840efd7412f0dbbff4e092", size = 10015, upload-time = "2021-11-23T12:28:01.701Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/ad/607454a5f991c5b3e14693a7113926758f889138371058a5f72f567fa131/types_click-7.1.8-py3-none-any.whl", hash = "sha256:8cb030a669e2e927461be9827375f83c16b8178c365852c060a34e24871e7e81", size = 12929, upload-time = "2021-11-23T12:27:59.493Z" },
@@ -10775,7 +10775,7 @@ wheels = [
 [[package]]
 name = "types-deprecated"
 version = "1.2.15.20250304"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0e/67/eeefaaabb03b288aad85483d410452c8bbcbf8b2bd876b0e467ebd97415b/types_deprecated-1.2.15.20250304.tar.gz", hash = "sha256:c329030553029de5cc6cb30f269c11f4e00e598c4241290179f63cda7d33f719", size = 8015, upload-time = "2025-03-04T02:48:17.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/e3/c18aa72ab84e0bc127a3a94e93be1a6ac2cb281371d3a45376ab7cfdd31c/types_deprecated-1.2.15.20250304-py3-none-any.whl", hash = "sha256:86a65aa550ea8acf49f27e226b8953288cd851de887970fbbdf2239c116c3107", size = 8553, upload-time = "2025-03-04T02:48:16.666Z" },
@@ -10784,7 +10784,7 @@ wheels = [
 [[package]]
 name = "types-paramiko"
 version = "3.5.0.20250708"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
@@ -10796,7 +10796,7 @@ wheels = [
 [[package]]
 name = "types-protobuf"
 version = "6.30.2.20250516"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/6c/5cf088aaa3927d1cc39910f60f220f5ff573ab1a6485b2836e8b26beb58c/types_protobuf-6.30.2.20250516.tar.gz", hash = "sha256:aecd1881770a9bb225ede66872ef7f0da4505edd0b193108edd9892e48d49a41", size = 62254, upload-time = "2025-05-16T03:06:50.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/66/06a9c161f5dd5deb4f5c016ba29106a8f1903eb9a1ba77d407dd6588fecb/types_protobuf-6.30.2.20250516-py3-none-any.whl", hash = "sha256:8c226d05b5e8b2623111765fa32d6e648bbc24832b4c2fddf0fa340ba5d5b722", size = 76480, upload-time = "2025-05-16T03:06:49.444Z" },
@@ -10805,7 +10805,7 @@ wheels = [
 [[package]]
 name = "types-psutil"
 version = "5.9.5.20240516"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/41/5d3d2f7b7e819e85820eadececc121ab805c0cb4cab5d88defb0a37eabed/types-psutil-5.9.5.20240516.tar.gz", hash = "sha256:bb296f59fc56458891d0feb1994717e548a1bcf89936a2877df8792b822b4696", size = 14771, upload-time = "2024-05-16T02:21:20.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/b0/872fd0f7b3998f18447a49b0ebae95994c9f589c79443551030caa8f94f0/types_psutil-5.9.5.20240516-py3-none-any.whl", hash = "sha256:83146ded949a10167d9895e567b3b71e53ebc5e23fd8363eab62b3c76cce7b89", size = 18356, upload-time = "2024-05-16T02:21:18.398Z" },
@@ -10814,7 +10814,7 @@ wheels = [
 [[package]]
 name = "types-psycopg2"
 version = "2.9.21.20250516"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/68/55/3f94eff9d1a1402f39e19523a90117fe6c97d7fc61957e7ee3e3052c75e1/types_psycopg2-2.9.21.20250516.tar.gz", hash = "sha256:6721018279175cce10b9582202e2a2b4a0da667857ccf82a97691bdb5ecd610f", size = 26514, upload-time = "2025-05-16T03:07:45.786Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/50/f5d74945ab09b9a3e966ad39027ac55998f917eca72ede7929eab962b5db/types_psycopg2-2.9.21.20250516-py3-none-any.whl", hash = "sha256:2a9212d1e5e507017b31486ce8147634d06b85d652769d7a2d91d53cb4edbd41", size = 24846, upload-time = "2025-05-16T03:07:44.849Z" },
@@ -10823,7 +10823,7 @@ wheels = [
 [[package]]
 name = "types-python-dateutil"
 version = "2.9.0.20250516"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/88/d65ed807393285204ab6e2801e5d11fbbea811adcaa979a2ed3b67a5ef41/types_python_dateutil-2.9.0.20250516.tar.gz", hash = "sha256:13e80d6c9c47df23ad773d54b2826bd52dbbb41be87c3f339381c1700ad21ee5", size = 13943, upload-time = "2025-05-16T03:06:58.385Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/3f/b0e8db149896005adc938a1e7f371d6d7e9eca4053a29b108978ed15e0c2/types_python_dateutil-2.9.0.20250516-py3-none-any.whl", hash = "sha256:2b2b3f57f9c6a61fba26a9c0ffb9ea5681c9b83e69cd897c6b5f668d9c0cab93", size = 14356, upload-time = "2025-05-16T03:06:57.249Z" },
@@ -10832,7 +10832,7 @@ wheels = [
 [[package]]
 name = "types-pytz"
 version = "2025.2.0.20250516"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/72/b0e711fd90409f5a76c75349055d3eb19992c110f0d2d6aabbd6cfbc14bf/types_pytz-2025.2.0.20250516.tar.gz", hash = "sha256:e1216306f8c0d5da6dafd6492e72eb080c9a166171fa80dd7a1990fd8be7a7b3", size = 10940, upload-time = "2025-05-16T03:07:01.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl", hash = "sha256:e0e0c8a57e2791c19f718ed99ab2ba623856b11620cb6b637e5f62ce285a7451", size = 10136, upload-time = "2025-05-16T03:07:01.075Z" },
@@ -10841,7 +10841,7 @@ wheels = [
 [[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250516"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload-time = "2025-05-16T03:08:04.019Z" },
@@ -10850,7 +10850,7 @@ wheels = [
 [[package]]
 name = "types-regex"
 version = "2024.11.6.20250403"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/75/012b90c8557d3abb3b58a9073a94d211c8f75c9b2e26bf0d8af7ecf7bc78/types_regex-2024.11.6.20250403.tar.gz", hash = "sha256:3fdf2a70bbf830de4b3a28e9649a52d43dabb57cdb18fbfe2252eefb53666665", size = 12394, upload-time = "2025-04-03T02:54:35.379Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/49/67200c4708f557be6aa4ecdb1fa212d67a10558c5240251efdc799cca22f/types_regex-2024.11.6.20250403-py3-none-any.whl", hash = "sha256:e22c0f67d73f4b4af6086a340f387b6f7d03bed8a0bb306224b75c51a29b0001", size = 10396, upload-time = "2025-04-03T02:54:34.555Z" },
@@ -10859,7 +10859,7 @@ wheels = [
 [[package]]
 name = "types-requests"
 version = "2.31.0.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "types-urllib3" },
 ]
@@ -10871,7 +10871,7 @@ wheels = [
 [[package]]
 name = "types-s3transfer"
 version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/42/c1/45038f259d6741c252801044e184fec4dbaeff939a58f6160d7c32bf4975/types_s3transfer-0.13.0.tar.gz", hash = "sha256:203dadcb9865c2f68fb44bc0440e1dc05b79197ba4a641c0976c26c9af75ef52", size = 14175, upload-time = "2025-05-28T02:16:07.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/5d/6bbe4bf6a79fb727945291aef88b5ecbdba857a603f1bbcf1a6be0d3f442/types_s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:79c8375cbf48a64bff7654c02df1ec4b20d74f8c5672fc13e382f593ca5565b3", size = 19588, upload-time = "2025-05-28T02:16:06.709Z" },
@@ -10880,7 +10880,7 @@ wheels = [
 [[package]]
 name = "types-simplejson"
 version = "3.19.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/6e/e4843fcc0c590555599ddd93fb4a15810484eedf10b8184dfeb579e386e3/types-simplejson-3.19.0.2.tar.gz", hash = "sha256:ebc81f886f89d99d6b80c726518aa2228bc77c26438f18fd81455e4f79f8ee1b", size = 3841, upload-time = "2023-07-20T15:15:53.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/6c/f38237f677232ea9d14dfd0374bf5097365dcbb566aac2476961d2df60f1/types_simplejson-3.19.0.2-py3-none-any.whl", hash = "sha256:8ba093dc7884f59b3e62aed217144085e675a269debc32678fd80e0b43b2b86f", size = 4128, upload-time = "2023-07-20T15:15:51.291Z" },
@@ -10889,7 +10889,7 @@ wheels = [
 [[package]]
 name = "types-sqlalchemy"
 version = "1.4.53.38"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/ce/0b7fa93dbc49b328807dedef8006223129e5a9543c74727dd7658eca5a9d/types-SQLAlchemy-1.4.53.38.tar.gz", hash = "sha256:5bb7463537e04e1aa5a3557eb725930df99226dcfd3c9bf93008025bfe5c169e", size = 118888, upload-time = "2023-05-01T15:15:28.572Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/4f/033a839a35ecbc5f71c0d74655d1237e909651aaebe7ceb825ac45cfdb4b/types_SQLAlchemy-1.4.53.38-py3-none-any.whl", hash = "sha256:7e60e74f823931cc9a9e8adb0a4c05e5533e6708b8a266807893a739faf4eaaa", size = 187916, upload-time = "2023-05-01T15:15:26.02Z" },
@@ -10898,7 +10898,7 @@ wheels = [
 [[package]]
 name = "types-tqdm"
 version = "4.67.0.20250516"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "types-requests" },
 ]
@@ -10910,7 +10910,7 @@ wheels = [
 [[package]]
 name = "types-urllib3"
 version = "1.26.25.14"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239, upload-time = "2023-07-20T15:19:31.307Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377, upload-time = "2023-07-20T15:19:30.379Z" },
@@ -10919,7 +10919,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10936,7 +10936,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10977,7 +10977,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10987,7 +10987,7 @@ resolution-markers = [
     "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
@@ -10997,7 +10997,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -11031,7 +11031,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -11041,7 +11041,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
@@ -11050,7 +11050,7 @@ wheels = [
 [[package]]
 name = "tzlocal"
 version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
@@ -11062,7 +11062,7 @@ wheels = [
 [[package]]
 name = "uc-micro-py"
 version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
@@ -11071,7 +11071,7 @@ wheels = [
 [[package]]
 name = "universal-pathlib"
 version = "0.2.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "fsspec", marker = "python_full_version < '3.13'" },
 ]
@@ -11083,7 +11083,7 @@ wheels = [
 [[package]]
 name = "uritemplate"
 version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
@@ -11092,7 +11092,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "1.26.20"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
@@ -11101,7 +11101,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.34.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -11113,7 +11113,7 @@ resolution-markers = [
 dependencies = [
     { name = "click", marker = "python_full_version < '3.10'" },
     { name = "h11", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
 wheels = [
@@ -11123,7 +11123,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.41.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -11159,7 +11159,7 @@ resolution-markers = [
 dependencies = [
     { name = "click", marker = "python_full_version >= '3.10'" },
     { name = "h11", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
@@ -11169,7 +11169,7 @@ wheels = [
 [[package]]
 name = "validators"
 version = "0.35.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
@@ -11178,7 +11178,7 @@ wheels = [
 [[package]]
 name = "watchfiles"
 version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
 ]
@@ -11297,7 +11297,7 @@ wheels = [
 [[package]]
 name = "wcwidth"
 version = "0.2.13"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
@@ -11306,16 +11306,16 @@ wheels = [
 [[package]]
 name = "weaviate-client"
 version = "4.18.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
-    { name = "authlib", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "authlib", version = "1.6.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "authlib", version = "1.3.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "authlib", version = "1.6.8", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "deprecation" },
     { name = "grpcio" },
     { name = "httpx" },
     { name = "protobuf" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "validators" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/76/14e07761c5fb7e8573e3cff562e2d9073c65f266db0e67511403d10435b1/weaviate_client-4.18.3.tar.gz", hash = "sha256:9d889246d62be36641a7f2b8cedf5fb665b804d46f7a53ae37e02d297a11f119", size = 783634, upload-time = "2025-12-03T09:38:28.261Z" }
@@ -11326,7 +11326,7 @@ wheels = [
 [[package]]
 name = "websockets"
 version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
@@ -11402,7 +11402,7 @@ wheels = [
 [[package]]
 name = "werkzeug"
 version = "2.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "markupsafe", marker = "python_full_version < '3.13'" },
 ]
@@ -11414,7 +11414,7 @@ wheels = [
 [[package]]
 name = "win-precise-time"
 version = "1.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/b0/21547e16a47206ccdd15769bf65e143ade1ffae67f0881c855f76e44e9fa/win-precise-time-1.4.2.tar.gz", hash = "sha256:89274785cbc5f2997e01675206da3203835a442c60fd97798415c6b3c179c0b9", size = 7982, upload-time = "2023-10-08T17:08:18.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/8b/ba6bdef9284fd75f816205bf9a198a2cf7b22459ff401174143ade5afe08/win_precise_time-1.4.2-cp310-cp310-win32.whl", hash = "sha256:7fa13a2247c2ef41cd5e9b930f40716eacc7fc1f079ea72853bd5613fe087a1a", size = 14700, upload-time = "2023-10-08T17:08:03.987Z" },
@@ -11430,7 +11430,7 @@ wheels = [
 [[package]]
 name = "win32-setctime"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
@@ -11439,7 +11439,7 @@ wheels = [
 [[package]]
 name = "wirerope"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "six", marker = "python_full_version < '3.13'" },
 ]
@@ -11451,7 +11451,7 @@ wheels = [
 [[package]]
 name = "wrapt"
 version = "1.17.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531, upload-time = "2025-01-14T10:35:45.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/d1/1daec934997e8b160040c78d7b31789f19b122110a75eca3d4e8da0049e1/wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984", size = 53307, upload-time = "2025-01-14T10:33:13.616Z" },
@@ -11526,7 +11526,7 @@ wheels = [
 [[package]]
 name = "wtforms"
 version = "3.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "markupsafe", marker = "python_full_version < '3.13'" },
 ]
@@ -11538,7 +11538,7 @@ wheels = [
 [[package]]
 name = "xxhash"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/ee/f9f1d656ad168681bb0f6b092372c1e533c4416b8069b1896a175c46e484/xxhash-3.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:87ff03d7e35c61435976554477a7f4cd1704c3596a89a8300d5ce7fc83874a71", size = 32845, upload-time = "2025-10-02T14:33:51.573Z" },
@@ -11671,7 +11671,7 @@ wheels = [
 [[package]]
 name = "yarl"
 version = "1.20.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
@@ -11787,7 +11787,7 @@ wheels = [
 [[package]]
 name = "zipp"
 version = "3.22.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/b6/7b3d16792fdf94f146bed92be90b4eb4563569eca91513c8609aebf0c167/zipp-3.22.0.tar.gz", hash = "sha256:dd2f28c3ce4bc67507bfd3781d21b7bb2be31103b51a4553ad7d90b84e57ace5", size = 25257, upload-time = "2025-05-26T14:46:32.217Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/da/f64669af4cae46f17b90798a827519ce3737d31dbafad65d391e49643dc4/zipp-3.22.0-py3-none-any.whl", hash = "sha256:fe208f65f2aca48b81f9e6fd8cf7b8b32c26375266b009b413d45306b6148343", size = 9796, upload-time = "2025-05-26T14:46:30.775Z" },
@@ -11796,7 +11796,7 @@ wheels = [
 [[package]]
 name = "zstandard"
 version = "0.23.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation == 'PyPy'" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ overrides = [{ name = "docstring-parser", marker = "sys_platform == 'never'" }]
 [[package]]
 name = "about-time"
 version = "4.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/3f/ccb16bdc53ebb81c1bf837c1ee4b5b0b69584fd2e4a802a2a79936691c0a/about-time-4.2.1.tar.gz", hash = "sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece", size = 15380, upload-time = "2022-12-21T04:15:54.991Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/cd/7ee00d6aa023b1d0551da0da5fee3bc23c3eeea632fbfc5126d1fec52b7e/about_time-4.2.1-py3-none-any.whl", hash = "sha256:8bbf4c75fe13cbd3d72f49a03b02c5c7dca32169b6d49117c257e7eb3eaee341", size = 13295, upload-time = "2022-12-21T04:15:53.613Z" },
@@ -55,7 +55,7 @@ wheels = [
 [[package]]
 name = "adbc-driver-manager"
 version = "1.8.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -65,7 +65,7 @@ resolution-markers = [
     "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/2a/00fe4974b7d134c8d0691a87f09460d949e607e1ef65a022c665e8bde64f/adbc_driver_manager-1.8.0.tar.gz", hash = "sha256:88ca0f4d8c02fc6859629acaf0504620da17a39549e64d4098a3497f7f1eb2d0", size = 203568, upload-time = "2025-09-12T12:31:24.233Z" }
 wheels = [
@@ -107,7 +107,7 @@ wheels = [
 [[package]]
 name = "adbc-driver-manager"
 version = "1.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -141,7 +141,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/b4/09a85ca2bb2ba53d6577745a0aae0766393b69d0ae1e645ff4d34bee6866/adbc_driver_manager-1.9.0.tar.gz", hash = "sha256:d6687acf57f92e469e78d53df6baf70ab62f8886ba8f2e0b25613aecd1807ae9", size = 205762, upload-time = "2025-11-07T01:46:55.953Z" }
 wheels = [
@@ -183,7 +183,7 @@ wheels = [
 [[package]]
 name = "adlfs"
 version = "2024.12.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "azure-core" },
@@ -200,7 +200,7 @@ wheels = [
 [[package]]
 name = "agate"
 version = "1.7.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
     { name = "isodate" },
@@ -217,7 +217,7 @@ wheels = [
 [[package]]
 name = "aiobotocore"
 version = "2.22.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aioitertools" },
@@ -235,7 +235,7 @@ wheels = [
 [[package]]
 name = "aiofile"
 version = "3.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "caio", marker = "python_full_version >= '3.10'" },
 ]
@@ -247,7 +247,7 @@ wheels = [
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
@@ -256,13 +256,13 @@ wheels = [
 [[package]]
 name = "aiohttp"
 version = "3.12.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
@@ -360,9 +360,9 @@ wheels = [
 [[package]]
 name = "aioitertools"
 version = "0.12.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/de/38491a84ab323b47c7f86e94d2830e748780525f7a10c8600b67ead7e9ea/aioitertools-0.12.0.tar.gz", hash = "sha256:c2a9055b4fbb7705f561b9d86053e8af5d10cc845d22c32008c43490b2d8dd6b", size = 19369, upload-time = "2024-09-02T03:33:40.349Z" }
 wheels = [
@@ -372,7 +372,7 @@ wheels = [
 [[package]]
 name = "aiosignal"
 version = "1.3.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
 ]
@@ -384,13 +384,13 @@ wheels = [
 [[package]]
 name = "alembic"
 version = "1.16.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/89/bfb4fe86e3fc3972d35431af7bedbc60fa606e8b17196704a1747f7aa4c3/alembic-1.16.1.tar.gz", hash = "sha256:43d37ba24b3d17bc1eb1024fe0f51cd1dc95aeb5464594a02c6bb9ca9864bfa4", size = 1955006, upload-time = "2025-05-21T23:11:05.991Z" }
 wheels = [
@@ -400,7 +400,7 @@ wheels = [
 [[package]]
 name = "alive-progress"
 version = "3.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "about-time" },
     { name = "grapheme" },
@@ -413,7 +413,7 @@ wheels = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -422,7 +422,7 @@ wheels = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -431,7 +431,7 @@ wheels = [
 [[package]]
 name = "ansicon"
 version = "1.89.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/e2/1c866404ddbd280efedff4a9f15abfe943cb83cde6e895022370f3a61f85/ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1", size = 67312, upload-time = "2019-04-29T20:23:57.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/f9/f1c10e223c7b56a38109a3f2eb4e7fe9a757ea3ed3a166754fb30f65e466/ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec", size = 63675, upload-time = "2019-04-29T20:23:53.83Z" },
@@ -440,13 +440,13 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "sniffio" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
@@ -456,7 +456,7 @@ wheels = [
 [[package]]
 name = "apache-airflow"
 version = "2.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-compat", marker = "python_full_version < '3.13'" },
@@ -470,8 +470,8 @@ dependencies = [
     { name = "apache-airflow-providers-sqlite", marker = "python_full_version < '3.13'" },
     { name = "argcomplete", marker = "python_full_version < '3.13'" },
     { name = "asgiref", marker = "python_full_version < '3.13'" },
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "blinker", marker = "python_full_version < '3.13'" },
     { name = "colorlog", marker = "python_full_version < '3.13'" },
     { name = "configupdater", marker = "python_full_version < '3.13'" },
@@ -537,7 +537,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-common-compat"
 version = "1.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -549,7 +549,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-common-io"
 version = "1.6.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -561,7 +561,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-common-sql"
 version = "1.27.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "methodtools", marker = "python_full_version < '3.13'" },
@@ -576,7 +576,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-fab"
 version = "1.5.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-compat", marker = "python_full_version < '3.13'" },
@@ -594,7 +594,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-ftp"
 version = "3.13.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -606,7 +606,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-http"
 version = "5.3.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
@@ -622,7 +622,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-imap"
 version = "3.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -634,7 +634,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-smtp"
 version = "2.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-compat", marker = "python_full_version < '3.13'" },
@@ -647,7 +647,7 @@ wheels = [
 [[package]]
 name = "apache-airflow-providers-sqlite"
 version = "4.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-sql", marker = "python_full_version < '3.13'" },
@@ -660,7 +660,7 @@ wheels = [
 [[package]]
 name = "apispec"
 version = "6.8.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging", marker = "python_full_version < '3.13'" },
 ]
@@ -677,7 +677,7 @@ yaml = [
 [[package]]
 name = "appdirs"
 version = "1.4.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
@@ -686,7 +686,7 @@ wheels = [
 [[package]]
 name = "argcomplete"
 version = "3.6.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/16/0f/861e168fc813c56a78b35f3c30d91c6757d1fd185af1110f1aec784b35d0/argcomplete-3.6.2.tar.gz", hash = "sha256:d0519b1bc867f5f4f4713c41ad0aba73a4a5f007449716b16f385f2166dc6adf", size = 73403, upload-time = "2025-04-03T04:57:03.52Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/da/e42d7a9d8dd33fa775f467e4028a47936da2f01e4b0e561f9ba0d74cb0ca/argcomplete-3.6.2-py3-none-any.whl", hash = "sha256:65b3133a29ad53fb42c48cf5114752c7ab66c1c38544fdf6460f450c09b42591", size = 43708, upload-time = "2025-04-03T04:57:01.591Z" },
@@ -695,10 +695,10 @@ wheels = [
 [[package]]
 name = "arro3-core"
 version = "0.8.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/e7/d84370ea85be641a8c57f4f8296e8465d30e46938cc9480d384a3ee0084c/arro3_core-0.8.0.tar.gz", hash = "sha256:b75d8281b87a87d3b66836bab89951ae06421970e5f880717723a93e38743f40", size = 93557, upload-time = "2026-02-23T15:12:20.622Z" }
 wheels = [
@@ -784,10 +784,10 @@ wheels = [
 [[package]]
 name = "asgiref"
 version = "3.8.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/38/b3395cc9ad1b56d2ddac9970bc8f4141312dbaec28bc7c218b0dfafd0f42/asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590", size = 35186, upload-time = "2024-03-22T14:39:36.863Z" }
 wheels = [
@@ -797,7 +797,7 @@ wheels = [
 [[package]]
 name = "asn1crypto"
 version = "1.5.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
@@ -806,7 +806,7 @@ wheels = [
 [[package]]
 name = "astatine"
 version = "0.3.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asttokens" },
     { name = "domdf-python-tools" },
@@ -819,7 +819,7 @@ wheels = [
 [[package]]
 name = "asttokens"
 version = "3.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978, upload-time = "2024-11-30T04:30:14.439Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918, upload-time = "2024-11-30T04:30:10.946Z" },
@@ -828,7 +828,7 @@ wheels = [
 [[package]]
 name = "async-timeout"
 version = "5.0.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
@@ -837,7 +837,7 @@ wheels = [
 [[package]]
 name = "atpublic"
 version = "6.0.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/40/e686038a07af08e8462a71dc9201867ffdde408b4d93be90a4ad0fbc83ef/atpublic-6.0.1.tar.gz", hash = "sha256:718932844f5bdfdf5d80ad4c64e13964f22274b4f8937d54a8d3811d6bc5dc05", size = 17520, upload-time = "2025-05-07T03:11:30.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/37/66f9fcdd6a56ab3da53291c7501890246c39bc7b5891e27cd956efe127ca/atpublic-6.0.1-py3-none-any.whl", hash = "sha256:f9a23902faf5ca1fdc6436b3712d79452f71abc61a810d22be1f31b40a8004c5", size = 6421, upload-time = "2025-05-07T03:11:29.398Z" },
@@ -846,7 +846,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "25.3.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -863,7 +863,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "25.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -904,7 +904,7 @@ wheels = [
 [[package]]
 name = "authlib"
 version = "1.3.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -924,7 +924,7 @@ wheels = [
 [[package]]
 name = "authlib"
 version = "1.6.8"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -968,12 +968,12 @@ wheels = [
 [[package]]
 name = "azure-core"
 version = "1.34.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "six" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/29/ff7a519a315e41c85bab92a7478c6acd1cf0b14353139a08caee4c691f77/azure_core-1.34.0.tar.gz", hash = "sha256:bdb544989f246a0ad1c85d72eeb45f2f835afdcbc5b45e43f0dbde7461c81ece", size = 297999, upload-time = "2025-05-01T23:17:27.59Z" }
 wheels = [
@@ -983,7 +983,7 @@ wheels = [
 [[package]]
 name = "azure-datalake-store"
 version = "0.0.53"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
     { name = "msal" },
@@ -997,14 +997,14 @@ wheels = [
 [[package]]
 name = "azure-identity"
 version = "1.23.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "cryptography" },
     { name = "msal" },
     { name = "msal-extensions" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/52/458c1be17a5d3796570ae2ed3c6b7b55b134b22d5ef8132b4f97046a9051/azure_identity-1.23.0.tar.gz", hash = "sha256:d9cdcad39adb49d4bb2953a217f62aec1f65bbb3c63c9076da2be2a47e53dde4", size = 265280, upload-time = "2025-05-14T00:18:30.408Z" }
 wheels = [
@@ -1014,13 +1014,13 @@ wheels = [
 [[package]]
 name = "azure-storage-blob"
 version = "12.25.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "cryptography" },
     { name = "isodate" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/f764536c25cc3829d36857167f03933ce9aee2262293179075439f3cd3ad/azure_storage_blob-12.25.1.tar.gz", hash = "sha256:4f294ddc9bc47909ac66b8934bd26b50d2000278b10ad82cc109764fdc6e0e3b", size = 570541, upload-time = "2025-03-27T17:13:05.424Z" }
 wheels = [
@@ -1030,7 +1030,7 @@ wheels = [
 [[package]]
 name = "babel"
 version = "2.17.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
@@ -1039,7 +1039,7 @@ wheels = [
 [[package]]
 name = "backports-tarfile"
 version = "1.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
@@ -1048,7 +1048,7 @@ wheels = [
 [[package]]
 name = "bandit"
 version = "1.8.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
@@ -1063,7 +1063,7 @@ wheels = [
 [[package]]
 name = "bcrypt"
 version = "4.3.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", hash = "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18", size = 25697, upload-time = "2025-02-28T01:24:09.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/2c/3d44e853d1fe969d229bd58d39ae6902b3d924af0e2b5a60d17d4b809ded/bcrypt-4.3.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f01e060f14b6b57bbb72fc5b4a83ac21c443c9a2ee708e04a10e9192f90a6281", size = 483719, upload-time = "2025-02-28T01:22:34.539Z" },
@@ -1121,7 +1121,7 @@ wheels = [
 [[package]]
 name = "beartype"
 version = "0.22.9"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
@@ -1130,11 +1130,11 @@ wheels = [
 [[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/e4/0c4c39e18fd76d6a628d4dd8da40543d136ce2d1752bd6eeeab0791f4d6b/beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195", size = 621067, upload-time = "2025-04-15T17:05:13.836Z" }
 wheels = [
@@ -1144,7 +1144,7 @@ wheels = [
 [[package]]
 name = "black"
 version = "23.9.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "mypy-extensions" },
@@ -1152,8 +1152,8 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/c3/257adbdbf2cc60bf844b5c0e3791a9d49e4fb4f7bcd8a2e875824ca0b7bc/black-23.9.1.tar.gz", hash = "sha256:24b6b3ff5c6d9ea08a8888f6977eae858e1f340d7260cf56d70a49823236b62d", size = 589529, upload-time = "2023-09-11T00:39:01.74Z" }
 wheels = [
@@ -1177,16 +1177,16 @@ wheels = [
 
 [package.optional-dependencies]
 jupyter = [
-    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "ipython", version = "9.5.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "ipython", version = "9.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tokenize-rt" },
 ]
 
 [[package]]
 name = "blessed"
 version = "1.21.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinxed", marker = "sys_platform == 'win32'" },
     { name = "wcwidth" },
@@ -1199,7 +1199,7 @@ wheels = [
 [[package]]
 name = "blinker"
 version = "1.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
@@ -1208,7 +1208,7 @@ wheels = [
 [[package]]
 name = "boto3"
 version = "1.37.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
@@ -1222,12 +1222,12 @@ wheels = [
 [[package]]
 name = "boto3-stubs"
 version = "1.38.28"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/dc/c4b318bdf66ff4973d3cbf0f218e47bdf558b94d921c8ff27d401e8ca4f9/boto3_stubs-1.38.28.tar.gz", hash = "sha256:fae8e009ea4d810b77e49d88247183b5d8d153bf268ebde8b4abdf58a701802f", size = 99065, upload-time = "2025-06-02T19:42:51.659Z" }
 wheels = [
@@ -1257,7 +1257,7 @@ sts = [
 [[package]]
 name = "botocore"
 version = "1.37.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
@@ -1271,7 +1271,7 @@ wheels = [
 [[package]]
 name = "botocore-stubs"
 version = "1.38.28"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-awscrt" },
 ]
@@ -1283,7 +1283,7 @@ wheels = [
 [[package]]
 name = "cachelib"
 version = "0.13.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/69/0b5c1259e12fbcf5c2abe5934b5c0c1294ec0f845e2b4b2a51a91d79a4fb/cachelib-0.13.0.tar.gz", hash = "sha256:209d8996e3c57595bee274ff97116d1d73c4980b2fd9a34c7846cd07fd2e1a48", size = 34418, upload-time = "2024-04-13T14:18:27.782Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/42/960fc9896ddeb301716fdd554bab7941c35fb90a1dc7260b77df3366f87f/cachelib-0.13.0-py3-none-any.whl", hash = "sha256:8c8019e53b6302967d4e8329a504acf75e7bc46130291d30188a6e4e58162516", size = 20914, upload-time = "2024-04-13T14:18:26.361Z" },
@@ -1292,7 +1292,7 @@ wheels = [
 [[package]]
 name = "cachetools"
 version = "5.5.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
@@ -1301,7 +1301,7 @@ wheels = [
 [[package]]
 name = "caio"
 version = "0.9.25"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
@@ -1330,7 +1330,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2025.1.31"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload-time = "2025-01-31T02:16:47.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload-time = "2025-01-31T02:16:45.015Z" },
@@ -1339,7 +1339,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "1.17.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pycparser" },
 ]
@@ -1408,7 +1408,7 @@ wheels = [
 [[package]]
 name = "chardet"
 version = "5.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
@@ -1417,7 +1417,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367, upload-time = "2025-05-02T08:34:42.01Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/28/9901804da60055b406e1a1c5ba7aac1276fb77f1dde635aabfc7fd84b8ab/charset_normalizer-3.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941", size = 201818, upload-time = "2025-05-02T08:31:46.725Z" },
@@ -1491,7 +1491,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.1.8"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -1503,7 +1503,7 @@ wheels = [
 [[package]]
 name = "clickclick"
 version = "20.10.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "python_full_version < '3.13'" },
     { name = "pyyaml", marker = "python_full_version < '3.13'" },
@@ -1516,7 +1516,7 @@ wheels = [
 [[package]]
 name = "clickhouse-connect"
 version = "0.8.17"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "lz4" },
@@ -1592,12 +1592,12 @@ wheels = [
 
 [package.optional-dependencies]
 arrow = [
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 numpy = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 pandas = [
     { name = "pandas", marker = "python_full_version >= '3.10'" },
@@ -1606,7 +1606,7 @@ pandas = [
 [[package]]
 name = "clickhouse-driver"
 version = "0.2.9"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytz" },
     { name = "tzlocal" },
@@ -1684,7 +1684,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -1693,7 +1693,7 @@ wheels = [
 [[package]]
 name = "coloredlogs"
 version = "15.0.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "humanfriendly" },
 ]
@@ -1705,7 +1705,7 @@ wheels = [
 [[package]]
 name = "colorlog"
 version = "6.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "python_full_version < '3.13' and sys_platform == 'win32'" },
 ]
@@ -1717,7 +1717,7 @@ wheels = [
 [[package]]
 name = "configupdater"
 version = "3.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/603bd8a65e040b23d25b5843836297b0f4e430f509d8ed2ef8f072fb4127/ConfigUpdater-3.2.tar.gz", hash = "sha256:9fdac53831c1b062929bf398b649b87ca30e7f1a735f3fbf482072804106306b", size = 140603, upload-time = "2023-11-27T17:16:45.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/f0/b59cb7613d9d0f866b6ff247c5953ad78363c27ff5d684a2a98899ab8220/ConfigUpdater-3.2-py2.py3-none-any.whl", hash = "sha256:0f65a041627d7693840b4dd743581db4c441c97195298a29d075f91b79539df2", size = 34688, upload-time = "2023-11-27T17:16:43.53Z" },
@@ -1726,7 +1726,7 @@ wheels = [
 [[package]]
 name = "connectorx"
 version = "0.3.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -1757,7 +1757,7 @@ wheels = [
 [[package]]
 name = "connectorx"
 version = "0.4.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -1816,7 +1816,7 @@ wheels = [
 [[package]]
 name = "connexion"
 version = "2.14.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "clickclick", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -1842,7 +1842,7 @@ flask = [
 [[package]]
 name = "cron-descriptor"
 version = "1.4.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/83/70bd410dc6965e33a5460b7da84cf0c5a7330a68d6d5d4c3dfdb72ca117e/cron_descriptor-1.4.5.tar.gz", hash = "sha256:f51ce4ffc1d1f2816939add8524f206c376a42c87a5fca3091ce26725b3b1bca", size = 30666, upload-time = "2024-08-24T18:16:48.654Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/20/2cfe598ead23a715a00beb716477cfddd3e5948cf203c372d02221e5b0c6/cron_descriptor-1.4.5-py3-none-any.whl", hash = "sha256:736b3ae9d1a99bc3dbfc5b55b5e6e7c12031e7ba5de716625772f8b02dcd6013", size = 50370, upload-time = "2024-08-24T18:16:46.783Z" },
@@ -1851,7 +1851,7 @@ wheels = [
 [[package]]
 name = "croniter"
 version = "6.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil", marker = "python_full_version < '3.13'" },
     { name = "pytz", marker = "python_full_version < '3.13'" },
@@ -1864,7 +1864,7 @@ wheels = [
 [[package]]
 name = "cryptography"
 version = "41.0.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
 ]
@@ -1893,14 +1893,14 @@ wheels = [
 [[package]]
 name = "cyclopts"
 version = "4.5.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "docstring-parser", marker = "python_full_version >= '3.10' and sys_platform == 'never'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
     { name = "rich-rst", marker = "python_full_version >= '3.10'" },
     { name = "tomli", marker = "python_full_version == '3.10.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/d2/f37df900b163f51b4faacdb01bf4895c198906d67c5b2a85c2522de85459/cyclopts-4.5.4.tar.gz", hash = "sha256:eed4d6c76d4391aa796d8fcaabd50e5aad7793261792beb19285f62c5c456c8b", size = 162438, upload-time = "2026-02-20T00:58:46.161Z" }
 wheels = [
@@ -1910,7 +1910,7 @@ wheels = [
 [[package]]
 name = "databricks-sdk"
 version = "0.73.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
@@ -1924,7 +1924,7 @@ wheels = [
 [[package]]
 name = "databricks-sql-connector"
 version = "4.1.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lz4" },
     { name = "oauthlib" },
@@ -1944,7 +1944,7 @@ wheels = [
 [[package]]
 name = "datasets"
 version = "4.5.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -1960,10 +1960,10 @@ dependencies = [
     { name = "httpx", marker = "python_full_version < '3.10'" },
     { name = "huggingface-hub", marker = "python_full_version < '3.10'" },
     { name = "multiprocess", marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "packaging", marker = "python_full_version < '3.10'" },
     { name = "pandas", marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyyaml", marker = "python_full_version < '3.10'" },
     { name = "requests", marker = "python_full_version < '3.10'" },
     { name = "tqdm", marker = "python_full_version < '3.10'" },
@@ -1977,7 +1977,7 @@ wheels = [
 [[package]]
 name = "datasets"
 version = "4.6.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -2017,12 +2017,12 @@ dependencies = [
     { name = "httpx", marker = "python_full_version >= '3.10'" },
     { name = "huggingface-hub", marker = "python_full_version >= '3.10'" },
     { name = "multiprocess", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyyaml", marker = "python_full_version >= '3.10'" },
     { name = "requests", marker = "python_full_version >= '3.10'" },
     { name = "tqdm", marker = "python_full_version >= '3.10'" },
@@ -2036,15 +2036,15 @@ wheels = [
 [[package]]
 name = "db-dtypes"
 version = "1.4.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/c8/83fd7a11ef8d960da6c58d1a36b430b0a1818ae7a1da6efe887d96c35f40/db_dtypes-1.4.3.tar.gz", hash = "sha256:d3cb08c32939d24e05501f17694be8c1c54cfb4620d61fb56fb311e8c3d8885e", size = 33379, upload-time = "2025-05-12T13:54:21.736Z" }
 wheels = [
@@ -2054,7 +2054,7 @@ wheels = [
 [[package]]
 name = "dbc"
 version = "0.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/53/d9cbbbd55ea9cf3028f11870f1f25cc3d920836f0090de02632088f883b2/dbc-0.1.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:9469e30a81b2350901259d6a6b53d1cb579692f534a5d077d294a83a7606f397", size = 3511476, upload-time = "2025-10-27T19:35:51.847Z" },
     { url = "https://files.pythonhosted.org/packages/2a/f6/8d0db43cd40506c458bf8533b705ccb04f2c6fe731d74cb8c853f540820c/dbc-0.1.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:d627f64b1ada1abdc20c583e778ca7f8c3a2aa738e77fa49bfa70cff41808d19", size = 3854094, upload-time = "2025-10-27T19:35:53.871Z" },
@@ -2066,15 +2066,15 @@ wheels = [
 [[package]]
 name = "dbt-athena-community"
 version = "1.7.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["athena", "glue", "lakeformation", "sts"] },
     { name = "dbt-core" },
     { name = "mmh3" },
     { name = "pyathena" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/26/b6ba74236e7524ca7eee12621765b7870c3fbe078b2d60b5464566b03c58/dbt-athena-community-1.7.2.tar.gz", hash = "sha256:3e705315de100be0ffa79f6618ac2f6e388940cb601b7b00d5989583cce1dcef", size = 89012, upload-time = "2024-02-06T09:32:43.066Z" }
@@ -2085,7 +2085,7 @@ wheels = [
 [[package]]
 name = "dbt-bigquery"
 version = "1.7.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dbt-core" },
     { name = "google-api-core" },
@@ -2101,7 +2101,7 @@ wheels = [
 [[package]]
 name = "dbt-core"
 version = "1.7.19"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agate" },
     { name = "cffi" },
@@ -2116,9 +2116,9 @@ dependencies = [
     { name = "logbook" },
     { name = "mashumaro", extra = ["msgpack"] },
     { name = "minimal-snowplow-tracker" },
-    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pathspec" },
     { name = "protobuf" },
@@ -2126,8 +2126,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlparse" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/66/32e97ff2dd9560a1b7e2b88a4fbaacc5bc1d0f668fede072c0a4c7f6c9a0/dbt_core-1.7.19.tar.gz", hash = "sha256:39f868f050be4f66f7791a6aad550b59b4f096cf79859e8efa2794fae5a7e318", size = 916539, upload-time = "2024-12-02T18:23:00.55Z" }
@@ -2138,7 +2138,7 @@ wheels = [
 [[package]]
 name = "dbt-duckdb"
 version = "1.7.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dbt-core" },
     { name = "duckdb" },
@@ -2151,7 +2151,7 @@ wheels = [
 [[package]]
 name = "dbt-extractor"
 version = "0.5.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/d0/4ee14955ad0214da695b3c15dc0acf2ab54c9d263242f36073c999cb699a/dbt_extractor-0.5.1.tar.gz", hash = "sha256:cd5d95576a8dea4190240aaf9936a37fd74b4b7913ca69a3c368fc4472bb7e13", size = 266278, upload-time = "2023-11-28T17:25:19.934Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/1f/ca6d66d67464df1ea8e814d09b1100d15672ae4ce7f0dff41f67956e5f7f/dbt_extractor-0.5.1-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3b91e6106b967d908b34f83929d3f50ee2b498876a1be9c055fe060ed728c556", size = 865677, upload-time = "2023-11-28T17:24:52.457Z" },
@@ -2174,11 +2174,11 @@ wheels = [
 [[package]]
 name = "dbt-fabric"
 version = "1.7.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-identity", marker = "python_full_version < '3.13'" },
     { name = "dbt-core", marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/f7/b94cc6672d50d0cef9f3910c49fd4a1ceebe26874fbd2b0ec95f39cd17cc/dbt-fabric-1.7.4.tar.gz", hash = "sha256:6f17f0ba683c2944c8f846589dca4b54106579af32ac5acafe701d1becc2496f", size = 25820, upload-time = "2024-02-02T21:00:42.189Z" }
 wheels = [
@@ -2188,7 +2188,7 @@ wheels = [
 [[package]]
 name = "dbt-postgres"
 version = "1.7.19"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agate" },
     { name = "dbt-core" },
@@ -2202,7 +2202,7 @@ wheels = [
 [[package]]
 name = "dbt-redshift"
 version = "1.7.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agate" },
     { name = "dbt-core" },
@@ -2217,19 +2217,19 @@ wheels = [
 [[package]]
 name = "dbt-semantic-interfaces"
 version = "0.4.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "importlib-metadata" },
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "more-itertools" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/38/e889ad15d281093e53a7ec1e692a387a92dc056fff56b8c2961634b1968b/dbt_semantic_interfaces-0.4.4.tar.gz", hash = "sha256:3b8126deb964c03d14e8af1cb4bdfb9f20c53dfcef28fa3a0bc158a8312e4070", size = 75128, upload-time = "2024-02-26T19:34:34.962Z" }
 wheels = [
@@ -2239,7 +2239,7 @@ wheels = [
 [[package]]
 name = "dbt-snowflake"
 version = "1.7.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agate" },
     { name = "dbt-core" },
@@ -2253,12 +2253,12 @@ wheels = [
 [[package]]
 name = "dbt-sqlserver"
 version = "1.7.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-identity", marker = "python_full_version < '3.13'" },
     { name = "dbt-core", marker = "python_full_version < '3.13'" },
     { name = "dbt-fabric", marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/97/d7244c6ab1ce380ec8ce453ecebe4692325028c7c2fe9863c5fbb163ca04/dbt-sqlserver-1.7.4.tar.gz", hash = "sha256:b9e85771a1c00e8f4aadefb37b00d02b3d49bc93ad7c52782fd9cae9db31dd98", size = 13386, upload-time = "2024-03-04T14:46:41.247Z" }
 wheels = [
@@ -2268,7 +2268,7 @@ wheels = [
 [[package]]
 name = "decopatch"
 version = "1.4.10"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "makefun" },
 ]
@@ -2280,7 +2280,7 @@ wheels = [
 [[package]]
 name = "decorator"
 version = "5.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
@@ -2289,7 +2289,7 @@ wheels = [
 [[package]]
 name = "deltalake"
 version = "1.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -2315,7 +2315,7 @@ wheels = [
 [[package]]
 name = "deltalake"
 version = "1.4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -2365,7 +2365,7 @@ wheels = [
 [[package]]
 name = "deprecated"
 version = "1.2.18"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
@@ -2377,7 +2377,7 @@ wheels = [
 [[package]]
 name = "deprecation"
 version = "2.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -2389,7 +2389,7 @@ wheels = [
 [[package]]
 name = "diff-cover"
 version = "9.3.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chardet" },
     { name = "jinja2" },
@@ -2404,7 +2404,7 @@ wheels = [
 [[package]]
 name = "dill"
 version = "0.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/80/630b4b88364e9a8c8c5797f4602d0f76ef820909ee32f0bacb9f90654042/dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0", size = 186976, upload-time = "2025-04-16T00:41:48.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/3d/9373ad9c56321fdab5b41197068e1d8c25883b3fea29dd361f9b55116869/dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049", size = 119668, upload-time = "2025-04-16T00:41:47.671Z" },
@@ -2421,8 +2421,8 @@ dependencies = [
     { name = "giturlparse" },
     { name = "humanize" },
     { name = "jsonpath-ng" },
-    { name = "orjson", version = "3.10.18", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version >= '3.11' and python_full_version < '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
-    { name = "orjson", version = "3.11.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14' or (python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.11' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
+    { name = "orjson", version = "3.10.18", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and python_full_version < '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version >= '3.11' and python_full_version < '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
+    { name = "orjson", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or (python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.11' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
     { name = "packaging" },
     { name = "pathvalidate" },
     { name = "pendulum" },
@@ -2436,12 +2436,12 @@ dependencies = [
     { name = "semver" },
     { name = "setuptools" },
     { name = "simplejson" },
-    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "sqlglot", version = "28.10.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sqlglot", version = "28.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "tenacity" },
     { name = "tomlkit" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tzdata" },
     { name = "win-precise-time", marker = "python_full_version < '3.13' and os_name == 'nt'" },
 ]
@@ -2449,8 +2449,8 @@ dependencies = [
 [package.optional-dependencies]
 athena = [
     { name = "botocore" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyathena" },
     { name = "s3fs" },
 ]
@@ -2462,8 +2462,8 @@ bigquery = [
     { name = "gcsfs" },
     { name = "google-cloud-bigquery" },
     { name = "grpcio" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 cli = [
     { name = "cron-descriptor" },
@@ -2475,8 +2475,8 @@ clickhouse = [
     { name = "clickhouse-connect" },
     { name = "clickhouse-driver" },
     { name = "gcsfs" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "s3fs" },
 ]
 databricks = [
@@ -2487,29 +2487,29 @@ dbml = [
     { name = "pydbml" },
 ]
 deltalake = [
-    { name = "deltalake", version = "1.2.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "deltalake", version = "1.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "deltalake", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "deltalake", version = "1.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 dremio = [
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 duckdb = [
     { name = "duckdb" },
 ]
 ducklake = [
     { name = "duckdb" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 fabric = [
     { name = "adlfs" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 filesystem = [
     { name = "botocore" },
@@ -2526,8 +2526,8 @@ gs = [
 ]
 hf = [
     { name = "huggingface-hub" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 http = [
     { name = "aiohttp" },
@@ -2540,24 +2540,24 @@ lancedb = [
     { name = "duckdb" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10'" },
     { name = "lancedb" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 motherduck = [
     { name = "duckdb" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 mssql = [
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 oracle = [
     { name = "oracledb" },
 ]
 parquet = [
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 postgis = [
     { name = "psycopg2-binary" },
@@ -2566,8 +2566,8 @@ postgres = [
     { name = "psycopg2-binary" },
 ]
 pyiceberg = [
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyiceberg" },
     { name = "pyiceberg-core" },
     { name = "sqlalchemy" },
@@ -2597,10 +2597,10 @@ sqlalchemy = [
 ]
 synapse = [
     { name = "adlfs" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
 weaviate = [
     { name = "weaviate-client" },
@@ -2609,19 +2609,19 @@ workspace = [
     { name = "duckdb" },
     { name = "fastmcp", marker = "python_full_version >= '3.10'" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10'" },
-    { name = "marimo", version = "0.14.10", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "marimo", version = "0.20.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "marimo", version = "0.14.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "marimo", version = "0.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mowidgets", marker = "python_full_version >= '3.11'" },
     { name = "pathspec" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydbml" },
 ]
 
 [package.dev-dependencies]
 adbc = [
-    { name = "adbc-driver-manager", version = "1.8.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "adbc-driver-manager", version = "1.9.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "adbc-driver-manager", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "adbc-driver-manager", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "dbc" },
 ]
 airflow = [
@@ -2629,8 +2629,8 @@ airflow = [
 ]
 dashboard-tests = [
     { name = "playwright" },
-    { name = "pytest-playwright", version = "0.7.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest-playwright", version = "0.7.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-playwright", version = "0.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-playwright", version = "0.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 dbt = [
     { name = "dbt-athena-community" },
@@ -2653,8 +2653,8 @@ dev = [
     { name = "flake8-print" },
     { name = "flake8-tidy-imports" },
     { name = "graphviz" },
-    { name = "griffe", version = "1.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "griffe", version = "1.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "griffe", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "griffe", version = "1.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pip" },
@@ -2699,18 +2699,18 @@ pipeline = [
     { name = "alive-progress" },
     { name = "cffi" },
     { name = "cryptography" },
-    { name = "datasets", version = "4.5.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "datasets", version = "4.6.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "datasets", version = "4.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "datasets", version = "4.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "enlighten" },
     { name = "greenlet" },
     { name = "pandas" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "regex" },
-    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "shapely", version = "2.1.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "shapely", version = "2.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "shapely", version = "2.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "sqlalchemy" },
     { name = "tqdm" },
 ]
@@ -2721,8 +2721,8 @@ sentry-sdk = [
     { name = "sentry-sdk" },
 ]
 sources = [
-    { name = "connectorx", version = "0.3.3", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "connectorx", version = "0.4.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "connectorx", version = "0.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "connectorx", version = "0.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mimesis" },
     { name = "openpyxl" },
     { name = "pymysql" },
@@ -2942,9 +2942,9 @@ sources = [
 [[package]]
 name = "dlt-runtime"
 version = "0.21.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "cron-descriptor", marker = "python_full_version >= '3.10'" },
     { name = "httpx", marker = "python_full_version >= '3.10'" },
     { name = "pathspec", marker = "python_full_version >= '3.10'" },
@@ -2959,11 +2959,11 @@ wheels = [
 [[package]]
 name = "dlthub"
 version = "0.22.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-jose", marker = "python_full_version >= '3.10'" },
     { name = "ruamel-yaml", marker = "python_full_version >= '3.10'" },
-    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/af/fe84689f8742a7a3dc3e538faf5bc001a70168a34c6375e17eb15d2ce3e1/dlthub-0.22.0.tar.gz", hash = "sha256:cede29e2d0340b48e6ec3d287b9573340707273509f4f697b23d7f4981d86b9d", size = 169355, upload-time = "2026-02-17T15:15:56.941Z" }
 wheels = [
@@ -2973,7 +2973,7 @@ wheels = [
 [[package]]
 name = "dnspython"
 version = "2.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
@@ -2982,7 +2982,7 @@ wheels = [
 [[package]]
 name = "docstring-parser"
 version = "0.17.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
@@ -2991,7 +2991,7 @@ wheels = [
 [[package]]
 name = "docstring-parser-fork"
 version = "0.0.14"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/bf/27f9cab2f0cd1d17a4420572088bbc19f36d726fbcf165edf226a8926dbc/docstring_parser_fork-0.0.14.tar.gz", hash = "sha256:a2743a63d8d36c09650594f7b4ab5b2758fee8629dcf794d1b221b23179baa5c", size = 34551, upload-time = "2025-09-07T17:27:38.272Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/50/98b146aea0f1cd7531d25f12bea69fa9ce8d1662124f93fb30dc4511b65e/docstring_parser_fork-0.0.14-py3-none-any.whl", hash = "sha256:4c544f234ef2cc2749a3df32b70c437d77888b1099143a1ad5454452c574b9af", size = 43063, upload-time = "2025-09-07T17:27:37.012Z" },
@@ -3000,7 +3000,7 @@ wheels = [
 [[package]]
 name = "docutils"
 version = "0.21.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
@@ -3009,11 +3009,11 @@ wheels = [
 [[package]]
 name = "domdf-python-tools"
 version = "3.10.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "natsort" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/8b/ab2d8a292bba8fe3135cacc8bfd3576710a14b8f2d0a8cde19130d5c9d21/domdf_python_tools-3.10.0.tar.gz", hash = "sha256:2ae308d2f4f1e9145f5f4ba57f840fbfd1c2983ee26e4824347789649d3ae298", size = 100458, upload-time = "2025-02-12T17:34:05.747Z" }
 wheels = [
@@ -3023,7 +3023,7 @@ wheels = [
 [[package]]
 name = "duckdb"
 version = "1.4.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7f/da/17c3eb5458af69d54dedc8d18e4a32ceaa8ce4d4c699d45d6d8287e790c3/duckdb-1.4.3.tar.gz", hash = "sha256:fea43e03604c713e25a25211ada87d30cd2a044d8f27afab5deba26ac49e5268", size = 18478418, upload-time = "2025-12-09T10:59:22.945Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/3a/ea8e237e1ba40203dea4ed6a8798ea51e66a4c4f34605697025e5fa06fdd/duckdb-1.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:efa7f1191c59e34b688fcd4e588c1b903a4e4e1f4804945902cf0b20e08a9001", size = 29016021, upload-time = "2025-12-09T10:57:46.847Z" },
@@ -3071,7 +3071,7 @@ wheels = [
 [[package]]
 name = "ecdsa"
 version = "0.19.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six", marker = "python_full_version >= '3.10'" },
 ]
@@ -3083,7 +3083,7 @@ wheels = [
 [[package]]
 name = "email-validator"
 version = "2.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dnspython" },
     { name = "idna" },
@@ -3096,7 +3096,7 @@ wheels = [
 [[package]]
 name = "enlighten"
 version = "1.14.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blessed" },
     { name = "prefixed" },
@@ -3109,7 +3109,7 @@ wheels = [
 [[package]]
 name = "et-xmlfile"
 version = "2.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
@@ -3118,7 +3118,7 @@ wheels = [
 [[package]]
 name = "eval-type-backport"
 version = "0.2.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/ea/8b0ac4469d4c347c6a385ff09dc3c048c2d021696664e26c7ee6791631b5/eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1", size = 9079, upload-time = "2024-12-21T20:09:46.005Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/31/55cd413eaccd39125368be33c46de24a1f639f2e12349b0361b4678f3915/eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a", size = 5830, upload-time = "2024-12-21T20:09:44.175Z" },
@@ -3127,10 +3127,10 @@ wheels = [
 [[package]]
 name = "exceptiongroup"
 version = "1.3.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3140,7 +3140,7 @@ wheels = [
 [[package]]
 name = "execnet"
 version = "2.1.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
@@ -3149,7 +3149,7 @@ wheels = [
 [[package]]
 name = "executing"
 version = "2.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
@@ -3158,18 +3158,18 @@ wheels = [
 [[package]]
 name = "fastembed"
 version = "0.7.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "loguru" },
     { name = "mmh3" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "onnxruntime", version = "1.19.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "onnxruntime", version = "1.22.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pillow", version = "10.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pillow", version = "11.2.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "onnxruntime", version = "1.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "onnxruntime", version = "1.22.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pillow", version = "10.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pillow", version = "11.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "py-rust-stemmers" },
     { name = "requests" },
     { name = "tokenizers" },
@@ -3183,9 +3183,9 @@ wheels = [
 [[package]]
 name = "fastmcp"
 version = "3.0.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "authlib", version = "1.6.8", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "authlib", version = "1.6.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "cyclopts", marker = "python_full_version >= '3.10'" },
     { name = "exceptiongroup", marker = "python_full_version >= '3.10'" },
     { name = "httpx", marker = "python_full_version >= '3.10'" },
@@ -3197,12 +3197,12 @@ dependencies = [
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "platformdirs", marker = "python_full_version >= '3.10'" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"], marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, extra = ["email"], marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, extra = ["email"], marker = "python_full_version >= '3.10'" },
     { name = "pyperclip", marker = "python_full_version >= '3.10'" },
     { name = "python-dotenv", marker = "python_full_version >= '3.10'" },
     { name = "pyyaml", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "watchfiles", marker = "python_full_version >= '3.10'" },
     { name = "websockets", marker = "python_full_version >= '3.10'" },
 ]
@@ -3214,7 +3214,7 @@ wheels = [
 [[package]]
 name = "filelock"
 version = "3.18.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
@@ -3223,7 +3223,7 @@ wheels = [
 [[package]]
 name = "flake8"
 version = "7.1.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mccabe" },
     { name = "pycodestyle" },
@@ -3237,10 +3237,10 @@ wheels = [
 [[package]]
 name = "flake8-bugbear"
 version = "22.12.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "flake8" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/b5/83a89114a82a2764ddfe27451df6b69c46513f88a3f66206514265b6f447/flake8-bugbear-22.12.6.tar.gz", hash = "sha256:4cdb2c06e229971104443ae293e75e64c6107798229202fbe4f4091427a30ac0", size = 44094, upload-time = "2022-12-06T19:07:02.569Z" }
@@ -3251,7 +3251,7 @@ wheels = [
 [[package]]
 name = "flake8-builtins"
 version = "1.5.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flake8" },
 ]
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "flake8-helper"
 version = "0.2.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flake8" },
 ]
@@ -3286,7 +3286,7 @@ wheels = [
 [[package]]
 name = "flake8-print"
 version = "5.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flake8" },
     { name = "pycodestyle" },
@@ -3299,7 +3299,7 @@ wheels = [
 [[package]]
 name = "flake8-tidy-imports"
 version = "4.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flake8" },
 ]
@@ -3311,7 +3311,7 @@ wheels = [
 [[package]]
 name = "flask"
 version = "2.2.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "python_full_version < '3.13'" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
@@ -3327,7 +3327,7 @@ wheels = [
 [[package]]
 name = "flask-appbuilder"
 version = "4.5.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apispec", extra = ["yaml"], marker = "python_full_version < '3.13'" },
     { name = "click", marker = "python_full_version < '3.13'" },
@@ -3336,8 +3336,8 @@ dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "flask-babel", marker = "python_full_version < '3.13'" },
     { name = "flask-jwt-extended", marker = "python_full_version < '3.13'" },
-    { name = "flask-limiter", version = "3.11.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "flask-limiter", version = "3.12", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "flask-limiter", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "flask-limiter", version = "3.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "flask-login", marker = "python_full_version < '3.13'" },
     { name = "flask-sqlalchemy", marker = "python_full_version < '3.13'" },
     { name = "flask-wtf", marker = "python_full_version < '3.13'" },
@@ -3360,7 +3360,7 @@ wheels = [
 [[package]]
 name = "flask-babel"
 version = "2.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -3375,7 +3375,7 @@ wheels = [
 [[package]]
 name = "flask-caching"
 version = "2.3.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachelib", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -3388,7 +3388,7 @@ wheels = [
 [[package]]
 name = "flask-jwt-extended"
 version = "4.7.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "pyjwt", marker = "python_full_version < '3.13'" },
@@ -3402,7 +3402,7 @@ wheels = [
 [[package]]
 name = "flask-limiter"
 version = "3.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -3413,10 +3413,10 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.10'" },
-    { name = "limits", version = "4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "limits", version = "4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ordered-set", marker = "python_full_version < '3.10'" },
     { name = "rich", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/a4/02f67783825a4207d4ae7de4c8be45596c3fba5b65ace77fd6dc3878020d/flask_limiter-3.11.0.tar.gz", hash = "sha256:57b037fb8be423ef7ebac4fbb279fbfdc42d9aa5378467ab6798d6ce3d912117", size = 303361, upload-time = "2025-03-11T20:37:59.839Z" }
 wheels = [
@@ -3426,7 +3426,7 @@ wheels = [
 [[package]]
 name = "flask-limiter"
 version = "3.12"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -3449,7 +3449,7 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "flask", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "limits", version = "5.2.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "limits", version = "5.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "ordered-set", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "rich", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
@@ -3461,7 +3461,7 @@ wheels = [
 [[package]]
 name = "flask-login"
 version = "0.6.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "werkzeug", marker = "python_full_version < '3.13'" },
@@ -3474,7 +3474,7 @@ wheels = [
 [[package]]
 name = "flask-session"
 version = "0.5.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachelib", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -3487,7 +3487,7 @@ wheels = [
 [[package]]
 name = "flask-sqlalchemy"
 version = "2.5.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
@@ -3500,7 +3500,7 @@ wheels = [
 [[package]]
 name = "flask-wtf"
 version = "1.2.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask", marker = "python_full_version < '3.13'" },
     { name = "itsdangerous", marker = "python_full_version < '3.13'" },
@@ -3514,7 +3514,7 @@ wheels = [
 [[package]]
 name = "flatbuffers"
 version = "25.2.10"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/30/eb5dce7994fc71a2f685d98ec33cc660c0a5887db5610137e60d8cbc4489/flatbuffers-25.2.10.tar.gz", hash = "sha256:97e451377a41262f8d9bd4295cc836133415cc03d8cb966410a4af92eb00d26e", size = 22170, upload-time = "2025-02-11T04:26:46.257Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/25/155f9f080d5e4bc0082edfda032ea2bc2b8fab3f4d25d46c1e9dd22a1a89/flatbuffers-25.2.10-py2.py3-none-any.whl", hash = "sha256:ebba5f4d5ea615af3f7fd70fc310636fbb2bbd1f566ac0a23d98dd412de50051", size = 30953, upload-time = "2025-02-11T04:26:44.484Z" },
@@ -3523,7 +3523,7 @@ wheels = [
 [[package]]
 name = "frozenlist"
 version = "1.6.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/f4/d744cba2da59b5c1d88823cf9e8a6c74e4659e2b27604ed973be2a0bf5ab/frozenlist-1.6.0.tar.gz", hash = "sha256:b99655c32c1c8e06d111e7f41c06c29a5318cb1835df23a45518e02a47c63b68", size = 42831, upload-time = "2025-04-17T22:38:53.099Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/03/22e4eb297981d48468c3d9982ab6076b10895106d3039302a943bb60fd70/frozenlist-1.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e6e558ea1e47fd6fa8ac9ccdad403e5dd5ecc6ed8dda94343056fa4277d5c65e", size = 160584, upload-time = "2025-04-17T22:35:48.163Z" },
@@ -3634,7 +3634,7 @@ wheels = [
 [[package]]
 name = "fsspec"
 version = "2025.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
@@ -3648,7 +3648,7 @@ http = [
 [[package]]
 name = "gcsfs"
 version = "2025.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "decorator" },
@@ -3666,7 +3666,7 @@ wheels = [
 [[package]]
 name = "gitdb"
 version = "4.0.12"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "smmap" },
 ]
@@ -3678,7 +3678,7 @@ wheels = [
 [[package]]
 name = "gitpython"
 version = "3.1.44"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
@@ -3690,7 +3690,7 @@ wheels = [
 [[package]]
 name = "giturlparse"
 version = "0.12.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/5f/543dc54c82842376139748226e5aa61eb95093992f63dd495af9c6b4f076/giturlparse-0.12.0.tar.gz", hash = "sha256:c0fff7c21acc435491b1779566e038757a205c1ffdcb47e4f81ea52ad8c3859a", size = 14907, upload-time = "2023-09-24T07:22:36.795Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/94/c6ff3388b8e3225a014e55aed957188639aa0966443e0408d38f0c9614a7/giturlparse-0.12.0-py2.py3-none-any.whl", hash = "sha256:412b74f2855f1da2fefa89fd8dde62df48476077a72fc19b62039554d27360eb", size = 15752, upload-time = "2023-09-24T07:22:35.465Z" },
@@ -3699,7 +3699,7 @@ wheels = [
 [[package]]
 name = "google-api-core"
 version = "2.11.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
@@ -3720,7 +3720,7 @@ grpc = [
 [[package]]
 name = "google-api-python-client"
 version = "2.170.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -3736,7 +3736,7 @@ wheels = [
 [[package]]
 name = "google-auth"
 version = "2.40.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "pyasn1-modules" },
@@ -3750,7 +3750,7 @@ wheels = [
 [[package]]
 name = "google-auth-httplib2"
 version = "0.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "httplib2" },
@@ -3763,7 +3763,7 @@ wheels = [
 [[package]]
 name = "google-auth-oauthlib"
 version = "1.2.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "requests-oauthlib" },
@@ -3776,7 +3776,7 @@ wheels = [
 [[package]]
 name = "google-cloud-bigquery"
 version = "3.19.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
@@ -3794,7 +3794,7 @@ wheels = [
 [[package]]
 name = "google-cloud-bigquery-storage"
 version = "2.32.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"], marker = "python_full_version >= '3.10'" },
     { name = "google-auth", marker = "python_full_version >= '3.10'" },
@@ -3809,7 +3809,7 @@ wheels = [
 [[package]]
 name = "google-cloud-core"
 version = "2.4.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -3822,7 +3822,7 @@ wheels = [
 [[package]]
 name = "google-cloud-dataproc"
 version = "5.18.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
     { name = "google-auth" },
@@ -3838,7 +3838,7 @@ wheels = [
 [[package]]
 name = "google-cloud-storage"
 version = "2.14.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -3855,7 +3855,7 @@ wheels = [
 [[package]]
 name = "google-crc32c"
 version = "1.7.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/ae/87802e6d9f9d69adfaedfcfd599266bf386a54d0be058b532d04c794f76d/google_crc32c-1.7.1.tar.gz", hash = "sha256:2bff2305f98846f3e825dbeec9ee406f89da7962accdb29356e4eadc251bd472", size = 14495, upload-time = "2025-03-26T14:29:13.32Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/69/b1b05cf415df0d86691d6a8b4b7e60ab3a6fb6efb783ee5cd3ed1382bfd3/google_crc32c-1.7.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:b07d48faf8292b4db7c3d64ab86f950c2e94e93a11fd47271c28ba458e4a0d76", size = 30467, upload-time = "2025-03-26T14:31:11.92Z" },
@@ -3896,7 +3896,7 @@ wheels = [
 [[package]]
 name = "google-re2"
 version = "1.1.20240702"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/34/ea9bfa2afbb6847b7bc7f90ab927dd31fcd7f478062a8a10045059367de1/google_re2-1.1.20240702.tar.gz", hash = "sha256:8788db69f6c93cb229df62c74b2d9aa8e64bf754e9495700f85812afa32efd2b", size = 11626, upload-time = "2024-07-01T14:09:10.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/9b/0fb72635a75405bce9e15fb94f994e59883a2757adda43978fc8eb6dad3e/google_re2-1.1.20240702-1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:46e7ed614ffaafccae017542d68e9bbf664c8c1e5ca37046adee640bbee4846e", size = 464159, upload-time = "2024-07-01T14:07:46.575Z" },
@@ -3944,7 +3944,7 @@ wheels = [
 [[package]]
 name = "google-resumable-media"
 version = "2.7.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-crc32c" },
 ]
@@ -3956,7 +3956,7 @@ wheels = [
 [[package]]
 name = "googleapis-common-protos"
 version = "1.70.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -3973,13 +3973,13 @@ grpc = [
 [[package]]
 name = "grapheme"
 version = "0.6.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e7/bbaab0d2a33e07c8278910c1d0d8d4f3781293dfbc70b5c38197159046bf/grapheme-0.6.0.tar.gz", hash = "sha256:44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca", size = 207306, upload-time = "2020-03-07T17:13:55.492Z" }
 
 [[package]]
 name = "graphviz"
 version = "0.21"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
@@ -3988,7 +3988,7 @@ wheels = [
 [[package]]
 name = "greenlet"
 version = "3.2.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/c1/a82edae11d46c0d83481aacaa1e578fea21d94a1ef400afd734d47ad95ad/greenlet-3.2.2.tar.gz", hash = "sha256:ad053d34421a2debba45aa3cc39acf454acbcd025b3fc1a9f8a0dee237abd485", size = 185797, upload-time = "2025-05-09T19:47:35.066Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/66/910217271189cc3f32f670040235f4bf026ded8ca07270667d69c06e7324/greenlet-3.2.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c49e9f7c6f625507ed83a7485366b46cbe325717c60837f7244fc99ba16ba9d6", size = 267395, upload-time = "2025-05-09T14:50:45.357Z" },
@@ -4050,7 +4050,7 @@ wheels = [
 [[package]]
 name = "griffe"
 version = "1.14.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4070,7 +4070,7 @@ wheels = [
 [[package]]
 name = "griffe"
 version = "1.15.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4114,7 +4114,7 @@ wheels = [
 [[package]]
 name = "grpc-google-iam-v1"
 version = "0.14.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos", extra = ["grpc"] },
     { name = "grpcio" },
@@ -4128,7 +4128,7 @@ wheels = [
 [[package]]
 name = "grpcio"
 version = "1.72.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/45/ff8c80a5a2e7e520d9c4d3c41484a11d33508253f6f4dd06d2c4b4158999/grpcio-1.72.1.tar.gz", hash = "sha256:87f62c94a40947cec1a0f91f95f5ba0aa8f799f23a1d42ae5be667b6b27b959c", size = 12584286, upload-time = "2025-06-02T10:14:11.595Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/a8/a468586ef3db8cd90f507c0e5655c50cdf136e936f674effddacd5e6f83b/grpcio-1.72.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:ce2706ff37be7a6de68fbc4c3f8dde247cab48cc70fee5fedfbc9cd923b4ee5a", size = 5210592, upload-time = "2025-06-02T10:08:34.416Z" },
@@ -4186,7 +4186,7 @@ wheels = [
 [[package]]
 name = "grpcio-status"
 version = "1.62.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
@@ -4200,7 +4200,7 @@ wheels = [
 [[package]]
 name = "gunicorn"
 version = "23.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging", marker = "python_full_version < '3.13'" },
 ]
@@ -4212,7 +4212,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -4221,7 +4221,7 @@ wheels = [
 [[package]]
 name = "h2"
 version = "4.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
@@ -4234,7 +4234,7 @@ wheels = [
 [[package]]
 name = "hf-xet"
 version = "1.3.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/cb/9bb543bd987ffa1ee48202cc96a756951b734b79a542335c566148ade36c/hf_xet-1.3.2.tar.gz", hash = "sha256:e130ee08984783d12717444e538587fa2119385e5bd8fc2bb9f930419b73a7af", size = 643646, upload-time = "2026-02-27T17:26:08.051Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/75/462285971954269432aad2e7938c5c7ff9ec7d60129cec542ab37121e3d6/hf_xet-1.3.2-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:335a8f36c55fd35a92d0062f4e9201b4015057e62747b7e7001ffb203c0ee1d2", size = 3761019, upload-time = "2026-02-27T17:25:49.441Z" },
@@ -4266,7 +4266,7 @@ wheels = [
 [[package]]
 name = "hpack"
 version = "4.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
@@ -4275,7 +4275,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -4288,7 +4288,7 @@ wheels = [
 [[package]]
 name = "httplib2"
 version = "0.22.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
@@ -4300,7 +4300,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -4320,7 +4320,7 @@ http2 = [
 [[package]]
 name = "httpx-sse"
 version = "0.4.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6e/fa/66bd985dd0b7c109a3bcb89272ee0bfb7e2b4d06309ad7b38ff866734b2a/httpx_sse-0.4.1.tar.gz", hash = "sha256:8f44d34414bc7b21bf3602713005c5df4917884f76072479b21f68befa4ea26e", size = 12998, upload-time = "2025-06-24T13:21:05.71Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/0a/6269e3473b09aed2dab8aa1a600c70f31f00ae1349bee30658f7e358a159/httpx_sse-0.4.1-py3-none-any.whl", hash = "sha256:cba42174344c3a5b06f255ce65b350880f962d99ead85e776f23c6618a377a37", size = 8054, upload-time = "2025-06-24T13:21:04.772Z" },
@@ -4329,7 +4329,7 @@ wheels = [
 [[package]]
 name = "huggingface-hub"
 version = "1.5.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
@@ -4339,8 +4339,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tqdm" },
     { name = "typer" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/76/b5efb3033d8499b17f9386beaf60f64c461798e1ee16d10bc9c0077beba5/huggingface_hub-1.5.0.tar.gz", hash = "sha256:f281838db29265880fb543de7a23b0f81d3504675de82044307ea3c6c62f799d", size = 695872, upload-time = "2026-02-26T15:35:32.745Z" }
 wheels = [
@@ -4350,7 +4350,7 @@ wheels = [
 [[package]]
 name = "humanfriendly"
 version = "10.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
@@ -4362,7 +4362,7 @@ wheels = [
 [[package]]
 name = "humanize"
 version = "4.12.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/d1/bbc4d251187a43f69844f7fd8941426549bbe4723e8ff0a7441796b0789f/humanize-4.12.3.tar.gz", hash = "sha256:8430be3a615106fdfceb0b2c1b41c4c98c6b0fc5cc59663a5539b111dd325fb0", size = 80514, upload-time = "2025-04-30T11:51:07.98Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1e/62a2ec3104394a2975a2629eec89276ede9dbe717092f6966fcf963e1bf0/humanize-4.12.3-py3-none-any.whl", hash = "sha256:2cbf6370af06568fa6d2da77c86edb7886f3160ecd19ee1ffef07979efc597f6", size = 128487, upload-time = "2025-04-30T11:51:06.468Z" },
@@ -4371,7 +4371,7 @@ wheels = [
 [[package]]
 name = "hyperframe"
 version = "6.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
@@ -4380,14 +4380,14 @@ wheels = [
 [[package]]
 name = "ibis-framework"
 version = "12.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "atpublic", marker = "python_full_version >= '3.10'" },
     { name = "parsy", marker = "python_full_version >= '3.10'" },
     { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
-    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sqlglot", version = "28.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "toolz", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tzdata", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/8e/2e7ad9bdeaf45350da7beeb67a0d4317d400dac882825eb7c3bd4d3c6ae1/ibis_framework-12.0.0.tar.gz", hash = "sha256:238624f2c14fdab8382ca2f4f667c3cdb81e29844cd5f8db8a325d0743767c61", size = 1351369, upload-time = "2026-02-07T14:31:13.171Z" }
@@ -4400,72 +4400,72 @@ bigquery = [
     { name = "db-dtypes", marker = "python_full_version >= '3.10'" },
     { name = "google-cloud-bigquery", marker = "python_full_version >= '3.10'" },
     { name = "google-cloud-bigquery-storage", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
     { name = "pandas-gbq", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "pydata-google-auth", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 clickhouse = [
     { name = "clickhouse-connect", extra = ["arrow", "numpy", "pandas"], marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 databricks = [
     { name = "databricks-sql-connector", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 duckdb = [
     { name = "duckdb", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 mssql = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "pandas", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "rich", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 postgres = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
     { name = "psycopg", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
 ]
 snowflake = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow-hotfix", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
     { name = "snowflake-connector-python", marker = "python_full_version >= '3.10'" },
@@ -4474,7 +4474,7 @@ snowflake = [
 [[package]]
 name = "idna"
 version = "3.10"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
@@ -4483,7 +4483,7 @@ wheels = [
 [[package]]
 name = "importlib-metadata"
 version = "6.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
@@ -4495,7 +4495,7 @@ wheels = [
 [[package]]
 name = "inflection"
 version = "0.5.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091, upload-time = "2020-08-22T08:16:29.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454, upload-time = "2020-08-22T08:16:27.816Z" },
@@ -4504,7 +4504,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
@@ -4513,7 +4513,7 @@ wheels = [
 [[package]]
 name = "ipython"
 version = "8.18.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4533,7 +4533,7 @@ dependencies = [
     { name = "pygments", marker = "python_full_version < '3.10'" },
     { name = "stack-data", marker = "python_full_version < '3.10'" },
     { name = "traitlets", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/b9/3ba6c45a6df813c09a48bac313c22ff83efa26cbb55011218d925a46e2ad/ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27", size = 5486330, upload-time = "2023-11-27T09:58:34.596Z" }
 wheels = [
@@ -4543,7 +4543,7 @@ wheels = [
 [[package]]
 name = "ipython"
 version = "8.37.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4563,7 +4563,7 @@ dependencies = [
     { name = "pygments", marker = "python_full_version == '3.10.*'" },
     { name = "stack-data", marker = "python_full_version == '3.10.*'" },
     { name = "traitlets", marker = "python_full_version == '3.10.*'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -4573,7 +4573,7 @@ wheels = [
 [[package]]
 name = "ipython"
 version = "9.5.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -4611,7 +4611,7 @@ dependencies = [
     { name = "pygments", marker = "python_full_version >= '3.11'" },
     { name = "stack-data", marker = "python_full_version >= '3.11'" },
     { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/71/a86262bf5a68bf211bcc71fe302af7e05f18a2852fdc610a854d20d085e6/ipython-9.5.0.tar.gz", hash = "sha256:129c44b941fe6d9b82d36fc7a7c18127ddb1d6f02f78f867f402e2e3adde3113", size = 4389137, upload-time = "2025-08-29T12:15:21.519Z" }
 wheels = [
@@ -4621,7 +4621,7 @@ wheels = [
 [[package]]
 name = "ipython-pygments-lexers"
 version = "1.1.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
@@ -4633,7 +4633,7 @@ wheels = [
 [[package]]
 name = "isodate"
 version = "0.6.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -4645,7 +4645,7 @@ wheels = [
 [[package]]
 name = "isort"
 version = "5.13.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
@@ -4654,7 +4654,7 @@ wheels = [
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
@@ -4663,7 +4663,7 @@ wheels = [
 [[package]]
 name = "jaraco-classes"
 version = "3.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -4675,7 +4675,7 @@ wheels = [
 [[package]]
 name = "jaraco-context"
 version = "6.0.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
@@ -4687,7 +4687,7 @@ wheels = [
 [[package]]
 name = "jaraco-functools"
 version = "4.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -4699,7 +4699,7 @@ wheels = [
 [[package]]
 name = "jedi"
 version = "0.19.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "parso" },
 ]
@@ -4711,7 +4711,7 @@ wheels = [
 [[package]]
 name = "jeepney"
 version = "0.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
@@ -4720,7 +4720,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -4732,7 +4732,7 @@ wheels = [
 [[package]]
 name = "jinxed"
 version = "1.3.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ansicon", marker = "sys_platform == 'win32'" },
 ]
@@ -4744,7 +4744,7 @@ wheels = [
 [[package]]
 name = "jmespath"
 version = "1.0.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
@@ -4753,7 +4753,7 @@ wheels = [
 [[package]]
 name = "jsonpath-ng"
 version = "1.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ply" },
 ]
@@ -4765,7 +4765,7 @@ wheels = [
 [[package]]
 name = "jsonref"
 version = "1.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
@@ -4774,10 +4774,10 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.24.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "jsonschema-specifications" },
     { name = "referencing" },
     { name = "rpds-py" },
@@ -4790,7 +4790,7 @@ wheels = [
 [[package]]
 name = "jsonschema-path"
 version = "0.4.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pathable", marker = "python_full_version >= '3.10'" },
     { name = "pyyaml", marker = "python_full_version >= '3.10'" },
@@ -4804,7 +4804,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.4.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -4816,7 +4816,7 @@ wheels = [
 [[package]]
 name = "keyring"
 version = "25.6.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "jaraco-classes" },
@@ -4834,7 +4834,7 @@ wheels = [
 [[package]]
 name = "lance-namespace"
 version = "0.4.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
@@ -4846,13 +4846,13 @@ wheels = [
 [[package]]
 name = "lance-namespace-urllib3-client"
 version = "0.4.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-dateutil" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/a9/4e527c2f05704565618b239b0965f829d1a194837f01234af3f8e2f33d92/lance_namespace_urllib3_client-0.4.5.tar.gz", hash = "sha256:184deda8cf8700926d994618187053c644eb1f2866a4479e7b80843cacc92b1c", size = 159726, upload-time = "2026-01-07T19:20:24.025Z" }
@@ -4863,19 +4863,19 @@ wheels = [
 [[package]]
 name = "lancedb"
 version = "0.26.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecation" },
     { name = "lance-namespace" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "overrides", marker = "python_full_version < '3.12'" },
     { name = "packaging" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "tqdm" },
 ]
 wheels = [
@@ -4890,7 +4890,7 @@ wheels = [
 [[package]]
 name = "lazy-object-proxy"
 version = "1.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/f9/1f56571ed82fb324f293661690635cf42c41deb8a70a6c9e6edc3e9bb3c8/lazy_object_proxy-1.11.0.tar.gz", hash = "sha256:18874411864c9fbbbaa47f9fc1dd7aea754c86cfde21278ef427639d1dd78e9c", size = 44736, upload-time = "2025-04-16T16:53:48.482Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/c8/457f1555f066f5bacc44337141294153dc993b5e9132272ab54a64ee98a2/lazy_object_proxy-1.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:132bc8a34f2f2d662a851acfd1b93df769992ed1b81e2b1fda7db3e73b0d5a18", size = 28045, upload-time = "2025-04-16T16:53:32.314Z" },
@@ -4911,7 +4911,7 @@ wheels = [
 [[package]]
 name = "leather"
 version = "0.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ed/6e/48a05e2f7f62a616d675cfee182643f2dd8023bf7429aa326f4bebd629c8/leather-0.4.0.tar.gz", hash = "sha256:f964bec2086f3153a6c16e707f20cb718f811f57af116075f4c0f4805c608b95", size = 43877, upload-time = "2024-02-23T22:03:36.657Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/30/9ec597c962c5249ebd5c580386e4b5f2884cd943af42634291ee3b406415/leather-0.4.0-py2.py3-none-any.whl", hash = "sha256:18290bc93749ae39039af5e31e871fcfad74d26c4c3ea28ea4f681f4571b3a2b", size = 30256, upload-time = "2024-02-23T22:03:34.75Z" },
@@ -4920,7 +4920,7 @@ wheels = [
 [[package]]
 name = "librt"
 version = "0.8.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/5f/63f5fa395c7a8a93558c0904ba8f1c8d1b997ca6a3de61bc7659970d66bf/librt-0.8.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:81fd938344fecb9373ba1b155968c8a329491d2ce38e7ddb76f30ffb938f12dc", size = 65697, upload-time = "2026-02-17T16:11:06.903Z" },
@@ -5017,7 +5017,7 @@ wheels = [
 [[package]]
 name = "limits"
 version = "4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -5029,7 +5029,7 @@ resolution-markers = [
 dependencies = [
     { name = "deprecated", marker = "python_full_version < '3.10'" },
     { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/54/f73e4810332f500b46b3fbf01d3258e0cbf1508d1be8d2438a1e174208c3/limits-4.2.tar.gz", hash = "sha256:d602ceae5d6b71063d5f9338904e32d569efaa84a7dd0399cde7ca6ff1a8fc9b", size = 85710, upload-time = "2025-03-11T18:55:13.637Z" }
 wheels = [
@@ -5039,7 +5039,7 @@ wheels = [
 [[package]]
 name = "limits"
 version = "5.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -5063,7 +5063,7 @@ resolution-markers = [
 dependencies = [
     { name = "deprecated", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "packaging", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/93/1d0d9feedbf58220be4160f5f3fbe51f52449d0699f896b32ce731756e30/limits-5.2.0.tar.gz", hash = "sha256:b6b659774f17befef2dd30a76dcd2bdecf3852e73b6627143d44ab4deda94b48", size = 95048, upload-time = "2025-05-16T19:40:20.741Z" }
 wheels = [
@@ -5073,7 +5073,7 @@ wheels = [
 [[package]]
 name = "linkify-it-py"
 version = "2.0.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "uc-micro-py", marker = "python_full_version < '3.13'" },
 ]
@@ -5085,7 +5085,7 @@ wheels = [
 [[package]]
 name = "lockfile"
 version = "0.12.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/17/47/72cb04a58a35ec495f96984dddb48232b551aafb95bde614605b754fe6f7/lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799", size = 20874, upload-time = "2015-11-25T18:29:58.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/22/9460e311f340cb62d26a38c419b1381b8593b0bb6b5d1f056938b086d362/lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa", size = 13564, upload-time = "2015-11-25T18:29:51.462Z" },
@@ -5094,13 +5094,13 @@ wheels = [
 [[package]]
 name = "logbook"
 version = "1.5.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2f/d9/16ac346f7c0102835814cc9e5b684aaadea101560bb932a2403bd26b2320/Logbook-1.5.3.tar.gz", hash = "sha256:66f454ada0f56eae43066f604a222b09893f98c1adc18df169710761b8f32fe8", size = 85783, upload-time = "2019-10-16T18:00:26.666Z" }
 
 [[package]]
 name = "loguru"
 version = "0.7.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "win32-setctime", marker = "sys_platform == 'win32'" },
@@ -5113,7 +5113,7 @@ wheels = [
 [[package]]
 name = "loro"
 version = "1.10.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/27/ea6f3298fc87ea5f2d60ebfbca088e7d9b2ceb3993f67c83bfb81778ec01/loro-1.10.3.tar.gz", hash = "sha256:68184ab1c2ab94af6ad4aaba416d22f579cabee0b26cbb09a1f67858207bbce8", size = 68833, upload-time = "2025-12-09T10:14:06.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/af/517956be7153d3450263f35ca70b1d7845b404e197045274db07b869e26f/loro-1.10.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:7e7e3461439c57efaadfd364a5a504a849653cf408c97086033004dffb3f2857", size = 3258650, upload-time = "2025-12-09T10:11:29.657Z" },
@@ -5247,7 +5247,7 @@ wheels = [
 [[package]]
 name = "lxml"
 version = "5.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/3d/14e82fc7c8fb1b7761f7e748fd47e2ec8276d137b6acfe5a4bb73853e08f/lxml-5.4.0.tar.gz", hash = "sha256:d12832e1dbea4be280b22fd0ea7c9b87f0d8fc51ba06e92dc62d52f804f78ebd", size = 3679479, upload-time = "2025-04-23T01:50:29.322Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/1f/a3b6b74a451ceb84b471caa75c934d2430a4d84395d38ef201d539f38cd1/lxml-5.4.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e7bc6df34d42322c5289e37e9971d6ed114e3776b45fa879f734bded9d1fea9c", size = 8076838, upload-time = "2025-04-23T01:44:29.325Z" },
@@ -5346,7 +5346,7 @@ wheels = [
 [[package]]
 name = "lz4"
 version = "4.4.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c6/5a/945f5086326d569f14c84ac6f7fcc3229f0b9b1e8cc536b951fd53dfb9e1/lz4-4.4.4.tar.gz", hash = "sha256:070fd0627ec4393011251a094e08ed9fdcc78cb4e7ab28f507638eee4e39abda", size = 171884, upload-time = "2025-04-01T22:55:58.62Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/80/4054e99cda2e003097f59aeb3ad470128f3298db5065174a84564d2d6983/lz4-4.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f170abb8416c4efca48e76cac2c86c3185efdf841aecbe5c190121c42828ced0", size = 220896, upload-time = "2025-04-01T22:55:13.577Z" },
@@ -5394,7 +5394,7 @@ wheels = [
 [[package]]
 name = "makefun"
 version = "1.16.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/cf/6780ab8bc3b84a1cce3e4400aed3d64b6db7d5e227a2f75b6ded5674701a/makefun-1.16.0.tar.gz", hash = "sha256:e14601831570bff1f6d7e68828bcd30d2f5856f24bad5de0ccb22921ceebc947", size = 73565, upload-time = "2025-05-09T15:00:42.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/c0/4bc973defd1270b89ccaae04cef0d5fa3ea85b59b108ad2c08aeea9afb76/makefun-1.16.0-py2.py3-none-any.whl", hash = "sha256:43baa4c3e7ae2b17de9ceac20b669e9a67ceeadff31581007cca20a07bbe42c4", size = 22923, upload-time = "2025-05-09T15:00:41.042Z" },
@@ -5403,7 +5403,7 @@ wheels = [
 [[package]]
 name = "mako"
 version = "1.3.10"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -5415,7 +5415,7 @@ wheels = [
 [[package]]
 name = "marimo"
 version = "0.14.10"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -5436,7 +5436,7 @@ dependencies = [
     { name = "itsdangerous", marker = "python_full_version < '3.11'" },
     { name = "jedi", marker = "python_full_version < '3.11'" },
     { name = "markdown", marker = "python_full_version < '3.11'" },
-    { name = "narwhals", version = "1.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "narwhals", version = "1.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "packaging", marker = "python_full_version < '3.11'" },
     { name = "psutil", marker = "python_full_version < '3.11'" },
     { name = "pygments", marker = "python_full_version < '3.11'" },
@@ -5444,10 +5444,10 @@ dependencies = [
     { name = "pyyaml", marker = "python_full_version < '3.11'" },
     { name = "starlette", marker = "python_full_version < '3.11'" },
     { name = "tomlkit", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "uvicorn", version = "0.34.3", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "uvicorn", version = "0.34.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "websockets", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/93/d646fccda297843c41fa088e831212a425036e1cf7ea1c1fca41d7f7ad56/marimo-0.14.10.tar.gz", hash = "sha256:195247aabaccb7559532daa0313b7f47647ba78b98e151fe2b85df1f67bff79e", size = 29134153, upload-time = "2025-07-03T00:54:02.37Z" }
@@ -5458,7 +5458,7 @@ wheels = [
 [[package]]
 name = "marimo"
 version = "0.20.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -5493,7 +5493,7 @@ dependencies = [
     { name = "loro", marker = "python_full_version >= '3.11'" },
     { name = "markdown", marker = "python_full_version >= '3.11'" },
     { name = "msgspec", marker = "python_full_version >= '3.11'" },
-    { name = "narwhals", version = "2.17.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", version = "2.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging", marker = "python_full_version >= '3.11'" },
     { name = "psutil", marker = "python_full_version >= '3.11'" },
     { name = "pygments", marker = "python_full_version >= '3.11'" },
@@ -5501,7 +5501,7 @@ dependencies = [
     { name = "pyyaml", marker = "python_full_version >= '3.11'" },
     { name = "starlette", marker = "python_full_version >= '3.11'" },
     { name = "tomlkit", marker = "python_full_version >= '3.11'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "websockets", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/be/84a28265e1698dbac439de8a1d428a18e07c4dd23fa72df72e8b4922e3ff/marimo-0.20.2.tar.gz", hash = "sha256:cdab009b65d58d571640ab8bb2ede68ab3b755c8f99f06b934a23f3b8aba3f34", size = 38237601, upload-time = "2026-02-22T20:19:42.198Z" }
@@ -5512,7 +5512,7 @@ wheels = [
 [[package]]
 name = "markdown"
 version = "3.8"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
 ]
@@ -5524,7 +5524,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "3.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -5536,7 +5536,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357, upload-time = "2024-10-18T15:20:51.44Z" },
@@ -5604,7 +5604,7 @@ wheels = [
 [[package]]
 name = "marshmallow"
 version = "3.26.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging", marker = "python_full_version < '3.13'" },
 ]
@@ -5616,7 +5616,7 @@ wheels = [
 [[package]]
 name = "marshmallow-oneofschema"
 version = "3.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow", marker = "python_full_version < '3.13'" },
 ]
@@ -5628,7 +5628,7 @@ wheels = [
 [[package]]
 name = "marshmallow-sqlalchemy"
 version = "0.28.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow", marker = "python_full_version < '3.13'" },
     { name = "packaging", marker = "python_full_version < '3.13'" },
@@ -5642,10 +5642,10 @@ wheels = [
 [[package]]
 name = "mashumaro"
 version = "3.14"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/47/0a450b281bef2d7e97ec02c8e1168d821e283f58e02e6c403b2bb4d73c1c/mashumaro-3.14.tar.gz", hash = "sha256:5ef6f2b963892cbe9a4ceb3441dfbea37f8c3412523f25d42e9b3a7186555f1d", size = 166160, upload-time = "2024-10-23T21:48:40.164Z" }
 wheels = [
@@ -5660,7 +5660,7 @@ msgpack = [
 [[package]]
 name = "matplotlib-inline"
 version = "0.1.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
@@ -5672,7 +5672,7 @@ wheels = [
 [[package]]
 name = "mccabe"
 version = "0.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
@@ -5681,22 +5681,22 @@ wheels = [
 [[package]]
 name = "mcp"
 version = "1.26.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
     { name = "httpx", marker = "python_full_version >= '3.10'" },
     { name = "httpx-sse", marker = "python_full_version >= '3.10'" },
     { name = "jsonschema", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydantic-settings", marker = "python_full_version >= '3.10'" },
     { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.10'" },
     { name = "python-multipart", marker = "python_full_version >= '3.10'" },
     { name = "pywin32", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
     { name = "sse-starlette", marker = "python_full_version >= '3.10'" },
     { name = "starlette", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "uvicorn", version = "0.41.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
@@ -5706,7 +5706,7 @@ wheels = [
 [[package]]
 name = "mdit-py-plugins"
 version = "0.4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", marker = "python_full_version < '3.13'" },
 ]
@@ -5718,7 +5718,7 @@ wheels = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -5727,7 +5727,7 @@ wheels = [
 [[package]]
 name = "methodtools"
 version = "0.4.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wirerope", marker = "python_full_version < '3.13'" },
 ]
@@ -5739,7 +5739,7 @@ wheels = [
 [[package]]
 name = "mimesis"
 version = "7.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/08/182b081de5fc7a148360c0da5d482f65e593e6e739fd5ab0e488e6b26adb/mimesis-7.1.0.tar.gz", hash = "sha256:c83b55d35536d7e9b9700a596b7ccfb639a740e3e1fb5e08062e8ab2a67dcb37", size = 4332255, upload-time = "2023-04-06T21:11:42Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/76/9cb8ef05ee9b07489fd3323f932acfb0e6fff753a3c368f25baa08635a53/mimesis-7.1.0-py3-none-any.whl", hash = "sha256:da65bea6d6d5d5d87d5c008e6b23ef5f96a49cce436d9f8708dabb5152da0290", size = 4371099, upload-time = "2023-04-06T21:11:39.831Z" },
@@ -5748,7 +5748,7 @@ wheels = [
 [[package]]
 name = "minimal-snowplow-tracker"
 version = "0.0.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "six" },
@@ -5758,7 +5758,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/e4/9f/004f810169a48ed5c
 [[package]]
 name = "mmh3"
 version = "4.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/96/aa247e82878b123468f0079ce2ac77e948315bab91ce45d2934a62e0af95/mmh3-4.1.0.tar.gz", hash = "sha256:a1cf25348b9acd229dda464a094d6170f47d2850a1fcb762a3b6172d2ce6ca4a", size = 26357, upload-time = "2024-01-09T06:46:04.536Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/5a/8609dc74421858f7e94a89dc69221ab9b2c14d0d63a139b46ec190eedc44/mmh3-4.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:be5ac76a8b0cd8095784e51e4c1c9c318c19edcd1709a06eb14979c8d850c31a", size = 39433, upload-time = "2024-01-09T06:44:25.903Z" },
@@ -5830,7 +5830,7 @@ wheels = [
 [[package]]
 name = "more-itertools"
 version = "10.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671, upload-time = "2025-04-22T14:17:41.838Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278, upload-time = "2025-04-22T14:17:40.49Z" },
@@ -5839,9 +5839,9 @@ wheels = [
 [[package]]
 name = "mowidgets"
 version = "0.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "marimo", version = "0.20.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "marimo", version = "0.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fb/f4f2f25e9df46e5bb5342201d6851b7b7449f69aa7673612c8ae5d152f8c/mowidgets-0.2.1.tar.gz", hash = "sha256:d3e154e1c27c8c97f31500cda13bcd32bc508df8de2801c3daae56dbb61f2332", size = 9793, upload-time = "2026-01-15T00:00:59.919Z" }
 wheels = [
@@ -5851,7 +5851,7 @@ wheels = [
 [[package]]
 name = "mpmath"
 version = "1.3.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
@@ -5860,7 +5860,7 @@ wheels = [
 [[package]]
 name = "msal"
 version = "1.32.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -5874,7 +5874,7 @@ wheels = [
 [[package]]
 name = "msal-extensions"
 version = "1.3.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "msal" },
 ]
@@ -5886,7 +5886,7 @@ wheels = [
 [[package]]
 name = "msgpack"
 version = "1.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/d0/7555686ae7ff5731205df1012ede15dd9d927f6227ea151e901c7406af4f/msgpack-1.1.0.tar.gz", hash = "sha256:dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e", size = 167260, upload-time = "2024-09-10T04:25:52.197Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/f9/a892a6038c861fa849b11a2bb0502c07bc698ab6ea53359e5771397d883b/msgpack-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7ad442d527a7e358a469faf43fda45aaf4ac3249c8310a82f0ccff9164e5dccd", size = 150428, upload-time = "2024-09-10T04:25:43.089Z" },
@@ -5949,7 +5949,7 @@ wheels = [
 [[package]]
 name = "msgspec"
 version = "0.20.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/9c/bfbd12955a49180cbd234c5d29ec6f74fe641698f0cd9df154a854fc8a15/msgspec-0.20.0.tar.gz", hash = "sha256:692349e588fde322875f8d3025ac01689fead5901e7fb18d6870a44519d62a29", size = 317862, upload-time = "2025-11-24T03:56:28.934Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/5e/151883ba2047cca9db8ed2f86186b054ad200bc231352df15b0c1dd75b1f/msgspec-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:23a6ec2a3b5038c233b04740a545856a068bc5cb8db184ff493a58e08c994fbf", size = 195191, upload-time = "2025-11-24T03:55:08.549Z" },
@@ -6013,10 +6013,10 @@ wheels = [
 [[package]]
 name = "multidict"
 version = "6.4.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/2f/a3470242707058fe856fe59241eee5635d79087100b7042a867368863a27/multidict-6.4.4.tar.gz", hash = "sha256:69ee9e6ba214b5245031b76233dd95408a0fd57fdb019ddcc1ead4790932a8e8", size = 90183, upload-time = "2025-05-19T14:16:37.381Z" }
 wheels = [
@@ -6128,7 +6128,7 @@ wheels = [
 [[package]]
 name = "multiprocess"
 version = "0.70.18"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
 ]
@@ -6154,14 +6154,14 @@ wheels = [
 [[package]]
 name = "mypy"
 version = "1.19.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
 wheels = [
@@ -6207,10 +6207,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-athena"
 version = "1.38.28"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/52/93a49eb0269da549337e6691c99d62d742928bacfaafcdd641ac6625a1f2/mypy_boto3_athena-1.38.28.tar.gz", hash = "sha256:5d7e74a59a4c778374848290d3c462665830954495912ec226ce270a4a4eae4d", size = 36553, upload-time = "2025-06-02T19:42:08.879Z" }
 wheels = [
@@ -6220,10 +6220,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-glue"
 version = "1.38.22"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/97/a479bc9405da1d6ae4d2bc88965e76e4d3c8c1c83188eb03c7a49d902826/mypy_boto3_glue-1.38.22.tar.gz", hash = "sha256:a9c529fafaaa9845d39c3204b3fb6cbbb633fa747faf6a084a2b2a381ef12a2b", size = 122519, upload-time = "2025-05-22T19:27:07.452Z" }
 wheels = [
@@ -6233,10 +6233,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-lakeformation"
 version = "1.38.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/51/1f87495c7f48037151a721ab4ba9c27c15b76eb8205e61be5c745eaebe81/mypy_boto3_lakeformation-1.38.0.tar.gz", hash = "sha256:0932699d6fa98cd02be94f753fc03425d12317301cdf534629be347f16238524", size = 34956, upload-time = "2025-04-22T21:27:53.038Z" }
 wheels = [
@@ -6246,10 +6246,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-s3"
 version = "1.38.39"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a7/cc2a5b095401b4d937ece53819ab9323572a82a6bbdc5a699b815fabe76b/mypy_boto3_s3-1.38.39.tar.gz", hash = "sha256:b272d1c9b359017ea7c5d79b4610ba93e91f557ad01da0d6e302bd7b7804f73b", size = 74169, upload-time = "2025-06-18T22:35:04.391Z" }
 wheels = [
@@ -6259,10 +6259,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-s3tables"
 version = "1.38.42"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/8c/c8d129f32737d09d2c23db5110a43164085b47c843460a5c89c748bf3f3f/mypy_boto3_s3tables-1.38.42.tar.gz", hash = "sha256:b3b24401f0e5e21f6c8ab35560a76a72e78983cf59f0b1adf6b7d07d9a6dabe5", size = 19731, upload-time = "2025-06-23T19:28:16.273Z" }
 wheels = [
@@ -6272,10 +6272,10 @@ wheels = [
 [[package]]
 name = "mypy-boto3-sts"
 version = "1.38.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/24/638ceabff74e07855b59c3bb863b0c11e69ff7ec8fa8678ff6db9ee38318/mypy_boto3_sts-1.38.0.tar.gz", hash = "sha256:143a96f06bd17ec4bbb120e04b65e646cb4345e2d0d4c3c596f8aa0458d12707", size = 16561, upload-time = "2025-04-22T21:35:39.729Z" }
 wheels = [
@@ -6285,7 +6285,7 @@ wheels = [
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
@@ -6294,7 +6294,7 @@ wheels = [
 [[package]]
 name = "narwhals"
 version = "1.41.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6317,7 +6317,7 @@ wheels = [
 [[package]]
 name = "narwhals"
 version = "2.17.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6352,7 +6352,7 @@ wheels = [
 [[package]]
 name = "natsort"
 version = "8.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
@@ -6361,7 +6361,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6378,7 +6378,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6395,7 +6395,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6430,7 +6430,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "1.26.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6493,7 +6493,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.2.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.13.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.13.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6569,7 +6569,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6656,7 +6656,7 @@ wheels = [
 [[package]]
 name = "oauthlib"
 version = "3.2.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352, upload-time = "2022-10-17T20:04:27.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688, upload-time = "2022-10-17T20:04:24.037Z" },
@@ -6665,7 +6665,7 @@ wheels = [
 [[package]]
 name = "onnxruntime"
 version = "1.19.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6677,7 +6677,7 @@ resolution-markers = [
 dependencies = [
     { name = "coloredlogs", marker = "python_full_version < '3.10'" },
     { name = "flatbuffers", marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "packaging", marker = "python_full_version < '3.10'" },
     { name = "protobuf", marker = "python_full_version < '3.10'" },
     { name = "sympy", marker = "python_full_version < '3.10'" },
@@ -6708,7 +6708,7 @@ wheels = [
 [[package]]
 name = "onnxruntime"
 version = "1.22.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -6744,9 +6744,9 @@ resolution-markers = [
 dependencies = [
     { name = "coloredlogs", marker = "python_full_version >= '3.10'" },
     { name = "flatbuffers", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "protobuf", marker = "python_full_version >= '3.10'" },
     { name = "sympy", marker = "python_full_version >= '3.10'" },
@@ -6775,9 +6775,9 @@ wheels = [
 [[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
@@ -6787,7 +6787,7 @@ wheels = [
 [[package]]
 name = "openpyxl"
 version = "3.1.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "et-xmlfile" },
 ]
@@ -6799,7 +6799,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-api"
 version = "1.27.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "importlib-metadata" },
@@ -6812,7 +6812,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp"
 version = "1.27.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version < '3.13'" },
@@ -6825,7 +6825,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.27.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto", marker = "python_full_version < '3.13'" },
 ]
@@ -6837,7 +6837,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.27.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
@@ -6855,7 +6855,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.27.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
@@ -6873,7 +6873,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-proto"
 version = "1.27.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf", marker = "python_full_version < '3.13'" },
 ]
@@ -6885,12 +6885,12 @@ wheels = [
 [[package]]
 name = "opentelemetry-sdk"
 version = "1.27.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-semantic-conventions", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0d/9a/82a6ac0f06590f3d72241a587cb8b0b751bd98728e896cc4cbd4847248e6/opentelemetry_sdk-1.27.0.tar.gz", hash = "sha256:d525017dea0ccce9ba4e0245100ec46ecdc043f2d7b8315d56b19aff0904fa6f", size = 145019, upload-time = "2024-08-28T21:35:46.708Z" }
 wheels = [
@@ -6900,7 +6900,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.48b0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-api", marker = "python_full_version < '3.13'" },
@@ -6913,11 +6913,11 @@ wheels = [
 [[package]]
 name = "oracledb"
 version = "3.4.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/9d/4e86cd410294ebbb1f90a609aaae61c5fa064a5c10e501de3f4c67664e6c/oracledb-3.4.1.tar.gz", hash = "sha256:f5920df5ac9446579e8409607bba31dc2d23a2286a5b0ea17cb0d78d419392a6", size = 852693, upload-time = "2025-11-12T03:21:36.157Z" }
 wheels = [
@@ -6956,7 +6956,7 @@ wheels = [
 [[package]]
 name = "ordered-set"
 version = "4.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4c/ca/bfac8bc689799bcca4157e0e0ced07e70ce125193fc2e166d2e685b7e2fe/ordered-set-4.1.0.tar.gz", hash = "sha256:694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8", size = 12826, upload-time = "2022-01-26T14:38:56.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/55/af02708f230eb77084a299d7b08175cff006dea4f2721074b92cdb0296c0/ordered_set-4.1.0-py3-none-any.whl", hash = "sha256:046e1132c71fcf3330438a539928932caf51ddbc582496833e23de611de14562", size = 7634, upload-time = "2022-01-26T14:38:48.677Z" },
@@ -6965,7 +6965,7 @@ wheels = [
 [[package]]
 name = "orjson"
 version = "3.10.18"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.13.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.13.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -7053,7 +7053,7 @@ wheels = [
 [[package]]
 name = "orjson"
 version = "3.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -7143,7 +7143,7 @@ wheels = [
 [[package]]
 name = "overrides"
 version = "7.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
@@ -7152,7 +7152,7 @@ wheels = [
 [[package]]
 name = "packaging"
 version = "24.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
@@ -7161,11 +7161,11 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.2.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -7218,19 +7218,19 @@ wheels = [
 [[package]]
 name = "pandas-gbq"
 version = "0.29.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "db-dtypes", marker = "python_full_version >= '3.10'" },
     { name = "google-api-core", marker = "python_full_version >= '3.10'" },
     { name = "google-auth", marker = "python_full_version >= '3.10'" },
     { name = "google-auth-oauthlib", marker = "python_full_version >= '3.10'" },
     { name = "google-cloud-bigquery", marker = "python_full_version >= '3.10'" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "pandas", marker = "python_full_version >= '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydata-google-auth", marker = "python_full_version >= '3.10'" },
     { name = "setuptools", marker = "python_full_version >= '3.10'" },
 ]
@@ -7242,7 +7242,7 @@ wheels = [
 [[package]]
 name = "paramiko"
 version = "3.5.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bcrypt" },
     { name = "cryptography" },
@@ -7256,7 +7256,7 @@ wheels = [
 [[package]]
 name = "parsedatetime"
 version = "2.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a8/20/cb587f6672dbe585d101f590c3871d16e7aec5a576a1694997a3777312ac/parsedatetime-2.6.tar.gz", hash = "sha256:4cb368fbb18a0b7231f4d76119165451c8d2e35951455dfee97c62a87b04d455", size = 60114, upload-time = "2020-05-31T23:50:57.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/a4/3dd804926a42537bf69fb3ebb9fd72a50ba84f807d95df5ae016606c976c/parsedatetime-2.6-py3-none-any.whl", hash = "sha256:cb96edd7016872f58479e35879294258c71437195760746faffedb692aef000b", size = 42548, upload-time = "2020-05-31T23:50:56.315Z" },
@@ -7265,7 +7265,7 @@ wheels = [
 [[package]]
 name = "parso"
 version = "0.8.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609, upload-time = "2024-04-05T09:43:55.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650, upload-time = "2024-04-05T09:43:53.299Z" },
@@ -7274,7 +7274,7 @@ wheels = [
 [[package]]
 name = "parsy"
 version = "2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/ea/e0853951be3b3e0ca41f962971816065b671ac88e257b99abcd0879198ce/parsy-2.1.tar.gz", hash = "sha256:fd5dd18d7b0b61f8275ee88665f430a20c02cf5a82d88557f35330530186d7ac", size = 45252, upload-time = "2023-02-22T15:26:55.628Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/05/1c84e2ebd1eb2817d92ae05a917e60e57b1c83f7b89e63c31df2cd6fcb70/parsy-2.1-py3-none-any.whl", hash = "sha256:8f18e7b11985e7802e7e3ecbd8291c6ca243d29820b1186e4c84605db4efffa0", size = 9111, upload-time = "2023-02-22T15:26:53.793Z" },
@@ -7283,7 +7283,7 @@ wheels = [
 [[package]]
 name = "pathable"
 version = "0.5.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
@@ -7292,7 +7292,7 @@ wheels = [
 [[package]]
 name = "pathspec"
 version = "0.11.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a0/2a/bd167cdf116d4f3539caaa4c332752aac0b3a0cc0174cdb302ee68933e81/pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3", size = 47032, upload-time = "2023-07-29T01:05:04.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/2a/9b1be29146139ef459188f5e420a66e835dda921208db600b7037093891f/pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20", size = 29603, upload-time = "2023-07-29T01:05:02.656Z" },
@@ -7301,7 +7301,7 @@ wheels = [
 [[package]]
 name = "pathvalidate"
 version = "3.2.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/87/c7a2f51cc62df0495acb0ed2533a7c74cc895e569a1b020ee5f6e9fa4e21/pathvalidate-3.2.3.tar.gz", hash = "sha256:59b5b9278e30382d6d213497623043ebe63f10e29055be4419a9c04c721739cb", size = 61717, upload-time = "2025-01-03T14:06:42.789Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/14/c5a0e1a947909810fc4c043b84cac472b70e438148d34f5393be1bac663f/pathvalidate-3.2.3-py3-none-any.whl", hash = "sha256:5eaf0562e345d4b6d0c0239d0f690c3bd84d2a9a3c4c73b99ea667401b27bee1", size = 24130, upload-time = "2025-01-03T14:06:39.568Z" },
@@ -7310,7 +7310,7 @@ wheels = [
 [[package]]
 name = "pbr"
 version = "6.1.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "setuptools" },
 ]
@@ -7322,7 +7322,7 @@ wheels = [
 [[package]]
 name = "pendulum"
 version = "3.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
     { name = "tzdata" },
@@ -7397,7 +7397,7 @@ wheels = [
 [[package]]
 name = "pexpect"
 version = "4.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ptyprocess", marker = "python_full_version < '3.10' or sys_platform != 'emscripten'" },
 ]
@@ -7409,7 +7409,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "10.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -7494,7 +7494,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "11.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -7614,7 +7614,7 @@ wheels = [
 [[package]]
 name = "pip"
 version = "25.1.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/59/de/241caa0ca606f2ec5fe0c1f4261b0465df78d786a38da693864a116c37f4/pip-25.1.1.tar.gz", hash = "sha256:3de45d411d308d5054c2168185d8da7f9a2cd753dbac8acbfa88a8909ecd9077", size = 1940155, upload-time = "2025-05-02T15:14:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/a2/d40fb2460e883eca5199c62cfc2463fd261f760556ae6290f88488c362c0/pip-25.1.1-py3-none-any.whl", hash = "sha256:2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af", size = 1825227, upload-time = "2025-05-02T15:13:59.102Z" },
@@ -7623,7 +7623,7 @@ wheels = [
 [[package]]
 name = "pipdeptree"
 version = "2.9.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/b2/2508e11f44e0e7b136555175f21c121f20642d43ab2a09797b178e968834/pipdeptree-2.9.6.tar.gz", hash = "sha256:f815caf165e89c576ce659b866c7a82ae4590420c2d020a92d32e45097f8bc73", size = 30858, upload-time = "2023-07-14T22:34:19.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/2c/63ad89d8e01d471b91c0ad4d69ed45f5221f70f3ece6c097beecb7c67f7a/pipdeptree-2.9.6-py3-none-any.whl", hash = "sha256:de93f990d21224297c9f03e057da5a3dc65ff732a0147945dd9421671f13626b", size = 19768, upload-time = "2023-07-14T22:34:17.109Z" },
@@ -7632,7 +7632,7 @@ wheels = [
 [[package]]
 name = "platformdirs"
 version = "4.3.8"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
@@ -7641,7 +7641,7 @@ wheels = [
 [[package]]
 name = "playwright"
 version = "1.58.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
@@ -7660,7 +7660,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -7669,7 +7669,7 @@ wheels = [
 [[package]]
 name = "ply"
 version = "3.11"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
@@ -7678,7 +7678,7 @@ wheels = [
 [[package]]
 name = "portalocker"
 version = "2.10.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
@@ -7690,7 +7690,7 @@ wheels = [
 [[package]]
 name = "prefixed"
 version = "0.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/48/ae/296470eca349da35bdec573e54320afa2b5b099c582e5d97be8bccac247e/prefixed-0.9.0.tar.gz", hash = "sha256:164403fa9ebc83280bbc4705f4b243a28837e164310b4e65c38ccab1ebafeeb3", size = 99277, upload-time = "2024-09-02T18:56:25.248Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/61/d9957a0ed189ac8a89075c59c97588fb1c77e51d8d44a26f5cdf001d260c/prefixed-0.9.0-py2.py3-none-any.whl", hash = "sha256:3cdb74bfc4cf0aba28f3574662b13afdcac27c463dcbef320fe5d03f4c5fbca8", size = 13509, upload-time = "2024-09-02T18:56:23.47Z" },
@@ -7699,7 +7699,7 @@ wheels = [
 [[package]]
 name = "prison"
 version = "0.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six", marker = "python_full_version < '3.13'" },
 ]
@@ -7711,7 +7711,7 @@ wheels = [
 [[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -7723,7 +7723,7 @@ wheels = [
 [[package]]
 name = "propcache"
 version = "0.3.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/07/c8/fdc6686a986feae3541ea23dcaa661bd93972d3940460646c6bb96e21c40/propcache-0.3.1.tar.gz", hash = "sha256:40d980c33765359098837527e18eddefc9a24cea5b45e078a7f3bb5b032c6ecf", size = 43651, upload-time = "2025-03-26T03:06:12.05Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/56/e27c136101addf877c8291dbda1b3b86ae848f3837ce758510a0d806c92f/propcache-0.3.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f27785888d2fdd918bc36de8b8739f2d6c791399552333721b58193f68ea3e98", size = 80224, upload-time = "2025-03-26T03:03:35.81Z" },
@@ -7828,7 +7828,7 @@ wheels = [
 [[package]]
 name = "proto-plus"
 version = "1.26.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -7840,7 +7840,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "4.25.8"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/01/34c8d2b6354906d728703cb9d546a0e534de479e25f1b581e4094c4a85cc/protobuf-4.25.8.tar.gz", hash = "sha256:6135cf8affe1fc6f76cced2641e4ea8d3e59518d1f24ae41ba97bcad82d397cd", size = 380920, upload-time = "2025-05-28T14:22:25.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/ff/05f34305fe6b85bbfbecbc559d423a5985605cad5eda4f47eae9e9c9c5c5/protobuf-4.25.8-cp310-abi3-win32.whl", hash = "sha256:504435d831565f7cfac9f0714440028907f1975e4bed228e58e72ecfff58a1e0", size = 392745, upload-time = "2025-05-28T14:22:10.524Z" },
@@ -7856,7 +7856,7 @@ wheels = [
 [[package]]
 name = "psutil"
 version = "7.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2a/80/336820c1ad9286a4ded7e845b2eccfcb27851ab8ac6abece774a6ff4d3de/psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456", size = 497003, upload-time = "2025-02-13T21:54:07.946Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/e6/2d26234410f8b8abdbf891c9da62bee396583f713fb9f3325a4760875d22/psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25", size = 238051, upload-time = "2025-02-13T21:54:12.36Z" },
@@ -7871,9 +7871,9 @@ wheels = [
 [[package]]
 name = "psycopg"
 version = "3.2.9"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
     { name = "tzdata", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/4a/93a6ab570a8d1a4ad171a1f4256e205ce48d828781312c0bbaff36380ecb/psycopg-3.2.9.tar.gz", hash = "sha256:2fbb46fcd17bc81f993f28c47f1ebea38d66ae97cc2dbc3cad73b37cefbff700", size = 158122, upload-time = "2025-05-13T16:11:15.533Z" }
@@ -7884,7 +7884,7 @@ wheels = [
 [[package]]
 name = "psycopg2-binary"
 version = "2.9.10"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/bdc8274dc0585090b4e3432267d7be4dfbfd8971c0fa59167c711105a6bf/psycopg2-binary-2.9.10.tar.gz", hash = "sha256:4b3df0e6990aa98acda57d983942eff13d824135fe2250e6522edaa782a06de2", size = 385764, upload-time = "2024-10-16T11:24:58.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/81/331257dbf2801cdb82105306042f7a1637cc752f65f2bb688188e0de5f0b/psycopg2_binary-2.9.10-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:0ea8e3d0ae83564f2fc554955d327fa081d065c8ca5cc6d2abb643e2c9c1200f", size = 3043397, upload-time = "2024-10-16T11:18:58.647Z" },
@@ -7950,7 +7950,7 @@ wheels = [
 [[package]]
 name = "ptyprocess"
 version = "0.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
@@ -7959,7 +7959,7 @@ wheels = [
 [[package]]
 name = "pure-eval"
 version = "0.2.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
@@ -7968,7 +7968,7 @@ wheels = [
 [[package]]
 name = "py"
 version = "1.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
@@ -7977,10 +7977,10 @@ wheels = [
 [[package]]
 name = "py-key-value-aio"
 version = "0.4.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
@@ -8002,7 +8002,7 @@ memory = [
 [[package]]
 name = "py-rust-stemmers"
 version = "0.1.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/63/4fbc14810c32d2a884e2e94e406a7d5bf8eee53e1103f558433817230342/py_rust_stemmers-0.1.5.tar.gz", hash = "sha256:e9c310cfb5c2470d7c7c8a0484725965e7cab8b1237e106a0863d5741da3e1f7", size = 9388, upload-time = "2025-02-19T13:56:28.708Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/28/2247e06de9896ac5d0fe9c6c16e611fd39549cb3197e25f12ca4437f12e7/py_rust_stemmers-0.1.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:bfbd9034ae00419ff2154e33b8f5b4c4d99d1f9271f31ed059e5c7e9fa005844", size = 286084, upload-time = "2025-02-19T13:54:52.061Z" },
@@ -8064,7 +8064,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "21.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8122,7 +8122,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "23.0.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8211,7 +8211,7 @@ wheels = [
 [[package]]
 name = "pyarrow-hotfix"
 version = "0.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d2/ed/c3e8677f7abf3981838c2af7b5ac03e3589b3ef94fcb31d575426abae904/pyarrow_hotfix-0.7.tar.gz", hash = "sha256:59399cd58bdd978b2e42816a4183a55c6472d4e33d183351b6069f11ed42661d", size = 9910, upload-time = "2025-04-25T10:17:06.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/c3/94ade4906a2f88bc935772f59c934013b4205e773bcb4239db114a6da136/pyarrow_hotfix-0.7-py3-none-any.whl", hash = "sha256:3236f3b5f1260f0e2ac070a55c1a7b339c4bb7267839bd2015e283234e758100", size = 7923, upload-time = "2025-04-25T10:17:05.224Z" },
@@ -8220,7 +8220,7 @@ wheels = [
 [[package]]
 name = "pyasn1"
 version = "0.6.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
@@ -8229,7 +8229,7 @@ wheels = [
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -8241,7 +8241,7 @@ wheels = [
 [[package]]
 name = "pyathena"
 version = "3.0.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
@@ -8256,7 +8256,7 @@ wheels = [
 [[package]]
 name = "pycodestyle"
 version = "2.12.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/aa/210b2c9aedd8c1cbeea31a50e42050ad56187754b34eb214c46709445801/pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521", size = 39232, upload-time = "2024-08-04T20:26:54.576Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/d8/a211b3f85e99a0daa2ddec96c949cac6824bd305b040571b82a03dd62636/pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3", size = 31284, upload-time = "2024-08-04T20:26:53.173Z" },
@@ -8265,7 +8265,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "2.22"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736, upload-time = "2024-03-30T13:22:22.564Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552, upload-time = "2024-03-30T13:22:20.476Z" },
@@ -8274,7 +8274,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.11.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8285,9 +8285,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "annotated-types", marker = "python_full_version < '3.10'" },
-    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-inspection", version = "0.4.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic-core", version = "2.33.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-inspection", version = "0.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/86/8ce9040065e8f924d642c58e4a344e33163a07f6b57f836d0d734e0ad3fb/pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a", size = 787102, upload-time = "2025-05-22T21:18:08.761Z" }
 wheels = [
@@ -8297,7 +8297,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.12.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8332,9 +8332,9 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "annotated-types", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic-core", version = "2.41.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
@@ -8349,7 +8349,7 @@ email = [
 [[package]]
 name = "pydantic-core"
 version = "2.33.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8359,7 +8359,7 @@ resolution-markers = [
     "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
 wheels = [
@@ -8466,7 +8466,7 @@ wheels = [
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8500,7 +8500,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
@@ -8629,11 +8629,11 @@ wheels = [
 [[package]]
 name = "pydantic-settings"
 version = "2.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-dotenv", marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-inspection", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180", size = 188394, upload-time = "2025-09-24T14:19:11.764Z" }
 wheels = [
@@ -8643,7 +8643,7 @@ wheels = [
 [[package]]
 name = "pydata-google-auth"
 version = "1.9.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth", marker = "python_full_version >= '3.10'" },
     { name = "google-auth-oauthlib", marker = "python_full_version >= '3.10'" },
@@ -8657,7 +8657,7 @@ wheels = [
 [[package]]
 name = "pydbml"
 version = "1.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
@@ -8669,7 +8669,7 @@ wheels = [
 [[package]]
 name = "pydoclint"
 version = "0.6.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "docstring-parser-fork" },
@@ -8683,10 +8683,10 @@ wheels = [
 [[package]]
 name = "pyee"
 version = "13.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/03/1fd98d5841cd7964a27d729ccf2199602fe05eb7a405c1462eb7277945ed/pyee-13.0.0.tar.gz", hash = "sha256:b391e3c5a434d1f5118a25615001dbc8f669cf410ab67d04c4d4e07c55481c37", size = 31250, upload-time = "2025-03-17T18:53:15.955Z" }
 wheels = [
@@ -8696,7 +8696,7 @@ wheels = [
 [[package]]
 name = "pyflakes"
 version = "3.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/f9/669d8c9c86613c9d568757c7f5824bd3197d7b1c6c27553bc5618a27cce2/pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f", size = 63788, upload-time = "2024-01-05T00:28:47.703Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/d7/f1b7db88d8e4417c5d47adad627a93547f44bdc9028372dbd2313f34a855/pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a", size = 62725, upload-time = "2024-01-05T00:28:45.903Z" },
@@ -8705,7 +8705,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.19.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
@@ -8714,14 +8714,14 @@ wheels = [
 [[package]]
 name = "pyiceberg"
 version = "0.9.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
     { name = "fsspec" },
     { name = "mmh3" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyparsing" },
     { name = "requests" },
     { name = "rich" },
@@ -8764,7 +8764,7 @@ wheels = [
 [[package]]
 name = "pyiceberg-core"
 version = "0.7.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c8/85/d3ec2e229d4e1bad3b9c4092889cae102eaf0d4ed62ce0e2de2b6e32cc4d/pyiceberg_core-0.7.0.tar.gz", hash = "sha256:8166883ace30a388d2f659634bec87731cad7bc52341c997fcdd4e13780e4345", size = 504657, upload-time = "2025-10-10T16:30:16.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/35/2942dcaf19ca1becc7f9a9001d0cf98168634732a33efbb06a6f382c36b1/pyiceberg_core-0.7.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:99e23463c30c4180329719fe1f120e779b20616a36bbdd42042b70063a13bd39", size = 56895735, upload-time = "2025-10-10T16:30:00.949Z" },
@@ -8777,7 +8777,7 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.10.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
@@ -8791,7 +8791,7 @@ crypto = [
 [[package]]
 name = "pymdown-extensions"
 version = "10.15"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
@@ -8804,7 +8804,7 @@ wheels = [
 [[package]]
 name = "pymysql"
 version = "1.1.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/ce59b5e5ed4ce8512f879ff1fa5ab699d211ae2495f1adaa5fbba2a1eada/pymysql-1.1.1.tar.gz", hash = "sha256:e127611aaf2b417403c60bf4dc570124aeb4a57f5f37b8e95ae399a42f904cd0", size = 47678, upload-time = "2024-05-21T11:03:43.722Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/94/e4181a1f6286f545507528c78016e00065ea913276888db2262507693ce5/PyMySQL-1.1.1-py3-none-any.whl", hash = "sha256:4de15da4c61dc132f4fb9ab763063e693d521a80fd0e87943b9a453dd4c19d6c", size = 44972, upload-time = "2024-05-21T11:03:41.216Z" },
@@ -8813,7 +8813,7 @@ wheels = [
 [[package]]
 name = "pynacl"
 version = "1.5.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
 ]
@@ -8833,7 +8833,7 @@ wheels = [
 [[package]]
 name = "pyodbc"
 version = "5.0.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8891,7 +8891,7 @@ wheels = [
 [[package]]
 name = "pyodbc"
 version = "5.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -8943,11 +8943,11 @@ wheels = [
 [[package]]
 name = "pyopenssl"
 version = "25.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/8c/cd89ad05804f8e3c17dea8f178c3f40eeab5694c30e0c9f5bcd49f576fc3/pyopenssl-25.1.0.tar.gz", hash = "sha256:8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b", size = 179937, upload-time = "2025-05-17T16:28:31.31Z" }
 wheels = [
@@ -8957,7 +8957,7 @@ wheels = [
 [[package]]
 name = "pyparsing"
 version = "3.2.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/22/f1129e69d94ffff626bdb5c835506b3a5b4f3d070f17ea295e12c2c6f60f/pyparsing-3.2.3.tar.gz", hash = "sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be", size = 1088608, upload-time = "2025-03-25T05:01:28.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/e7/df2285f3d08fee213f2d041540fa4fc9ca6c2d44cf36d3a035bf2a8d2bcc/pyparsing-3.2.3-py3-none-any.whl", hash = "sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf", size = 111120, upload-time = "2025-03-25T05:01:24.908Z" },
@@ -8966,7 +8966,7 @@ wheels = [
 [[package]]
 name = "pyperclip"
 version = "1.11.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
@@ -8975,7 +8975,7 @@ wheels = [
 [[package]]
 name = "pyreadline3"
 version = "3.5.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
@@ -8984,7 +8984,7 @@ wheels = [
 [[package]]
 name = "pytest"
 version = "7.4.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -9001,7 +9001,7 @@ wheels = [
 [[package]]
 name = "pytest-asyncio"
 version = "0.23.8"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -9013,7 +9013,7 @@ wheels = [
 [[package]]
 name = "pytest-base-url"
 version = "2.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "requests" },
@@ -9026,7 +9026,7 @@ wheels = [
 [[package]]
 name = "pytest-cases"
 version = "3.8.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "decopatch" },
     { name = "makefun" },
@@ -9040,7 +9040,7 @@ wheels = [
 [[package]]
 name = "pytest-console-scripts"
 version = "1.4.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "pytest" },
@@ -9053,7 +9053,7 @@ wheels = [
 [[package]]
 name = "pytest-forked"
 version = "1.6.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "py" },
     { name = "pytest" },
@@ -9066,7 +9066,7 @@ wheels = [
 [[package]]
 name = "pytest-mock"
 version = "3.14.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -9078,7 +9078,7 @@ wheels = [
 [[package]]
 name = "pytest-order"
 version = "1.3.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -9090,7 +9090,7 @@ wheels = [
 [[package]]
 name = "pytest-playwright"
 version = "0.7.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -9113,7 +9113,7 @@ wheels = [
 [[package]]
 name = "pytest-playwright"
 version = "0.7.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -9160,7 +9160,7 @@ wheels = [
 [[package]]
 name = "pytest-timeout"
 version = "2.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -9172,7 +9172,7 @@ wheels = [
 [[package]]
 name = "pytest-xdist"
 version = "3.8.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest" },
@@ -9185,7 +9185,7 @@ wheels = [
 [[package]]
 name = "python-daemon"
 version = "3.1.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lockfile", marker = "python_full_version < '3.13'" },
 ]
@@ -9197,7 +9197,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -9209,7 +9209,7 @@ wheels = [
 [[package]]
 name = "python-dotenv"
 version = "1.1.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
@@ -9218,7 +9218,7 @@ wheels = [
 [[package]]
 name = "python-jose"
 version = "3.5.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ecdsa", marker = "python_full_version >= '3.10'" },
     { name = "pyasn1", marker = "python_full_version >= '3.10'" },
@@ -9232,7 +9232,7 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.20"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
@@ -9241,7 +9241,7 @@ wheels = [
 [[package]]
 name = "python-nvd3"
 version = "0.16.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2", marker = "python_full_version < '3.13'" },
     { name = "python-slugify", marker = "python_full_version < '3.13'" },
@@ -9251,7 +9251,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/54/e7/2a0bf4d9209d23a91
 [[package]]
 name = "python-slugify"
 version = "8.0.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "text-unidecode" },
 ]
@@ -9263,7 +9263,7 @@ wheels = [
 [[package]]
 name = "pytimeparse"
 version = "1.1.8"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/5d/231f5f33c81e09682708fb323f9e4041408d8223e2f0fb9742843328778f/pytimeparse-1.1.8.tar.gz", hash = "sha256:e86136477be924d7e670646a98561957e8ca7308d44841e21f5ddea757556a0a", size = 9403, upload-time = "2018-05-18T17:40:42.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/b4/afd75551a3b910abd1d922dbd45e49e5deeb4d47dc50209ce489ba9844dd/pytimeparse-1.1.8-py2.py3-none-any.whl", hash = "sha256:04b7be6cc8bd9f5647a6325444926c3ac34ee6bc7e69da4367ba282f076036bd", size = 9969, upload-time = "2018-05-18T17:40:41.28Z" },
@@ -9272,7 +9272,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2025.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
@@ -9281,7 +9281,7 @@ wheels = [
 [[package]]
 name = "pywin32"
 version = "310"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/da/a5f38fffbba2fb99aa4aa905480ac4b8e83ca486659ac8c95bce47fb5276/pywin32-310-cp310-cp310-win32.whl", hash = "sha256:6dd97011efc8bf51d6793a82292419eba2c71cf8e7250cfac03bba284454abc1", size = 8848240, upload-time = "2025-03-17T00:55:46.783Z" },
     { url = "https://files.pythonhosted.org/packages/aa/fe/d873a773324fa565619ba555a82c9dabd677301720f3660a731a5d07e49a/pywin32-310-cp310-cp310-win_amd64.whl", hash = "sha256:c3e78706e4229b915a0821941a84e7ef420bf2b77e08c9dae3c76fd03fd2ae3d", size = 9601854, upload-time = "2025-03-17T00:55:48.783Z" },
@@ -9302,7 +9302,7 @@ wheels = [
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
@@ -9311,7 +9311,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
@@ -9364,17 +9364,17 @@ wheels = [
 [[package]]
 name = "qdrant-client"
 version = "1.14.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "httpx", extra = ["http2"] },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "portalocker" },
     { name = "protobuf" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/56/3f355f931c239c260b4fe3bd6433ec6c9e6185cd5ae0970fe89d0ca6daee/qdrant_client-1.14.3.tar.gz", hash = "sha256:bb899e3e065b79c04f5e47053d59176150c0a5dabc09d7f476c8ce8e52f4d281", size = 286766, upload-time = "2025-06-16T11:13:47.838Z" }
@@ -9390,7 +9390,7 @@ fastembed = [
 [[package]]
 name = "redshift-connector"
 version = "2.0.917"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
@@ -9409,13 +9409,13 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.36.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "attrs", version = "25.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "rpds-py" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
@@ -9425,7 +9425,7 @@ wheels = [
 [[package]]
 name = "regex"
 version = "2024.11.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz", hash = "sha256:7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519", size = 399494, upload-time = "2024-11-06T20:12:31.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/3c/4651f6b130c6842a8f3df82461a8950f923925db8b6961063e82744bddcc/regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ff590880083d60acc0433f9c3f713c51f7ac6ebb9adf889c79a261ecf541aa91", size = 482674, upload-time = "2024-11-06T20:08:57.575Z" },
@@ -9510,7 +9510,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.32.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -9525,7 +9525,7 @@ wheels = [
 [[package]]
 name = "requests-mock"
 version = "1.12.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
@@ -9537,7 +9537,7 @@ wheels = [
 [[package]]
 name = "requests-oauthlib"
 version = "2.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
@@ -9550,7 +9550,7 @@ wheels = [
 [[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests", marker = "python_full_version < '3.13'" },
 ]
@@ -9562,7 +9562,7 @@ wheels = [
 [[package]]
 name = "requirements-parser"
 version = "0.13.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -9574,7 +9574,7 @@ wheels = [
 [[package]]
 name = "rfc3339-validator"
 version = "0.1.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six", marker = "python_full_version < '3.13'" },
 ]
@@ -9586,12 +9586,12 @@ wheels = [
 [[package]]
 name = "rich"
 version = "13.9.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
@@ -9601,7 +9601,7 @@ wheels = [
 [[package]]
 name = "rich-argparse"
 version = "1.7.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "rich" },
 ]
@@ -9613,7 +9613,7 @@ wheels = [
 [[package]]
 name = "rich-rst"
 version = "1.3.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils", marker = "python_full_version >= '3.10'" },
     { name = "rich", marker = "python_full_version >= '3.10'" },
@@ -9626,7 +9626,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "0.25.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/a6/60184b7fc00dd3ca80ac635dd5b8577d444c57e8e8742cecabfacb829921/rpds_py-0.25.1.tar.gz", hash = "sha256:8960b6dac09b62dac26e75d7e2c4a22efb835d827a7278c34f72b2b84fa160e3", size = 27304, upload-time = "2025-05-21T12:46:12.502Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/09/e1158988e50905b7f8306487a576b52d32aa9a87f79f7ab24ee8db8b6c05/rpds_py-0.25.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:f4ad628b5174d5315761b67f212774a32f5bad5e61396d38108bd801c0a8f5d9", size = 373140, upload-time = "2025-05-21T12:42:38.834Z" },
@@ -9750,7 +9750,7 @@ wheels = [
 [[package]]
 name = "rsa"
 version = "4.9.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -9762,7 +9762,7 @@ wheels = [
 [[package]]
 name = "ruamel-yaml"
 version = "0.18.16"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ruamel-yaml-clib", marker = "python_full_version >= '3.10' and python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
 ]
@@ -9774,7 +9774,7 @@ wheels = [
 [[package]]
 name = "ruamel-yaml-clib"
 version = "0.2.15"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", hash = "sha256:46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600", size = 225794, upload-time = "2025-11-16T16:12:59.761Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/5a/4ab767cd42dcd65b83c323e1620d7c01ee60a52f4032fb7b61501f45f5c2/ruamel_yaml_clib-0.2.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:88eea8baf72f0ccf232c22124d122a7f26e8a24110a0273d9bcddcb0f7e1fa03", size = 147454, upload-time = "2025-11-16T16:13:02.54Z" },
@@ -9842,7 +9842,7 @@ wheels = [
 [[package]]
 name = "ruff"
 version = "0.3.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/6a/5cdb9e5ae04210ddc5b7b6cf31aeca50654de595e73e59961ce1a662656c/ruff-0.3.7.tar.gz", hash = "sha256:d5c1aebee5162c2226784800ae031f660c350e7a3402c4d1f8ea4e97e232e3ba", size = 2164419, upload-time = "2024-04-12T03:54:39.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/59/8416cddfcc65b710d79374358a81632f2c4810326e8391d5a3c23f1cc422/ruff-0.3.7-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0e8377cccb2f07abd25e84fc5b2cbe48eeb0fea9f1719cad7caedb061d70e5ce", size = 16845547, upload-time = "2024-04-12T03:53:41.335Z" },
@@ -9866,7 +9866,7 @@ wheels = [
 [[package]]
 name = "s3fs"
 version = "2025.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiobotocore" },
     { name = "aiohttp" },
@@ -9880,7 +9880,7 @@ wheels = [
 [[package]]
 name = "s3transfer"
 version = "0.11.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
@@ -9892,7 +9892,7 @@ wheels = [
 [[package]]
 name = "scramp"
 version = "1.4.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asn1crypto" },
 ]
@@ -9904,7 +9904,7 @@ wheels = [
 [[package]]
 name = "secretstorage"
 version = "3.3.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography", marker = "os_name != 'nt' and sys_platform != 'emscripten'" },
     { name = "jeepney", marker = "os_name != 'nt' and sys_platform != 'emscripten'" },
@@ -9917,7 +9917,7 @@ wheels = [
 [[package]]
 name = "semver"
 version = "3.0.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
@@ -9926,7 +9926,7 @@ wheels = [
 [[package]]
 name = "sentry-sdk"
 version = "2.29.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
@@ -9939,7 +9939,7 @@ wheels = [
 [[package]]
 name = "setproctitle"
 version = "1.3.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/af/56efe21c53ac81ac87e000b15e60b3d8104224b4313b6eacac3597bd183d/setproctitle-1.3.6.tar.gz", hash = "sha256:c9f32b96c700bb384f33f7cf07954bb609d35dd82752cef57fb2ee0968409169", size = 26889, upload-time = "2025-04-29T13:35:00.184Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/db/8214810cae49e2e474ea741aaa7d6111486f27377e864f0eb6d297c9be56/setproctitle-1.3.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ebcf34b69df4ca0eabaaaf4a3d890f637f355fed00ba806f7ebdd2d040658c26", size = 17412, upload-time = "2025-04-29T13:32:38.795Z" },
@@ -10027,7 +10027,7 @@ wheels = [
 [[package]]
 name = "setuptools"
 version = "80.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
@@ -10036,7 +10036,7 @@ wheels = [
 [[package]]
 name = "shapely"
 version = "2.0.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10046,7 +10046,7 @@ resolution-markers = [
     "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/c0/a911d1fd765d07a2b6769ce155219a281bfbe311584ebe97340d75c5bdb1/shapely-2.0.7.tar.gz", hash = "sha256:28fe2997aab9a9dc026dc6a355d04e85841546b2a5d232ed953e3321ab958ee5", size = 283413, upload-time = "2025-01-31T01:10:20.787Z" }
 wheels = [
@@ -10085,7 +10085,7 @@ wheels = [
 [[package]]
 name = "shapely"
 version = "2.1.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10119,9 +10119,9 @@ resolution-markers = [
     "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/3c/2da625233f4e605155926566c0e7ea8dda361877f48e8b1655e53456f252/shapely-2.1.1.tar.gz", hash = "sha256:500621967f2ffe9642454808009044c21e5b35db89ce69f8a2042c2ffd0e2772", size = 315422, upload-time = "2025-05-19T11:04:41.265Z" }
 wheels = [
@@ -10170,7 +10170,7 @@ wheels = [
 [[package]]
 name = "shellingham"
 version = "1.5.4"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
@@ -10179,7 +10179,7 @@ wheels = [
 [[package]]
 name = "simplejson"
 version = "3.19.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c0/5c/61e2afbe62bbe2e328d4d1f426f6e39052b73eddca23b5ba524026561250/simplejson-3.19.1.tar.gz", hash = "sha256:6277f60848a7d8319d27d2be767a7546bc965535b28070e310b3a9af90604a4c", size = 85207, upload-time = "2023-04-06T20:38:16.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/90/d37e7e026b1f460577f8480581a25494987ae2a31fd61305c30aa62342e1/simplejson-3.19.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:66d780047c31ff316ee305c3f7550f352d87257c756413632303fc59fef19eac", size = 94834, upload-time = "2023-04-06T20:36:34.537Z" },
@@ -10227,7 +10227,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -10236,7 +10236,7 @@ wheels = [
 [[package]]
 name = "smmap"
 version = "5.0.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
@@ -10245,7 +10245,7 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
@@ -10254,7 +10254,7 @@ wheels = [
 [[package]]
 name = "snowflake-connector-python"
 version = "3.15.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asn1crypto" },
     { name = "boto3" },
@@ -10273,8 +10273,8 @@ dependencies = [
     { name = "requests" },
     { name = "sortedcontainers" },
     { name = "tomlkit" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/ff/7c1b2cbb5a43b21abebfa58c83926266e9f5ea05123e795753da6ce84f96/snowflake_connector_python-3.15.0.tar.gz", hash = "sha256:1ef52e2fb3ecc295139737d3d759f85d962ef7278c6990c3bd9c17fcb82508d6", size = 774355, upload-time = "2025-04-28T23:15:36.681Z" }
@@ -10313,7 +10313,7 @@ secure-local-storage = [
 [[package]]
 name = "sortedcontainers"
 version = "2.4.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
@@ -10322,7 +10322,7 @@ wheels = [
 [[package]]
 name = "soupsieve"
 version = "2.7"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
@@ -10331,7 +10331,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy"
 version = "1.4.54"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
 ]
@@ -10366,7 +10366,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy-jsonfield"
 version = "1.0.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
 ]
@@ -10378,7 +10378,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy-utils"
 version = "0.41.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
 ]
@@ -10390,7 +10390,7 @@ wheels = [
 [[package]]
 name = "sqlfluff"
 version = "2.3.5"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appdirs" },
     { name = "chardet" },
@@ -10405,8 +10405,8 @@ dependencies = [
     { name = "tblib" },
     { name = "toml", marker = "python_full_version < '3.11'" },
     { name = "tqdm" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/4d/62bbe63bfaff220af7a23fbc165763aefe4d62e818b26f5fd52f44cc4a43/sqlfluff-2.3.5.tar.gz", hash = "sha256:fd77ef5a41ebfa798235a5b28bcfa71f7521e9336159a08b40b545953e84c3c3", size = 697029, upload-time = "2023-10-27T19:32:09.91Z" }
 wheels = [
@@ -10416,7 +10416,7 @@ wheels = [
 [[package]]
 name = "sqlglot"
 version = "28.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10457,7 +10457,7 @@ wheels = [
 [[package]]
 name = "sqlglot"
 version = "28.10.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10474,7 +10474,7 @@ wheels = [
 [[package]]
 name = "sqlparse"
 version = "0.5.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
@@ -10483,7 +10483,7 @@ wheels = [
 [[package]]
 name = "sse-starlette"
 version = "3.0.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
 ]
@@ -10495,7 +10495,7 @@ wheels = [
 [[package]]
 name = "stack-data"
 version = "0.6.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asttokens" },
     { name = "executing" },
@@ -10509,10 +10509,10 @@ wheels = [
 [[package]]
 name = "starlette"
 version = "0.47.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/d0/0332bd8a25779a0e2082b0e179805ad39afad642938b371ae0882e7f880d/starlette-0.47.0.tar.gz", hash = "sha256:1f64887e94a447fed5f23309fb6890ef23349b7e478faa7b24a851cd4eb844af", size = 2582856, upload-time = "2025-05-29T15:45:27.628Z" }
 wheels = [
@@ -10522,7 +10522,7 @@ wheels = [
 [[package]]
 name = "stevedore"
 version = "5.4.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pbr" },
 ]
@@ -10534,7 +10534,7 @@ wheels = [
 [[package]]
 name = "strictyaml"
 version = "1.7.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
 ]
@@ -10546,7 +10546,7 @@ wheels = [
 [[package]]
 name = "sympy"
 version = "1.14.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mpmath" },
 ]
@@ -10558,7 +10558,7 @@ wheels = [
 [[package]]
 name = "tabulate"
 version = "0.9.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
@@ -10567,7 +10567,7 @@ wheels = [
 [[package]]
 name = "tblib"
 version = "3.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/95/4b3044ec4bf248186769629bbfb495a458deb6e4c1f9eff7f298ae1e336e/tblib-3.1.0.tar.gz", hash = "sha256:06404c2c9f07f66fee2d7d6ad43accc46f9c3361714d9b8426e7f47e595cd652", size = 30766, upload-time = "2025-03-31T12:58:27.473Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/44/aa5c8b10b2cce7a053018e0d132bd58e27527a0243c4985383d5b6fd93e9/tblib-3.1.0-py3-none-any.whl", hash = "sha256:670bb4582578134b3d81a84afa1b016128b429f3d48e6cbbaecc9d15675e984e", size = 12552, upload-time = "2025-03-31T12:58:26.142Z" },
@@ -10576,7 +10576,7 @@ wheels = [
 [[package]]
 name = "tenacity"
 version = "8.5.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a3/4d/6a19536c50b849338fcbe9290d562b52cbdcf30d8963d3588a68a4107df1/tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78", size = 47309, upload-time = "2024-07-05T07:25:31.836Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/3f/8ba87d9e287b9d385a02a7114ddcef61b26f86411e121c9003eb509a1773/tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687", size = 28165, upload-time = "2024-07-05T07:25:29.591Z" },
@@ -10585,7 +10585,7 @@ wheels = [
 [[package]]
 name = "termcolor"
 version = "3.1.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/6c/3d75c196ac07ac8749600b60b03f4f6094d54e132c4d94ebac6ee0e0add0/termcolor-3.1.0.tar.gz", hash = "sha256:6a6dd7fbee581909eeec6a756cff1d7f7c376063b14e4a298dc4980309e55970", size = 14324, upload-time = "2025-04-30T11:37:53.791Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/bd/de8d508070629b6d84a30d01d57e4a65c69aa7f5abe7560b8fad3b50ea59/termcolor-3.1.0-py3-none-any.whl", hash = "sha256:591dd26b5c2ce03b9e43f391264626557873ce1d379019786f99b0c2bee140aa", size = 7684, upload-time = "2025-04-30T11:37:52.382Z" },
@@ -10594,7 +10594,7 @@ wheels = [
 [[package]]
 name = "text-unidecode"
 version = "1.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
@@ -10603,7 +10603,7 @@ wheels = [
 [[package]]
 name = "thrift"
 version = "0.20.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -10612,7 +10612,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3c/2d/8946864f716ac82dc
 [[package]]
 name = "tokenize-rt"
 version = "6.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/ed/8f07e893132d5051d86a553e749d5c89b2a4776eb3a579b72ed61f8559ca/tokenize_rt-6.2.0.tar.gz", hash = "sha256:8439c042b330c553fdbe1758e4a05c0ed460dbbbb24a606f11f0dee75da4cad6", size = 5476, upload-time = "2025-05-23T23:48:00.035Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/f0/3fe8c6e69135a845f4106f2ff8b6805638d4e85c264e70114e8126689587/tokenize_rt-6.2.0-py2.py3-none-any.whl", hash = "sha256:a152bf4f249c847a66497a4a95f63376ed68ac6abf092a2f7cfb29d044ecff44", size = 6004, upload-time = "2025-05-23T23:47:58.812Z" },
@@ -10621,7 +10621,7 @@ wheels = [
 [[package]]
 name = "tokenizers"
 version = "0.22.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
@@ -10646,7 +10646,7 @@ wheels = [
 [[package]]
 name = "toml"
 version = "0.10.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
@@ -10655,7 +10655,7 @@ wheels = [
 [[package]]
 name = "tomli"
 version = "2.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
@@ -10694,7 +10694,7 @@ wheels = [
 [[package]]
 name = "tomlkit"
 version = "0.12.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/07/d34a911a98e64b07f862da4b10028de0c1ac2222ab848eaf5dd1877c4b1b/tomlkit-0.12.1.tar.gz", hash = "sha256:38e1ff8edb991273ec9f6181244a6a391ac30e9f5098e7535640ea6be97a7c86", size = 190535, upload-time = "2023-07-27T14:50:22.643Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/6d/808775ed618e51edaa7bbe6759e22e1c7eafe359af6e084700c6d39d3455/tomlkit-0.12.1-py3-none-any.whl", hash = "sha256:712cbd236609acc6a3e2e97253dfc52d4c2082982a88f61b640ecf0817eab899", size = 37335, upload-time = "2023-07-27T14:50:21.12Z" },
@@ -10703,7 +10703,7 @@ wheels = [
 [[package]]
 name = "toolz"
 version = "1.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/0b/d80dfa675bf592f636d1ea0b835eab4ec8df6e9415d8cfd766df54456123/toolz-1.0.0.tar.gz", hash = "sha256:2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02", size = 66790, upload-time = "2024-10-04T16:17:04.001Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl", hash = "sha256:292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236", size = 56383, upload-time = "2024-10-04T16:17:01.533Z" },
@@ -10712,7 +10712,7 @@ wheels = [
 [[package]]
 name = "tqdm"
 version = "4.67.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -10724,7 +10724,7 @@ wheels = [
 [[package]]
 name = "traitlets"
 version = "5.14.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
@@ -10733,7 +10733,7 @@ wheels = [
 [[package]]
 name = "typer"
 version = "0.23.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "click" },
@@ -10748,7 +10748,7 @@ wheels = [
 [[package]]
 name = "types-awscrt"
 version = "0.27.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/36/6c/583522cfb3c330e92e726af517a91c13247e555e021791a60f1b03c6ff16/types_awscrt-0.27.2.tar.gz", hash = "sha256:acd04f57119eb15626ab0ba9157fc24672421de56e7bd7b9f61681fedee44e91", size = 16304, upload-time = "2025-05-16T03:10:08.712Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/82/1ee2e5c9d28deac086ab3a6ff07c8bc393ef013a083f546c623699881715/types_awscrt-0.27.2-py3-none-any.whl", hash = "sha256:49a045f25bbd5ad2865f314512afced933aed35ddbafc252e2268efa8a787e4e", size = 37761, upload-time = "2025-05-16T03:10:07.466Z" },
@@ -10757,7 +10757,7 @@ wheels = [
 [[package]]
 name = "types-cachetools"
 version = "6.0.0.20250525"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/d0/55ff0eeda141436c1bd2142cd026906870c661b3f7755070d6da7ea7210f/types_cachetools-6.0.0.20250525.tar.gz", hash = "sha256:baf06f234cac3aeb44c07893447ba03ecdb6c0742ba2607e28a35d38e6821b02", size = 8925, upload-time = "2025-05-25T03:13:53.498Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8c/4ab0a17ece30fe608270b89cf066387051862899fff9f54ab12511fc7fdd/types_cachetools-6.0.0.20250525-py3-none-any.whl", hash = "sha256:1de8f0fe4bdcb187a48d2026c1e3672830f67943ad2bf3486abe031b632f1252", size = 8938, upload-time = "2025-05-25T03:13:52.406Z" },
@@ -10766,7 +10766,7 @@ wheels = [
 [[package]]
 name = "types-click"
 version = "7.1.8"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/ff/0e6a56108d45c80c61cdd4743312d0304d8192482aea4cce96c554aaa90d/types-click-7.1.8.tar.gz", hash = "sha256:b6604968be6401dc516311ca50708a0a28baa7a0cb840efd7412f0dbbff4e092", size = 10015, upload-time = "2021-11-23T12:28:01.701Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/ad/607454a5f991c5b3e14693a7113926758f889138371058a5f72f567fa131/types_click-7.1.8-py3-none-any.whl", hash = "sha256:8cb030a669e2e927461be9827375f83c16b8178c365852c060a34e24871e7e81", size = 12929, upload-time = "2021-11-23T12:27:59.493Z" },
@@ -10775,7 +10775,7 @@ wheels = [
 [[package]]
 name = "types-deprecated"
 version = "1.2.15.20250304"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0e/67/eeefaaabb03b288aad85483d410452c8bbcbf8b2bd876b0e467ebd97415b/types_deprecated-1.2.15.20250304.tar.gz", hash = "sha256:c329030553029de5cc6cb30f269c11f4e00e598c4241290179f63cda7d33f719", size = 8015, upload-time = "2025-03-04T02:48:17.894Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/e3/c18aa72ab84e0bc127a3a94e93be1a6ac2cb281371d3a45376ab7cfdd31c/types_deprecated-1.2.15.20250304-py3-none-any.whl", hash = "sha256:86a65aa550ea8acf49f27e226b8953288cd851de887970fbbdf2239c116c3107", size = 8553, upload-time = "2025-03-04T02:48:16.666Z" },
@@ -10784,7 +10784,7 @@ wheels = [
 [[package]]
 name = "types-paramiko"
 version = "3.5.0.20250708"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
@@ -10796,7 +10796,7 @@ wheels = [
 [[package]]
 name = "types-protobuf"
 version = "6.30.2.20250516"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/6c/5cf088aaa3927d1cc39910f60f220f5ff573ab1a6485b2836e8b26beb58c/types_protobuf-6.30.2.20250516.tar.gz", hash = "sha256:aecd1881770a9bb225ede66872ef7f0da4505edd0b193108edd9892e48d49a41", size = 62254, upload-time = "2025-05-16T03:06:50.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/66/06a9c161f5dd5deb4f5c016ba29106a8f1903eb9a1ba77d407dd6588fecb/types_protobuf-6.30.2.20250516-py3-none-any.whl", hash = "sha256:8c226d05b5e8b2623111765fa32d6e648bbc24832b4c2fddf0fa340ba5d5b722", size = 76480, upload-time = "2025-05-16T03:06:49.444Z" },
@@ -10805,7 +10805,7 @@ wheels = [
 [[package]]
 name = "types-psutil"
 version = "5.9.5.20240516"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/41/5d3d2f7b7e819e85820eadececc121ab805c0cb4cab5d88defb0a37eabed/types-psutil-5.9.5.20240516.tar.gz", hash = "sha256:bb296f59fc56458891d0feb1994717e548a1bcf89936a2877df8792b822b4696", size = 14771, upload-time = "2024-05-16T02:21:20.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/b0/872fd0f7b3998f18447a49b0ebae95994c9f589c79443551030caa8f94f0/types_psutil-5.9.5.20240516-py3-none-any.whl", hash = "sha256:83146ded949a10167d9895e567b3b71e53ebc5e23fd8363eab62b3c76cce7b89", size = 18356, upload-time = "2024-05-16T02:21:18.398Z" },
@@ -10814,7 +10814,7 @@ wheels = [
 [[package]]
 name = "types-psycopg2"
 version = "2.9.21.20250516"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/68/55/3f94eff9d1a1402f39e19523a90117fe6c97d7fc61957e7ee3e3052c75e1/types_psycopg2-2.9.21.20250516.tar.gz", hash = "sha256:6721018279175cce10b9582202e2a2b4a0da667857ccf82a97691bdb5ecd610f", size = 26514, upload-time = "2025-05-16T03:07:45.786Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/50/f5d74945ab09b9a3e966ad39027ac55998f917eca72ede7929eab962b5db/types_psycopg2-2.9.21.20250516-py3-none-any.whl", hash = "sha256:2a9212d1e5e507017b31486ce8147634d06b85d652769d7a2d91d53cb4edbd41", size = 24846, upload-time = "2025-05-16T03:07:44.849Z" },
@@ -10823,7 +10823,7 @@ wheels = [
 [[package]]
 name = "types-python-dateutil"
 version = "2.9.0.20250516"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/88/d65ed807393285204ab6e2801e5d11fbbea811adcaa979a2ed3b67a5ef41/types_python_dateutil-2.9.0.20250516.tar.gz", hash = "sha256:13e80d6c9c47df23ad773d54b2826bd52dbbb41be87c3f339381c1700ad21ee5", size = 13943, upload-time = "2025-05-16T03:06:58.385Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/3f/b0e8db149896005adc938a1e7f371d6d7e9eca4053a29b108978ed15e0c2/types_python_dateutil-2.9.0.20250516-py3-none-any.whl", hash = "sha256:2b2b3f57f9c6a61fba26a9c0ffb9ea5681c9b83e69cd897c6b5f668d9c0cab93", size = 14356, upload-time = "2025-05-16T03:06:57.249Z" },
@@ -10832,7 +10832,7 @@ wheels = [
 [[package]]
 name = "types-pytz"
 version = "2025.2.0.20250516"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/72/b0e711fd90409f5a76c75349055d3eb19992c110f0d2d6aabbd6cfbc14bf/types_pytz-2025.2.0.20250516.tar.gz", hash = "sha256:e1216306f8c0d5da6dafd6492e72eb080c9a166171fa80dd7a1990fd8be7a7b3", size = 10940, upload-time = "2025-05-16T03:07:01.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl", hash = "sha256:e0e0c8a57e2791c19f718ed99ab2ba623856b11620cb6b637e5f62ce285a7451", size = 10136, upload-time = "2025-05-16T03:07:01.075Z" },
@@ -10841,7 +10841,7 @@ wheels = [
 [[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250516"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload-time = "2025-05-16T03:08:04.019Z" },
@@ -10850,7 +10850,7 @@ wheels = [
 [[package]]
 name = "types-regex"
 version = "2024.11.6.20250403"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/75/012b90c8557d3abb3b58a9073a94d211c8f75c9b2e26bf0d8af7ecf7bc78/types_regex-2024.11.6.20250403.tar.gz", hash = "sha256:3fdf2a70bbf830de4b3a28e9649a52d43dabb57cdb18fbfe2252eefb53666665", size = 12394, upload-time = "2025-04-03T02:54:35.379Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/49/67200c4708f557be6aa4ecdb1fa212d67a10558c5240251efdc799cca22f/types_regex-2024.11.6.20250403-py3-none-any.whl", hash = "sha256:e22c0f67d73f4b4af6086a340f387b6f7d03bed8a0bb306224b75c51a29b0001", size = 10396, upload-time = "2025-04-03T02:54:34.555Z" },
@@ -10859,7 +10859,7 @@ wheels = [
 [[package]]
 name = "types-requests"
 version = "2.31.0.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-urllib3" },
 ]
@@ -10871,7 +10871,7 @@ wheels = [
 [[package]]
 name = "types-s3transfer"
 version = "0.13.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/42/c1/45038f259d6741c252801044e184fec4dbaeff939a58f6160d7c32bf4975/types_s3transfer-0.13.0.tar.gz", hash = "sha256:203dadcb9865c2f68fb44bc0440e1dc05b79197ba4a641c0976c26c9af75ef52", size = 14175, upload-time = "2025-05-28T02:16:07.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/5d/6bbe4bf6a79fb727945291aef88b5ecbdba857a603f1bbcf1a6be0d3f442/types_s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:79c8375cbf48a64bff7654c02df1ec4b20d74f8c5672fc13e382f593ca5565b3", size = 19588, upload-time = "2025-05-28T02:16:06.709Z" },
@@ -10880,7 +10880,7 @@ wheels = [
 [[package]]
 name = "types-simplejson"
 version = "3.19.0.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/6e/e4843fcc0c590555599ddd93fb4a15810484eedf10b8184dfeb579e386e3/types-simplejson-3.19.0.2.tar.gz", hash = "sha256:ebc81f886f89d99d6b80c726518aa2228bc77c26438f18fd81455e4f79f8ee1b", size = 3841, upload-time = "2023-07-20T15:15:53.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/6c/f38237f677232ea9d14dfd0374bf5097365dcbb566aac2476961d2df60f1/types_simplejson-3.19.0.2-py3-none-any.whl", hash = "sha256:8ba093dc7884f59b3e62aed217144085e675a269debc32678fd80e0b43b2b86f", size = 4128, upload-time = "2023-07-20T15:15:51.291Z" },
@@ -10889,7 +10889,7 @@ wheels = [
 [[package]]
 name = "types-sqlalchemy"
 version = "1.4.53.38"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/ce/0b7fa93dbc49b328807dedef8006223129e5a9543c74727dd7658eca5a9d/types-SQLAlchemy-1.4.53.38.tar.gz", hash = "sha256:5bb7463537e04e1aa5a3557eb725930df99226dcfd3c9bf93008025bfe5c169e", size = 118888, upload-time = "2023-05-01T15:15:28.572Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/4f/033a839a35ecbc5f71c0d74655d1237e909651aaebe7ceb825ac45cfdb4b/types_SQLAlchemy-1.4.53.38-py3-none-any.whl", hash = "sha256:7e60e74f823931cc9a9e8adb0a4c05e5533e6708b8a266807893a739faf4eaaa", size = 187916, upload-time = "2023-05-01T15:15:26.02Z" },
@@ -10898,7 +10898,7 @@ wheels = [
 [[package]]
 name = "types-tqdm"
 version = "4.67.0.20250516"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-requests" },
 ]
@@ -10910,7 +10910,7 @@ wheels = [
 [[package]]
 name = "types-urllib3"
 version = "1.26.25.14"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/de/b9d7a68ad39092368fb21dd6194b362b98a1daeea5dcfef5e1adb5031c7e/types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f", size = 11239, upload-time = "2023-07-20T15:19:31.307Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/7b/3fc711b2efea5e85a7a0bbfe269ea944aa767bbba5ec52f9ee45d362ccf3/types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e", size = 15377, upload-time = "2023-07-20T15:19:30.379Z" },
@@ -10919,7 +10919,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.14.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10936,7 +10936,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10977,7 +10977,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -10987,7 +10987,7 @@ resolution-markers = [
     "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
@@ -10997,7 +10997,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -11031,7 +11031,7 @@ resolution-markers = [
     "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -11041,7 +11041,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2025.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
@@ -11050,7 +11050,7 @@ wheels = [
 [[package]]
 name = "tzlocal"
 version = "5.3.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
@@ -11062,7 +11062,7 @@ wheels = [
 [[package]]
 name = "uc-micro-py"
 version = "1.0.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/7a/146a99696aee0609e3712f2b44c6274566bc368dfe8375191278045186b8/uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a", size = 6043, upload-time = "2024-02-09T16:52:01.654Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/87/1f677586e8ac487e29672e4b17455758fce261de06a0d086167bb760361a/uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5", size = 6229, upload-time = "2024-02-09T16:52:00.371Z" },
@@ -11071,7 +11071,7 @@ wheels = [
 [[package]]
 name = "universal-pathlib"
 version = "0.2.6"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec", marker = "python_full_version < '3.13'" },
 ]
@@ -11083,7 +11083,7 @@ wheels = [
 [[package]]
 name = "uritemplate"
 version = "4.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
@@ -11092,7 +11092,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "1.26.20"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
@@ -11101,7 +11101,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.34.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -11113,7 +11113,7 @@ resolution-markers = [
 dependencies = [
     { name = "click", marker = "python_full_version < '3.10'" },
     { name = "h11", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
 wheels = [
@@ -11123,7 +11123,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.41.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -11159,7 +11159,7 @@ resolution-markers = [
 dependencies = [
     { name = "click", marker = "python_full_version >= '3.10'" },
     { name = "h11", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
@@ -11169,7 +11169,7 @@ wheels = [
 [[package]]
 name = "validators"
 version = "0.35.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
@@ -11178,7 +11178,7 @@ wheels = [
 [[package]]
 name = "watchfiles"
 version = "1.1.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "python_full_version >= '3.10'" },
 ]
@@ -11297,7 +11297,7 @@ wheels = [
 [[package]]
 name = "wcwidth"
 version = "0.2.13"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
@@ -11306,16 +11306,16 @@ wheels = [
 [[package]]
 name = "weaviate-client"
 version = "4.18.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "authlib", version = "1.3.1", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "authlib", version = "1.6.8", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "authlib", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "authlib", version = "1.6.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "deprecation" },
     { name = "grpcio" },
     { name = "httpx" },
     { name = "protobuf" },
-    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "validators" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/76/14e07761c5fb7e8573e3cff562e2d9073c65f266db0e67511403d10435b1/weaviate_client-4.18.3.tar.gz", hash = "sha256:9d889246d62be36641a7f2b8cedf5fb665b804d46f7a53ae37e02d297a11f119", size = 783634, upload-time = "2025-12-03T09:38:28.261Z" }
@@ -11326,7 +11326,7 @@ wheels = [
 [[package]]
 name = "websockets"
 version = "15.0.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
@@ -11402,7 +11402,7 @@ wheels = [
 [[package]]
 name = "werkzeug"
 version = "2.2.3"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe", marker = "python_full_version < '3.13'" },
 ]
@@ -11414,7 +11414,7 @@ wheels = [
 [[package]]
 name = "win-precise-time"
 version = "1.4.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/b0/21547e16a47206ccdd15769bf65e143ade1ffae67f0881c855f76e44e9fa/win-precise-time-1.4.2.tar.gz", hash = "sha256:89274785cbc5f2997e01675206da3203835a442c60fd97798415c6b3c179c0b9", size = 7982, upload-time = "2023-10-08T17:08:18.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/8b/ba6bdef9284fd75f816205bf9a198a2cf7b22459ff401174143ade5afe08/win_precise_time-1.4.2-cp310-cp310-win32.whl", hash = "sha256:7fa13a2247c2ef41cd5e9b930f40716eacc7fc1f079ea72853bd5613fe087a1a", size = 14700, upload-time = "2023-10-08T17:08:03.987Z" },
@@ -11430,7 +11430,7 @@ wheels = [
 [[package]]
 name = "win32-setctime"
 version = "1.2.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
@@ -11439,7 +11439,7 @@ wheels = [
 [[package]]
 name = "wirerope"
 version = "1.0.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six", marker = "python_full_version < '3.13'" },
 ]
@@ -11451,7 +11451,7 @@ wheels = [
 [[package]]
 name = "wrapt"
 version = "1.17.2"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531, upload-time = "2025-01-14T10:35:45.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/d1/1daec934997e8b160040c78d7b31789f19b122110a75eca3d4e8da0049e1/wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984", size = 53307, upload-time = "2025-01-14T10:33:13.616Z" },
@@ -11526,7 +11526,7 @@ wheels = [
 [[package]]
 name = "wtforms"
 version = "3.2.1"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe", marker = "python_full_version < '3.13'" },
 ]
@@ -11538,7 +11538,7 @@ wheels = [
 [[package]]
 name = "xxhash"
 version = "3.6.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/ee/f9f1d656ad168681bb0f6b092372c1e533c4416b8069b1896a175c46e484/xxhash-3.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:87ff03d7e35c61435976554477a7f4cd1704c3596a89a8300d5ce7fc83874a71", size = 32845, upload-time = "2025-10-02T14:33:51.573Z" },
@@ -11671,7 +11671,7 @@ wheels = [
 [[package]]
 name = "yarl"
 version = "1.20.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
@@ -11787,7 +11787,7 @@ wheels = [
 [[package]]
 name = "zipp"
 version = "3.22.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/b6/7b3d16792fdf94f146bed92be90b4eb4563569eca91513c8609aebf0c167/zipp-3.22.0.tar.gz", hash = "sha256:dd2f28c3ce4bc67507bfd3781d21b7bb2be31103b51a4553ad7d90b84e57ace5", size = 25257, upload-time = "2025-05-26T14:46:32.217Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/da/f64669af4cae46f17b90798a827519ce3737d31dbafad65d391e49643dc4/zipp-3.22.0-py3-none-any.whl", hash = "sha256:fe208f65f2aca48b81f9e6fd8cf7b8b32c26375266b009b413d45306b6148343", size = 9796, upload-time = "2025-05-26T14:46:30.775Z" },
@@ -11796,7 +11796,7 @@ wheels = [
 [[package]]
 name = "zstandard"
 version = "0.23.0"
-source = { registry = "https://pypi-dot-etsy-batchjobs-prod-dot-us-central1.etsycloud.com/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation == 'PyPy'" },
 ]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Fixes the `--non-interactive` flag to consistently accept all confirmations instead of using default values. Previously, when `--non-interactive` was used, CLI commands would still abort if the confirmation default was `False`, making the flag unreliable for automation.

**Changes:**
- Modified `NonInteractiveAction` to set `ALWAYS_CHOOSE_VALUE = True` instead of `ALWAYS_CHOOSE_DEFAULT = True`
- Updated user-facing message to clarify behavior: "Confirmations are automatically accepted"
- Added test coverage for `drop`, `sync`, and `drop-pending-packages` commands in non-interactive mode

**Behavior:**
- Before: `--non-interactive` would use the default answer (could be `True` or `False`)
- After: `--non-interactive` always accepts confirmations (`True`), allowing commands to proceed

This makes the flag reliable for CI/CD pipelines and automated scripts where prompts cannot be answered interactively.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #3592

<!--
Provide any additional context about the PR here.
-->
### Additional Context

**Testing:**
- Added [test_non_interactive.py](tests/workspace/cli/test_non_interactive.py) with three test cases covering all affected commands
- All tests verify that commands execute without prompting when using the non-interactive flag
- Tests confirm actual command execution (not just output) by checking state changes

**Implementation notes:**
- The fix leverages the existing `ALWAYS_CHOOSE_VALUE` mechanism in [echo.py](dlt/_workspace/cli/echo.py)
- When set, `confirm()` and `prompt()` return the specified value instead of prompting the user
- Test fixtures were reorganized in conftest.py to share common setup across test modules


<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->




