### PR TITLE
Add Vale prose linter for documentation quality via Trunk

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/configs/.vale.ini
+++ b/.trunk/configs/.vale.ini
@@ -1,0 +1,5 @@
+[formats]
+markdoc = md
+
+[*.md]
+BasedOnStyles = Vale

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,23 @@
+version: 0.1
+cli:
+  version: 1.25.0
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.7.6
+      uri: https://github.com/trunk-io/plugins
+lint:
+  enabled: true
+  linters:
+    - name: vale
+      version: 3.14.1
+      paths:
+        - docs
+actions:
+  enabled:
+    - trunk-announce
+    - trunk-cache-prune
+    - trunk-upgrade-available
+    - trunk-pre-push
+  disabled:
+    - trunk-fmt-pre-commit


### PR DESCRIPTION
### Description

Part of the **Docs as a product** initiative. This PR introduces [Vale](https://vale.sh/) to enforce consistent writing style and terminology across our documentation — a gap called out explicitly in our docs strategy.

#### Why Vale

Inconsistent terminology and style drift across docs contributed by different teams (product, DevRel, SolEng) erodes user trust, hurts SEO, and causes AI coding assistants to produce unreliable output. Vale is the industry standard prose linter used by GitLab, Spotify, and Linode to solve exactly this problem — configurable, CI-friendly, and extensible with custom vocabulary rules.

#### Why Trunk as the runner

Rather than adding Vale as a standalone tool with its own config, CI step, and install process, this PR uses [Trunk](https://docs.trunk.io/code-quality/overview/getting-started/configuration/lint) as a managed wrapper.

- Trunk only flags issues in *new or changed lines*, not the entire file — a concept they call "hold the line." This means enabling Vale doesn't halt engineering with thousands of pre-existing warnings. Teams can adopt linting incrementally without a "fix the world" prerequisite.
- Trunk runs all enabled linters against your files in parallel, so a single `trunk check` invocation runs everything without sequential scripts or glue code.
- Trunk has out-of-the-box support for [dozens of linters](https://docs.trunk.io/code-quality/overview/linters/supported). Starting with Vale today doesn't preclude adding markdownlint, semgrep, or other tools tomorrow — they all compose under the same `trunk check` command. See [this config](https://github.com/elviskahoro/oss-linter-trunk/tree/main/configs) for an example of a multi-linter setup.
- Trunk pins and downloads the exact Vale version (v3.14.1), so every contributor and CI runner uses the same binary without "works on my machine" issues.
- Trunk is purely a runner — the Vale config (`.vale.ini`, style rules) is fully portable. If we later decide against Trunk, we keep all the Vale work and just change how we invoke it.

### Scope

- Vale is scoped exclusively to `docs/**` — zero impact on source code.
- `trunk-fmt-pre-commit` is disabled to preserve existing ruff/black workflows.

### Changes

- `.trunk/trunk.yaml` — Trunk CLI config (v1.25.0) with Vale v3.14.1, scoped to `docs/**` only
- `.trunk/configs/.vale.ini` — Vale style config with markdoc format support
- `.trunk/.gitignore` — excludes Trunk build artifacts and user-local config from version control

### Next steps

- Add custom Vale style rules for dlt-specific terminology (e.g. `dlt` casing, product names, API terms)
- Integrate into CI for docs-only PRs