### PR TITLE
fix(databricks): replace deprecated _user_agent_entry with user_agent_entry

### DIFF
--- a/dlt/destinations/impl/databricks/configuration.py
+++ b/dlt/destinations/impl/databricks/configuration.py
@@ -165,8 +165,8 @@ class DatabricksCredentials(CredentialsConfiguration):
         )
 
         if self.user_agent_entry:
-            conn_params["_user_agent_entry"] = (
-                conn_params.get("_user_agent_entry") or self.user_agent_entry
+            conn_params["user_agent_entry"] = (
+                conn_params.get("user_agent_entry") or self.user_agent_entry
             )
 
         if self.client_id and self.client_secret:

--- a/tests/load/databricks/test_databricks_configuration.py
+++ b/tests/load/databricks/test_databricks_configuration.py
@@ -51,7 +51,7 @@ def test_databricks_credentials_to_connector_params():
     assert params["extra_a"] == "a"
     assert params["extra_b"] == "b"
     assert params["_socket_timeout"] == credentials.socket_timeout
-    assert params["_user_agent_entry"] == DATABRICKS_APPLICATION_ID
+    assert params["user_agent_entry"] == DATABRICKS_APPLICATION_ID
 
     displayable_location = str(credentials)
     assert displayable_location.startswith(


### PR DESCRIPTION
## Summary

Replace the deprecated `_user_agent_entry` connection parameter with the non-prefixed `user_agent_entry` in `DatabricksCredentials.to_connector_params()`.

Every connection to Databricks printed the following warning because dlt passed the old key name:

```
[WARN] Parameter '_user_agent_entry' is deprecated; use 'user_agent_entry' instead.
This parameter will be removed in the upcoming releases.
```

The change is a two-line substitution — the logic (prefer an explicit value from `connection_parameters` over dlt's built-in `DATABRICKS_APPLICATION_ID`) is unchanged.

## Issue

Closes #3934

## Local verification

Tested via a standalone Python script that exercises `DatabricksCredentials.to_connector_params()` directly (no live Databricks connection needed):

```
$ python3 verify_fix.py

PASS T1: dlt default uses user_agent_entry = dltHub_dlt
PASS T2: connection_parameters preserved, user_agent_entry = dltHub_dlt
PASS T3: explicit connection_parameters['user_agent_entry'] wins: myapp
PASS T4: user_agent_entry=None → key absent

=== LOCAL_TEST_PASSED ===
```

Cases covered:

| # | Scenario | Expected key | Result |
|---|----------|-------------|--------|
| T1 | Default `user_agent_entry=DATABRICKS_APPLICATION_ID` | `user_agent_entry` set, `_user_agent_entry` absent | ✓ |
| T2 | Extra `connection_parameters` present | Both extra params and `user_agent_entry` set | ✓ |
| T3 | `user_agent_entry` overridden via `connection_parameters` | Override wins | ✓ |
| T4 | `user_agent_entry=None` | Neither key present | ✓ |

The existing integration test assertion (`params["_user_agent_entry"]`) is updated to `params["user_agent_entry"]` to reflect the corrected key name.

## Risk

**Low.** The only change is the dict key written into `conn_params`. The Databricks SQL connector accepts `user_agent_entry` (the new name) just as it accepted `_user_agent_entry` before, but without emitting the deprecation warning. No behaviour, value, or logic changes.
