### PR TITLE
Feat/3525 update dataset schema api clean

### DIFF
--- a/dlt/dataset/dataset.py
+++ b/dlt/dataset/dataset.py
@@ -144,7 +144,6 @@ class Dataset:
             # force re-fetch
             self._schema = schema_name
 
-
     def _ipython_key_completions_(self) -> list[str]:
         """Provide table names as completion suggestion in interactive environments."""
         return self.tables

--- a/dlt/dataset/dataset.py
+++ b/dlt/dataset/dataset.py
@@ -44,6 +44,8 @@ class Dataset:
         self._destination_reference = destination
         self._destination: AnyDestination = Destination.from_reference(destination)
         self._dataset_name = dataset_name
+        # store original input to allow refresh()
+        self._schema_input: Union[dlt.Schema, str, None] = schema
         self._schema: Union[dlt.Schema, str, None] = schema
         self._pipeline_name: Optional[str] = None
         """If _schema not provided, used to get default schema from state"""
@@ -106,43 +108,23 @@ class Dataset:
         # return only completed tables
         return self.schema.data_table_names() + self.schema.dlt_table_names()
 
-    def sync_schema(
-        self,
-        schema: Union[dlt.Schema, str, None] = None,
-        local_only: bool = False,
-    ) -> None:
-        """Syncs the schema of the dataset.
+    def refresh(self) -> "Dataset":
+        """Return a new ``Dataset`` instance with a refreshed schema.
 
