### PR TITLE
Fix/3592 bypass non interactive flag prompts

### DIFF
--- a/dlt/_workspace/cli/_dlt.py
+++ b/dlt/_workspace/cli/_dlt.py
@@ -68,11 +68,8 @@ class NonInteractiveAction(argparse.Action):
         values: Any,
         option_string: str = None,
     ) -> None:
-        fmt.ALWAYS_CHOOSE_DEFAULT = True
-        fmt.note(
-            "Non interactive mode. Default choices are automatically made for confirmations and"
-            " prompts."
-        )
+        fmt.ALWAYS_CHOOSE_VALUE = True
+        fmt.note("Non interactive mode. Confirmations are automatically accepted.")
 
 
 class DebugAction(argparse.Action):

--- a/dlt/_workspace/cli/_dlt.py
+++ b/dlt/_workspace/cli/_dlt.py
@@ -68,8 +68,34 @@ class NonInteractiveAction(argparse.Action):
         values: Any,
         option_string: str = None,
     ) -> None:
+        fmt.ALWAYS_CHOOSE_DEFAULT = True
+        fmt.note(
+            "Non interactive mode. Default choices are automatically made for confirmations and"
+            " prompts."
+        )
+
+
+class YesAction(argparse.Action):
+    def __init__(
+        self,
+        option_strings: Sequence[str],
+        dest: Any = argparse.SUPPRESS,
+        default: Any = argparse.SUPPRESS,
+        help: str = None,  # noqa
+    ) -> None:
+        super(YesAction, self).__init__(
+            option_strings=option_strings, dest=dest, default=default, nargs=0, help=help
+        )
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: str = None,
+    ) -> None:
         fmt.ALWAYS_CHOOSE_VALUE = True
-        fmt.note("Non interactive mode. Confirmations are automatically accepted.")
+        fmt.note("Automatically accepting all confirmations.")
 
 
 class DebugAction(argparse.Action):
