### PR TITLE
fix: add pandas to filesystem source dependencies

### DIFF
--- a/dlt/sources/filesystem/readers.py
+++ b/dlt/sources/filesystem/readers.py
@@ -3,7 +3,7 @@ from dlt.common import json
 from dlt.common.typing import copy_sig_any
 from dlt.sources import TDataItems, DltResource, DltSource
 from dlt.sources.filesystem import FileItemDict
-from dlt.common.libs.pandas import pandas as pd
+from dlt.common.libs.pandas import pandas
 
 from .helpers import fetch_arrow, fetch_json
 
@@ -23,8 +23,6 @@ def _read_csv(
     Returns:
         TDataItem: The file content
     """
-    
-
     # apply defaults to pandas kwargs
     kwargs = {**{"header": "infer", "chunksize": chunksize}, **pandas_kwargs}
     # For some remote file systems (for example, sftp/paramiko), decoding may happen before
@@ -42,9 +40,8 @@ def _read_csv(
         # Here we use pandas chunksize to read the file in chunks and avoid loading the whole file
         # in memory.
         with file_obj.open(mode=open_mode, **open_kwargs) as file:
-            for df in pd.read_csv(file, **kwargs): # type: ignore[attr-defined]
+            for df in pandas.read_csv(file, **kwargs):
                 yield df.to_dict(orient="records")
-
 
 # NOTE inconsistent kwarg convention across readers `chunk_size` vs. `chunksize`
 # snakecased `chunk_size` is the more appropriate Python convention

--- a/dlt/sources/filesystem/readers.py
+++ b/dlt/sources/filesystem/readers.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, Any, Iterable, Iterator, Optional
-
 from dlt.common import json
 from dlt.common.typing import copy_sig_any
 from dlt.sources import TDataItems, DltResource, DltSource
 from dlt.sources.filesystem import FileItemDict
+from dlt.common.libs import pandas as pd
 
 from .helpers import fetch_arrow, fetch_json
 
@@ -23,7 +23,7 @@ def _read_csv(
     Returns:
         TDataItem: The file content
     """
-    import pandas as pd
+    
 
     # apply defaults to pandas kwargs
     kwargs = {**{"header": "infer", "chunksize": chunksize}, **pandas_kwargs}

--- a/dlt/sources/filesystem/readers.py
+++ b/dlt/sources/filesystem/readers.py
@@ -3,7 +3,7 @@ from dlt.common import json
 from dlt.common.typing import copy_sig_any
 from dlt.sources import TDataItems, DltResource, DltSource
 from dlt.sources.filesystem import FileItemDict
-from dlt.common.libs import pandas as pd
+from dlt.common.libs.pandas import pandas as pd
 
 from .helpers import fetch_arrow, fetch_json
 
@@ -42,7 +42,7 @@ def _read_csv(
         # Here we use pandas chunksize to read the file in chunks and avoid loading the whole file
         # in memory.
         with file_obj.open(mode=open_mode, **open_kwargs) as file:
-            for df in pd.read_csv(file, **kwargs):
+            for df in pd.read_csv(file, **kwargs): # type: ignore[attr-defined]
                 yield df.to_dict(orient="records")
 
 


### PR DESCRIPTION
## Description
Running `dlt init filesystem <destination>` followed by `pip install -r requirements.txt` 
does not install pandas. However, the generated pipeline uses `read_csv()` which requires 
pandas, causing a confusing `ModuleNotFoundError` at runtime.

**Changes:**
- Add `pandas>=1.3.0` to the `filesystem` extra in `pyproject.toml` so it is included 
  when running `pip install -r requirements.txt` after `dlt init filesystem`
- Add `MissingDependencyException` in `_read_csv` for a clear, actionable error message 
  if pandas is not installed
- Update `uv.lock` to reflect new pandas dependency

## Related Issues
- Closes #3876

## Additional Context
The fix follows the same `MissingDependencyException` pattern already used in 
`dlt/sources/sql_database/helpers.py` for optional dependencies like `connectorx`.