### PR TITLE
update name to dlt Connector App

### DIFF
--- a/docs/website/docs/walkthroughs/run-in-snowflake/database-connector-app.md
+++ b/docs/website/docs/walkthroughs/run-in-snowflake/database-connector-app.md
@@ -1,10 +1,10 @@
 ---
-title: Database Connector App
-description: How to use the database connector app
-keywords: [snowflake, native app, database connector app]
+title: dlt Connector App
+description: How to use the dlt Connector App
+keywords: [snowflake, native app, dlt connector app]
 ---
 
-# Snowflake Native App
+# dlt Connector App
 
 The dlt Connector App is a Snowflake Native App that lets you move data from external SQL databases (PostgreSQL, MySQL, MSSQL) into Snowflake using a simple web UI. It runs entirely within your Snowflake account — no external infrastructure required.
 

--- a/docs/website/docs/walkthroughs/run-in-snowflake/run-in-snowflake.md
+++ b/docs/website/docs/walkthroughs/run-in-snowflake/run-in-snowflake.md
@@ -10,7 +10,7 @@ You can run dlt within Snowflake AI Data Cloud in a few different ways.
 ## Ways to run dlt
 
 1. **Snowflake Native App**  
-   Install the **Database Connector App** from the Snowflake Marketplace and run pipelines through the built-in UI.  
+   Install the **dlt Connector App** from the Snowflake Marketplace and run pipelines through the built-in UI.  
 
 2. **Snowflake Notebook**  
    Run a dlt pipeline directly inside a Snowflake Notebook for interactive development and testing.  


### PR DESCRIPTION
Update Snowflake Native App documentation to match new name (dlt Connector App).