@@ -122,6 +148,12 @@ def _create_parser() -> Tuple[argparse.ArgumentParser, Dict[str, SupportsCliComm
             "Non interactive mode. Default choices are automatically made for confirmations and"
             " prompts."
         ),
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action=YesAction,
+        help="Automatically accept all confirmations without prompting.",
     )
     parser.add_argument(
         "--debug",

--- a/tests/workspace/cli/conftest.py
+++ b/tests/workspace/cli/conftest.py
@@ -6,6 +6,14 @@ from dlt._workspace._workspace_context import WorkspaceRunContext
 
 from tests.workspace.utils import isolated_workspace
 
+# Import fixtures from utils to make them available to all tests
+from tests.workspace.cli.utils import (  # noqa: F401
+    _cached_init_repo,
+    cloned_init_repo,
+    repo_dir,
+    auto_echo_default_choice,
+)
+
 
 @pytest.fixture(autouse=True)
 def auto_isolated_workspace(

--- a/tests/workspace/cli/test_non_interactive.py
+++ b/tests/workspace/cli/test_non_interactive.py
@@ -1,0 +1,139 @@
+import io
+import os
+import contextlib
+from subprocess import CalledProcessError
+
+import dlt
+from dlt.common.runners.venv import Venv
+
+from dlt._workspace.cli import echo, _init_command, _pipeline_command
+
+from tests.workspace.cli.utils import (
+    repo_dir,
+    cloned_init_repo,
+    _cached_init_repo,
+)
+
+
+def test_non_interactive_drop_command(repo_dir: str) -> None:
+    """Test that --non-interactive flag makes drop command proceed without prompts."""
+    # init_command will use auto_echo_default_choice from the fixture
+    _init_command.init_command("chess", "duckdb", repo_dir)
+
+    # clean up any existing pipeline
+    try:
+        pipeline = dlt.attach(pipeline_name="chess_pipeline")
+        pipeline.drop()
+    except Exception:
+        pass
+
+    # run the pipeline
+    os.environ.pop("DESTINATION__DUCKDB__CREDENTIALS", None)
+    venv = Venv.restore_current()
+    try:
+        venv.run_script("chess_pipeline.py")
+    except CalledProcessError as cpe:
+        print(cpe.stdout)
+        print(cpe.stderr)
+        raise
+
+    # verify the resource exists before drop
+    pipeline = dlt.attach(pipeline_name="chess_pipeline")
+    assert "players_games" in pipeline.default_schema.tables
+
+    # test drop command with non-interactive mode (simulates --non-interactive flag)
+    # We use echo.always_choose to set ALWAYS_CHOOSE_VALUE = True
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        with echo.always_choose(False, True):
+            _pipeline_command.pipeline_command(
+                "drop", "chess_pipeline", None, 0, resources=["players_games"]
+            )
+        _out = buf.getvalue()
+
+        # verify the command output shows it will drop the resource
+        assert "Selected resource(s): ['players_games']" in _out
+
+    # verify the command actually executed (resource was dropped)
+    pipeline = dlt.attach(pipeline_name="chess_pipeline")
+    assert "players_games" not in pipeline.default_schema.tables
+
+
+def test_non_interactive_sync_command(repo_dir: str) -> None:
+    """Test that --non-interactive flag makes sync command proceed without prompts."""
+    _init_command.init_command("chess", "duckdb", repo_dir)
+
+    # clean up any existing pipeline
+    try:
+        pipeline = dlt.attach(pipeline_name="chess_pipeline")
+        pipeline.drop()
+    except Exception:
+        pass
+
+    # run the pipeline
+    os.environ.pop("DESTINATION__DUCKDB__CREDENTIALS", None)
+    venv = Venv.restore_current()
+    try:
+        venv.run_script("chess_pipeline.py")
+    except CalledProcessError as cpe:
+        print(cpe.stdout)
+        print(cpe.stderr)
+        raise
+
+    # test sync command with non-interactive mode
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        with echo.always_choose(False, True):
+            _pipeline_command.pipeline_command("sync", "chess_pipeline", None, 0)
+        _out = buf.getvalue()
+
+        # verify sync was executed
+        assert "Dropping local state" in _out
+        assert "Restoring from destination" in _out
+
+    # after sync there's no trace
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        _pipeline_command.pipeline_command("info", "chess_pipeline", None, 0)
+        _out = buf.getvalue()
+        assert "Pipeline does not have last run trace." in _out
+
+
+def test_non_interactive_drop_pending_packages(repo_dir: str) -> None:
+    """Test that --non-interactive flag makes drop-pending-packages command proceed."""
+    _init_command.init_command("chess", "dummy", repo_dir)
+    os.environ["EXCEPTION_PROB"] = "1.0"
+
+    # clean up any existing pipeline
+    try:
+        pipeline = dlt.attach(pipeline_name="chess_pipeline")
+        pipeline.drop()
+    except Exception:
+        pass
+
+    # run pipeline with exception to create pending packages
+    venv = Venv.restore_current()
+    try:
+        venv.run_script("chess_pipeline.py")
+    except CalledProcessError:
+        pass  # expected to fail
+
+    # verify there are pending packages
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        _pipeline_command.pipeline_command("info", "chess_pipeline", None, 1)
+        _out = buf.getvalue()
+        assert (
+            "extracted packages ready to be normalized" in _out
+            or "normalized packages ready to be loaded" in _out
+        )
+
+    # test drop-pending-packages with non-interactive mode
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        with echo.always_choose(False, True):
+            _pipeline_command.pipeline_command("drop-pending-packages", "chess_pipeline", None, 1)
+        _out = buf.getvalue()
+
+        assert "Pending packages deleted" in _out
+
+    # verify packages were deleted
+    with io.StringIO() as buf, contextlib.redirect_stdout(buf):
+        _pipeline_command.pipeline_command("drop-pending-packages", "chess_pipeline", None, 1)
+        _out = buf.getvalue()
+        assert "No pending packages found" in _out

--- a/tests/workspace/cli/test_yes_flag.py
+++ b/tests/workspace/cli/test_yes_flag.py
@@ -15,8 +15,8 @@ from tests.workspace.cli.utils import (
 )
 
 
-def test_non_interactive_drop_command(repo_dir: str) -> None:
-    """Test that --non-interactive flag makes drop command proceed without prompts."""
+def test_yes_flag_drop_command(repo_dir: str) -> None:
+    """Test that --yes/-y flag makes drop command proceed without prompts."""
     # init_command will use auto_echo_default_choice from the fixture
     _init_command.init_command("chess", "duckdb", repo_dir)
 
@@ -41,7 +41,7 @@ def test_non_interactive_drop_command(repo_dir: str) -> None:
     pipeline = dlt.attach(pipeline_name="chess_pipeline")
     assert "players_games" in pipeline.default_schema.tables
 
-    # test drop command with non-interactive mode (simulates --non-interactive flag)
+    # test drop command with --yes flag (simulates --yes/-y behavior)
     # We use echo.always_choose to set ALWAYS_CHOOSE_VALUE = True
     with io.StringIO() as buf, contextlib.redirect_stdout(buf):
         with echo.always_choose(False, True):
@@ -58,8 +58,8 @@ def test_non_interactive_drop_command(repo_dir: str) -> None:
     assert "players_games" not in pipeline.default_schema.tables
 
 
-def test_non_interactive_sync_command(repo_dir: str) -> None:
-    """Test that --non-interactive flag makes sync command proceed without prompts."""
+def test_yes_flag_sync_command(repo_dir: str) -> None:
+    """Test that --yes/-y flag makes sync command proceed without prompts."""
     _init_command.init_command("chess", "duckdb", repo_dir)
 
     # clean up any existing pipeline
@@ -79,7 +79,7 @@ def test_non_interactive_sync_command(repo_dir: str) -> None:
         print(cpe.stderr)
         raise
 
-    # test sync command with non-interactive mode
+    # test sync command with --yes flag
     with io.StringIO() as buf, contextlib.redirect_stdout(buf):
         with echo.always_choose(False, True):
             _pipeline_command.pipeline_command("sync", "chess_pipeline", None, 0)
@@ -96,8 +96,8 @@ def test_non_interactive_sync_command(repo_dir: str) -> None:
         assert "Pipeline does not have last run trace." in _out
 
 
-def test_non_interactive_drop_pending_packages(repo_dir: str) -> None:
-    """Test that --non-interactive flag makes drop-pending-packages command proceed."""
+def test_yes_flag_drop_pending_packages(repo_dir: str) -> None:
+    """Test that --yes/-y flag makes drop-pending-packages command proceed."""
     _init_command.init_command("chess", "dummy", repo_dir)
     os.environ["EXCEPTION_PROB"] = "1.0"
 
@@ -124,7 +124,7 @@ def test_non_interactive_drop_pending_packages(repo_dir: str) -> None:
             or "normalized packages ready to be loaded" in _out
         )
 
-    # test drop-pending-packages with non-interactive mode
+    # test drop-pending-packages with --yes flag
     with io.StringIO() as buf, contextlib.redirect_stdout(buf):
         with echo.always_choose(False, True):
             _pipeline_command.pipeline_command("drop-pending-packages", "chess_pipeline", None, 1)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Fixes the `--non-interactive` flag to consistently accept all confirmations instead of using default values. Previously, when `--non-interactive` was used, CLI commands would still abort if a confirmation's default was `False`, making the flag unreliable for automation and CI/CD workflows.

**Changes:**
- Modified `NonInteractiveAction` in [dlt/_workspace/cli/_dlt.py](dlt/_workspace/cli/_dlt.py) to set `ALWAYS_CHOOSE_VALUE = True` instead of `ALWAYS_CHOOSE_DEFAULT = True`
- Updated user-facing message to clarify behavior: "Confirmations are automatically accepted"
- Added comprehensive test coverage in [tests/workspace/cli/test_non_interactive.py](tests/workspace/cli/test_non_interactive.py) for `drop`, `sync`, and `drop-pending-packages` commands
- Updated [tests/workspace/cli/conftest.py](tests/workspace/cli/conftest.py) to properly import test fixtures

**Behavior:**
- **Before**: `--non-interactive` would use the default answer for each prompt (could be `True` or `False`)
- **After**: `--non-interactive` always accepts confirmations (`True`), allowing commands to proceed without user interaction

This makes the flag reliable for CI/CD pipelines and automated scripts where prompts cannot be answered interactively.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #3592 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

**Testing:**
- Added [test_non_interactive.py](tests/workspace/cli/test_non_interactive.py) 
- New tests use `echo.always_choose(False, True)` context manager to simulate `--non-interactive` behavior
- Ran `make format && make lint` - all checks pass
- Ran `make test-workspace` - all tests pass

**Implementation notes:**
- The fix leverages the existing `ALWAYS_CHOOSE_VALUE` in [echo.py](dlt/_workspace/cli/echo.py)
- When set to `True`, `confirm()` and `prompt()` return `True` instead of prompting the user
- The `--non-interactive` flag only affects behavior when explicitly used - no changes to default CLI behavior

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
