### PR TITLE
Allow attaching to ducklake without specifying data storage location

### DIFF
--- a/dlt/destinations/impl/ducklake/configuration.py
+++ b/dlt/destinations/impl/ducklake/configuration.py
@@ -19,8 +19,6 @@ from dlt.destinations.impl.duckdb.factory import _set_duckdb_raw_capabilities
 
 
 DEFAULT_DUCKLAKE_NAME = "ducklake"
-DUCKLAKE_STORAGE_PATTERN = "%s.files"
-
 
 def _get_ducklake_capabilities() -> DestinationCapabilitiesContext:
     caps = DestinationCapabilitiesContext()
@@ -38,7 +36,7 @@ class DuckLakeCredentials(DuckDbBaseCredentials):
     metadata_schema: Optional[str] = None
     catalog: ConnectionStringCredentials = None
     # NOTE: consider moving to DuckLakeClientConfiguration so bucket_url is not a secret
-    storage: FilesystemConfiguration = None
+    storage: Optional[FilesystemConfiguration] = None # storage does not need to be specified when attaching to an existing ducklake
 
     __config_gen_annotations__: ClassVar[list[str]] = [
         "ducklake_name",
@@ -52,7 +50,7 @@ class DuckLakeCredentials(DuckDbBaseCredentials):
         ducklake_name: str = DEFAULT_DUCKLAKE_NAME,
         metadata_schema: Optional[str] = None,
         catalog: Union[str, ConnectionStringCredentials] = None,
-        storage: Union[str, FilesystemConfiguration] = None,
+        storage: Optional[Union[str, FilesystemConfiguration]] = None,
     ) -> None:
         """Initialize DuckLake credentials by passing ducklake name, catalog and storage
         configuration.
@@ -73,8 +71,8 @@ class DuckLakeCredentials(DuckDbBaseCredentials):
                 derived from the name_or_conn_str argument.
             storage: Either a storage URL string (for example,
                 "file://...", "s3://bucket/prefix") or a FilesystemConfiguration
-                instance. If omitted, it will create a folder for data with name
-                derived from the name_or_conn_str argument.
+                instance. If omitted, it will attempt to attach to an existing
+                ducklake using the storage location from the catalog.
 
         """
         self.ducklake_name = ducklake_name
@@ -102,11 +100,6 @@ class DuckLakeCredentials(DuckDbBaseCredentials):
             ).resolve()
             config_exception.drop_traces_for_field("catalog")
 
-        if self.storage is None and "bucket_url" in config_exception.traces["storage"][0].traces:  # type: ignore
-            self.storage = FilesystemConfigurationWithLocalFiles(
-                bucket_url=DUCKLAKE_STORAGE_PATTERN % self.ducklake_name, local_dir="."
-            ).resolve()
-
         if not self.is_partial():
             self.resolve()
 
@@ -120,8 +113,10 @@ class DuckLakeCredentials(DuckDbBaseCredentials):
         self.conn_pool = DuckDbConnectionPool(self, always_open_connection=True)
 
     @property
-    def storage_url(self) -> str:
+    def storage_url(self) -> Union[str, None]:
         """Convert file:// url into native os path so duckdb can read it"""
+        if self.storage is None:
+            return None
         if self.storage.is_local_filesystem:
             return self.storage.make_local_path(self.storage.bucket_url)
         else:

--- a/dlt/destinations/impl/ducklake/ducklake.py
+++ b/dlt/destinations/impl/ducklake/ducklake.py
@@ -135,11 +135,14 @@ class DuckLakeCopyJob(DuckDbCopyJob):
         # job client not available before run_managed called
         if not self._job_client:
             return m
