### PR TITLE
fix: clearer error from `dlt.attach()` when pipeline cannot be restored

### DIFF
--- a/dlt/pipeline/__init__.py
+++ b/dlt/pipeline/__init__.py
@@ -244,15 +244,24 @@ def attach(
         )
 
         # we cannot restore the pipeline if the destination is not provided
-        # or found in the env, wipe the working folder and re-raise
+        # or found in the config, wipe the working folder and re-raise
         if not p.destination:
             p._wipe_working_folder()
             raise CannotRestorePipelineException(
                 pipeline_name,
                 p.working_dir,
-                f"the pipeline was not found in {p.working_dir} found and no destination was"
-                " provided to restore from.",
-            )
+                f"No local pipeline state found in '{p.working_dir}'.\n\n"
+                "dlt can restore pipeline state from a destination, but requires a destination."
+                " Pass it as an argument to dlt.attach() or configure it via dlt's"
+                " config system.\n\n"
+                f'`dlt.attach(pipeline_name="{pipeline_name}", destination="<your-destination>",'
+                ' dataset_name="<your-dataset>")`\n\n'
+                f"Note: if no dataset_name is provided, dlt looks in '{pipeline_name}_dataset'"
+                " by default.\n\n"
+                "If you only need to read or query data without pipeline state, use"
+                " `dlt.dataset()` instead:\n\n"
+                '`dlt.dataset(destination="<your-destination>", dataset_name="<your-dataset>")`',
+            ) from None
         p.sync_destination()
 
         # if remote state was not found,
@@ -262,9 +271,16 @@ def attach(
             raise CannotRestorePipelineException(
                 pipeline_name,
                 p.working_dir,
-                f"the pipeline was not found in {p.working_dir} found and provided destination and"
-                " dataset do not contain state for this pipeline.",
-            )
+                f"Checked local state in '{p.working_dir}' and remote state in dataset"
+                f" '{p.dataset_name}' on destination '{p.destination.destination_name}'."
+                " No state found for this pipeline in either location.\n\n"
+                "If the pipeline was run with a different dataset name, pass the correct"
+                " dataset_name= to dlt.attach() or configure it via dlt's config system.\n\n"
+                "If you only need to read or query data without pipeline state, use"
+                " `dlt.dataset()` instead:\n\n"
+                f'`dlt.dataset(destination="{p.destination.destination_name}",'
+                f' dataset_name="{p.dataset_name}")`',
+            ) from None
         return p
 
 

--- a/tests/load/pipeline/test_pipelines.py
+++ b/tests/load/pipeline/test_pipelines.py
@@ -314,7 +314,8 @@ def test_attach_edgecases(destination_config: DestinationTestConfiguration) -> N
     p._wipe_working_folder()
     with pytest.raises(CannotRestorePipelineException) as exc_info:
         dlt.attach("test_attach_edgecases")
-    assert "no destination was provided to restore from" in str(exc_info.value)
+    assert "No local pipeline state found" in str(exc_info.value)
+    assert "dlt can restore pipeline state from a destination" in str(exc_info.value)
     # no working folder left behing
     assert not p._pipeline_storage.has_folder("")
 
@@ -323,9 +324,7 @@ def test_attach_edgecases(destination_config: DestinationTestConfiguration) -> N
     with pytest.raises(CannotRestorePipelineException) as exc_info:
         dlt.attach("test_attach_edgecases", destination="duckdb", dataset_name="incorrect")
     # no working folder left behing
-    assert "provided destination and dataset do not contain state for this pipeline" in str(
-        exc_info.value
-    )
+    assert "No state found for this pipeline in either location" in str(exc_info.value)
     assert not p._pipeline_storage.has_folder("")
 
     # re-attaching with destination and dataset name will work

--- a/tests/workspace/cli/common/test_cli_invoke.py
+++ b/tests/workspace/cli/common/test_cli_invoke.py
@@ -60,7 +60,7 @@ def test_invoke_pipeline(script_runner: ScriptRunner) -> None:
     # info on non existing pipeline
     result = script_runner.run(["dlt", "pipeline", "debug_pipeline", "info"])
     assert result.returncode == -2
-    assert "the pipeline was not found in" in result.stderr
+    assert "No local pipeline state found" in result.stderr
 
     shutil.copytree(
         os.path.join(WORKSPACE_CLI_CASES_DIR, "deploy_pipeline"), ".", dirs_exist_ok=True

--- a/tests/workspace/cli/test_pipeline_command.py
+++ b/tests/workspace/cli/test_pipeline_command.py
@@ -154,7 +154,7 @@ def test_pipeline_command_operations(repo_dir: str) -> None:
             )
         _out = buf.getvalue()
 
-        assert "could not be restored: the pipeline was not found in " in _out
+        assert "No local pipeline state found" in _out
         assert "Selected resource(s): ['players_profiles']" in _out
 
         # Command was executed


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR rewrites the `CannotRestorePipelineException` raised by `dlt.attach()` when pipeline state cannot be restored. The previous error told users only that the pipeline was not found at a path, without explaining what was missing or how to recover. The new messages name the requirements, show a concrete example interpolated with the user's own pipeline name, and offer `dlt.dataset()` as a lighter-weight alternative when pipeline state is not actually needed. Also suppresses a redundant inner exception that was cluttering tracebacks.


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #3394 

<!--
Provide any additional context about the PR here.
-->

### Changes
1. **Rewrote the "no destination" error message** — names the required inputs, shows a concrete `dlt.attach(...)` example with the user's pipeline name, and offers `dlt.dataset()` as a lighter alternative.

2. **Rewrote the "remote state not found" error message** — reports both locations checked and offers a `dlt.dataset()` example interpolated with the user's actual destination and dataset.

3. **Suppressed the inner exception chain with `raise ... from None`** — hides a redundant duplicate exception from tracebacks while preserving `__context__` for debuggers and observability tools.

4. **Updated test assertions** in `tests/load/pipeline/test_pipelines.py` and `tests/workspace/cli/common/test_cli_invoke.py` to match the new wording.

5. **Corrected the inline comment** above the raise (`env` → `config`).

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
