### PR TITLE
feat: add column documentation support for Iceberg tables

### DIFF
--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -67,6 +67,39 @@ def ensure_iceberg_compatible_arrow_schema(schema: pa.Schema) -> pa.Schema:
     return cast_arrow_schema_types(schema, ARROW_TO_ICEBERG_COMPATIBLE_ARROW_TYPE_MAP)
 
 
+def add_column_docs_to_arrow_schema(
+    schema: pa.Schema,
+    column_descriptions: Optional[Dict[str, str]] = None,
+) -> pa.Schema:
+    """Adds column documentation to a PyArrow schema via field metadata.
+
+    Column descriptions are added as the b"doc" key in field metadata,
+    which PyIceberg's pyarrow_to_schema() converts to NestedField.doc.
+
+    Args:
+        schema: The PyArrow schema to add documentation to.
+        column_descriptions: Optional dictionary mapping column names to
+            their description strings. If None or empty, the original
+            schema is returned unchanged.
+
+    Returns:
+        A new PyArrow schema with documentation added to field metadata.
+        Fields without descriptions preserve their original metadata.
+    """
+    if not column_descriptions:
+        return schema
+
+    new_fields = []
+    for field in schema:
+        if field.name in column_descriptions:
+            metadata = {**(field.metadata or {}), b"doc": column_descriptions[field.name].encode()}
+            new_fields.append(field.with_metadata(metadata))
+        else:
+            new_fields.append(field)
+
+    return pa.schema(new_fields)
+
+
 def ensure_iceberg_compatible_arrow_data(data: pa.Table) -> pa.Table:
     schema = ensure_iceberg_compatible_arrow_schema(data.schema)
     return data.cast(schema)
@@ -392,6 +425,7 @@ def evolve_table(
     table_id: str,
     table_location: str,
     schema: Optional[pa.Schema] = None,
+    column_descriptions: Optional[Dict[str, str]] = None,
 ) -> IcebergTable:
     try:
         table = catalog.load_table(table_id)
@@ -408,6 +442,12 @@ def evolve_table(
     if schema is not None:
         with table.update_schema() as update:
             update.union_by_name(ensure_iceberg_compatible_arrow_schema(schema))
+
+    # update column docs if provided
+    if column_descriptions:
+        with table.update_schema() as update:
+            for col_name, doc in column_descriptions.items():
+                update.update_column(col_name, doc=doc)
 
     return table
 

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -260,20 +260,26 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
             write_iceberg_table,
             merge_iceberg_table,
             create_table,
+            add_column_docs_to_arrow_schema,
         )
         from dlt.destinations.impl.filesystem.iceberg_partition_spec import (
             build_iceberg_partition_spec,
         )
+        from dlt.destinations.impl.filesystem.iceberg_adapter import (
+            TABLE_PROPERTIES_HINT,
+            get_column_descriptions,
+        )
+
+        column_descriptions = get_column_descriptions(self._load_table)
 
         try:
             table = self._job_client.load_open_table(
                 "iceberg",
                 self.load_table_name,
                 schema=self.arrow_dataset.schema,
+                column_descriptions=column_descriptions,
             )
         except DestinationUndefinedEntity:
-            from dlt.destinations.impl.filesystem.iceberg_adapter import TABLE_PROPERTIES_HINT
-
             location = self._job_client.get_open_table_location("iceberg", self.load_table_name)
             table_id = f"{self._job_client.dataset_name}.{self.load_table_name}"
 
@@ -289,9 +295,16 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
                 properties = None
 
             if spec_list:
+                arrow_schema = self.arrow_dataset.schema
+                if column_descriptions:
+                    arrow_schema = add_column_docs_to_arrow_schema(
+                        arrow_schema, column_descriptions
+                    )
+
                 partition_spec, iceberg_schema = build_iceberg_partition_spec(
-                    self.arrow_dataset.schema, spec_list
+                    arrow_schema, spec_list
                 )