-        Args:
-            schema (Union[dlt.Schema, str, None]): The schema to sync. If a string is provided,
-                it is treated as the schema name. If None, the current schema name or dataset name
-                is used.
-            local_only (bool): If True, only local schema is used. If False, schema is fetched
-                from the destination if local schema is not found.
+        Only valid when the dataset was created with a schema name string or ``None``.
+        Raises ``TypeError`` if a ``dlt.Schema`` instance was passed at construction time,
+        since there is no name to re-fetch the schema from.
         """
-        # reset schema and clients
-        self._sqlglot_schema = None
-        self._sql_client = None
-        self._opened_sql_client = None
-        self._table_client = None
-        if schema:
-            self._schema = schema
-            return
-
-        # default behavior: reset schema to name (or None) forcing a re-fetch
-        if self._schema:
-            schema_name = (
-                self._schema.name if isinstance(self._schema, dlt.Schema) else self._schema
+        if isinstance(self._schema_input, dlt.Schema):
+            raise TypeError(
+                "refresh() is not supported when the Dataset was created with a Schema instance."
+                " Use a schema name string or None instead so the schema can be re-fetched."
             )
-        else:
-            schema_name = self.dataset_name
-
-        if local_only:
-            # force local schema
-            self._schema = dlt.Schema(schema_name)
-        else:
-            # force re-fetch
-            self._schema = schema_name
+        return Dataset(
+            destination=self._destination_reference,
+            dataset_name=self._dataset_name,
+            schema=self._schema_input,
+        )
 
     def _ipython_key_completions_(self) -> list[str]:
         """Provide table names as completion suggestion in interactive environments."""
@@ -551,5 +533,5 @@ def _get_latest_load_id(dataset: dlt.Dataset) -> Optional[str]:
         .select(dataset.schema.naming.normalize_identifier(C_DLT_LOADS_TABLE_LOAD_ID))
         .max()
     )
-    load_id: list[str] = query.fetchone()
-    return load_id[0] if load_id else None
+    load_id = query.fetchone()
+    return load_id[0] if load_id else None  # type: ignore[no-any-return]

--- a/dlt/dataset/dataset.py
+++ b/dlt/dataset/dataset.py
@@ -106,6 +106,45 @@ class Dataset:
         # return only completed tables
         return self.schema.data_table_names() + self.schema.dlt_table_names()
 
+    def sync_schema(
+        self,
+        schema: Union[dlt.Schema, str, None] = None,
+        local_only: bool = False,
+    ) -> None:
+        """Syncs the schema of the dataset.
+
+        Args:
+            schema (Union[dlt.Schema, str, None]): The schema to sync. If a string is provided,
+                it is treated as the schema name. If None, the current schema name or dataset name
+                is used.
+            local_only (bool): If True, only local schema is used. If False, schema is fetched
+                from the destination if local schema is not found.
+        """
+        # reset schema and clients
+        self._sqlglot_schema = None
+        self._sql_client = None
+        self._opened_sql_client = None
+        self._table_client = None
+        if schema:
+            self._schema = schema
+            return
+
+        # default behavior: reset schema to name (or None) forcing a re-fetch
+        if self._schema:
+            schema_name = (
+                self._schema.name if isinstance(self._schema, dlt.Schema) else self._schema
+            )
+        else:
+            schema_name = self.dataset_name
+
+        if local_only:
+            # force local schema
+            self._schema = dlt.Schema(schema_name)
+        else:
+            # force re-fetch
+            self._schema = schema_name
+
+
     def _ipython_key_completions_(self) -> list[str]:
         """Provide table names as completion suggestion in interactive environments."""
         return self.tables
@@ -513,5 +552,5 @@ def _get_latest_load_id(dataset: dlt.Dataset) -> Optional[str]:
         .select(dataset.schema.naming.normalize_identifier(C_DLT_LOADS_TABLE_LOAD_ID))
         .max()
     )
-    load_id = query.fetchone()
-    return load_id[0] if load_id else None  # type: ignore[no-any-return]
+    load_id: list[str] = query.fetchone()
+    return load_id[0] if load_id else None

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,4 +1,3 @@
-
 import pytest
 import dlt
 import os
@@ -7,64 +6,67 @@ from dlt.common.schema import Schema
 
 import time
 
+
 def test_sync_schema() -> None:
-    pipeline_name = 'test_sync_schema_unit_test'
-    dataset_name = 'test_data_sync_schema'
-    
+    pipeline_name = "test_sync_schema_unit_test"
+    dataset_name = "test_data_sync_schema"
+
     # Use unique dir to avoid windows locking issues
     pipelines_dir = os.path.abspath(f"temp_pipelines_dir_{int(time.time())}")
-    
+
     try:
         # Setup primary pipeline
         pipeline = dlt.pipeline(
             pipeline_name=pipeline_name,
-            destination='duckdb',
+            destination="duckdb",
             dataset_name=dataset_name,
-            pipelines_dir=pipelines_dir
+            pipelines_dir=pipelines_dir,
         )
 
         # Run with first resource
-        pipeline.run([{'id': 1, 'name': 'Sharma'}], table_name='users')
+        pipeline.run([{"id": 1, "name": "Sharma"}], table_name="users")
 
         # Create dataset
         dataset = pipeline.dataset()
-        assert 'users' in dataset.tables
+        assert "users" in dataset.tables
 
         # Use a SECOND pipeline instance to modify the destination of the first dataset
         pipeline_b = dlt.pipeline(
             pipeline_name=pipeline_name,
-            destination='duckdb',
+            destination="duckdb",
             dataset_name=dataset_name,
-            pipelines_dir=pipelines_dir
+            pipelines_dir=pipelines_dir,
         )
-        pipeline_b.run([{'id': 1, 'amount': 100}], table_name='orders')
+        pipeline_b.run([{"id": 1, "amount": 100}], table_name="orders")
 
         # Check if the FIRST dataset sees the change (Should be stale initially)
-        tables_before = dataset.tables        
+        _ = dataset.tables
 
         # Sync schema
         dataset.sync_schema()
         tables_after = dataset.tables
-        assert 'orders' in tables_after
-        
+        assert "orders" in tables_after
+
         # Test Behavior: Local only
         dataset.sync_schema(local_only=True)
         # CURRENT BEHAVIOR: local_only=True creates a NEW dlt.Schema(name) which is empty (except dlt tables).
         # It does NOT load from file because Dataset doesn't know where the pipeline file is.
         # So 'orders' will vanish.
-        assert 'orders' not in dataset.tables
+        assert "orders" not in dataset.tables
 
         # Test Behavior: Explicit schema
         dummy_schema = Schema("dummy")
-        dummy_schema.update_table({"name": "fake_table", "columns": {"col1": {"name": "col1", "data_type": "text"}}})
-        
+        dummy_schema.update_table(
+            {"name": "fake_table", "columns": {"col1": {"name": "col1", "data_type": "text"}}}
+        )
+
         dataset.sync_schema(schema=dummy_schema)
         assert dataset.schema.name == "dummy"
         assert "fake_table" in dataset.tables
         assert "users" not in dataset.tables
 
     finally:
-        time.sleep(1) # else it might give error on windows ¯\_(ツ)_/¯
+        time.sleep(1)  # else it might give error on windows ¯\_(ツ)_/¯
         if os.path.exists(pipelines_dir):
             shutil.rmtree(pipelines_dir, ignore_errors=True)
 

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,0 +1,73 @@
+
+import pytest
+import dlt
+import os
+import shutil
+from dlt.common.schema import Schema
+
+import time
+
+def test_sync_schema() -> None:
+    pipeline_name = 'test_sync_schema_unit_test'
+    dataset_name = 'test_data_sync_schema'
+    
+    # Use unique dir to avoid windows locking issues
+    pipelines_dir = os.path.abspath(f"temp_pipelines_dir_{int(time.time())}")
+    
+    try:
+        # Setup primary pipeline
+        pipeline = dlt.pipeline(
+            pipeline_name=pipeline_name,
+            destination='duckdb',
+            dataset_name=dataset_name,
+            pipelines_dir=pipelines_dir
+        )
+
+        # Run with first resource
+        pipeline.run([{'id': 1, 'name': 'Sharma'}], table_name='users')
+
+        # Create dataset
+        dataset = pipeline.dataset()
+        assert 'users' in dataset.tables
+
+        # Use a SECOND pipeline instance to modify the destination of the first dataset
+        pipeline_b = dlt.pipeline(
+            pipeline_name=pipeline_name,
+            destination='duckdb',
+            dataset_name=dataset_name,
+            pipelines_dir=pipelines_dir
+        )
+        pipeline_b.run([{'id': 1, 'amount': 100}], table_name='orders')
+
+        # Check if the FIRST dataset sees the change (Should be stale initially)
+        tables_before = dataset.tables        
+
+        # Sync schema
+        dataset.sync_schema()
+        tables_after = dataset.tables
+        assert 'orders' in tables_after
+        
+        # Test Behavior: Local only
+        dataset.sync_schema(local_only=True)
+        # CURRENT BEHAVIOR: local_only=True creates a NEW dlt.Schema(name) which is empty (except dlt tables).
+        # It does NOT load from file because Dataset doesn't know where the pipeline file is.
+        # So 'orders' will vanish.
+        assert 'orders' not in dataset.tables
+
+        # Test Behavior: Explicit schema
+        dummy_schema = Schema("dummy")
+        dummy_schema.update_table({"name": "fake_table", "columns": {"col1": {"name": "col1", "data_type": "text"}}})
+        
+        dataset.sync_schema(schema=dummy_schema)
+        assert dataset.schema.name == "dummy"
+        assert "fake_table" in dataset.tables
+        assert "users" not in dataset.tables
+
+    finally:
+        time.sleep(1) # else it might give error on windows ¯\_(ツ)_/¯
+        if os.path.exists(pipelines_dir):
+            shutil.rmtree(pipelines_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_sync_schema()

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -3,73 +3,74 @@ import dlt
 import os
 import shutil
 from dlt.common.schema import Schema
+from dlt.dataset.dataset import Dataset
 
 import time
 
+def test_refresh_returns_new_instance_with_updated_schema() -> None:
+    """refresh() returns a new Dataset that picks up destination changes without mutating the original."""
+    pipeline_name = "test_refresh_new_instance"
+    dataset_name = "test_data_refresh_new"
 
-def test_sync_schema() -> None:
-    pipeline_name = "test_sync_schema_unit_test"
-    dataset_name = "test_data_sync_schema"
-
-    # Use unique dir to avoid windows locking issues
-    pipelines_dir = os.path.abspath(f"temp_pipelines_dir_{int(time.time())}")
+    pipelines_dir = os.path.abspath(f"temp_pipelines_refresh_{int(time.time())}")
 
     try:
-        # Setup primary pipeline
         pipeline = dlt.pipeline(
             pipeline_name=pipeline_name,
             destination="duckdb",
             dataset_name=dataset_name,
             pipelines_dir=pipelines_dir,
         )
+        pipeline.run([{"id": 1, "name": "Alice"}], table_name="users")
 
-        # Run with first resource
-        pipeline.run([{"id": 1, "name": "Sharma"}], table_name="users")
-
-        # Create dataset
         dataset = pipeline.dataset()
         assert "users" in dataset.tables
 
-        # Use a SECOND pipeline instance to modify the destination of the first dataset
+        # Second pipeline run adds a new table
         pipeline_b = dlt.pipeline(
             pipeline_name=pipeline_name,
             destination="duckdb",
             dataset_name=dataset_name,
             pipelines_dir=pipelines_dir,
         )
-        pipeline_b.run([{"id": 1, "amount": 100}], table_name="orders")
+        time.sleep(2)  # allow Windows to release file handles from first run
+        pipeline_b.run([{"id": 1, "amount": 99}], table_name="orders")
 
-        # Check if the FIRST dataset sees the change (Should be stale initially)
-        _ = dataset.tables
-
-        # Sync schema
-        dataset.sync_schema()
-        tables_after = dataset.tables
-        assert "orders" in tables_after
-
-        # Test Behavior: Local only
-        dataset.sync_schema(local_only=True)
-        # CURRENT BEHAVIOR: local_only=True creates a NEW dlt.Schema(name) which is empty (except dlt tables).
-        # It does NOT load from file because Dataset doesn't know where the pipeline file is.
-        # So 'orders' will vanish.
+        # Original dataset is stale – orders not visible yet
         assert "orders" not in dataset.tables
 
-        # Test Behavior: Explicit schema
-        dummy_schema = Schema("dummy")
-        dummy_schema.update_table(
-            {"name": "fake_table", "columns": {"col1": {"name": "col1", "data_type": "text"}}}
-        )
+        # refresh() returns a *new* Dataset instance
+        refreshed = dataset.refresh()
+        assert refreshed is not dataset
+        assert isinstance(refreshed, Dataset)
 
-        dataset.sync_schema(schema=dummy_schema)
-        assert dataset.schema.name == "dummy"
-        assert "fake_table" in dataset.tables
-        assert "users" not in dataset.tables
+        # New instance sees the updated schema
+        assert "orders" in refreshed.tables
+        assert "users" in refreshed.tables
+
+        # Original instance is still stale (it was NOT mutated)
+        assert "orders" not in dataset.tables
 
     finally:
-        time.sleep(1)  # else it might give error on windows ¯\_(ツ)_/¯
+        time.sleep(1)
         if os.path.exists(pipelines_dir):
             shutil.rmtree(pipelines_dir, ignore_errors=True)
 
 
+def test_refresh_raises_when_schema_instance_provided() -> None:
+    """refresh() raises TypeError if the Dataset was created with a Schema instance."""
+    schema = Schema("my_schema")
+
+    dataset = Dataset(
+        destination="duckdb",
+        dataset_name="dummy_ds",
+        schema=schema,
+    )
+
+    with pytest.raises(TypeError, match="refresh\\(\\) is not supported"):
+        dataset.refresh()
+
+
 if __name__ == "__main__":
-    test_sync_schema()
+    test_refresh_returns_new_instance_with_updated_schema()
+    test_refresh_raises_when_schema_instance_provided()

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,60 +1,80 @@
 import pytest
 import dlt
-import os
-import shutil
 from dlt.common.schema import Schema
 from dlt.dataset.dataset import Dataset
 
 import time
 
-def test_refresh_returns_new_instance_with_updated_schema() -> None:
-    """refresh() returns a new Dataset that picks up destination changes without mutating the original."""
+def test_pipeline_dataset_refresh_raises_type_error(tmp_path) -> None:
+    """refresh() raises TypeError when Dataset is created via pipeline.dataset() (which uses a Schema instance)."""
+    pipeline_name = "test_refresh_type_error"
+    dataset_name = "test_data_refresh_type_error"
+
+    pipelines_dir = str(tmp_path / "pipelines_error")
+
+    pipeline = dlt.pipeline(
+        pipeline_name=pipeline_name,
+        destination="duckdb",
+        dataset_name=dataset_name,
+        pipelines_dir=pipelines_dir,
+    )
+    pipeline.run([{"id": 1, "name": "Alice"}], table_name="users")
+
+    dataset = pipeline.dataset()
+    assert "users" in dataset.tables
+
+    # dataset from pipeline has a dlt.Schema instance, so refresh() is unsupported
+    with pytest.raises(TypeError, match="refresh\\(\\) is not supported"):
+        dataset.refresh()
+
+
+def test_refresh_returns_new_instance_with_updated_schema(tmp_path) -> None:
+    """refresh() returns a new Dataset that picks up destination changes when initialized with a schema string."""
     pipeline_name = "test_refresh_new_instance"
     dataset_name = "test_data_refresh_new"
 
-    pipelines_dir = os.path.abspath(f"temp_pipelines_refresh_{int(time.time())}")
+    pipelines_dir = str(tmp_path / "pipelines_refresh")
 
-    try:
-        pipeline = dlt.pipeline(
-            pipeline_name=pipeline_name,
-            destination="duckdb",
-            dataset_name=dataset_name,
-            pipelines_dir=pipelines_dir,
-        )
-        pipeline.run([{"id": 1, "name": "Alice"}], table_name="users")
+    pipeline = dlt.pipeline(
+        pipeline_name=pipeline_name,
+        destination="duckdb",
+        dataset_name=dataset_name,
+        pipelines_dir=pipelines_dir,
+    )
+    pipeline.run([{"id": 1, "name": "Alice"}], table_name="users")
 
-        dataset = pipeline.dataset()
-        assert "users" in dataset.tables
+    # Create Dataset manually providing the schema name as string
+    dataset = Dataset(
+        destination=pipeline.destination,
+        dataset_name=dataset_name,
+        schema=pipeline.default_schema_name,
+    )
+    assert "users" in dataset.tables
 
-        # Second pipeline run adds a new table
-        pipeline_b = dlt.pipeline(
-            pipeline_name=pipeline_name,
-            destination="duckdb",
-            dataset_name=dataset_name,
-            pipelines_dir=pipelines_dir,
-        )
-        time.sleep(2)  # allow Windows to release file handles from first run
-        pipeline_b.run([{"id": 1, "amount": 99}], table_name="orders")
+    # Second pipeline run adds a new table
+    pipeline_b = dlt.pipeline(
+        pipeline_name=pipeline_name,
+        destination="duckdb",
+        dataset_name=dataset_name,
+        pipelines_dir=pipelines_dir,
+    )
+    time.sleep(2)  # allow Windows to release file handles from first run
+    pipeline_b.run([{"id": 1, "amount": 99}], table_name="orders")
 
-        # Original dataset is stale – orders not visible yet
-        assert "orders" not in dataset.tables
+    # Original dataset is stale – orders not visible yet
+    assert "orders" not in dataset.tables
 
-        # refresh() returns a *new* Dataset instance
-        refreshed = dataset.refresh()
-        assert refreshed is not dataset
-        assert isinstance(refreshed, Dataset)
+    # refresh() returns a *new* Dataset instance
+    refreshed = dataset.refresh()
+    assert refreshed is not dataset
+    assert isinstance(refreshed, Dataset)
 
-        # New instance sees the updated schema
-        assert "orders" in refreshed.tables
-        assert "users" in refreshed.tables
+    # New instance sees the updated schema
+    assert "orders" in refreshed.tables
+    assert "users" in refreshed.tables
 
-        # Original instance is still stale (it was NOT mutated)
-        assert "orders" not in dataset.tables
-
-    finally:
-        time.sleep(1)
-        if os.path.exists(pipelines_dir):
-            shutil.rmtree(pipelines_dir, ignore_errors=True)
+    # Original instance is still stale (it was NOT mutated)
+    assert "orders" not in dataset.tables
 
 
 def test_refresh_raises_when_schema_instance_provided() -> None:
@@ -69,8 +89,3 @@ def test_refresh_raises_when_schema_instance_provided() -> None:
 
     with pytest.raises(TypeError, match="refresh\\(\\) is not supported"):
         dataset.refresh()
-
-
-if __name__ == "__main__":
-    test_refresh_returns_new_instance_with_updated_schema()
-    test_refresh_raises_when_schema_instance_provided()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR adds a `refresh` method to `dlt.Dataset`, allowing us to refresh a dataset’s schema.

1. It supports picking up schema changes across isolated pipeline runs without mutating the original `Dataset` object.
2. It explicitly raises a `TypeError` if a user attempts to refresh a pipeline-bound dataset that was statically initialized with a `dlt.Schema` directly (such as via `pipeline.dataset()`).

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
- Fixes #3525

<!--
Provide any additional context about the PR here.
-->
### Additional Context
- Added a new method `refresh` to `dlt\dataset\dataset.py`
- Added unit tests to `tests\dataset\test_dataset.py`
- Closed previous PR due to rebase issues (#3585)
<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
