### PR TITLE
Fix logging more frequent than log_period

### DIFF
--- a/dlt/common/runtime/collector.py
+++ b/dlt/common/runtime/collector.py
@@ -160,7 +160,6 @@ class LogCollector(Collector):
                 total=total,
             )
             self.messages[counter_key] = None
-            self.last_log_time = None
         else:
             counter_info = self.counter_info[counter_key]
             if inc_total:

--- a/dlt/common/runtime/collector.py
+++ b/dlt/common/runtime/collector.py
@@ -254,7 +254,8 @@ class LogCollector(Collector):
         self.counters = defaultdict(int)
         self.counter_info = {}
         self.messages = {}
-        self.last_log_time = self._clock()
+        # log immediately on the first update
+        self.last_log_time = None
 
     def _stop(self) -> None:
         self.on_log()

--- a/tests/common/runtime/test_collector.py
+++ b/tests/common/runtime/test_collector.py
@@ -1,7 +1,8 @@
+import io
 from collections import defaultdict
 
 import pytest
-from dlt.common.runtime.collector import NullCollector, DictCollector, Collector
+from dlt.common.runtime.collector import NullCollector, DictCollector, LogCollector, Collector
 
 
 def test_null_collector() -> None:
@@ -46,3 +47,27 @@ def test_dict_collector_reset_counters():
 
     with DictCollector()("test2") as collector:
         assert collector.counters == defaultdict(int)
+
+
+def test_log_collector_respects_log_period() -> None:
+    # adding more counters do not dump them all immediately
+    clock = [0.0]
+    buf = io.StringIO()
+    collector = LogCollector(log_period=10.0, logger=buf, dump_system_stats=False)
+    collector._clock = lambda: clock[0]  # type: ignore[assignment]
+
+    with collector("Extract"):
+        # first update logs immediately so the step shows up at once
+        collector.update("resource_0", inc=1)
+        assert buf.getvalue().count("Extract") == 1
+        # many new counters within the same period add no further logs
+        for i in range(1, 100):
+            collector.update(f"resource_{i}", inc=1)
+        assert buf.getvalue().count("Extract") == 1
+        # crossing log_period emits exactly one more log
+        clock[0] = 10.0
+        collector.update("resource_100", inc=1)
+        assert buf.getvalue().count("Extract") == 2
+
+    # _stop always emits a final log
+    assert buf.getvalue().count("Extract") == 3


### PR DESCRIPTION
Remove line that resets `last_log_time` whenever a counter is added to the log collector.

This line causes a log to be emitted every time a line is added to the log message, which can result in far more frequent logs than the max specified by `log_period`.

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes https://github.com/dlt-hub/dlt/issues/2532


<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
Tested in my dlt project and it fixes the logging issue. Logs are emitted at the specified frequency, except for when changing stages e.g. extract to load, when they can be more frequent.