### PR TITLE
docs: cookbook section

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -150,17 +150,27 @@ const config = {
           {
             type: 'docsVersionDropdown',
           },
-          { to: 'https://dlthub.com/blog', label: 'Blog', position: 'left' },
+          {
+            type: 'docSidebar',
+            sidebarId: 'docsSidebar',
+            position: 'left',
+            label: 'dlt',
+          },
+          {
+            type: 'docSidebar',
+            sidebarId: 'cookbookSidebar',
+            position: 'left',
+            label: 'Cookbook',
+          },
           { to: '/release-highlights', label: "What's new?", position: 'left' },
+          { to: 'https://dlthub.com/blog', label: 'Blog', position: 'right' },
           {
             href: 'https://dlthub.com/community',
-            label: 'Join community',
             position: 'right',
             className: 'slack-navbar',
           },
           {
             href: 'https://github.com/dlt-hub/dlt',
-            label: 'Star us',
             position: 'right',
             className: 'github-navbar',
             "aria-label": "GitHub repository",

--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -151,7 +151,7 @@ const config = {
             type: 'docsVersionDropdown',
           },
           { to: 'https://dlthub.com/blog', label: 'Blog', position: 'left' },
-          { to: 'https://dlthub.com/docs/release-highlights', label: "What's new?", position: 'left' },
+          { to: '/release-highlights', label: "What's new?", position: 'left' },
           {
             href: 'https://dlthub.com/community',
             label: 'Join community',

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -419,17 +419,6 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Code examples',
-      link: {
-        type: 'doc',
-        id: 'examples/index',
-      },
-      items: [
-        'walkthroughs/dispatch-to-multiple-tables',
-      ],
-    },
-    {
-      type: 'category',
       label: 'Reference',
       link: {
         type: 'generated-index',
@@ -576,12 +565,25 @@ const sidebars = {
     },
     'hub/command-line-interface',
     'hub/EULA',
-    ],
+  ],
+  cookbookSidebar: [
+    {
+      type: 'category',
+      label: 'Cookbook',
+      link: {
+        type: 'doc',
+        id: 'examples/index',
+      },
+      items: [
+        'walkthroughs/dispatch-to-multiple-tables',
+      ],
+    },
+  ]
 };
 
  // insert examples
-for (const item of sidebars.docsSidebar) {
-    if (item.label === 'Code examples') {
+for (const item of sidebars.cookbookSidebar) {
+    if (item.label === 'Cookbook') {
       for (let examplePath of walkSync("./docs_processed/examples")) {
         examplePath = examplePath.replace(/\\/g, "/");
         examplePath = examplePath.replace("docs_processed/", "");

--- a/docs/website/tools/update_versions.js
+++ b/docs/website/tools/update_versions.js
@@ -79,6 +79,48 @@ if (branch != "devel") {
     process.exit(1)
 }
 
+/**
+ * Backfills sidebar keys that exist in the current sidebars config but are absent
+ * from versioned sidebar snapshots (i.e. sidebars added after a version was tagged).
+ *
+ * Docusaurus requires every sidebar referenced in navbar items to exist in every
+ * versioned snapshot. When a new sidebar is introduced in `devel`, older snapshots
+ * won't have it, causing build failures. This function patches each snapshot JSON
+ * file by adding missing keys as empty arrays, which satisfies Docusaurus without
+ * altering the content of those older versions.
+ *
+ * @param {string} versionedSidebarsFolder - Path to the versioned_sidebars directory.
+ * @param {Object} currentSidebars - The sidebar config object exported from sidebars.js.
+ */
+function backfillVersionedSidebars(versionedSidebarsFolder, currentSidebars) {
+    const files = fs.readdirSync(versionedSidebarsFolder).filter(f => f.endsWith('.json'));
+    for (const file of files) {
+        const filePath = `${versionedSidebarsFolder}/${file}`;
+        const snapshot = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        let patched = false;
+        for (const key of Object.keys(currentSidebars)) {
+            if (!snapshot[key]) {
+              snapshot[key] = [
+                {
+                  type: 'category',
+                  label: 'Cookbook',
+                  link: {
+                    type: 'doc',
+                    id: 'examples/index',
+                  },
+                  items: []
+                },
+              ];
+                patched = true;
+            }
+        }
+        if (patched) {
+            fs.writeFileSync(filePath, JSON.stringify(snapshot, null, 2), 'utf8');
+            console.log(`Patched ${file}: added missing sidebar keys`);
+        }
+    }
+}
+
 selectedVersions.reverse()
 for (const version of selectedVersions) {
 
@@ -104,7 +146,9 @@ for (const version of selectedVersions) {
 
     console.log(`Moving snapshot`)
     fs.cpSync(REPO_DOCS_DIR+"/"+VERSIONED_DOCS_FOLDER, VERSIONED_DOCS_FOLDER, {recursive: true})
-    fs.cpSync(REPO_DOCS_DIR+"/"+VERSIONED_SIDEBARS_FOLDER, VERSIONED_SIDEBARS_FOLDER, {recursive: true})    
+    fs.cpSync(REPO_DOCS_DIR+"/"+VERSIONED_SIDEBARS_FOLDER, VERSIONED_SIDEBARS_FOLDER, {recursive: true})
+
+    backfillVersionedSidebars(VERSIONED_SIDEBARS_FOLDER, require('../sidebars.js'));
 }
 
 fs.cpSync(REPO_DOCS_DIR+"/versions.json", "versions.json")

--- a/docs/website/tools/update_versions.js
+++ b/docs/website/tools/update_versions.js
@@ -80,37 +80,40 @@ if (branch != "devel") {
 }
 
 /**
- * Backfills sidebar keys that exist in the current sidebars config but are absent
- * from versioned sidebar snapshots (i.e. sidebars added after a version was tagged).
+ * Backfills sidebar keys that are absent from versioned sidebar snapshots.
  *
  * Docusaurus requires every sidebar referenced in navbar items to exist in every
- * versioned snapshot. When a new sidebar is introduced in `devel`, older snapshots
- * won't have it, causing build failures. This function patches each snapshot JSON
- * file by adding missing keys as empty arrays, which satisfies Docusaurus without
- * altering the content of those older versions.
+ * versioned snapshot. When a new sidebar is introduced in `devel` after a version
+ * was tagged, older snapshots won't have it, causing build failures. This function
+ * patches each snapshot JSON file by inserting a fallback entry for each missing
+ * sidebar ID, pointing back to the docs root so the navbar tab remains functional.
+ *
+ * Note: sidebars.js is intentionally NOT required here — it calls walkSync on
+ * docs_processed/ at load time, which does not exist during update_versions.js
+ * execution in CI.
  *
  * @param {string} versionedSidebarsFolder - Path to the versioned_sidebars directory.
- * @param {Object} currentSidebars - The sidebar config object exported from sidebars.js.
+ * @param {string[]} sidebarIds - Sidebar IDs to backfill if absent from a snapshot.
  */
-function backfillVersionedSidebars(versionedSidebarsFolder, currentSidebars) {
+function backfillVersionedSidebars(versionedSidebarsFolder, sidebarIds) {
     const files = fs.readdirSync(versionedSidebarsFolder).filter(f => f.endsWith('.json'));
     for (const file of files) {
         const filePath = `${versionedSidebarsFolder}/${file}`;
         const snapshot = JSON.parse(fs.readFileSync(filePath, 'utf8'));
         let patched = false;
-        for (const key of Object.keys(currentSidebars)) {
-            if (!snapshot[key]) {
-              snapshot[key] = [
-                {
-                  type: 'category',
-                  label: 'Cookbook',
-                  link: {
-                    type: 'doc',
-                    id: 'examples/index',
-                  },
-                  items: []
-                },
-              ];
+        for (const id of sidebarIds) {
+            if (!snapshot[id]) {
+                snapshot[id] = [
+                    {
+                        type: 'category',
+                        label: 'Cookbook',
+                        link: {
+                            type: 'doc',
+                            id: 'examples/index',
+                        },
+                        items: [],
+                    },
+                ];
                 patched = true;
             }
         }
@@ -148,7 +151,7 @@ for (const version of selectedVersions) {
     fs.cpSync(REPO_DOCS_DIR+"/"+VERSIONED_DOCS_FOLDER, VERSIONED_DOCS_FOLDER, {recursive: true})
     fs.cpSync(REPO_DOCS_DIR+"/"+VERSIONED_SIDEBARS_FOLDER, VERSIONED_SIDEBARS_FOLDER, {recursive: true})
 
-    backfillVersionedSidebars(VERSIONED_SIDEBARS_FOLDER, require('../sidebars.js'));
+    backfillVersionedSidebars(VERSIONED_SIDEBARS_FOLDER, ['cookbookSidebar']);
 }
 
 fs.cpSync(REPO_DOCS_DIR+"/versions.json", "versions.json")


### PR DESCRIPTION
This moves the tested examples to a dedicated top header tab

Changes:
- `Cookbook` tab added
- content moved to cookbook was deduplicated
- `dlt` tab added; this allows to navigate back to "main docs" after you clicked `Cookbook`
  - in the future, we will have `dltHub` tab
- remove the text labels for Slack and GitHub (clean up the UI, gain some horizontal space)