### PR TITLE
repo(ci): remove 3.9 from CI matrices

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     defaults:
       run:

--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -27,9 +27,6 @@ jobs:
 
           # linux tests
           - os: ubuntu-latest
-            python-version: "3.9"
-            shell: bash
-          - os: ubuntu-latest
             python-version: "3.10"
             shell: bash
           - os: ubuntu-latest
@@ -57,7 +54,7 @@ jobs:
             python-version: "3.11"
             shell: bash
             uv_sync_args: '--upgrade' # could also be 'direct'
-          
+
           # windows tests
           - os: windows-latest
             python-version: "3.11"
@@ -102,7 +99,7 @@ jobs:
         run: make install-common-core
         env:
           UV_SYNC_ARGS: ${{ matrix.uv_sync_args }}
-    
+
       - name: Run common tests with minimum dependencies
         run: make test-common-core
         env:
@@ -118,7 +115,7 @@ jobs:
 
       - name: Run min dependencies source tests
         run: make test-common-source
-  
+
       - name: Install duckdb dependencies
         run: make install-pipeline-min
         env:

--- a/.github/workflows/test_tools_dashboard.yml
+++ b/.github/workflows/test_tools_dashboard.yml
@@ -53,7 +53,7 @@ jobs:
             shell: bash
             uv_sync_args: '--upgrade' # could also be 'direct'
 
-          
+
           # windows tests
           - os: windows-latest
             python-version: "3.12"
@@ -104,12 +104,12 @@ jobs:
         env:
           PYTEST_XDIST_N: auto
 
-      # Run workspace dashboard e2e tests (does not pass with python 3.9
+      # Run workspace dashboard e2e tests
       - name: Run dashboard e2e
         run: |
           pytest --browser chromium tests/e2e
-        if: matrix.python-version != '3.9' && matrix.python-version != '3.14.0-beta.4'
-  
+        if: matrix.python-version != '3.14.0-beta.4'
+
   matrix_job_required_check:
     name: common | common tests
     needs: run_common


### PR DESCRIPTION
Python 3.9 reached end-of-life in October 2025. Removing from CI to then be able to upgrading typing et al.

resolves #3587 #3619 