### PR TITLE
fix(clickhouse): use lightweight DELETE for single-table merge (#2248)

### DIFF
--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -165,15 +165,16 @@ class BigQueryMergeJob(SqlMergeFollowupJob):
         cls,
         root_table_name: str,
         staging_root_table_name: str,
-        key_clauses: Sequence[str],
+        primary_keys: Sequence[str],
+        merge_keys: Sequence[str],
         for_delete: bool,
     ) -> List[str]:
-        sql: List[str] = [
+        key_clauses = cls._gen_key_table_clauses(primary_keys, merge_keys)
+        return [
             f"FROM {root_table_name} AS d WHERE EXISTS (SELECT 1 FROM {staging_root_table_name} AS"
             f" s WHERE {clause.format(d='d', s='s')})"
             for clause in key_clauses
         ]
-        return sql
 
 
 class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):

--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -1,3 +1,4 @@
+import re
 from copy import deepcopy
 from textwrap import dedent
 from typing import Any, Literal, Optional, List, Sequence, cast
@@ -20,7 +21,6 @@ from dlt.common.destination.client import (
     LoadJob,
 )
 from dlt.common.schema import Schema, TColumnSchema
-from dlt.common.schema.exceptions import SchemaCorruptedException
 from dlt.common.schema.typing import TColumnType
 from dlt.common import logger
 from dlt.common.schema.utils import (
@@ -256,6 +256,20 @@ class ClickHouseMergeJob(SqlMergeFollowupJob):
         key_clauses: Sequence[str],
         for_delete: bool,
     ) -> List[str]:
+        if for_delete:
+            # ClickHouse lightweight DELETE doesn't support table aliases or
+            # correlated subqueries with qualified column references. Use IN
+            # with one DELETE per key group (like BigQuery's OR-split pattern).
+            sql: List[str] = []
+            for clause in key_clauses:
+                # extract column identifiers from "{d}.col = {s}.col AND ..."
+                cols = re.findall(r"\{s\}\.(\S+)", clause)
+                col_tuple = ", ".join(cols)
+                sql.append(
+                    f"FROM {root_table_name} WHERE ({col_tuple}) IN"
+                    f" (SELECT {col_tuple} FROM {staging_root_table_name})"
+                )
+            return sql
         join_conditions = " OR ".join([c.format(d="d", s="s") for c in key_clauses])
         return [
             f"FROM {root_table_name} AS d JOIN {staging_root_table_name} AS s ON {join_conditions}"
@@ -267,7 +281,7 @@ class ClickHouseMergeJob(SqlMergeFollowupJob):
 
     @classmethod
     def requires_temp_table_for_delete(cls) -> bool:
-        return True
+        return False
 
 
 class ClickHouseClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):

--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -1,4 +1,3 @@
-import re
 from copy import deepcopy
 from textwrap import dedent
 from typing import Any, Literal, Optional, List, Sequence, cast
@@ -253,7 +252,8 @@ class ClickHouseMergeJob(SqlMergeFollowupJob):
         cls,
         root_table_name: str,
         staging_root_table_name: str,
-        key_clauses: Sequence[str],
+        primary_keys: Sequence[str],
+        merge_keys: Sequence[str],
         for_delete: bool,
     ) -> List[str]:
         if for_delete:
@@ -261,15 +261,15 @@ class ClickHouseMergeJob(SqlMergeFollowupJob):
             # correlated subqueries with qualified column references. Use IN
             # with one DELETE per key group (like BigQuery's OR-split pattern).
             sql: List[str] = []
-            for clause in key_clauses:
-                # extract column identifiers from "{d}.col = {s}.col AND ..."
-                cols = re.findall(r"\{s\}\.(\S+)", clause)
-                col_tuple = ", ".join(cols)
-                sql.append(
-                    f"FROM {root_table_name} WHERE ({col_tuple}) IN"
-                    f" (SELECT {col_tuple} FROM {staging_root_table_name})"
-                )
+            for cols in (primary_keys, merge_keys):
+                if cols:
+                    col_tuple = ", ".join(cols)
+                    sql.append(
+                        f"FROM {root_table_name} WHERE ({col_tuple}) IN"
+                        f" (SELECT {col_tuple} FROM {staging_root_table_name})"
+                    )
             return sql
+        key_clauses = cls._gen_key_table_clauses(primary_keys, merge_keys)
         join_conditions = " OR ".join([c.format(d="d", s="s") for c in key_clauses])
         return [
             f"FROM {root_table_name} AS d JOIN {staging_root_table_name} AS s ON {join_conditions}"

--- a/dlt/destinations/impl/mssql/mssql.py
+++ b/dlt/destinations/impl/mssql/mssql.py
@@ -58,19 +58,21 @@ class MsSqlMergeJob(SqlMergeFollowupJob):
         cls,
         root_table_name: str,
         staging_root_table_name: str,
-        key_clauses: Sequence[str],
+        primary_keys: Sequence[str],
+        merge_keys: Sequence[str],
         for_delete: bool,
     ) -> List[str]:
         """Generate sql clauses that may be used to select or delete rows in root table of destination dataset"""
         if for_delete:
             # MS SQL doesn't support alias in DELETE FROM
