### PR TITLE
fix: drop Iceberg tables from catalog when using refresh='drop_sources'

### DIFF
--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -72,6 +72,15 @@ def ensure_iceberg_compatible_arrow_data(data: pa.Table) -> pa.Table:
     return data.cast(schema)
 
 
+def drop_iceberg_table(catalog: IcebergCatalog, table_id: str) -> None:
+    """Drop an Iceberg table from the catalog."""
+    try:
+        catalog.drop_table(table_id)
+        logger.info(f"Dropped Iceberg table {table_id} from catalog")
+    except NoSuchTableError:
+        logger.warning(f"Iceberg table {table_id} does not exist in catalog, nothing to drop")
+
+
 def write_iceberg_table(
     table: IcebergTable,
     data: pa.Table,

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -686,7 +686,27 @@ class FilesystemClient(
 
         return initial_version, current_version
 
+    def _drop_iceberg_tables_from_catalog(self, tables: Iterable[str]) -> None:
+        """Drop Iceberg tables from the catalog before truncating files."""
+        from dlt.common.libs.pyiceberg import drop_iceberg_table
+
+        # Check if any of the tables use iceberg format
+        iceberg_tables = [
+            t
+            for t in tables
+            if t in self.schema.tables and self.schema.tables[t].get("table_format") == "iceberg"
+        ]
+        if not iceberg_tables:
+            return
+
+        catalog = self.get_open_table_catalog("iceberg")
+        for table in iceberg_tables:
+            table_id = f"{self.dataset_name}.{table}"
+            drop_iceberg_table(catalog, table_id)
+
     def drop_tables(self, *tables: str, delete_schema: bool = True) -> None:
+        self._drop_iceberg_tables_from_catalog(tables)
+
         self.truncate_tables(list(tables))
         if not delete_schema:
             return

--- a/tests/common/libs/test_pyiceberg.py
+++ b/tests/common/libs/test_pyiceberg.py
@@ -12,6 +12,7 @@ sqlalchemy = pytest.importorskip("sqlalchemy", minversion="2.0")
 
 from dlt.common.libs.pyiceberg import (
     get_catalog,
+    drop_iceberg_table,
 )
 
 # ============================================================================
@@ -452,3 +453,40 @@ def test_catalog_from_yaml_parametrized(catalog_config, tmp_path, monkeypatch):
     namespaces = catalog.list_namespaces()
     namespace_list = [ns[0] if isinstance(ns, tuple) else ns for ns in namespaces]
     assert test_namespace in namespace_list
+
+
+def test_drop_iceberg_table(sqlite_catalog_config):
+    """Test dropping an Iceberg table from the catalog.
+
+    This test verifies that:
+    1. drop_iceberg_table successfully removes a table from the catalog
+    2. NoSuchTableError is handled gracefully when table doesn't exist
+    """
+    from pyiceberg.exceptions import NoSuchTableError, NamespaceAlreadyExistsError
+    import pyarrow as pa
+
+    catalog = get_catalog("drop_test_catalog", iceberg_catalog_config=sqlite_catalog_config)
+
+    namespace = "drop_test_ns"
+    try:
+        catalog.create_namespace(namespace)
+    except NamespaceAlreadyExistsError:
+        pass
+
+    # Create a simple table
+    table_id = f"{namespace}.test_table"
+    schema = pa.schema(
+        [pa.field("id", pa.int64(), nullable=False), pa.field("name", pa.string(), nullable=True)]
+    )
+
+    table = catalog.create_table(table_id, schema=schema)
+
+    assert catalog.load_table(table_id) is not None
+
+    drop_iceberg_table(catalog, table_id)
+
+    with pytest.raises(NoSuchTableError):
+        catalog.load_table(table_id)
+
+    # Dropping non-existent table should not raise error (just log warning)
+    drop_iceberg_table(catalog, table_id)

--- a/tests/load/pipeline/test_refresh_modes.py
+++ b/tests/load/pipeline/test_refresh_modes.py
@@ -167,6 +167,49 @@ def test_refresh_drop_sources(
     destinations_configs(
         default_sql_configs=True,
         local_filesystem_configs=True,
+        subset=["filesystem"],
+        table_format_local_configs=True,
+        with_table_format="iceberg",
+    ),
+    ids=lambda x: x.name,
+)
+def test_refresh_drop_sources_iceberg(destination_config: DestinationTestConfiguration):
+    """Test that refresh='drop_sources' properly drops Iceberg tables from catalog.
+
+    This test verifies the fix for the issue where Iceberg tables were not being
+    dropped from the catalog when using refresh='drop_sources', causing
+    'Table already exists' errors on subsequent runs.
+    """
+    pipeline = destination_config.setup_pipeline(
+        "iceberg_refresh_test", refresh="drop_sources", dev_mode=True
+    )
+
+    # First run - creates Iceberg table
+    info = pipeline.run([1, 2, 3], table_name="digits", **destination_config.run_kwargs)
+    assert_load_info(info)
+    # Get only the value column (first column) to ignore dlt system columns
+    first_run_data = [r[0] for r in pipeline.dataset().digits.fetchall()]
+    assert first_run_data == [1, 2, 3]
+
+    # Second run with drop_sources - should drop table from catalog and recreate
+    # This should NOT raise 'Table already exists' error
+    info = pipeline.run([4, 5, 6], table_name="digits", **destination_config.run_kwargs)
+    assert_load_info(info)
+    second_run_data = [r[0] for r in pipeline.dataset().digits.fetchall()]
+    assert second_run_data == [4, 5, 6]
+
+    # Third run to verify table still works
+    info = pipeline.run([7, 8, 9], table_name="digits", **destination_config.run_kwargs)
+    assert_load_info(info)
+    third_run_data = [r[0] for r in pipeline.dataset().digits.fetchall()]
+    assert third_run_data == [7, 8, 9]
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_sql_configs=True,
+        local_filesystem_configs=True,
         subset=["duckdb", "filesystem", "iceberg"],
         table_format_local_configs=True,
     ),


### PR DESCRIPTION
### Description

Fixes an issue where Iceberg tables were not being dropped from the catalog when using `refresh="drop_sources"`. Previously, only filesystem files were truncated, leaving stale catalog entries on subsequent runs.

**Changes:**
- Added `drop_iceberg_table()` helper function to `dlt/common/libs/pyiceberg.py` that wraps `catalog.drop_table()` with graceful error handling
- Added `_drop_iceberg_tables_from_catalog()` method to `FilesystemClient` that identifies Iceberg tables and drops them from the catalog
- Modified `drop_tables()` to call catalog drop before truncating files

**Example:**
```python
@dlt.resource(table_format="iceberg")
def orders():
    yield {"order_id": 1, "amount": 100.0}

pipeline = dlt.pipeline(
    pipeline_name="test_pipeline",
    destination="filesystem",
    dataset_name="test_dataset",
)

# Both runs now succeed
pipeline.run(orders(), refresh="drop_sources")  # First run - creates table
pipeline.run(orders(), refresh="drop_sources")  # Second run - drops and recreates
```

### Related Issues

- Closes #3800