### PR TITLE
Rename dlthub-runtime to dlthub-platform

### DIFF
--- a/docs/website/docs/dlt-ecosystem/llm-tooling/explore-and-transform.md
+++ b/docs/website/docs/dlt-ecosystem/llm-tooling/explore-and-transform.md
@@ -170,5 +170,5 @@ By the end of this guide you should have:
 - A working `@dlt.hub.transformation` script that populates the CDM
 
 Next steps:
-- [Deploy and schedule your pipeline](llm-native-workflow.md#handover-to-other-toolkits) with the `dlthub-runtime` toolkit
+- [Deploy and schedule your pipeline](llm-native-workflow.md#handover-to-other-toolkits) with the `dlthub-platform` toolkit
 - [Replace the local destination with your data warehouse](../../walkthroughs/share-a-dataset.md)

--- a/docs/website/docs/dlt-ecosystem/llm-tooling/llm-native-workflow.md
+++ b/docs/website/docs/dlt-ecosystem/llm-tooling/llm-native-workflow.md
@@ -299,11 +299,11 @@ Once your pipeline is validated, you can continue to the next phase of the data 
   Two skills drive the workflow: `/explore-data` (entry point skill) connects to your data, profiles it by mapping the intent to the available data and identifying potential gaps, while `/build-notebook` assembles the charts into a marimo dashboard and launches it in your browser.
   The toolkit is designed for iterative development: create one chart and launch the notebook, then iterate — add or refine charts and re-launch.
 
-- **`dlthub-runtime`** — deploy, schedule, and monitor your pipeline in production
+- **`dlthub-platform`** — deploy, schedule, and monitor your pipeline in production
 
 ```sh
 uv run dlthub ai toolkit install data-exploration
-uv run dlthub ai toolkit install dlthub-runtime
+uv run dlthub ai toolkit install dlthub-platform
 ```
 
 ## Results

--- a/docs/website/docs/hub/getting-started/installation.md
+++ b/docs/website/docs/hub/getting-started/installation.md
@@ -62,7 +62,7 @@ If you don't have `uv` yet, either [install it first](#configuration-of-the-pyth
 pipx run dlthub-start
 ```
 
-Either way, it prompts for a workspace name, scaffold, and which AI agents to wire up (Claude / Cursor / Codex), scaffolds a workspace with `.dlt/.workspace` already set, vendors the AI toolkits (`rest-api-pipeline`, `transformations`, `dlthub-runtime`, `data-exploration`), and runs `uv sync` so `dlt[hub]` and all workspace dependencies are installed.
+Either way, it prompts for a workspace name, scaffold, and which AI agents to wire up (Claude / Cursor / Codex), scaffolds a workspace with `.dlt/.workspace` already set, vendors the AI toolkits (`rest-api-pipeline`, `transformations`, `dlthub-platform`, `data-exploration`), and runs `uv sync` so `dlt[hub]` and all workspace dependencies are installed.
 
 For the recommended defaults non-interactively, pass a name explicitly:
 

--- a/tests/workspace/cli/dlthub/ai/utils.py
+++ b/tests/workspace/cli/dlthub/ai/utils.py
@@ -19,7 +19,7 @@ from dlt._workspace.cli.dlthub.ai.utils import (
 from dlt._workspace.cli.dlthub.ai.typing import TToolkitIndexEntry, TToolkitInfo
 
 # known toolkits in the repo (init is now visible)
-KNOWN_TOOLKITS = ["data-exploration", "init", "rest-api-pipeline", "dlthub-runtime"]
+KNOWN_TOOLKITS = ["data-exploration", "init", "rest-api-pipeline", "dlthub-platform"]
 INSTALLABLE_TOOLKITS = [t for t in KNOWN_TOOLKITS if t != "init"]
 AGENT_NAMES = ["claude", "cursor", "codex"]
 


### PR DESCRIPTION
Fix CI failure related to renamed `dlthub-runtime` to `dlthub-platform` in dlt-hub/dlthub-ai-workbench/pull/59