+        storage = self._job_client.config.credentials.storage
+        if storage is None:
+            return m
         # TODO: read location from catalog. ducklake supports customized table layouts
         return m._replace(
             remote_url=str(
                 pathlib.Path().joinpath(
-                    self._job_client.config.credentials.storage.bucket_url,
+                    storage.bucket_url,
                     self._job_client.sql_client.dataset_name,
                     self.load_table_name,
                 )
@@ -179,8 +182,11 @@ class DuckLakeClient(DuckDbClient):
 
     def initialize_storage(self, truncate_tables: Iterable[str] = None) -> None:
         super().initialize_storage(truncate_tables)
-        # create local storage
-        if self.config.credentials.storage.is_local_filesystem:
+        # create local storage directory if storage is configured and local
+        if (
+            self.config.credentials.storage is not None
+            and self.config.credentials.storage.is_local_filesystem
+        ):
             os.makedirs(self.config.credentials.storage_url, exist_ok=True)
 
     def create_load_job(

--- a/dlt/destinations/impl/ducklake/sql_client.py
+++ b/dlt/destinations/impl/ducklake/sql_client.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Optional, Type
+from typing import ClassVar, List, Optional, Type
 
 from duckdb import DuckDBPyConnection
 
@@ -52,7 +52,7 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         # setup secrets and attach ducklake for each opened connections. connection pool
         # creates a separate connection for each sql_client
         try:
-            if not self.credentials.storage.is_local_filesystem:
+            if self.credentials.storage is not None and not self.credentials.storage.is_local_filesystem:
                 self.create_secret(
                     self.credentials.storage.bucket_url, self.credentials.storage.credentials
                 )
@@ -124,11 +124,13 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         ducklake_name: str,
         metadata_schema: Optional[str] = None,
         catalog: ConnectionStringCredentials,
-        storage_url: str,
+        storage_url: Optional[str] = None,
         override_data_path: bool = False,
     ) -> str:
-        attach_params = ""
         metadata_schema = metadata_schema or ducklake_name
+        params: List[str] = []
+        if storage_url:
+            params.append(f"DATA_PATH '{storage_url}'")
         if isinstance(catalog, DuckDbCredentials):
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:{catalog._conn_str()}'"
         elif catalog.drivername in ("postgres", "postgresql", "mysql"):
@@ -138,22 +140,23 @@ class DuckLakeSqlClient(DuckDbSqlClient):
 
             db_url = catalog.to_url().render_as_string(hide_password=False)
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:{catalog.drivername}:{db_url}'"
-            attach_params = f", METADATA_SCHEMA '{metadata_schema}'"
+            params.append(f"METADATA_SCHEMA '{metadata_schema}'")
         elif catalog.drivername == "md":
             logger.warning(
                 "Motherduck requires token present in the environment and will most probably crash."
             )
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:md:{catalog.database}'"
-            attach_params = f", METADATA_SCHEMA '{metadata_schema}'"
+            params.append(f"METADATA_SCHEMA '{metadata_schema}'")
         elif catalog.drivername in ("sqlite", "duckdb"):
             # attach sqllite with multi-process access
             attach_statement = f"ATTACH IF NOT EXISTS 'ducklake:{catalog.database}'"
-            attach_params = ", META_TYPE 'sqlite', META_JOURNAL_MODE 'WAL', META_BUSY_TIMEOUT 1000"
+            params.extend(["META_TYPE 'sqlite'", "META_JOURNAL_MODE 'WAL'", "META_BUSY_TIMEOUT 1000"])
         else:
             raise NotImplementedError(str(catalog))
         attach_statement += f" AS {ducklake_name}"
-        override_param = ", OVERRIDE_DATA_PATH true" if override_data_path else ""
-        attach_statement += f" (DATA_PATH '{storage_url}'{attach_params}{override_param})"
+        if override_data_path:
+            params.append("OVERRIDE_DATA_PATH true")
+        attach_statement += f" ({', '.join(params)})"
         return attach_statement
 
     @property

--- a/tests/load/ducklake/test_ducklake_client.py
+++ b/tests/load/ducklake/test_ducklake_client.py
@@ -71,8 +71,8 @@ def test_default_credentials() -> None:
     assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     assert credentials.catalog is not None
     assert credentials.catalog.drivername == "sqlite"
-    assert credentials.storage is not None
-    assert credentials.storage.local_dir == "."
+    # storage is optional — not set by default; duckdb auto-determines it from the catalog path
+    assert credentials.storage is None
 
 
 def test_ducklake_urls() -> None:
@@ -98,12 +98,11 @@ def test_ducklake_configuration_default() -> None:
     conn_str = credentials.catalog.to_native_representation()
     assert conn_str.startswith("sqlite:")
     assert conn_str.endswith(str(local_dir / "ducklake.sqlite"))
-    # storage in local dir, default name
-    assert credentials.storage_url == str(local_dir / "ducklake.files")
-    # file url
-    assert credentials.storage.bucket_url.startswith("file://")
-    # fingerprint is local
-    assert configuration.fingerprint() == digest128("file://")
+    # storage is not set by default; duckdb auto-determines it from the catalog path
+    assert credentials.storage_url is None
+    assert credentials.storage is None
+    # fingerprint is empty when no storage is configured
+    assert configuration.fingerprint() == ""
 
 
 def test_ducklake_configuration_duckdb_catalog() -> None:
@@ -121,7 +120,9 @@ def test_ducklake_configuration_duckdb_catalog() -> None:
     assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     conn_str = credentials.catalog.to_native_representation()
     assert conn_str.endswith(str(local_dir / "ducklake.duckdb"))
-    assert configuration.fingerprint() == digest128("file://")
+    # storage is not set by default
+    assert credentials.storage_url is None
+    assert configuration.fingerprint() == ""
 
 
 def test_ducklake_configuration_ducklake_name() -> None:
@@ -137,9 +138,9 @@ def test_ducklake_configuration_ducklake_name() -> None:
     assert credentials.ducklake_name == "my_ducklake"
     conn_str = credentials.catalog.to_native_representation()
     assert conn_str.endswith(str(local_dir / "my_ducklake.sqlite"))
-    assert credentials.storage_url == str(local_dir / "my_ducklake.files")
-    # fingerprint is local
-    assert configuration.fingerprint() == digest128("file://")
+    # storage is not set by default
+    assert credentials.storage_url is None
+    assert configuration.fingerprint() == ""
 
 
 def test_ducklake_configuration_destination_name() -> None:
@@ -155,9 +156,9 @@ def test_ducklake_configuration_destination_name() -> None:
     assert credentials.ducklake_name == DEFAULT_DUCKLAKE_NAME
     conn_str = credentials.catalog.to_native_representation()
     assert conn_str.endswith(str(local_dir / "ducklake.sqlite"))
-    assert credentials.storage_url == str(local_dir / "ducklake.files")
-    # fingerprint is local
-    assert configuration.fingerprint() == digest128("file://")
+    # storage is not set by default
+    assert credentials.storage_url is None
+    assert configuration.fingerprint() == ""
 
 
 def test_ducklake_configuration_pipeline_name() -> None:
@@ -175,7 +176,8 @@ def test_ducklake_configuration_pipeline_name() -> None:
     # no impact on locations
     conn_str = credentials.catalog.to_native_representation()
     assert conn_str.endswith(str(local_dir / "ducklake.sqlite"))
-    assert credentials.storage_url == str(local_dir / "ducklake.files")
+    # storage is not set by default
+    assert credentials.storage_url is None
 
 
 def test_ducklake_configuration_storage_credentials() -> None:
@@ -225,7 +227,8 @@ def test_ducklake_configuration_catalog_credentials() -> None:
         credentials.catalog.to_native_representation()
         == "postgresql://loader:loader@localhost:5432/dlt_data"
     )
-    assert credentials.storage_url == str(local_dir / "ducklake.files")
+    # storage is not set by default — for postgres catalog, data path must be explicit
+    assert credentials.storage_url is None
 
 
 def test_ducklake_metadata_schema_config() -> None:
@@ -306,6 +309,41 @@ def test_ducklake_attach_statement_with_metadata_schema() -> None:
     assert expected_attach_statement == attach_statement
 
 
+def test_attach_statement_no_storage_url_sqlite() -> None:
+    """When no storage_url is given for a sqlite/duckdb catalog, DATA_PATH is omitted.
+
+    DuckLake will derive the storage path from the catalog filename automatically.
+    """
+    attach_statement = DuckLakeSqlClient.build_attach_statement(
+        catalog=ConnectionStringCredentials("sqlite:////path/to/catalog.sqlite"),
+        ducklake_name="foo",
+        storage_url=None,
+    )
+    assert "DATA_PATH" not in attach_statement
+    assert attach_statement == (
+        "ATTACH IF NOT EXISTS 'ducklake:/path/to/catalog.sqlite'"
+        " AS foo (META_TYPE 'sqlite', META_JOURNAL_MODE 'WAL', META_BUSY_TIMEOUT 1000)"
+    )
+
+
+def test_attach_statement_no_storage_url_postgres() -> None:
+    """When no storage_url is given for a postgres catalog, DATA_PATH is omitted.
+
+    This is valid when connecting to an existing DuckLake whose data path is stored
+    in the catalog metadata.
+    """
+    attach_statement = DuckLakeSqlClient.build_attach_statement(
+        catalog=ConnectionStringCredentials("postgres://loader:loader@localhost:5432/dlt_data"),
+        ducklake_name="foo",
+        storage_url=None,
+    )
+    assert "DATA_PATH" not in attach_statement
+    assert attach_statement == (
+        "ATTACH IF NOT EXISTS 'ducklake:postgres:postgres://loader:loader@localhost:5432/dlt_data'"
+        " AS foo (METADATA_SCHEMA 'foo')"
+    )
+
+
 def test_ducklake_override_data_path_config() -> None:
     configuration = resolve_configuration(
         DuckLakeClientConfiguration(override_data_path=True)._bind_dataset_name(dataset_name="foo")
@@ -363,13 +401,16 @@ def test_ducklake_conn_pool_always_open() -> None:
 
 
 @pytest.mark.no_load
-def test_ducklake_factory_instantiation() -> None:
-    # force parallel loads on sqlite
+def test_ducklake_factory_instantiation(tmp_path: pathlib.Path) -> None:
+    # force parallel loads on sqlite and provide explicit storage
     worker = get_test_worker_id()
 
     ducklake = dlt.destinations.ducklake(
         loader_parallelism_strategy="parallel",
-        credentials=DuckLakeCredentials(ducklake_name=f"ducklake_{worker}"),
+        credentials=DuckLakeCredentials(
+            ducklake_name=f"ducklake_{worker}",
+            storage=str(tmp_path),
+        ),
     )
     pipeline = dlt.pipeline("test_factory", destination=ducklake, dataset_name="foo")
 
@@ -397,3 +438,83 @@ def test_ducklake_factory_instantiation() -> None:
         "lake_catalog",
         catalog=catalog_credentials,
     )
+
+
+def test_ducklake_no_storage_connect_to_existing(tmp_path: pathlib.Path) -> None:
+    """Verify that an existing DuckLake can be opened without specifying storage.
+
+    DuckLake stores the data path in its catalog. When reconnecting, omitting storage
+    causes DuckLake to read the data path from the catalog automatically.
+    ref: https://ducklake.select/docs/stable/duckdb/usage/connecting
+    """
+    catalog_db = str(tmp_path / "catalog.ducklake")
+    storage_dir = str(tmp_path / "my_files")
+    ducklake_name = "existing_lake"
+
+    # create a new ducklake with an explicit storage path
+    conn = duckdb.connect(":memory:")
+    conn.execute("INSTALL ducklake; LOAD ducklake")
+    conn.execute(
+        f"ATTACH 'ducklake:{catalog_db}' AS {ducklake_name}"
+        f" (DATA_PATH '{storage_dir}')"
+    )
+    conn.execute(f"USE {ducklake_name}")
+    conn.execute("CREATE TABLE items (id INTEGER, val TEXT)")
+    conn.execute("INSERT INTO items VALUES (1, 'hello'), (2, 'world')")
+    conn.execute(f"USE memory; DETACH {ducklake_name}")
+    conn.close()
+
+    # reconnect to the same catalog without specifying storage
+    conn2 = duckdb.connect(":memory:")
+    conn2.execute("LOAD ducklake")
+    conn2.execute(f"ATTACH IF NOT EXISTS 'ducklake:{catalog_db}' AS {ducklake_name}")
+    conn2.execute(f"USE {ducklake_name}")
+    rows = conn2.execute("SELECT id, val FROM items ORDER BY id").fetchall()
+    assert rows == [(1, "hello"), (2, "world")]
+    conn2.execute(f"USE memory; DETACH {ducklake_name}")
+    conn2.close()
+
+
+@pytest.mark.no_load
+def test_ducklake_pipeline_no_storage(tmp_path: pathlib.Path) -> None:
+    """A dlt pipeline can reconnect to an existing DuckLake without specifying storage.
+
+    DuckLake stores the data path in its catalog. On a second connection that omits
+    DATA_PATH, DuckLake reads the data path directly from the catalog.
+    ref: https://ducklake.select/docs/stable/duckdb/usage/connecting
+    """
+    from dlt.destinations import ducklake as ducklake_dest
+
+    catalog_db = str(tmp_path / "my_catalog.duckdb")
+    storage_dir = str(tmp_path / "my_catalog.duckdb.files")
+
+    # first run: create the ducklake with explicit storage
+    destination_with_storage = ducklake_dest(
+        credentials=DuckLakeCredentials(
+            ducklake_name="auto_lake",
+            catalog=ConnectionStringCredentials({"drivername": "duckdb", "database": catalog_db}),
+            storage=storage_dir,
+        )
+    )
+    pipeline = dlt.pipeline(
+        "no_storage_pipeline", destination=destination_with_storage, dataset_name="ds"
+    )
+    load_info = pipeline.run([{"x": 1}, {"x": 2}], table_name="nums")
+    assert load_info.has_failed_jobs is False
+    assert pathlib.Path(storage_dir).exists()
+
+    # second run: reconnect without storage — use data path from catalog
+    destination_no_storage = ducklake_dest(
+        credentials=DuckLakeCredentials(
+            ducklake_name="auto_lake",
+            catalog=ConnectionStringCredentials({"drivername": "duckdb", "database": catalog_db}),
+        )
+    )
+    pipeline2 = dlt.pipeline(
+        "no_storage_pipeline_2", destination=destination_no_storage, dataset_name="ds"
+    )
+    load_info2 = pipeline2.run([{"x": 3}], table_name="nums")
+    assert load_info2.has_failed_jobs is False
+
+    rows = pipeline2.dataset().nums["x"].fetchall()
+    assert sorted(rows) == [(1,), (2,), (3,)]

--- a/tests/load/ducklake/test_ducklake_pipeline.py
+++ b/tests/load/ducklake/test_ducklake_pipeline.py
@@ -7,7 +7,6 @@ from dlt.common.destination.reference import TDestinationReferenceArg
 from dlt.common.utils import uniq_id
 from dlt.destinations.impl.ducklake.configuration import (
     DuckLakeCredentials,
-    DUCKLAKE_STORAGE_PATTERN,
 )
 from dlt.destinations import ducklake
 
@@ -22,6 +21,7 @@ from tests.load.utils import (
 from tests.pipeline.utils import assert_load_info
 from tests.utils import get_test_storage_root
 
+DUCKLAKE_STORAGE_PATTERN = "%s.files"
 
 @pytest.mark.parametrize(
     "catalog",


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Data storage location only has to be specified when creating a new ducklake, see https://ducklake.select/docs/stable/duckdb/usage/connecting. For existing ducklakes the storage location can be read from the catalog. Specifying the storage location in code also means that any change to the storage location in the catalog breaks the code.

This change removes the autogenerated data path that is inserted when a storage location is not supplied and changes the attach sql generation so that it can omit a data path if one is not supplied.

Amends existing tests so they work when storage is not specified and adds four new tests that test connecting to a ducklake without a data path for sqlite and postgres catalogs, creating a new ducklake and then attaching to it again without specifying a data path, and running dlt pipelines that create a new ducklake and then attach to it without specifying a data path.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves https://github.com/dlt-hub/dlt/issues/3796
<!--
Provide any additional context about the PR here.
-->
### Additional Context

- I've run tests locally and all pass excepting `test_ducklake_factory_instantiation` which needs S3 credentials which I don't have.
- This is my first contribution to dlt - any notes or guidance would be appreciated. 
-  A similar change has recently been implemented in dagster/ducklake https://github.com/dagster-io/community-integrations/pull/275

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
