### PR TITLE
fix: correctly materialize empty tables for multi-table resources

### DIFF
--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -345,41 +345,49 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
     ) -> None:
         schema = source.schema
         json_extractor = extractors["object"]
-        resources_with_items = set().union(*[e.resources_with_items for e in extractors.values()])
+        tables_with_items = set().union(*[e.tables_with_items for e in extractors.values()])
         # find REPLACE resources that did not yield any pipe items and create empty jobs for them
         # NOTE: do not include tables that have never seen data
         data_tables = {t["name"]: t for t in schema.data_tables(seen_data_only=True)}
         tables_by_resources = utils.group_tables_by_resource(data_tables)
         for resource in source.resources.selected.values():
-            if resource.write_disposition != "replace" or resource.name in resources_with_items:
-                continue
             if resource.name not in tables_by_resources:
                 continue
             for table in tables_by_resources[resource.name]:
+                write_disposition = table.get("write_disposition") or resource.write_disposition
+                if write_disposition != "replace" or (resource.name, table["name"]) in tables_with_items:
+                    continue
                 # we only need to write empty files for the root tables
                 if not utils.is_nested_table(table):
                     json_extractor.write_empty_items_file(table["name"])
 
         # collect resources that received empty materialized lists and had no items
-        resources_with_empty = (
+        tables_with_empty = (
             set()
-            .union(*[e.resources_with_empty for e in extractors.values()])
-            .difference(resources_with_items)
+            .union(*[e.tables_with_empty for e in extractors.values()])
+            .difference(tables_with_items)
         )
         # get all possible tables
         data_tables = {t["name"]: t for t in schema.data_tables()}
         tables_by_resources = utils.group_tables_by_resource(data_tables)
-        for resource_name in resources_with_empty:
+
+        resources_and_tables = {}
+        for resource_name, table_name in tables_with_empty:
+            resources_and_tables.setdefault(resource_name, []).append(table_name)
+
+        for resource_name, table_names in resources_and_tables.items():
             if resource := source.resources.selected.get(resource_name):
                 if tables := tables_by_resources.get(resource_name):
                     # write empty tables
                     for table in tables:
+                        if table["name"] not in table_names:
+                            continue
                         # we only need to write empty files for the root tables
                         if not utils.is_nested_table(table):
                             json_extractor.write_empty_items_file(table["name"])
                 else:
                     table_name = json_extractor._get_static_table_name(resource, None)
-                    if table_name:
+                    if table_name and table_name in table_names:
                         json_extractor.write_empty_items_file(table_name)
 
     def _extract_single_source(

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -371,7 +371,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
         tables_by_resources = utils.group_tables_by_resource(data_tables)
         for resource_name in resources_with_empty:
             if resource := source.resources.selected.get(resource_name):
-                if tables := tables_by_resources.get("resource_name"):
+                if tables := tables_by_resources.get(resource_name):
                     # write empty tables
                     for table in tables:
                         # we only need to write empty files for the root tables

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -355,40 +355,20 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                 continue
             for table in tables_by_resources[resource.name]:
                 write_disposition = table.get("write_disposition") or resource.write_disposition
-                if write_disposition != "replace" or (resource.name, table["name"]) in tables_with_items:
+                if write_disposition != "replace" or table["name"] in tables_with_items:
                     continue
                 # we only need to write empty files for the root tables
                 if not utils.is_nested_table(table):
                     json_extractor.write_empty_items_file(table["name"])
 
-        # collect resources that received empty materialized lists and had no items
+        # collect tables that received empty materialized lists and had no items
         tables_with_empty = (
             set()
             .union(*[e.tables_with_empty for e in extractors.values()])
             .difference(tables_with_items)
         )
-        # get all possible tables
-        data_tables = {t["name"]: t for t in schema.data_tables()}
-        tables_by_resources = utils.group_tables_by_resource(data_tables)
-
-        resources_and_tables: Dict[str, List[str]] = {}
-        for resource_name, table_name in tables_with_empty:
-            resources_and_tables.setdefault(resource_name, []).append(table_name)
-
-        for resource_name, table_names in resources_and_tables.items():
-            if resource := source.resources.selected.get(resource_name):
-                if tables := tables_by_resources.get(resource_name):
-                    # write empty tables
-                    for table in tables:
-                        if table["name"] not in table_names:
-                            continue
-                        # we only need to write empty files for the root tables
-                        if not utils.is_nested_table(table):
-                            json_extractor.write_empty_items_file(table["name"])
-                else:
-                    table_name = json_extractor._get_static_table_name(resource, None)
-                    if table_name and table_name in table_names:
-                        json_extractor.write_empty_items_file(table_name)
+        for table_name in tables_with_empty:
+            json_extractor.write_empty_items_file(table_name)
 
     def _extract_single_source(
         self,

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -371,7 +371,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
         data_tables = {t["name"]: t for t in schema.data_tables()}
         tables_by_resources = utils.group_tables_by_resource(data_tables)
 
-        resources_and_tables = {}
+        resources_and_tables: Dict[str, List[str]] = {}
         for resource_name, table_name in tables_with_empty:
             resources_and_tables.setdefault(resource_name, []).append(table_name)
 

--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -1,6 +1,6 @@
 from copy import copy
 from functools import lru_cache, partial
-from typing import Set, Dict, Any, Optional, List, Union, Tuple
+from typing import Set, Dict, Any, Optional, List, Union
 
 from dlt.common.configuration import known_sections, resolve_configuration, with_config
 from dlt.common import logger, json
@@ -120,10 +120,10 @@ class Extractor:
         self.schema = schema
         self.naming = schema.naming
         self.collector = collector
-        self.tables_with_items: Set[Tuple[str, str]] = set()
-        """Tracks (resource, table) pairs that received items"""
-        self.tables_with_empty: Set[Tuple[str, str]] = set()
-        """Tracks (resource, table) pairs that received empty materialized list"""
+        self.tables_with_items: Set[str] = set()
+        """Tracks tables that received items"""
+        self.tables_with_empty: Set[str] = set()
+        """Tracks tables that received empty materialized list"""
         self.load_id = load_id
         self.item_storage = item_storage
         self._table_contracts: Dict[str, TSchemaContractDict] = {}
@@ -186,10 +186,10 @@ class Extractor:
         self.collector.update(table_name, inc=new_rows_count)
         # if there were rows or item was empty arrow table
         if new_rows_count > 0 or self.__class__ is ArrowExtractor:
-            self.tables_with_items.add((resource_name, table_name))
+            self.tables_with_items.add(table_name)
         else:
             if isinstance(items, MaterializedEmptyList):
-                self.tables_with_empty.add((resource_name, table_name))
+                self.tables_with_empty.add(table_name)
 
     def _import_item(
         self,
@@ -206,7 +206,7 @@ class Extractor:
             meta.file_format,
         )
         self.collector.update(table_name, inc=metrics.items_count)
-        self.tables_with_items.add((resource_name, table_name))
+        self.tables_with_items.add(table_name)
 
     def _write_to_dynamic_table(self, resource: DltResource, items: TDataItems, meta: Any) -> None:
         if not isinstance(items, list):

--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -1,6 +1,6 @@
 from copy import copy
 from functools import lru_cache, partial
-from typing import Set, Dict, Any, Optional, List, Union
+from typing import Set, Dict, Any, Optional, List, Union, Tuple
 
 from dlt.common.configuration import known_sections, resolve_configuration, with_config
 from dlt.common import logger, json
@@ -120,10 +120,10 @@ class Extractor:
         self.schema = schema
         self.naming = schema.naming
         self.collector = collector
-        self.resources_with_items: Set[str] = set()
-        """Tracks resources that received items"""
-        self.resources_with_empty: Set[str] = set()
-        """Track resources that received empty materialized list"""
+        self.tables_with_items: Set[Tuple[str, str]] = set()
+        """Tracks (resource, table) pairs that received items"""
+        self.tables_with_empty: Set[Tuple[str, str]] = set()
+        """Tracks (resource, table) pairs that received empty materialized list"""
         self.load_id = load_id
         self.item_storage = item_storage
         self._table_contracts: Dict[str, TSchemaContractDict] = {}
@@ -186,10 +186,10 @@ class Extractor:
         self.collector.update(table_name, inc=new_rows_count)
         # if there were rows or item was empty arrow table
         if new_rows_count > 0 or self.__class__ is ArrowExtractor:
-            self.resources_with_items.add(resource_name)
+            self.tables_with_items.add((resource_name, table_name))
         else:
             if isinstance(items, MaterializedEmptyList):
-                self.resources_with_empty.add(resource_name)
+                self.tables_with_empty.add((resource_name, table_name))
 
     def _import_item(
         self,
@@ -206,7 +206,7 @@ class Extractor:
             meta.file_format,
         )
         self.collector.update(table_name, inc=metrics.items_count)
-        self.resources_with_items.add(resource_name)
+        self.tables_with_items.add((resource_name, table_name))
 
     def _write_to_dynamic_table(self, resource: DltResource, items: TDataItems, meta: Any) -> None:
         if not isinstance(items, list):

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -13,6 +13,7 @@ from dlt.common.storages import (
 )
 from dlt.common.storages.schema_storage import SchemaStorage
 from dlt.common.typing import TTableNames, TDataItems
+from dlt.common.utils import uniq_id
 
 from dlt.extract import DltResource, DltSource
 from dlt.extract.exceptions import DataItemRequiredForDynamicTableHints, ResourceExtractionError
@@ -611,6 +612,55 @@ def test_materialize_table_schema_with_pipe_items():
         if job.job_file_info.table_name == "empty_list":
             found_empty_list = True
     assert found_empty_list
+
+
+@pytest.mark.parametrize(
+    "yield_one,yield_two",
+    [(True, False), (False, True), (False, False), (True, True)],
+    ids=["only_first", "only_second", "neither", "both"],
+)
+def test_materialize_table_schema_multi_table(yield_one: bool, yield_two: bool) -> None:
+    """Empty table materialization works correctly for resources that produce multiple tables."""
+
+    @dlt.resource
+    def multi_table():
+        yield dlt.mark.with_hints(
+            dlt.mark.materialize_table_schema(),
+            dlt.mark.make_hints(
+                table_name="table_one",
+                write_disposition="replace",
+                columns={"col_one": {"data_type": "text"}},
+            ),
+            create_table_variant=True,
+        )
+        yield dlt.mark.with_hints(
+            dlt.mark.materialize_table_schema(),
+            dlt.mark.make_hints(
+                table_name="table_two",
+                write_disposition="replace",
+                columns={"col_two": {"data_type": "bigint"}},
+            ),
+            create_table_variant=True,
+        )
+        if yield_one:
+            yield dlt.mark.with_table_name({"col_one": "val"}, table_name="table_one")
+        if yield_two:
+            yield dlt.mark.with_table_name({"col_two": 5}, table_name="table_two")
+
+    p = dlt.pipeline(
+        pipeline_name="materialize_multi_" + uniq_id(),
+        destination="duckdb",
+        dev_mode=True,
+    )
+    extract_info = p.extract(multi_table())
+
+    extracted_tables = {
+        job.job_file_info.table_name
+        for job in extract_info.load_packages[0].jobs["new_jobs"]
+    }
+    # both tables should always have jobs — either with data or empty files
+    assert "table_one" in extracted_tables
+    assert "table_two" in extracted_tables
 
 
 @pytest.mark.parametrize(

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -655,8 +655,7 @@ def test_materialize_table_schema_multi_table(yield_one: bool, yield_two: bool) 
     extract_info = p.extract(multi_table())
 
     extracted_tables = {
-        job.job_file_info.table_name
-        for job in extract_info.load_packages[0].jobs["new_jobs"]
+        job.job_file_info.table_name for job in extract_info.load_packages[0].jobs["new_jobs"]
     }
     # both tables should always have jobs — either with data or empty files
     assert "table_one" in extracted_tables

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -85,6 +85,7 @@ from tests.pipeline.utils import (
     load_table_counts,
     load_tables_to_dicts,
     many_delayed,
+    table_exists,
 )
 
 from dlt.destinations.dataset import get_destination_client_initial_config
@@ -3554,6 +3555,109 @@ def test_yielding_empty_list_creates_table() -> None:
             rows = list(cur.fetchall())
             assert len(rows) == 1
             assert rows[0] == (1, None)
+
+
+@pytest.mark.parametrize(
+    "yield_one,yield_two",
+    [(True, False), (False, True), (False, False), (True, True)],
+    ids=["only_first", "only_second", "neither", "both"],
+)
+def test_materialize_table_schema_multi_table_duckdb(yield_one: bool, yield_two: bool) -> None:
+    """End-to-end check that a multi-table resource materializes both tables in duckdb,
+    whether they receive data or not. Dispatch happens via `with_table_name` and table
+    variants are pre-declared with `materialize_table_schema()`.
+    """
+
+    @dlt.resource
+    def multi_table():
+        yield dlt.mark.with_hints(
+            dlt.mark.materialize_table_schema(),
+            dlt.mark.make_hints(
+                table_name="table_one",
+                write_disposition="replace",
+                columns={"col_one": {"data_type": "text"}},
+            ),
+            create_table_variant=True,
+        )
+        yield dlt.mark.with_hints(
+            dlt.mark.materialize_table_schema(),
+            dlt.mark.make_hints(
+                table_name="table_two",
+                write_disposition="replace",
+                columns={"col_two": {"data_type": "bigint"}},
+            ),
+            create_table_variant=True,
+        )
+        if yield_one:
+            yield dlt.mark.with_table_name({"col_one": "val"}, table_name="table_one")
+        if yield_two:
+            yield dlt.mark.with_table_name({"col_two": 5}, table_name="table_two")
+
+    pipeline = dlt.pipeline(
+        pipeline_name="materialize_multi_e2e_" + uniq_id(),
+        destination="duckdb",
+        dev_mode=True,
+    )
+    load_info = pipeline.run(multi_table())
+    assert_load_info(load_info)
+
+    expected = {
+        "table_one": 1 if yield_one else 0,
+        "table_two": 1 if yield_two else 0,
+    }
+    assert_table_counts(pipeline, expected)
+
+    schema_tables = pipeline.default_schema.tables
+    assert "col_one" in schema_tables["table_one"]["columns"]
+    assert "col_two" in schema_tables["table_two"]["columns"]
+
+
+def test_materialize_table_schema_with_nested_hints_duckdb() -> None:
+    """Pre-declared nested table via `nested_hints` is added to the schema but does NOT
+    materialize at the destination when only the root yields `materialize_table_schema()`.
+    The normalizer attaches parent/child linking columns only when real nested data flows
+    through it, so an empty nested table cannot be meaningfully created up front.
+    """
+
+    @dlt.resource(
+        name="users",
+        write_disposition="replace",
+        columns=[
+            {"name": "id", "data_type": "bigint", "nullable": False},
+            {"name": "name", "data_type": "text"},
+        ],
+        nested_hints={
+            "purchases": dlt.mark.make_nested_hints(
+                columns=[{"name": "price", "data_type": "decimal"}],
+            ),
+        },
+    )
+    def users_with_nested():
+        yield dlt.mark.materialize_table_schema()
+
+    pipeline = dlt.pipeline(
+        pipeline_name="materialize_nested_e2e_" + uniq_id(),
+        destination="duckdb",
+        dev_mode=True,
+    )
+    load_info = pipeline.run(users_with_nested())
+    assert_load_info(load_info)
+
+    # root table is materialized empty in duckdb with declared columns
+    assert table_exists(pipeline, "users")
+    assert load_table_counts(pipeline, "users") == {"users": 0}
+    users_columns = pipeline.default_schema.tables["users"]["columns"]
+    assert {"id", "name", "_dlt_load_id", "_dlt_id"}.issubset(users_columns.keys())
+
+    # nested table is computed into the schema from `nested_hints`
+    assert "users__purchases" in pipeline.default_schema.tables
+    nested_columns = pipeline.default_schema.tables["users__purchases"]["columns"]
+    assert "price" in nested_columns
+
+    # but it is NOT created at the destination — no MaterializedEmptyList ever flows
+    # through `_write_item` for the nested name, and parent linkage columns are produced
+    # by the normalizer only on real nested rows
+    assert not table_exists(pipeline, "users__purchases")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Continuation of #3814

This PR adjusts the extractor in the way that it tracks empty tables, not resources to allow multi empty table materialization.

A relevant tests is added.


Resolves https://github.com/dlt-hub/dlt/issues/3840
