### PR TITLE
Chore: ci from fork

### DIFF
--- a/.github/workflows/fork_tests_with_secrets.yml
+++ b/.github/workflows/fork_tests_with_secrets.yml
@@ -2,8 +2,11 @@ name: dlt | fork tests with secrets
 
 on:
   pull_request_target:
-    branches: [master, devel, runtime]
+    branches: [devel]
     types: [labeled, synchronize]
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/fork_tests_with_secrets.yml
+++ b/.github/workflows/fork_tests_with_secrets.yml
@@ -1,0 +1,36 @@
+name: dlt | fork tests with secrets
+
+on:
+  pull_request_target:
+    branches: [master, devel, runtime]
+    types: [labeled, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  authorize:
+    name: authorize fork run (requires reviewer approval)
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository
+      && contains(github.event.pull_request.labels.*.name, 'ci from fork')
+    runs-on: ubuntu-latest
+    environment: fork-ci
+    steps:
+      - run: echo "Fork PR authorized — running secret-requiring tests against ${{ github.event.pull_request.head.sha }}"
+
+  test_destinations_remote:
+    name: test remote destinations with secrets (fork)
+    needs: [authorize]
+    uses: ./.github/workflows/test_destinations_remote.yml
+    secrets: inherit
+    with:
+      run_full_test_suite: ${{ contains(github.event.pull_request.labels.*.name, 'ci full') }}
+
+  test_tools_dbt_runner:
+    name: test dbt runner (fork)
+    needs: [authorize]
+    uses: ./.github/workflows/test_tools_dbt_runner.yml
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml
 
-  # if the PR is from a fork, we need to authorize the secrets access and remote destinations run with a lable
-  authorize_run_from_fork:
-    name: check if fork and if so wether secrets are available
-    # run when label is assigned OR when we are not a fork
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ci from fork') || (github.event.pull_request.head.repo.full_name == github.repository && (github.event.action == 'opened' || github.event.action == 'synchronize'))}}
+  # gate for secret-requiring jobs: secrets are only available for internal (same-repo) PRs under pull_request.
+  # fork PRs with the `ci from fork` label are handled separately by fork_tests_with_secrets.yml (pull_request_target).
+  authorize_secrets:
+    name: secrets available (internal PRs only)
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && (github.event.action == 'opened' || github.event.action == 'synchronize') }}
     runs-on: ubuntu-latest
     steps:
       - run: true
@@ -89,7 +89,7 @@ jobs:
 
   test_destinations_remote:
     name: test remote destinations with secrets
-    needs: [authorize_run_from_fork, test_common]
+    needs: [authorize_secrets, test_common]
     uses: ./.github/workflows/test_destinations_remote.yml
     secrets: inherit
     with:
@@ -100,12 +100,12 @@ jobs:
   #
   test_tools_dbt_runner:
     name: test dbt runner
-    needs: [test_common, authorize_run_from_fork]
+    needs: [test_common, authorize_secrets]
     uses: ./.github/workflows/test_tools_dbt_runner.yml
     secrets: inherit
   
   # dbt cloud tests currently are disabled, TODO: explain why
   # test_tools_dbt_cloud:
-  #   needs: [test_common, authorize_run_from_fork]
+  #   needs: [test_common, authorize_secrets]
   #   uses: ./.github/workflows/test_tools_dbt_cloud.yml
   #   secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     name: docs changes
     uses: ./.github/workflows/get_docs_changes.yml
 
-  # gate for secret-requiring jobs: secrets are only available for internal (same-repo) PRs under pull_request.
+  # check for secret-requiring jobs: secrets are only available for internal (same-repo) PRs under pull_request.
   # fork PRs with the `ci from fork` label are handled separately by fork_tests_with_secrets.yml (pull_request_target).
   authorize_secrets:
     name: secrets available (internal PRs only)


### PR DESCRIPTION
This PR adjusts the main workflow in the way that:
- It runs tests that require secrets only on internal PRs (where the head repo matches the target repo)
- PRs from forks use the new `fork_tests_with_secrets.yml` workflow that runs secret-requiring tests, triggered when:
    - The `ci from fork` label is added (needs to be added once)
    - New pushes to the fork branch automatically re-trigger the workflow (no need to re-label) 
    - Each triggered run requires a maintainer to manually approve it via the fork-ci environment before secrets are exposed  

> This will need a new environment `fork-ci` with `Required reviewers` enabled under `Environment protection rules`



Resolves #3850 