### PR TITLE
fix: correctly materialize empty tables for multi-table resources

### DIFF
--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -359,7 +359,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
         data_tables = {t["name"]: t for t in schema.data_tables()}
         tables_by_resources = utils.group_tables_by_resource(data_tables)
 
-        resources_and_tables = {}
+        resources_and_tables: Dict[str, List[str]] = {}
         for resource_name, table_name in tables_with_empty:
             resources_and_tables.setdefault(resource_name, []).append(table_name)
 

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -359,7 +359,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
         tables_by_resources = utils.group_tables_by_resource(data_tables)
         for resource_name in resources_with_empty:
             if resource := source.resources.selected.get(resource_name):
-                if tables := tables_by_resources.get("resource_name"):
+                if tables := tables_by_resources.get(resource_name):
                     # write empty tables
                     for table in tables:
                         # we only need to write empty files for the root tables

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -333,41 +333,49 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
     ) -> None:
         schema = source.schema
         json_extractor = extractors["object"]
-        resources_with_items = set().union(*[e.resources_with_items for e in extractors.values()])
+        tables_with_items = set().union(*[e.tables_with_items for e in extractors.values()])
         # find REPLACE resources that did not yield any pipe items and create empty jobs for them
         # NOTE: do not include tables that have never seen data
         data_tables = {t["name"]: t for t in schema.data_tables(seen_data_only=True)}
         tables_by_resources = utils.group_tables_by_resource(data_tables)
         for resource in source.resources.selected.values():
-            if resource.write_disposition != "replace" or resource.name in resources_with_items:
-                continue
             if resource.name not in tables_by_resources:
                 continue
             for table in tables_by_resources[resource.name]:
+                write_disposition = table.get("write_disposition") or resource.write_disposition
+                if write_disposition != "replace" or (resource.name, table["name"]) in tables_with_items:
+                    continue
                 # we only need to write empty files for the root tables
                 if not utils.is_nested_table(table):
                     json_extractor.write_empty_items_file(table["name"])
 
         # collect resources that received empty materialized lists and had no items
-        resources_with_empty = (
+        tables_with_empty = (
             set()
-            .union(*[e.resources_with_empty for e in extractors.values()])
-            .difference(resources_with_items)
+            .union(*[e.tables_with_empty for e in extractors.values()])
+            .difference(tables_with_items)
         )
         # get all possible tables
         data_tables = {t["name"]: t for t in schema.data_tables()}
         tables_by_resources = utils.group_tables_by_resource(data_tables)
-        for resource_name in resources_with_empty:
+
+        resources_and_tables = {}
+        for resource_name, table_name in tables_with_empty:
+            resources_and_tables.setdefault(resource_name, []).append(table_name)
+
+        for resource_name, table_names in resources_and_tables.items():
             if resource := source.resources.selected.get(resource_name):
                 if tables := tables_by_resources.get(resource_name):
                     # write empty tables
                     for table in tables:
+                        if table["name"] not in table_names:
+                            continue
                         # we only need to write empty files for the root tables
                         if not utils.is_nested_table(table):
                             json_extractor.write_empty_items_file(table["name"])
                 else:
                     table_name = json_extractor._get_static_table_name(resource, None)
-                    if table_name:
+                    if table_name and table_name in table_names:
                         json_extractor.write_empty_items_file(table_name)
 
     def _extract_single_source(

--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -1,6 +1,6 @@
 from copy import copy
 from functools import lru_cache, partial
-from typing import Set, Dict, Any, Optional, List, Union
+from typing import Set, Dict, Any, Optional, List, Union, Tuple
 
 from dlt.common.configuration import known_sections, resolve_configuration, with_config
 from dlt.common import logger, json
@@ -120,10 +120,10 @@ class Extractor:
         self.schema = schema
         self.naming = schema.naming
         self.collector = collector
-        self.resources_with_items: Set[str] = set()
-        """Tracks resources that received items"""
-        self.resources_with_empty: Set[str] = set()
-        """Track resources that received empty materialized list"""
+        self.tables_with_items: Set[Tuple[str, str]] = set()
+        """Tracks (resource, table) pairs that received items"""
+        self.tables_with_empty: Set[Tuple[str, str]] = set()
+        """Tracks (resource, table) pairs that received empty materialized list"""
         self.load_id = load_id
         self.item_storage = item_storage
         self._table_contracts: Dict[str, TSchemaContractDict] = {}
@@ -186,10 +186,10 @@ class Extractor:
         self.collector.update(table_name, inc=new_rows_count)
         # if there were rows or item was empty arrow table
         if new_rows_count > 0 or self.__class__ is ArrowExtractor:
-            self.resources_with_items.add(resource_name)
+            self.tables_with_items.add((resource_name, table_name))
         else:
             if isinstance(items, MaterializedEmptyList):
-                self.resources_with_empty.add(resource_name)
+                self.tables_with_empty.add((resource_name, table_name))
 
     def _import_item(
         self,
@@ -206,7 +206,7 @@ class Extractor:
             meta.file_format,
         )
         self.collector.update(table_name, inc=metrics.items_count)
-        self.resources_with_items.add(resource_name)
+        self.tables_with_items.add((resource_name, table_name))
 
     def _write_to_dynamic_table(self, resource: DltResource, items: TDataItems, meta: Any) -> None:
         if not isinstance(items, list):


### PR DESCRIPTION
### Description

Currently, empty table materialization does not work correctly for resources that generate multiple tables. This PR changes it so that empty tables are tracked in addition to resources to correctly write empty table files during extraction.

Fixes #3840

### Additional Context

- I have run `make test-common` locally. A few tests failed due to my local venv setup, but they seemed unrelated.
- Here is an example that fails with dlt version 1.24.0, but works with these changes:

```python
import dlt
import duckdb


@dlt.resource
def data(yield_one, yield_two):
    yield dlt.mark.with_hints(
        dlt.mark.materialize_table_schema(),
        dlt.mark.make_hints(
            table_name="table_one",
            write_disposition="replace",
            columns={"column_one": {"data_type": "text"}},
        ),
        create_table_variant=True,
    )
    yield dlt.mark.with_hints(
        dlt.mark.materialize_table_schema(),
        dlt.mark.make_hints(
            table_name="table_two",
            write_disposition="replace",
            columns={"column_two": {"data_type": "bigint"}},
        ),
        create_table_variant=True,
    )
    if yield_one:
        yield dlt.mark.with_table_name(
            {"column_one": "something"},
            table_name="table_one",
        )
    if yield_two:
        yield dlt.mark.with_table_name(
            {"column_two": 5},
            table_name="table_two",
        )


con = duckdb.connect(":memory:")

dlt.run(
    data(yield_one=True, yield_two=False),
    destination=dlt.destinations.duckdb(con),
)
assert len(con.sql("SELECT * FROM table_one")) == 1
assert len(con.sql("SELECT * FROM table_two")) == 0

dlt.run(
    data(yield_one=False, yield_two=False),
    destination=dlt.destinations.duckdb(con),
)
assert len(con.sql("SELECT * FROM table_one")) == 0
assert len(con.sql("SELECT * FROM table_two")) == 0

dlt.run(
    data(yield_one=True, yield_two=True),
    destination=dlt.destinations.duckdb(con),
)
assert len(con.sql("SELECT * FROM table_one")) == 1
assert len(con.sql("SELECT * FROM table_two")) == 1
```