+            key_clauses = cls._gen_key_table_clauses(primary_keys, merge_keys)
             return [
                 f"FROM {root_table_name} WHERE EXISTS (SELECT 1 FROM"
                 f" {staging_root_table_name} WHERE"
                 f" {' OR '.join([c.format(d=root_table_name,s=staging_root_table_name) for c in key_clauses])})"
             ]
         return SqlMergeFollowupJob.gen_key_table_clauses(
-            root_table_name, staging_root_table_name, key_clauses, for_delete
+            root_table_name, staging_root_table_name, primary_keys, merge_keys, for_delete
         )
 
     @classmethod

--- a/dlt/destinations/impl/redshift/redshift.py
+++ b/dlt/destinations/impl/redshift/redshift.py
@@ -155,7 +155,8 @@ class RedshiftMergeJob(SqlMergeFollowupJob):
         cls,
         root_table_name: str,
         staging_root_table_name: str,
-        key_clauses: Sequence[str],
+        primary_keys: Sequence[str],
+        merge_keys: Sequence[str],
         for_delete: bool,
     ) -> List[str]:
         """Generate sql clauses that may be used to select or delete rows in root table of destination dataset
@@ -163,13 +164,14 @@ class RedshiftMergeJob(SqlMergeFollowupJob):
         A list of clauses may be returned for engines that do not support OR in subqueries. Like BigQuery
         """
         if for_delete:
+            key_clauses = cls._gen_key_table_clauses(primary_keys, merge_keys)
             return [
                 f"FROM {root_table_name} WHERE EXISTS (SELECT 1 FROM"
                 f" {staging_root_table_name} WHERE"
                 f" {' OR '.join([c.format(d=root_table_name,s=staging_root_table_name) for c in key_clauses])})"
             ]
         return SqlMergeFollowupJob.gen_key_table_clauses(
-            root_table_name, staging_root_table_name, key_clauses, for_delete
+            root_table_name, staging_root_table_name, primary_keys, merge_keys, for_delete
         )
 
 

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -39,15 +39,16 @@ class SnowflakeMergeJob(SqlMergeFollowupJob):
         cls,
         root_table_name: str,
         staging_root_table_name: str,
-        key_clauses: Sequence[str],
+        primary_keys: Sequence[str],
+        merge_keys: Sequence[str],
         for_delete: bool,
     ) -> List[str]:
-        sql: List[str] = [
+        key_clauses = cls._gen_key_table_clauses(primary_keys, merge_keys)
+        return [
             f"FROM {root_table_name} AS d WHERE EXISTS (SELECT 1 FROM {staging_root_table_name} AS"
             f" s WHERE {clause.format(d='d', s='s')})"
             for clause in key_clauses
         ]
-        return sql
 
 
 class SnowflakeStagingReplaceJob(SqlStagingReplaceFollowupJob):

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -201,30 +201,33 @@ class SqlMergeFollowupJob(SqlFollowupJob):
         cls, primary_keys: Sequence[str], merge_keys: Sequence[str]
     ) -> List[str]:
         """Generate sql clauses to select rows to delete via merge and primary key. Return select all clause if no keys defined."""
+        assert primary_keys or merge_keys
+
         clauses: List[str] = []
-        if primary_keys or merge_keys:
-            if primary_keys:
-                clauses.append(
-                    " AND ".join(["%s.%s = %s.%s" % ("{d}", c, "{s}", c) for c in primary_keys])
-                )
-            if merge_keys:
-                clauses.append(
-                    " AND ".join(["%s.%s = %s.%s" % ("{d}", c, "{s}", c) for c in merge_keys])
-                )
-        return clauses or ["1=1"]
+        if primary_keys:
+            clauses.append(
+                " AND ".join(["%s.%s = %s.%s" % ("{d}", c, "{s}", c) for c in primary_keys])
+            )
+        if merge_keys:
+            clauses.append(
+                " AND ".join(["%s.%s = %s.%s" % ("{d}", c, "{s}", c) for c in merge_keys])
+            )
+        return clauses
 
     @classmethod
     def gen_key_table_clauses(
         cls,
         root_table_name: str,
         staging_root_table_name: str,
-        key_clauses: Sequence[str],
+        primary_keys: Sequence[str],
+        merge_keys: Sequence[str],
         for_delete: bool,
     ) -> List[str]:
         """Generate sql clauses that may be used to select or delete rows in root table of destination dataset
 
         A list of clauses may be returned for engines that do not support OR in subqueries. Like BigQuery
         """
