### PR TITLE
Increase timeout for schema assertion in e2e dashboard test

### DIFF
--- a/tests/e2e/helpers/dashboard/test_e2e.py
+++ b/tests/e2e/helpers/dashboard/test_e2e.py
@@ -118,7 +118,9 @@ def test_multi_schema_selection(page: Page, multi_schema_pipeline: Any):
     _open_section(page, "schema")
     page.get_by_text("Show raw schema as yaml").click()
 
-    expect(page.locator(".cm-line", has_text="name: fruitshop_customers").first).to_be_attached()
+    expect(page.locator(".cm-line", has_text="name: fruitshop_customers").first).to_be_attached(
+        timeout=15000
+    )
 
     def _select_schema_and_verify(
         schema_selector: Any,


### PR DESCRIPTION
The default 5s Playwright timeout for to_be_attached() is insufficient on Windows CI resulting in random CI failures. Match the 15s timeout used by other assertions in the same test.
