### PR TITLE
(fix) preserve insert_at step ordering across resource clone

### DIFF
--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -470,22 +470,16 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
             self._pipe.insert_step(item_transform, insert_at)
         return self
 
-    def _remove_incremental_step(self) -> int:
-        """Removes incremental step from pipe, returns its previous index (-1 if not found)"""
-        return self._pipe.remove_by_type(Incremental, IncrementalResourceWrapper)
+    def _remove_incremental_step(self) -> Optional[int]:
+        """Removes incremental step from pipe, returns its previous index (None if not found)"""
+        idx = self._pipe.remove_by_type(Incremental, IncrementalResourceWrapper)
+        return idx if idx >= 0 else None
 
     def set_incremental(
         self,
         new_incremental: Union[Incremental[Any], IncrementalResourceWrapper],
-        insert_at: Optional[int] = None,
     ) -> Optional[Union[Incremental[Any], IncrementalResourceWrapper]]:
-        """Set/replace the incremental transform for the resource.
-
-        Args:
-            new_incremental: The Incremental instance/hint to set or replace.
-            insert_at: Explicit pipe index for the incremental step. When provided,
-                bypasses `placement_affinity` ordering to preserve user-defined step order.
-        """
+        """Set/replace the incremental transform for the resource, preserving step position."""
         if new_incremental is Incremental.EMPTY:
             new_incremental = None
         if new_incremental:
@@ -493,27 +487,23 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
             if resource_primary_key := self._hints.get("primary_key"):
                 new_incremental.set_deduplication_key(resource_primary_key, from_hints=True)
         incremental = self.incremental
+        existing_idx: Optional[int] = None
         if incremental is not None:
             if isinstance(new_incremental, IncrementalResourceWrapper):
-                # completely replace the wrapper, preserving position if not given
-                prev_idx = self._remove_incremental_step()
-                if insert_at is None and prev_idx >= 0:
-                    insert_at = prev_idx
-                self.add_step(new_incremental, insert_at=insert_at)
+                # completely replace the wrapper at the same position
+                existing_idx = self._remove_incremental_step()
+                self.add_step(new_incremental, insert_at=existing_idx)
             elif isinstance(incremental, IncrementalResourceWrapper):
                 incremental.set_incremental(new_incremental, from_hints=True)
             else:
-                prev_idx = self._remove_incremental_step()
-                if insert_at is None and prev_idx >= 0:
-                    insert_at = prev_idx
-                # re-add the step
+                existing_idx = self._remove_incremental_step()
                 incremental = None
         if incremental is None:
             # if there's no wrapper add incremental as a transform
             if new_incremental:
                 if not isinstance(new_incremental, IncrementalResourceWrapper):
                     new_incremental = Incremental.ensure_instance(new_incremental)
