### PR TITLE
feat(incremental): set-based incremental

### DIFF
--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -75,6 +75,8 @@ try:
 except MissingDependencyException:
     pandas = None
 
+from dlt.common.libs.sqlglot import sge as exp
+
 
 class IncrementalMetricsRow(TypedDict, total=False):
     unfiltered_items_count: int
@@ -445,6 +447,14 @@ class Incremental(
                 )
 
         return last_value
+
+    @property
+    def unprocessed_values(self) -> set[Any]:
+        unprocessed_ids = get_unprocessed_ids(self.initial_value)
+        # hack because you need to store a cursor that is within the existing values
+        self.last_value_func = lambda x: x
+        self.initial_value = self.initial_value[0]
+        return set(unprocessed_ids)
 
     def _transform_item(
         self, transformer: IncrementalTransform, row: TDataItem
@@ -905,6 +915,58 @@ def incremental_config_to_instance(cfg: TIncrementalConfig) -> Incremental[Any]:
     if isinstance(cfg, Incremental):
         return cfg
     return Incremental(**cfg)
+
+
+def _get_unprocessed_ids_query(
+    ids: list[str],
+    processed_table: str,
+    id_column: str,
+) -> exp.Select:
+    if not ids:
+        raise ValueError("ids list must not be empty")
+
+    unnest_subquery = exp.Subquery(
+        this=exp.select(
+            exp.alias_(
+                exp.Anonymous(
+                    this="unnest",
+                    expressions=[exp.Array(expressions=[exp.Literal.string(v) for v in ids])],
+                ),
+                id_column,
+            )
+        ),
+        alias="i",
+    )
+
+    return (
+        exp.select(f"i.{id_column}")
+        .from_(unnest_subquery)
+        .join(f"{processed_table} AS p", join_type="LEFT", on=f"p.{id_column} = i.{id_column}")
+        .where(f"p.{id_column} IS NULL")
+    )
+
+
+def get_unprocessed_ids(ids: list[Any]) -> set[Any]:
+    import dlt
+
+    resource = dlt.current.resource()
+    if not (pk := resource._hints.get("primary_key")):
+        raise ValueError("Missing `primary_key` hint.")
+
+    table_name: str = resource.table_name  # type: ignore[assignment]
+    dataset = dlt.current.pipeline().dataset()
+
+    # table doesn't exist; no ids were processed
+    if table_name not in dataset.tables:
+        return set(ids)
+
+    query = _get_unprocessed_ids_query(
+        ids=ids,
+        processed_table=table_name,
+        id_column=pk,  # type: ignore[arg-type]
+    )
+    unprocessed_ids = {r[0] for r in dataset(query, _execute_raw_query=True).fetchall()}
+    return unprocessed_ids
 
 
 __all__ = [

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -1591,6 +1591,47 @@ def test_incremental_merge_preserves_dedup_key_flag() -> None:
     assert copied.primary_key == ()
 
 
+def test_incremental_hash_based():
+    @dlt.resource(primary_key="i")
+    def resource(ids=dlt.sources.incremental("i")):
+        for i in ids.unprocessed_values:
+            yield {"i": i}
+
+    ids1 = ["a", "b", "d"]
+
+    pipeline = dlt.pipeline("incremental_hash", destination="duckdb")
+
+    # LOAD 1
+    extract_info1 = pipeline.extract(resource(ids1))
+
+    load1_count = extract_info1.metrics[extract_info1.loads_ids[0]][0]["resource_metrics"][
+        "resource"
+    ].items_count
+    assert load1_count == len(ids1)
+    # manually complete the load
+    pipeline.normalize()
+    pipeline.load()
+
+    loaded_values = (r[0] for r in pipeline.dataset().table("resource").fetchall())
+    assert set(loaded_values) == set(ids1)
+
+    # LOAD 2
+    ids2 = ["a", "b", "c", "d"]
+    extract_info2 = pipeline.extract(resource(ids2))
+
+    load2_count = extract_info2.metrics[extract_info2.loads_ids[0]][0]["resource_metrics"][
+        "resource"
+    ].items_count
+    new_items_count = len(set(ids1).symmetric_difference(set(ids2)))
+    assert load2_count == new_items_count
+    # manually complete the load
+    pipeline.normalize()
+    pipeline.load()
+
+    loaded_values2 = (r[0] for r in pipeline.dataset().table("resource").fetchall())
+    assert set(loaded_values2) == set(ids2)
+
+
 @pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
 @pytest.mark.parametrize("dedup_key", [(), "alt_id"])
 def test_incremental_dedup_key_survives_resource_pk(


### PR DESCRIPTION
> WIP; code is rough, but simple

# Summary
The `Incremental`  object gains an `.unprocessed_values`  property. It compares the resource input `ids` to the data on the dataset, allowing to skip already processed ids.

In the next snippet, the user can safely rerun the `customers()`  resource with an evolving list of `ids` and only process the new values.

```python
@dlt.resource(primary_key="id")
def customers(ids=dlt.sources.incremental("id")):
    for id_ in ids.unprocessed_values:
        data = ...  # get data based on id_
        yield data

pipeline = dlt.pipeline("crm", destination="duckdb")

# processes 3 ids
pipeline.run(customers(["a", "b", "c"]))

# processes 1 id; only the unseen value
pipeline.run(customers(["a", "b", "d", "c"]))
``` 

# Problem
Current incremental features in `dlt` rely on **ordered** values (e.g., lists), typically timestamps or monotonic ids. This doesn't work for  **unordered** values (i.e., sets) like urls, uuids.

The current workaround is to store processed entities in the pipeline state ([docs](https://dlthub.com/docs/general-usage/incremental/advanced-state#advanced-state-usage-storing-a-list-of-processed-entities))
```python
@dlt.resource
def customers(ids):
    processed_ids = dlt.current.resource_state().setdefault("processed_ids", [])
    for id_ in ids:
        if id_ not in processed_ids:
            data = ...  # get data based on id_
            yield data
            processed_ids.append(id_)     
```

This solution has several limitations:

1. the list of processed ids is stored as part of a JSON blob in a column of the internal `_dlt_pipeline_state` table
  a. the full list of processed ids is duplicated on each `pipeline.run()`
  b. this state memory footprint and JSON serde cost grow
  c. can't compare new ids to existing ids in SQL; must be done in Python
2. users need to correctly implement this logic for each resource
3. the list of processed ids can be desynced with the actual table stored on destination (e.g., it appears processed in the resource state, but the data table was deleted to be rebuilt)
  a. to fix, user must drop the full resource state (undesirable) or write ad-hoc script to selectively drop processed_ids

# Solution
This solution reuses existing `Incremental` apparatus and follows this algorithm:
1. enter `@dlt.resource`
2. the parameter with `ids = dlt.sources.incremental("id")`  creates an `Incremental` object
3. accessing the `Incremental.unprocessed_values`  property executes an SQL query against the destination
  a. compare the resource argument `ids` to the column specified in `Incremental(cursor_path=)` (`"id"`  in this case)
  b. return the symmetric difference, i.e., items unique to `ids`  input
5. user has access to the original `ids` input and the set of `unprocessed_values` for their logic

Assumptions:
- Need to be using a SQL destination
- SQLGlot should be able to transpile the SQL query (needs per-destination tests)
- The input type for the incremental cursor is a collection of values that can safely be passed to a SQLGlot expression (i.e., simple objects like `str`, `int`, `float`)

## Alternative solutions
- Similar deduplication logic existings for some incremental strategies or write dispositions. They are typically applied at the Load phase. Here, we deduplicate at the Extract phase. This is important to efficiently skip processed entities in resources and transformers

## Remaining design decisions
- need to ensure it doesn't conflict with existing Incremental usage. Currently, it hijacks `.last_value_func`  and `.initial_value`, but only when user explicitly use `.unprocessed_values`. This could conflict with other parts of the codebase
- find a better name than `.unprocessed_values`
- race condition risk: if something writes to the table where `.unprocessed_values` is evaluated, two resources could have desync sets (generally unlikely that multiple resource work on the same table though)
- it currently uses the `primary_key`  hint, but it might not be necessary if relying on the cursor_path argument