+        key_clauses = cls._gen_key_table_clauses(primary_keys, merge_keys)
         return [
             f"FROM {root_table_name} as d WHERE EXISTS (SELECT 1 FROM {staging_root_table_name} as"
             f" s WHERE {' OR '.join([c.format(d='d',s='s') for c in key_clauses])})"
@@ -587,21 +590,27 @@ class SqlMergeFollowupJob(SqlFollowupJob):
         append_fallback = (len(primary_keys) + len(merge_keys)) == 0
 
         if not append_fallback:
-            key_clauses = cls._gen_key_table_clauses(primary_keys, merge_keys)
-
             row_key_column: str = None
             root_key_column: str = None
 
             if len(table_chain) == 1 and not cls.requires_temp_table_for_delete():
                 key_table_clauses = cls.gen_key_table_clauses(
-                    root_table_name, staging_root_table_name, key_clauses, for_delete=True
+                    root_table_name,
+                    staging_root_table_name,
+                    primary_keys,
+                    merge_keys,
+                    for_delete=True,
                 )
                 # if no nested tables, just delete data from root table
                 for clause in key_table_clauses:
                     sql.append(f"DELETE {clause}")
             else:
                 key_table_clauses = cls.gen_key_table_clauses(
-                    root_table_name, staging_root_table_name, key_clauses, for_delete=False
+                    root_table_name,
+                    staging_root_table_name,
+                    primary_keys,
+                    merge_keys,
+                    for_delete=False,
                 )
                 # use row_key or unique hint to create temp table with all identifiers to delete
                 row_key_column = escape_column_id(

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -2,7 +2,7 @@ from copy import copy
 import os
 import pytest
 import random
-from typing import List, cast
+from typing import List
 import yaml
 
 import dlt
@@ -16,9 +16,9 @@ from dlt.common.schema.exceptions import (
     UnboundColumnException,
     CannotCoerceNullException,
 )
-from dlt.common.schema.typing import TLoaderMergeStrategy, TTableFormat
+from dlt.common.schema.typing import TLoaderMergeStrategy
 from dlt.common.typing import StrAny
-from dlt.common.utils import digest128, uniq_id
+from dlt.common.utils import digest128
 from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.destination.exceptions import DestinationCapabilitiesException
 from dlt.common.libs.pyarrow import row_tuples_to_arrow
@@ -1809,6 +1809,67 @@ def test_merge_arrow(
             {"id": 1, "name": "foo"},
             {"id": 2, "name": "updated bar"},
         ],
+    )
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_sql_configs=True,
+        local_filesystem_configs=True,
+        table_format_local_configs=True,
+        supports_merge=True,
+    ),
+    ids=lambda x: x.name,
+)
+def test_merge_arrow_merge_key_only(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Arrow merge with only merge_key (no primary_key, no _dlt_id).
+
+    Reproduces https://github.com/dlt-hub/dlt/issues/2248 — destinations that required
+    a temp table for delete (e.g. ClickHouse) would fail with MergeDispositionException
+    because no row_key column existed.
+    """
+    pipeline = destination_config.setup_pipeline("merge_arrow_mk", dev_mode=True)
+
+    @dlt.resource(
+        write_disposition="merge",
+        merge_key="id",
+        table_format=destination_config.table_format,
+    )
+    def arrow_items(rows, schema_columns, timezone="UTC"):
+        yield row_tuples_to_arrow(
+            rows,
+            DestinationCapabilitiesContext.generic_capabilities(),
+            columns=schema_columns,
+            tz=timezone,
+        )
+
+    schema_columns = {
+        "id": {"name": "id", "nullable": False, "data_type": "bigint"},
+        "name": {"name": "name", "nullable": True, "data_type": "text"},
+    }
+    test_rows = [(1, "foo"), (2, "bar")]
+
+    load_info = pipeline.run(arrow_items(test_rows, schema_columns))
+    assert_load_info(load_info)
+
+    tables = load_tables_to_dicts(pipeline, "arrow_items")
+    assert_records_as_set(
+        tables["arrow_items"],
+        [{"id": 1, "name": "foo"}, {"id": 2, "name": "bar"}],
+    )
+
+    # update one record — merge_key delete removes matching rows, then re-inserts
+    test_rows = [(1, "foo"), (2, "updated bar")]
+    load_info = pipeline.run(arrow_items(test_rows, schema_columns))
+    assert_load_info(load_info)
+
+    tables = load_tables_to_dicts(pipeline, "arrow_items")
+    assert_records_as_set(
+        tables["arrow_items"],
+        [{"id": 1, "name": "foo"}, {"id": 2, "name": "updated bar"}],
     )
 
 

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -1831,6 +1831,7 @@ def test_merge_arrow_merge_key_only(
     a temp table for delete (e.g. ClickHouse) would fail with MergeDispositionException
     because no row_key column existed.
     """
+    skip_if_unsupported_merge_strategy(destination_config, "delete-insert")
     pipeline = destination_config.setup_pipeline("merge_arrow_mk", dev_mode=True)
 
     @dlt.resource(

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -1832,6 +1832,8 @@ def test_merge_arrow_merge_key_only(
     because no row_key column existed.
     """
     skip_if_unsupported_merge_strategy(destination_config, "delete-insert")
+    if destination_config.destination_type == "athena":
+        pytest.skip("Athena requires _dlt_id for merge (no correlated subquery support)")
     pipeline = destination_config.setup_pipeline("merge_arrow_mk", dev_mode=True)
 
     @dlt.resource(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
`_dlt_id` won't be required to merge arrow tables (no nested tables) for clickhouse. may help #2248 (but is not a full fix)
