### PR TITLE
fix: check duckdb version to install lance extension

### DIFF
--- a/dlt/destinations/impl/lancedb/sql_client.py
+++ b/dlt/destinations/impl/lancedb/sql_client.py
@@ -10,13 +10,13 @@ inferface.
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any, AnyStr, Iterator, TYPE_CHECKING
+from packaging import version as pkg_version
+from typing import Any, Iterator, TYPE_CHECKING
 
 import sqlglot
 import sqlglot.expressions as exp
 import duckdb
 
-import dlt
 from dlt.destinations.exceptions import DatabaseUndefinedRelation
 from dlt.common.destination.dataset import DBApiCursor
 from dlt.common.destination.capabilities import DestinationCapabilitiesContext
@@ -44,7 +44,13 @@ def _install_and_load_lance_duckdb_extension(duckdb_con: DuckDBPyConnection) -> 
     DuckDB ensures installation is only done once per system.
     Extension loading must be done on every connection
     """
-    duckdb_con.execute("INSTALL lance FROM community;")
+    duckdb_version = pkg_version.parse(duckdb.__version__)
+    if duckdb_version > pkg_version.Version("1.5.0"):
+        install_extension_cmd = "INSTALL lance;"
+    else:
+        install_extension_cmd = "INSTALL lance FROM community;"
+
+    duckdb_con.execute(install_extension_cmd)
     duckdb_con.execute("LOAD lance;")
 
 

--- a/dlt/destinations/impl/lancedb/sql_client.py
+++ b/dlt/destinations/impl/lancedb/sql_client.py
@@ -45,7 +45,7 @@ def _install_and_load_lance_duckdb_extension(duckdb_con: DuckDBPyConnection) -> 
     Extension loading must be done on every connection
     """
     duckdb_version = pkg_version.parse(duckdb.__version__)
-    if duckdb_version > pkg_version.Version("1.5.0"):
+    if duckdb_version >= pkg_version.Version("1.5.0"):
         install_extension_cmd = "INSTALL lance;"
     else:
         install_extension_cmd = "INSTALL lance FROM community;"


### PR DESCRIPTION
On `duckdb` release 1.5, the `lance`  extension was promoted from community to built-in. This changed the required SQL command to install the extension. This broke the `dlt` features when using the latest `duckdb` dependencies. This wasn't caught by CI because it uses the locked `duckdb` version or lowest deps, not latest deps.

I didn't add tests because checking for different `duckdb` version is a bit annoying on CI. We would ideally need it, but the logic is rather simple here