### PR TITLE
button now links to same domain; no need to refresh website

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -151,7 +151,7 @@ const config = {
             type: 'docsVersionDropdown',
           },
           { to: 'https://dlthub.com/blog', label: 'Blog', position: 'left' },
-          { to: 'https://dlthub.com/docs/release-highlights', label: "What's new?", position: 'left' },
+          { to: '/release-highlights', label: "What's new?", position: 'left' },
           {
             href: 'https://dlthub.com/community',
             label: 'Join community',


### PR DESCRIPTION
Problem: pointing to the full url requires reloading the full page (see clip for before and after)


https://github.com/user-attachments/assets/bcc32bd6-89c0-45ca-8f1f-775c2baf198a