-                self.add_step(new_incremental, insert_at=insert_at)
+                self.add_step(new_incremental, insert_at=existing_idx)
         return new_incremental
 
     def _set_hints(
@@ -690,28 +680,23 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         except Exception:
             pass
 
-    def _eject_config(self) -> Optional[int]:
+    def _eject_config(self) -> bool:
         """Unwraps the pipe generator step from config injection and incremental wrappers by restoring the original step.
 
-        Removes the step with incremental wrapper. Should be used before a subsequent _inject_config is called on the
-        same pipe to successfully wrap it with new incremental and config injection.
+        Should be used before a subsequent _inject_config is called on the same pipe to successfully
+        wrap it with new incremental and config injection.
         Note that resources with bound arguments cannot be ejected.
-
-        Returns:
-            Index where incremental step was located, or `None` if nothing was ejected.
         """
         if not self._pipe.is_empty and not self._args_bound:
             orig_gen = getattr(self._pipe.gen, "__GEN__", None)
             if orig_gen:
-                incr_idx = self._remove_incremental_step()
                 self._pipe.replace_gen(orig_gen)
-                return incr_idx if incr_idx >= 0 else 0
-        return None
+                return True
+        return False
 
     def _inject_config(
         self,
         incremental_from_hints_override: Optional[bool] = None,
-        incremental_insert_at: Optional[int] = None,
     ) -> Self:
         """Wraps the pipe generation step in incremental and config injection wrappers and adds pipe step with
         Incremental transform.
@@ -734,7 +719,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
                     ),
                 )
             incr_f = incremental.wrap(sig, gen)
-            self.set_incremental(incremental, insert_at=incremental_insert_at)
+            self.set_incremental(incremental)
         else:
             incr_f = gen
         resource_sections = (known_sections.SOURCES, self.section, self.name)
@@ -803,11 +788,9 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         # try to eject and then inject configuration and incremental wrapper when resource is cloned
         # this makes sure that a take config values from a right section and wrapper has a separated
         # instance in the pipeline
-        incr_idx = cloned_r._eject_config()
-        if incr_idx is not None:
+        if cloned_r._eject_config():
             cloned_r._inject_config(
                 incremental_from_hints_override=incremental_from_hints,
-                incremental_insert_at=incr_idx,
             )
         return cloned_r
 

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -470,17 +470,21 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
             self._pipe.insert_step(item_transform, insert_at)
         return self
 
-    def _remove_incremental_step(self) -> None:
-        self._pipe.remove_by_type(Incremental, IncrementalResourceWrapper)
+    def _remove_incremental_step(self) -> int:
+        """Removes incremental step from pipe, returns its previous index (-1 if not found)"""
+        return self._pipe.remove_by_type(Incremental, IncrementalResourceWrapper)
 
     def set_incremental(
-        self, new_incremental: Union[Incremental[Any], IncrementalResourceWrapper]
+        self,
+        new_incremental: Union[Incremental[Any], IncrementalResourceWrapper],
+        insert_at: Optional[int] = None,
     ) -> Optional[Union[Incremental[Any], IncrementalResourceWrapper]]:
         """Set/replace the incremental transform for the resource.
 
         Args:
-            new_incremental: The Incremental instance/hint to set or replace
-            from_hints: If the incremental is set from hints. Defaults to False.
+            new_incremental: The Incremental instance/hint to set or replace.
+            insert_at: Explicit pipe index for the incremental step. When provided,
+                bypasses `placement_affinity` ordering to preserve user-defined step order.
         """
         if new_incremental is Incremental.EMPTY:
             new_incremental = None
@@ -490,17 +494,18 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
                 new_incremental.set_deduplication_key(resource_primary_key, from_hints=True)
         incremental = self.incremental
         if incremental is not None:
-            # if isinstance(new_incremental, Mapping):
-            #     new_incremental = Incremental.ensure_instance(new_incremental)
-
             if isinstance(new_incremental, IncrementalResourceWrapper):
-                # Completely replace the wrapper
-                self._remove_incremental_step()
-                self.add_step(new_incremental)
+                # completely replace the wrapper, preserving position if not given
+                prev_idx = self._remove_incremental_step()
+                if insert_at is None and prev_idx >= 0:
+                    insert_at = prev_idx
+                self.add_step(new_incremental, insert_at=insert_at)
             elif isinstance(incremental, IncrementalResourceWrapper):
                 incremental.set_incremental(new_incremental, from_hints=True)
             else:
-                self._remove_incremental_step()
+                prev_idx = self._remove_incremental_step()
+                if insert_at is None and prev_idx >= 0:
+                    insert_at = prev_idx
                 # re-add the step
                 incremental = None
         if incremental is None:
@@ -508,7 +513,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
             if new_incremental:
                 if not isinstance(new_incremental, IncrementalResourceWrapper):
                     new_incremental = Incremental.ensure_instance(new_incremental)
-                self.add_step(new_incremental)
+                self.add_step(new_incremental, insert_at=insert_at)
         return new_incremental
 
     def _set_hints(
@@ -685,23 +690,29 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         except Exception:
             pass
 
-    def _eject_config(self) -> bool:
+    def _eject_config(self) -> Optional[int]:
         """Unwraps the pipe generator step from config injection and incremental wrappers by restoring the original step.
 
         Removes the step with incremental wrapper. Should be used before a subsequent _inject_config is called on the
         same pipe to successfully wrap it with new incremental and config injection.
         Note that resources with bound arguments cannot be ejected.
 
+        Returns:
+            Index where incremental step was located, or `None` if nothing was ejected.
         """
         if not self._pipe.is_empty and not self._args_bound:
             orig_gen = getattr(self._pipe.gen, "__GEN__", None)
             if orig_gen:
-                self._remove_incremental_step()
+                incr_idx = self._remove_incremental_step()
                 self._pipe.replace_gen(orig_gen)
-                return True
-        return False
+                return incr_idx if incr_idx >= 0 else 0
+        return None
 
-    def _inject_config(self, incremental_from_hints_override: Optional[bool] = None) -> Self:
+    def _inject_config(
+        self,
+        incremental_from_hints_override: Optional[bool] = None,
+        incremental_insert_at: Optional[int] = None,
+    ) -> Self:
         """Wraps the pipe generation step in incremental and config injection wrappers and adds pipe step with
         Incremental transform.
         """
@@ -723,7 +734,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
                     ),
                 )
             incr_f = incremental.wrap(sig, gen)
-            self.set_incremental(incremental)
+            self.set_incremental(incremental, insert_at=incremental_insert_at)
         else:
             incr_f = gen
         resource_sections = (known_sections.SOURCES, self.section, self.name)
@@ -792,8 +803,12 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         # try to eject and then inject configuration and incremental wrapper when resource is cloned
         # this makes sure that a take config values from a right section and wrapper has a separated
         # instance in the pipeline
-        if cloned_r._eject_config():
-            cloned_r._inject_config(incremental_from_hints_override=incremental_from_hints)
+        incr_idx = cloned_r._eject_config()
+        if incr_idx is not None:
+            cloned_r._inject_config(
+                incremental_from_hints_override=incremental_from_hints,
+                incremental_insert_at=incr_idx,
+            )
         return cloned_r
 
     def _update_wrapper(self) -> None:

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -1240,6 +1240,87 @@ def test_set_default_value_for_incremental_cursor(item_type: TestDataItemFormat)
     assert s["last_value"] == 4
 
 
+def test_insert_at_ordering_preserved_after_clone() -> None:
+    """Step ordering via insert_at must survive the eject/inject cycle triggered by resource clone"""
+
+    @dlt.source
+    def my_source():
+        @dlt.resource
+        def events():
+            yield [
+                {"id": 1, "updated_at": 1},
+                {"id": 2, "updated_at": 2},
+                {"id": 3, "updated_at": 3},
+            ]
+
+        return events
+
+    def count_rows(items, meta, metrics):
+        if isinstance(items, list):
+            metrics["row_count"] = metrics.get("row_count", 0) + len(items)
+
+    source = my_source()
+    r = source.events
+    r.apply_hints(incremental=dlt.sources.incremental("updated_at", initial_value=2))
+    r.add_metrics(count_rows, insert_at=len(r._pipe))
+
+    p = dlt.pipeline(pipeline_name="p" + uniq_id(), destination="duckdb", dev_mode=True)
+    p.run(r)
+
+    for step in p.last_trace.steps:
+        if step.step == "extract":
+            for load_id, metrics_list in step.step_info.metrics.items():
+                for m in metrics_list:
+                    for resource_name, resource_m in m["resource_metrics"].items():
+                        if resource_m.custom_metrics:
+                            # metrics step ran after incremental, so only 2 rows pass
+                            assert resource_m.custom_metrics["row_count"] == 2, (
+                                f"Expected 2 rows after incremental filter, "
+                                f"got {resource_m.custom_metrics['row_count']}"
+                            )
+
+
+def test_insert_at_ordering_preserved_signature_incremental() -> None:
+    """Step ordering via insert_at must survive clone with signature-based incremental"""
+
+    @dlt.source
+    def my_source():
+        @dlt.resource
+        def events(updated_at=dlt.sources.incremental("updated_at", initial_value=2)):
+            yield [
+                {"id": 1, "updated_at": 1},
+                {"id": 2, "updated_at": 2},
+                {"id": 3, "updated_at": 3},
+            ]
+
+        return events
+
+    source = my_source()
+    r = source.events
+
+    # verify step ordering before clone: incremental should be the last step
+    from dlt.extract.incremental import IncrementalResourceWrapper
+
+    incr_idx = r._pipe.find(IncrementalResourceWrapper)
+    assert incr_idx > 0
+    original_steps_count = len(r._pipe)
+
+    # add a filter after incremental
+    r.add_filter(lambda item: item["id"] != 999, insert_at=len(r._pipe))
+
+    # the filter should be after the incremental
+    assert len(r._pipe) == original_steps_count + 1
+
+    p = dlt.pipeline(pipeline_name="p" + uniq_id(), destination="duckdb", dev_mode=True)
+    p.run(r)
+
+    # the incremental wrapper filters at generator level for signature-based,
+    # but step order should still be preserved after clone
+    with p.sql_client() as c:
+        rows = c.execute_sql("SELECT count(*) FROM events")
+        assert rows[0][0] == 2
+
+
 def test_json_path_cursor() -> None:
     @dlt.resource
     def some_data(last_timestamp=dlt.sources.incremental("item.timestamp|modifiedAt")):

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -1264,24 +1264,29 @@ def test_insert_at_ordering_preserved_after_clone() -> None:
     r.apply_hints(incremental=dlt.sources.incremental("updated_at", initial_value=2))
     r.add_metrics(count_rows, insert_at=len(r._pipe))
 
+    # verify step layout is preserved across clone
+    layout_before = [type(s).__name__ for s in r._pipe._steps]
+    incr_idx_before = r._pipe.find(Incremental, IncrementalResourceWrapper)
+
+    cloned = r._clone()
+
+    layout_after = [type(s).__name__ for s in cloned._pipe._steps]
+    incr_idx_after = cloned._pipe.find(Incremental, IncrementalResourceWrapper)
+    assert layout_after == layout_before
+    assert incr_idx_after == incr_idx_before
+
     p = dlt.pipeline(pipeline_name="p" + uniq_id(), destination="duckdb", dev_mode=True)
     p.run(r)
 
-    for step in p.last_trace.steps:
-        if step.step == "extract":
-            for load_id, metrics_list in step.step_info.metrics.items():
-                for m in metrics_list:
-                    for resource_name, resource_m in m["resource_metrics"].items():
-                        if resource_m.custom_metrics:
-                            # metrics step ran after incremental, so only 2 rows pass
-                            assert resource_m.custom_metrics["row_count"] == 2, (
-                                f"Expected 2 rows after incremental filter, "
-                                f"got {resource_m.custom_metrics['row_count']}"
-                            )
+    extract_info = p.last_trace.last_extract_info
+    resource_metrics = extract_info.metrics[extract_info.loads_ids[0]][0]["resource_metrics"][
+        "events"
+    ]
+    assert resource_metrics.custom_metrics["row_count"] == 2
 
 
-def test_insert_at_ordering_preserved_signature_incremental() -> None:
-    """Step ordering via insert_at must survive clone with signature-based incremental"""
+def test_insert_at_ordering_preserved_after_clone_arg_based() -> None:
+    """Step ordering via insert_at must survive clone with argument-based incremental"""
 
     @dlt.source
     def my_source():
@@ -1298,27 +1303,19 @@ def test_insert_at_ordering_preserved_signature_incremental() -> None:
     source = my_source()
     r = source.events
 
-    # verify step ordering before clone: incremental should be the last step
-    from dlt.extract.incremental import IncrementalResourceWrapper
-
-    incr_idx = r._pipe.find(IncrementalResourceWrapper)
-    assert incr_idx > 0
-    original_steps_count = len(r._pipe)
-
-    # add a filter after incremental
+    # add a filter after the incremental step
     r.add_filter(lambda item: item["id"] != 999, insert_at=len(r._pipe))
 
-    # the filter should be after the incremental
-    assert len(r._pipe) == original_steps_count + 1
+    # verify step layout is preserved across clone
+    layout_before = [type(s).__name__ for s in r._pipe._steps]
+    incr_idx_before = r._pipe.find(Incremental, IncrementalResourceWrapper)
 
-    p = dlt.pipeline(pipeline_name="p" + uniq_id(), destination="duckdb", dev_mode=True)
-    p.run(r)
+    cloned = r._clone()
 
-    # the incremental wrapper filters at generator level for signature-based,
-    # but step order should still be preserved after clone
-    with p.sql_client() as c:
-        rows = c.execute_sql("SELECT count(*) FROM events")
-        assert rows[0][0] == 2
+    layout_after = [type(s).__name__ for s in cloned._pipe._steps]
+    incr_idx_after = cloned._pipe.find(Incremental, IncrementalResourceWrapper)
+    assert layout_after == layout_before
+    assert incr_idx_after == incr_idx_before
 
 
 def test_json_path_cursor() -> None:


### PR DESCRIPTION
The eject/inject cycle during pipeline.run() re-added the Incremental step via append_step(), which sorts by placement_affinity and destroys any explicit insert_at positioning. Save the incremental step index on eject and restore it on inject so user-defined step order is preserved.

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #3838 
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
