### PR TITLE
test: add SPN Fabric token refresh automation

### DIFF
--- a/.github/workflows/test_destinations_remote.yml
+++ b/.github/workflows/test_destinations_remote.yml
@@ -158,6 +158,7 @@ jobs:
               filesystem_drivers: "[\"memory\"]"
               extras: "--extra fabric"
               pre_install_commands: "sudo apt-get update && sudo ACCEPT_EULA=Y apt-get install --yes msodbcsql18"
+              post_secrets_commands: "uv run python tests/load/fabric/refresh_spn_fabric_token.py"
 
             # Postgres and Redshift (used to be test_destinations.yml)
             - name: redshift
@@ -244,6 +245,10 @@ jobs:
 
       - name: create secrets.toml
         run: pwd && echo "$DLT_SECRETS_TOML" > tests/.dlt/secrets.toml
+
+      - name: Run post secrets commands
+        run: ${{ matrix.post_secrets_commands }}
+        if: ${{ matrix.post_secrets_commands }}
 
       # NOTE: essential tests are always run
       - name: Run essential tests Linux

--- a/dlt/dataset/relation.py
+++ b/dlt/dataset/relation.py
@@ -613,7 +613,9 @@ class Relation(WithSqlClient):
             self._dataset.schema.tables, self._table_name
         )["name"]
         if root_table_name == self._table_name:
-            raise ValueError(f"{root_table_name} is a root table, but load id column is not present.")
+            raise ValueError(
+                f"{root_table_name} is a root table, but load id column is not present."
+            )
 
         join_alias = "_dlt_root"
         joined = self.join(root_table_name, alias=join_alias)

--- a/tests/load/fabric/refresh_spn_fabric_token.py
+++ b/tests/load/fabric/refresh_spn_fabric_token.py
@@ -1,0 +1,42 @@
+# https://learn.microsoft.com/en-us/fabric/data-warehouse/service-principals#token-renewal-and-initialization-requirements
+
+import os
+
+import requests
+
+from azure.identity import ClientSecretCredential
+
+import dlt
+from dlt.destinations.impl.fabric.configuration import FabricCredentials
+
+
+def main() -> None:
+    # get SPN credentials
+    os.environ["DLT_PROJECT_DIR"] = "tests"
+    credentials = dlt.secrets.get("destination.fabric.credentials", FabricCredentials)
+    if credentials is None:
+        raise RuntimeError("`destination.fabric.credentials` is not configured.")
+
+    # get bearer token
+    token = (
+        ClientSecretCredential(
+            tenant_id=credentials.azure_tenant_id,
+            client_id=credentials.azure_client_id,
+            client_secret=credentials.azure_client_secret,
+        )
+        .get_token("https://api.fabric.microsoft.com/.default")
+        .token
+    )
+
+    # call public Fabric API endpoint to refresh token (any endpoint will do)
+    response = requests.get(
+        "https://api.fabric.microsoft.com/v1/workspaces",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    print("Refreshed Fabric SPN token successfully.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description
The SPN owning the Fabric warehouse needs to refresh its Fabric token at least every thirty days: https://learn.microsoft.com/en-us/fabric/data-warehouse/service-principals#token-renewal-and-initialization-requirements. This PR automates that process, so that our CI tests for the `fabric` destination are always able to run.