+
                 create_table(
                     self._job_client.get_open_table_catalog("iceberg"),
                     table_id,
@@ -301,11 +314,15 @@ class IcebergLoadFilesystemJob(TableFormatLoadFilesystemJob):
                     properties=properties,
                 )
             else:
+                schema = self.arrow_dataset.schema
+                if column_descriptions:
+                    schema = add_column_docs_to_arrow_schema(schema, column_descriptions)
+
                 create_table(
                     self._job_client.get_open_table_catalog("iceberg"),
                     table_id,
                     table_location=location,
-                    schema=self.arrow_dataset.schema,
+                    schema=schema,
                     properties=properties,
                 )
             # run again with created table

--- a/dlt/destinations/impl/filesystem/iceberg_adapter.py
+++ b/dlt/destinations/impl/filesystem/iceberg_adapter.py
@@ -261,3 +261,22 @@ def create_identity_specs(column_names: List[str]) -> List[PartitionSpec]:
         List of PartitionSpec objects with identity transform
     """
     return [iceberg_partition.identity(column_name) for column_name in column_names]
+
+
+def get_column_descriptions(table_schema: PreparedTableSchema) -> Dict[str, str]:
+    """Extracts column descriptions from dlt table schema columns.
+
+    Args:
+        table_schema: The dlt prepared table schema containing column definitions.
+
+    Returns:
+        A dictionary mapping column names to their description strings.
+        Columns without descriptions are omitted.
+    """
+    descriptions: Dict[str, str] = {}
+    for col_name, col in table_schema.get("columns", {}).items():
+        desc = col.get("description")
+        if desc:
+            descriptions[col_name] = desc
+
+    return descriptions

--- a/tests/common/libs/test_pyiceberg.py
+++ b/tests/common/libs/test_pyiceberg.py
@@ -12,6 +12,7 @@ sqlalchemy = pytest.importorskip("sqlalchemy", minversion="2.0")
 
 from dlt.common.libs.pyiceberg import (
     get_catalog,
+    add_column_docs_to_arrow_schema,
 )
 
 # ============================================================================
@@ -452,3 +453,88 @@ def test_catalog_from_yaml_parametrized(catalog_config, tmp_path, monkeypatch):
     namespaces = catalog.list_namespaces()
     namespace_list = [ns[0] if isinstance(ns, tuple) else ns for ns in namespaces]
     assert test_namespace in namespace_list
+
+
+def test_add_column_docs_to_arrow_schema():
+    """Test adding column documentation to PyArrow schema via field metadata."""
+    pa = pytest.importorskip("pyarrow")
+
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("name", pa.string()),
+            pa.field("email", pa.string()),
+        ]
+    )
+
+    column_descriptions = {
+        "id": "Unique identifier",
+        "name": "Full name of the user",
+    }
+
+    result_schema = add_column_docs_to_arrow_schema(schema, column_descriptions)
+
+    assert result_schema is not None
+    assert len(result_schema) == 3
+
+    id_field = result_schema.field("id")
+    name_field = result_schema.field("name")
+    email_field = result_schema.field("email")
+
+    assert id_field.metadata is not None
+    assert id_field.metadata.get(b"doc") == b"Unique identifier"
+
+    assert name_field.metadata is not None
+    assert name_field.metadata.get(b"doc") == b"Full name of the user"
+
+    assert email_field.metadata is None
+
+
+def test_add_column_docs_to_arrow_schema_no_descriptions():
+    """Test that schema is returned unchanged when no descriptions provided."""
+    pa = pytest.importorskip("pyarrow")
+
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("name", pa.string()),
+        ]
+    )
+
+    result_schema = add_column_docs_to_arrow_schema(schema, None)
+
+    assert result_schema is schema
+
+
+def test_add_column_docs_to_arrow_schema_empty_descriptions():
+    """Test that schema is returned unchanged when descriptions dict is empty."""
+    pa = pytest.importorskip("pyarrow")
+
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+        ]
+    )
+
+    result_schema = add_column_docs_to_arrow_schema(schema, {})
+
+    assert result_schema is schema
+
+
+def test_add_column_docs_to_arrow_schema_preserves_existing_metadata():
+    """Test that existing field metadata is preserved when adding doc."""
+    pa = pytest.importorskip("pyarrow")
+
+    schema = pa.schema(
+        [
+            pa.field("id", pa.int64(), metadata={b"custom": b"value"}),
+        ]
+    )
+
+    column_descriptions = {"id": "ID description"}
+
+    result_schema = add_column_docs_to_arrow_schema(schema, column_descriptions)
+
+    id_field = result_schema.field("id")
+    assert id_field.metadata.get(b"custom") == b"value"
+    assert id_field.metadata.get(b"doc") == b"ID description"

--- a/tests/load/filesystem/test_iceberg_adapter.py
+++ b/tests/load/filesystem/test_iceberg_adapter.py
@@ -1,7 +1,9 @@
 import pytest
+from typing import cast
 
 import dlt
 import pyarrow as pa
+from dlt.common.destination.typing import PreparedTableSchema
 from dlt.destinations.adapters import iceberg_adapter, iceberg_partition
 from dlt.destinations.impl.filesystem.iceberg_adapter import (
     PARTITION_HINT,
@@ -9,6 +11,7 @@ from dlt.destinations.impl.filesystem.iceberg_adapter import (
     PartitionSpec,
     parse_partition_hints,
     create_identity_specs,
+    get_column_descriptions,
 )
 from dlt.destinations.impl.filesystem.iceberg_partition_spec import (
     build_iceberg_partition_spec,
@@ -18,6 +21,57 @@ from dlt.destinations.impl.filesystem.iceberg_partition_spec import (
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
+
+
+def test_get_column_descriptions_extracts_descriptions() -> None:
+    table_schema = cast(
+        PreparedTableSchema,
+        {
+            "name": "test_table",
+            "columns": {
+                "id": {"name": "id", "data_type": "bigint", "description": "Unique identifier"},
+                "name": {"name": "name", "data_type": "text", "description": "User name"},
+                "email": {"name": "email", "data_type": "text"},
+            },
+        },
+    )
+
+    result = get_column_descriptions(table_schema)
+
+    assert result == {"id": "Unique identifier", "name": "User name"}
+
+
+def test_get_column_descriptions_returns_empty_when_no_descriptions() -> None:
+    table_schema = cast(
+        PreparedTableSchema,
+        {
+            "name": "test_table",
+            "columns": {
+                "id": {"name": "id", "data_type": "bigint"},
+                "name": {"name": "name", "data_type": "text"},
+            },
+        },
+    )
+
+    result = get_column_descriptions(table_schema)
+
+    assert result == {}
+
+
+def test_get_column_descriptions_returns_empty_when_no_columns() -> None:
+    table_schema = cast(PreparedTableSchema, {"name": "test_table"})
+
+    result = get_column_descriptions(table_schema)
+
+    assert result == {}
+
+
+def test_get_column_descriptions_handles_empty_columns() -> None:
+    table_schema = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
+
+    result = get_column_descriptions(table_schema)
+
+    assert result == {}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Adds support for propagating column descriptions from dlt schema to Iceberg tables' `NestedField.doc` attribute via PyArrow field metadata.

Users can now specify column descriptions via `@dlt.resource(columns={...})` and table comments via `table_properties={"comment": "..."}`.

**Example:**
```python
@dlt.resource(columns={
    "order_id": {"description": "Unique sales order identifier"},
    "customer_id": {"description": "Customer identifier"},
    "order_date": {"description": "Order date"},
})
def orders():
    yield {"order_id": 1, "customer_id": 100, "order_date": "2024-01-01"}

iceberg_adapter(orders, table_properties={"comment": "Sales orders"})
pipeline.run(orders)
```

### Related Issues

- Closes #3791
