### PR TITLE
feat (dlthub pro): static_egress_ips

### DIFF
--- a/dlt/_workspace/deployment/decorators.py
+++ b/dlt/_workspace/deployment/decorators.py
@@ -371,7 +371,8 @@ def job(
 
         require: Runtime resource requirements. Accepts `TRequireSpec` with:
             `dependency_groups`, `profile` (workspace profile), `machine`
-            (machine spec), `region` (runner placement).
+            (machine spec), `region` (runner placement), `static_egress_ips`
+            (static outbound IPs for third-party allowlists).
 
         deliver: A `@dlt.source`, standalone `@dlt.resource`, or called source
             instance for delivery association.
@@ -472,7 +473,7 @@ def interactive(
             `tags`, `starred`, `manual`. The `interface` argument is merged
             into expose automatically.
         require: Runtime resource requirements. Accepts `TRequireSpec` with:
-            `dependency_groups`, `profile`, `machine`, `region`.
+            `dependency_groups`, `profile`, `machine`, `region`, `static_egress_ips`.
         spec: Optional configuration spec class.
 
     Returns:
@@ -539,7 +540,7 @@ def pipeline_run(
         expose: UI presentation (`TJobExposeSpec`): `tags`, `starred`, `manual`.
 
         require: Resource requirements (`TRequireSpec`): `dependency_groups`,
-            `profile`, `machine`, `region`.
+            `profile`, `machine`, `region`, `static_egress_ips`.
 
         interval: Overall time range for interval-based scheduling.
 

--- a/dlt/_workspace/deployment/typing.py
+++ b/dlt/_workspace/deployment/typing.py
@@ -106,6 +106,8 @@ class TRequireSpec(TypedDict, total=False):
     """Runner region for placement (e.g. `"us-east-1"`, `"eu-west"`)."""
     timezone: str
     """IANA timezone for cron ticks and intervals (e.g. `"America/New_York"`). Default: UTC."""
+    static_egress_ips: bool
+    """When `True`, route outbound traffic through the workspace static egress IPs."""
 
 
 class TEntryPoint(TypedDict):

--- a/docs/website/docs/hub/runtime/job-configuration.md
+++ b/docs/website/docs/hub/runtime/job-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Job configuration
 description: Per-job options on the dltHub platform — execution timeouts, dependency groups, and TOML configuration sections
-keywords: [dlthub platform, job configuration, timeout, dependency groups, execute, require, expose, section]
+keywords: [dlthub platform, job configuration, timeout, dependency groups, static egress, execute, require, expose, section]
 ---
 
 # Job configuration
@@ -43,6 +43,18 @@ def transform(run_context: TJobRunContext):
 ```
 
 The dltHub platform composes the execution environment from the workspace's base dependencies plus the job's declared groups.
+
+## Static egress IPs
+
+Use this when you must whitelist outbound IP addresses so external systems can grant your jobs access to private resources. Opt in per job so outbound requests use your workspace's static egress IPs:
+
+```py
+@run.pipeline(my_pipeline, require={"static_egress_ips": True})
+def sync_from_vendor():
+    ...
+```
+
+Static egress routing forces job traffic through the US region. See [Regions and data residency](regions.md) for how regional data planes relate to your organization.
 
 ## Job configuration via TOML
 

--- a/docs/website/docs/hub/runtime/job-configuration.md
+++ b/docs/website/docs/hub/runtime/job-configuration.md
@@ -56,6 +56,13 @@ def sync_from_vendor():
 
 Static egress routing forces job traffic through the US region. See [Regions and data residency](regions.md) for how regional data planes relate to your organization.
 
+The static egress IPs are:
+- 4.205.113.62
+- 44.221.24.144
+- 34.193.87.36
+- 98.80.106.70
+- 54.81.217.233
+
 ## Job configuration via TOML
 
 Jobs read configuration through dlt's standard config system. The default section is the containing module name:

--- a/tests/workspace/deployment/test_decorators.py
+++ b/tests/workspace/deployment/test_decorators.py
@@ -368,7 +368,19 @@ def test_job_definition_omits_unset_fields() -> None:
     assert "tags" not in job_def
     assert "deliver" not in job_def
     assert "expose" not in job_def
+    assert "require" not in job_def
     assert job_def["triggers"] == []
+
+
+def test_require_static_egress_ips_stored_on_job_definition() -> None:
+    """`require.static_egress_ips` is passed through to the job definition."""
+
+    @job(require={"static_egress_ips": True})
+    def vendor_sync():
+        pass
+
+    job_def = vendor_sync.to_job_definition()
+    assert job_def["require"]["static_egress_ips"] is True
 
 
 def test_config_key_discovery() -> None:


### PR DESCRIPTION
This PR adds a new optional parameter static_egress_ips (bool) to the job definition in order to provide dlthub Pro customers to opt in to have fixed egress ips on their jobs. 
It applies to bare job definitions, pipeline run and interactive script decorators (which use job definitions under the hood)

It also updates docs to document this in our dlthubpro docs and explictely lists static IPs