### PR TITLE
fix: relax JSON normalizer type validation

### DIFF
--- a/dlt/common/normalizers/json/relational.py
+++ b/dlt/common/normalizers/json/relational.py
@@ -332,7 +332,7 @@ class DataItemNormalizer(DataItemNormalizerBase[RelationalNormalizerConfig]):
             RelationalNormalizerConfig,
             self.schema._normalizers_config["json"].get("config") or {},
         )
-        DataItemNormalizer._validate_normalizer_config(self.schema, config)
+        self._validate_normalizer_config(self.schema, config)
 
         # add hints, do not compile.
         self.schema._merge_hints(

--- a/dlt/common/normalizers/json/relational.py
+++ b/dlt/common/normalizers/json/relational.py
@@ -1,4 +1,5 @@
 from functools import lru_cache, partial
+from importlib import import_module
 from typing import (
     ClassVar,
     Dict,
@@ -37,6 +38,7 @@ from dlt.common.schema.utils import (
 )
 from dlt.common.utils import update_dict_nested
 from dlt.common.normalizers.json import (
+    SupportsDataItemNormalizer,
     TNormalizedRowIterator,
     wrap_in_dict,
     DataItemNormalizer as DataItemNormalizerBase,
@@ -433,7 +435,8 @@ class DataItemNormalizer(DataItemNormalizerBase[RelationalNormalizerConfig]):
     def ensure_this_normalizer(cls, norm_config: TJSONNormalizer) -> None:
         # make sure schema has right normalizer
         present_normalizer = norm_config["module"]
-        if present_normalizer != cls.__module__:
+        module = cast(SupportsDataItemNormalizer, import_module(present_normalizer))
+        if not issubclass(module.DataItemNormalizer, cls):
             raise InvalidJsonNormalizer(cls.__module__, present_normalizer)
 
     @classmethod

--- a/dlt/common/schema/normalizers.py
+++ b/dlt/common/schema/normalizers.py
@@ -9,7 +9,6 @@ from dlt.common import known_env
 from dlt.common.configuration.inject import with_config
 from dlt.common.configuration.specs import known_sections
 from dlt.common.schema.configuration import SchemaConfiguration
-from dlt.common.normalizers.exceptions import InvalidJsonNormalizer
 from dlt.common.normalizers.json import SupportsDataItemNormalizer, DataItemNormalizer
 from dlt.common.normalizers.naming import NamingConvention
 from dlt.common.normalizers.naming.exceptions import (
@@ -107,20 +106,18 @@ def import_normalizers(
     if "." not in json_module_name:
         json_module_name = f"{DEFAULT_JSON_NAMESPACE}.{json_module_name}"
         item_normalizer["module"] = json_module_name
+    json_module = cast(SupportsDataItemNormalizer, import_module(json_module_name))
     # if max_table_nesting is set, we need to set the max_table_nesting in the json_normalizer
     if destination_capabilities and destination_capabilities.max_table_nesting is not None:
         # TODO: this is a hack, we need a better method to do this
         from dlt.common.normalizers.json.relational import DataItemNormalizer
 
-        try:
-            DataItemNormalizer.ensure_this_normalizer(item_normalizer)
+        if issubclass(json_module.DataItemNormalizer, DataItemNormalizer):
             item_normalizer.setdefault("config", {})
             item_normalizer["config"]["max_nesting"] = destination_capabilities.max_table_nesting  # type: ignore[index]
-        except InvalidJsonNormalizer:
+        else:
             # not a right normalizer
             logger.warning(f"JSON Normalizer {item_normalizer} does not support max_nesting")
-            pass
-    json_module = cast(SupportsDataItemNormalizer, import_module(json_module_name))
     explicit_normalizers["json"] = item_normalizer
     return (
         explicit_normalizers,

--- a/dlt/common/schema/normalizers.py
+++ b/dlt/common/schema/normalizers.py
@@ -8,6 +8,7 @@ from dlt.common import logger
 from dlt.common import known_env
 from dlt.common.configuration.inject import with_config
 from dlt.common.configuration.specs import known_sections
+from dlt.common.normalizers.exceptions import InvalidJsonNormalizer
 from dlt.common.schema.configuration import SchemaConfiguration
 from dlt.common.normalizers.json import SupportsDataItemNormalizer, DataItemNormalizer
 from dlt.common.normalizers.naming import NamingConvention
@@ -106,18 +107,21 @@ def import_normalizers(
     if "." not in json_module_name:
         json_module_name = f"{DEFAULT_JSON_NAMESPACE}.{json_module_name}"
         item_normalizer["module"] = json_module_name
-    json_module = cast(SupportsDataItemNormalizer, import_module(json_module_name))
     # if max_table_nesting is set, we need to set the max_table_nesting in the json_normalizer
     if destination_capabilities and destination_capabilities.max_table_nesting is not None:
         # TODO: this is a hack, we need a better method to do this
         from dlt.common.normalizers.json.relational import DataItemNormalizer
 
-        if issubclass(json_module.DataItemNormalizer, DataItemNormalizer):
+        try:
+            DataItemNormalizer.ensure_this_normalizer(item_normalizer)
+            
             item_normalizer.setdefault("config", {})
             item_normalizer["config"]["max_nesting"] = destination_capabilities.max_table_nesting  # type: ignore[index]
-        else:
+        except InvalidJsonNormalizer:
             # not a right normalizer
             logger.warning(f"JSON Normalizer {item_normalizer} does not support max_nesting")
+
+    json_module = cast(SupportsDataItemNormalizer, import_module(json_module_name))
     explicit_normalizers["json"] = item_normalizer
     return (
         explicit_normalizers,

--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -394,16 +394,20 @@ class DltSource(Iterable[TDataItem]):
     @property
     def max_table_nesting(self) -> int:
         """A schema hint that sets the maximum depth of nested table above which the remaining nodes are loaded as structs or JSON."""
-        return RelationalNormalizer.get_normalizer_config(self._schema).get("max_nesting")
+        data_normalizer = self._schema.data_item_normalizer
+        assert isinstance(data_normalizer, RelationalNormalizer)
+        return data_normalizer.get_normalizer_config(self._schema).get("max_nesting")
 
     @max_table_nesting.setter
     def max_table_nesting(self, value: int) -> None:
+        data_normalizer = self._schema.data_item_normalizer
+        assert isinstance(data_normalizer, RelationalNormalizer)
         if value is None:
             # this also check the normalizer type
-            config = RelationalNormalizer.get_normalizer_config(self._schema)
+            config = data_normalizer.get_normalizer_config(self._schema)
             config.pop("max_nesting", None)
         else:
-            RelationalNormalizer.update_normalizer_config(self._schema, {"max_nesting": value})
+            data_normalizer.update_normalizer_config(self._schema, {"max_nesting": value})
 
     @property
     def root_key(self) -> Optional[bool]:
@@ -411,8 +415,10 @@ class DltSource(Iterable[TDataItem]):
         This option is most useful if you plan to change write disposition of a resource to disable/enable merge.
 
         """
+        data_normalizer = self._schema.data_item_normalizer
+        assert isinstance(data_normalizer, RelationalNormalizer)
         # this also check the normalizer type
-        config = RelationalNormalizer.get_normalizer_config(self._schema)
+        config = data_normalizer.get_normalizer_config(self._schema)
         is_root_key = config.get("root_key_propagation")
         if is_root_key is None:
             # if not found get legacy value
@@ -424,12 +430,14 @@ class DltSource(Iterable[TDataItem]):
 
     @root_key.setter
     def root_key(self, value: bool) -> None:
+        data_normalizer = self._schema.data_item_normalizer
+        assert isinstance(data_normalizer, RelationalNormalizer)
         # this also check the normalizer type
-        config = RelationalNormalizer.get_normalizer_config(self._schema)
+        config = data_normalizer.get_normalizer_config(self._schema)
         if value is None:
             value = self._get_root_key_legacy(config)
         if value is not None:
-            RelationalNormalizer.update_normalizer_config(
+            data_normalizer.update_normalizer_config(
                 self._schema,
                 {"root_key_propagation": value},
             )

--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -394,20 +394,16 @@ class DltSource(Iterable[TDataItem]):
     @property
     def max_table_nesting(self) -> int:
         """A schema hint that sets the maximum depth of nested table above which the remaining nodes are loaded as structs or JSON."""
-        data_normalizer = self._schema.data_item_normalizer
-        assert isinstance(data_normalizer, RelationalNormalizer)
-        return data_normalizer.get_normalizer_config(self._schema).get("max_nesting")
+        return RelationalNormalizer.get_normalizer_config(self._schema).get("max_nesting")
 
     @max_table_nesting.setter
     def max_table_nesting(self, value: int) -> None:
-        data_normalizer = self._schema.data_item_normalizer
-        assert isinstance(data_normalizer, RelationalNormalizer)
         if value is None:
             # this also check the normalizer type
-            config = data_normalizer.get_normalizer_config(self._schema)
+            config = RelationalNormalizer.get_normalizer_config(self._schema)
             config.pop("max_nesting", None)
         else:
-            data_normalizer.update_normalizer_config(self._schema, {"max_nesting": value})
+            RelationalNormalizer.update_normalizer_config(self._schema, {"max_nesting": value})
 
     @property
     def root_key(self) -> Optional[bool]:
@@ -415,10 +411,8 @@ class DltSource(Iterable[TDataItem]):
         This option is most useful if you plan to change write disposition of a resource to disable/enable merge.
 
         """
-        data_normalizer = self._schema.data_item_normalizer
-        assert isinstance(data_normalizer, RelationalNormalizer)
         # this also check the normalizer type
-        config = data_normalizer.get_normalizer_config(self._schema)
+        config = RelationalNormalizer.get_normalizer_config(self._schema)
         is_root_key = config.get("root_key_propagation")
         if is_root_key is None:
             # if not found get legacy value
@@ -430,14 +424,12 @@ class DltSource(Iterable[TDataItem]):
 
     @root_key.setter
     def root_key(self, value: bool) -> None:
-        data_normalizer = self._schema.data_item_normalizer
-        assert isinstance(data_normalizer, RelationalNormalizer)
         # this also check the normalizer type
-        config = data_normalizer.get_normalizer_config(self._schema)
+        config = RelationalNormalizer.get_normalizer_config(self._schema)
         if value is None:
             value = self._get_root_key_legacy(config)
         if value is not None:
-            data_normalizer.update_normalizer_config(
+            RelationalNormalizer.update_normalizer_config(
                 self._schema,
                 {"root_key_propagation": value},
             )


### PR DESCRIPTION
### Description

Support various operations that previously only worked on the `dlt.common.normalizers.json.relational` normalizer. This includes `dlt.common.normalizers.json.relational_no_coercion` or any derived custom normalizers such as:

```python
from dlt.common.normalizers.json import relational

class DataItemNormalizer(relational.DataItemNormalizer):
    pass
```
This also fixes `max_nesting` configuration on these normalizer subtypes.

```python
import os
import dlt

os.environ["SCHEMA__JSON_NORMALIZER"] = (
    '{"module": "dlt.common.normalizers.json.relational_no_coercion", "config": {"max_nesting": 3}}'
)

@dlt.source
def nothing():
    yield from []

source = nothing()
print(source.max_table_nesting)  # 3
```

### Related Issues

- Fixes #3892
