### PR TITLE
Don't filter out steps with exceptions in trace.asdict()

### DIFF
--- a/dlt/pipeline/trace.py
+++ b/dlt/pipeline/trace.py
@@ -170,7 +170,11 @@ class PipelineTrace(SupportsHumanize, _PipelineTrace):
         """A dictionary representation of PipelineTrace that can be loaded with `dlt`"""
         d = self._asdict()
         # run step is the same as load step
-        d["steps"] = [step.asdict() for step in self.steps if step.step != "run"]
+        d["steps"] = [
+            step.asdict()
+            for step in self.steps
+            if step.step != "run" or step.step_exception is not None
+        ]
         return d
 
     @property

--- a/tests/pipeline/test_pipeline_trace.py
+++ b/tests/pipeline/test_pipeline_trace.py
@@ -472,6 +472,37 @@ def test_save_load_trace() -> None:
     assert pipeline.last_trace.last_normalize_info is None
 
 
+def test_run_step_with_exception_not_filtered_in_asdict() -> None:
+    """Run step carrying an exception from sync_destination must survive asdict()."""
+    pipeline = dlt.pipeline(destination="dummy")
+
+    def _failing_sync(self, *args, **kwargs):
+        raise PipelineStepFailed(pipeline, "sync", None, RuntimeError("sync failed"))
+
+    with patch.object(Pipeline, "_sync_destination", _failing_sync):
+        with pytest.raises(PipelineStepFailed):
+            pipeline.run([1, 2, 3], table_name="items")
+
+    trace = pipeline.last_trace
+    assert trace is not None
+
+    # only the "run" step should exist because extract/normalize/load never started
+    run_steps = [s for s in trace.steps if s.step == "run"]
+    assert len(run_steps) == 1
+    assert run_steps[0].step_exception is not None
+    assert "sync failed" in run_steps[0].step_exception
+
+    # asdict() must include the run step with the exception
+    trace_dict = trace.asdict()
+    dict_steps = trace_dict["steps"]
+    run_dict_steps = [s for s in dict_steps if s["step"] == "run"]
+    assert len(run_dict_steps) == 1
+    assert run_dict_steps[0]["step_exception"] is not None
+    assert "sync failed" in run_dict_steps[0]["step_exception"]
+
+    assert_trace_serializable(trace)
+
+
 def test_save_load_empty_trace() -> None:
     os.environ["COMPLETED_PROB"] = "1.0"
     os.environ["RESTORE_FROM_DESTINATION"] = "false"


### PR DESCRIPTION
This PR adjusts trace.asdict() in the way that it does NOT filter out pipelines that fail in the sync step during run before extract.

An appropriate test is added.