### PR TITLE
fix: scope fruit_pipeline fixture to module to avoid duckdb lock race

### DIFF
--- a/tests/e2e/helpers/dashboard/conftest.py
+++ b/tests/e2e/helpers/dashboard/conftest.py
@@ -40,7 +40,7 @@ def simple_incremental_pipeline() -> Any:
     return po
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def fruit_pipeline() -> Any:
     pf = dlt.pipeline(pipeline_name="fruit_pipeline", destination="duckdb")
     pf.run(fruitshop_source())

--- a/tests/e2e/helpers/dashboard/conftest.py
+++ b/tests/e2e/helpers/dashboard/conftest.py
@@ -41,12 +41,8 @@ def simple_incremental_pipeline() -> Any:
 
 
 @pytest.fixture(scope="module")
-def fruit_pipeline(pipelines_dir: Path) -> Any:
-    pf = dlt.pipeline(
-        pipeline_name="fruit_pipeline",
-        destination="duckdb",
-        pipelines_dir=str(pipelines_dir),
-    )
+def fruit_pipeline() -> Any:
+    pf = dlt.pipeline(pipeline_name="fruit_pipeline", destination="duckdb")
     pf.run(fruitshop_source())
     return pf
 

--- a/tests/e2e/helpers/dashboard/conftest.py
+++ b/tests/e2e/helpers/dashboard/conftest.py
@@ -41,8 +41,12 @@ def simple_incremental_pipeline() -> Any:
 
 
 @pytest.fixture(scope="module")
-def fruit_pipeline() -> Any:
-    pf = dlt.pipeline(pipeline_name="fruit_pipeline", destination="duckdb")
+def fruit_pipeline(pipelines_dir: Path) -> Any:
+    pf = dlt.pipeline(
+        pipeline_name="fruit_pipeline",
+        destination="duckdb",
+        pipelines_dir=str(pipelines_dir),
+    )
     pf.run(fruitshop_source())
     return pf
 

--- a/tests/e2e/helpers/dashboard/test_e2e.py
+++ b/tests/e2e/helpers/dashboard/test_e2e.py
@@ -19,6 +19,9 @@ from tests.utils import (
     autouse_test_storage,
     preserve_environ,
     deactivate_pipeline,
+    auto_module_test_storage,
+    auto_module_test_run_context,
+    preserve_module_environ,
 )
 from dlt._workspace.helpers.dashboard import strings as app_strings, utils
 


### PR DESCRIPTION
Attempt to fix a flaky duckdb file-lock race in the dashboard e2e suite. It looks like between runs of  test_fruit_pipeline, test_sections_query_param, and test_sections_query_param_all the module-scoped dashboard subprocess can still hold a duckdb file handle

CI failures:
- https://github.com/dlt-hub/dlt/actions/runs/25791644840/job/75786299816
- https://github.com/dlt-hub/dlt/actions/runs/25791644840/job/75786300041