### PR TITLE
snowflake: add snowflake_adapter for table/column comments and tags

### DIFF
--- a/dlt/destinations/adapters.py
+++ b/dlt/destinations/adapters.py
@@ -10,6 +10,7 @@ from dlt.destinations.impl.clickhouse.clickhouse_adapter import clickhouse_adapt
 from dlt.destinations.impl.athena.athena_adapter import athena_adapter, athena_partition
 from dlt.destinations.impl.postgres.postgres_adapter import postgres_adapter
 from dlt.destinations.impl.databricks.databricks_adapter import databricks_adapter
+from dlt.destinations.impl.snowflake.snowflake_adapter import snowflake_adapter
 from dlt.destinations.impl.filesystem.iceberg_adapter import iceberg_adapter, iceberg_partition
 
 __all__ = [
@@ -25,6 +26,7 @@ __all__ = [
     "athena_partition",
     "postgres_adapter",
     "databricks_adapter",
+    "snowflake_adapter",
     "iceberg_adapter",
     "iceberg_partition",
 ]

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, List, Dict, Literal, Any
+from typing import Any, Dict, List, Literal, Optional, Sequence, cast
 
 from dlt.common import logger
 from dlt.common.data_writers.escape import escape_snowflake_literal
@@ -31,6 +31,12 @@ from dlt.destinations.path_utils import get_file_format_and_compression
 
 SUPPORTED_HINTS: Dict[TColumnHint, str] = {"unique": "UNIQUE"}
 COLUMN_COMMENT_HINT: Literal["x-snowflake-column-comment"] = "x-snowflake-column-comment"
+# Extension hints applied via snowflake_adapter (see snowflake_adapter.py).
+# Kept as module-level literals so _get_table_update_sql can read them
+# without a circular import on the adapter module.
+TABLE_COMMENT_HINT: Literal["x-snowflake-table-comment"] = "x-snowflake-table-comment"
+TABLE_TAGS_HINT: Literal["x-snowflake-table-tags"] = "x-snowflake-table-tags"
+COLUMN_TAGS_HINT: Literal["x-snowflake-column-tags"] = "x-snowflake-column-tags"
 
 
 class SnowflakeMergeJob(SqlMergeFollowupJob):
@@ -284,7 +290,70 @@ class SnowflakeClient(SqlJobClientWithStagingDataset, SupportsStagingDestination
         self, table_name: str, new_columns: Sequence[TColumnSchema], generate_alter: bool
     ) -> List[str]:
         sql = super()._get_table_update_sql(table_name, new_columns, generate_alter)
-        return self._add_cluster_sql(sql, table_name, generate_alter)
+        sql = self._add_cluster_sql(sql, table_name, generate_alter)
+        sql = self._add_comment_and_tag_sql(sql, table_name, new_columns)
+        return sql
+
+    def _add_comment_and_tag_sql(
+        self,
+        sql: List[str],
+        table_name: str,
+        new_columns: Sequence[TColumnSchema],
+    ) -> List[str]:
+        """Append COMMENT ON TABLE and ALTER TABLE … SET TAG statements
+        for any extension hints set by snowflake_adapter.
+
+        Table-level COMMENT falls back to the generic `description` hint
+        when `x-snowflake-table-comment` is absent — matches the
+        column-level fallback at `_get_column_def_sql`.
+
+        Tags are always emitted as separate ALTER TABLE statements after
+        the CREATE/ALTER, because Snowflake's SET TAG clause cannot be
+        composed into the CREATE TABLE DDL. Each tag fires its own
+        statement to keep error attribution clean (one bad tag doesn't
+        invalidate the others).
+
+        Idempotent in practice: re-running the loader re-issues the same
+        ALTER statements, which Snowflake treats as overwrites.
+        """
+        table = self.prepare_load_table(table_name)
+        qualified_name = self.sql_client.make_qualified_table_name(table_name)
+
+        # ── Table comment ────────────────────────────────────────────────
+        comment = table.get(TABLE_COMMENT_HINT) or table.get("description")
+        if comment:
+            escaped_comment = escape_snowflake_literal(comment)
+            sql.append(f"COMMENT ON TABLE {qualified_name} IS {escaped_comment}")
+
+        # ── Table tags ───────────────────────────────────────────────────
+        table_tags = table.get(TABLE_TAGS_HINT)
+        if table_tags:
+            table_tags = cast(Dict[str, Any], table_tags)
+            for tag_name, tag_value in table_tags.items():
+                escaped_value = escape_snowflake_literal(str(tag_value))
+                # tag_name is a Snowflake identifier (optionally
+                # db.schema.name). Do NOT quote it — Snowflake would
+                # treat the result as a delimited identifier and fail
+                # to resolve the tag object.
+                sql.append(
+                    f"ALTER TABLE {qualified_name} SET TAG {tag_name} = {escaped_value}"
+                )
+
+        # ── Column tags ──────────────────────────────────────────────────
+        for column in new_columns:
+            column_tags = column.get(COLUMN_TAGS_HINT)
+            if not column_tags:
+                continue
+            column_tags = cast(Dict[str, Any], column_tags)
+            quoted_col = self.sql_client.escape_column_name(column["name"])
+            for tag_name, tag_value in column_tags.items():
+                escaped_value = escape_snowflake_literal(str(tag_value))
+                sql.append(
+                    f"ALTER TABLE {qualified_name} ALTER COLUMN {quoted_col}"
+                    f" SET TAG {tag_name} = {escaped_value}"
+                )
+
+        return sql
 
     def _from_db_type(
         self, bq_t: str, precision: Optional[int], scale: Optional[int]

--- a/dlt/destinations/impl/snowflake/snowflake_adapter.py
+++ b/dlt/destinations/impl/snowflake/snowflake_adapter.py
@@ -1,0 +1,152 @@
+from typing import Any, Dict, Literal, Optional, cast
+
+from dlt.common.schema.typing import TTableSchemaColumns
+from dlt.destinations.utils import get_resource_for_adapter
+from dlt.extract import DltResource
+from dlt.extract.items import TTableHintTemplate
+
+
+TABLE_COMMENT_HINT: Literal["x-snowflake-table-comment"] = "x-snowflake-table-comment"
+TABLE_TAGS_HINT: Literal["x-snowflake-table-tags"] = "x-snowflake-table-tags"
+COLUMN_TAGS_HINT: Literal["x-snowflake-column-tags"] = "x-snowflake-column-tags"
+# COLUMN_COMMENT_HINT is already defined in snowflake.py (the destination
+# resolves it together with the generic `description` column hint).
+# Re-exported here so adapter callers don't need to know which module it lives in.
+from dlt.destinations.impl.snowflake.snowflake import COLUMN_COMMENT_HINT
+
+
+def _validate_tags_dict(tags: Dict[str, Any], *, label: str) -> None:
+    """Snowflake tags are first-class objects with names + string values.
+    Validate the user-supplied shape early so the eventual ALTER TABLE
+    SET TAG runs cleanly."""
+    if not isinstance(tags, dict):
+        raise ValueError(
+            f"`{label}` must be a dict of {{tag_name: value}}. Snowflake tags"
+            " differ from Databricks tags in that the tag name must reference"
+            " a tag object that already exists in your Snowflake account"
+            " (see CREATE TAG). The adapter does NOT create tag objects —"
+            " issue CREATE TAG <name> via your governance tooling first."
+        )
+    for k, v in tags.items():
+        if not isinstance(k, str) or not k.strip():
+            raise ValueError(
+                f"`{label}` keys must be non-empty strings naming a tag object."
+                " Qualified names (db.schema.tag) and unqualified names are both"
+                f" accepted. Got: {k!r}"
+            )
+        if not isinstance(v, (str, int, bool, float)):
+            raise ValueError(
+                f"`{label}[{k!r}]` value must be a string, int, bool, or float."
+                f" Got {type(v).__name__}. Snowflake stores tag values as STRING;"
+                " non-strings are CAST to STRING."
+            )
+
+
+def snowflake_adapter(
+    data: Any,
+    table_comment: Optional[str] = None,
+    table_tags: Optional[Dict[str, Any]] = None,
+    column_comments: Optional[Dict[str, str]] = None,
+    column_tags: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> DltResource:
+    """Apply Snowflake-specific table and column metadata to a dlt resource.
+
+    Mirrors the pattern of `databricks_adapter` / `bigquery_adapter`.
+    The hints are stored as extension keys (`x-snowflake-…`) and emitted
+    as DDL when the table is created or altered by the Snowflake
+    destination:
+
+    - `table_comment` → `COMMENT ON TABLE <name> IS '…'`. Falls back to
+      the generic `description` table hint when not set, so any resource
+      already using `apply_hints(additional_table_hints={"description": …})`
+      gets table comments for free without re-wiring.
+    - `table_tags` → `ALTER TABLE <name> SET TAG <key> = '<value>'` per
+      pair. Tag objects must already exist in Snowflake (CREATE TAG); the
+      adapter is intentionally non-DDL-creating to avoid privilege bloat
+      on the loader role.
+    - `column_comments` → emitted inline in CREATE TABLE as
+      `<col> <type> COMMENT '<value>'`. The Snowflake destination already
+      honors a `description` column hint; this argument is for callers who
+      want to keep table-level prose separate from column metadata.
+    - `column_tags` → `ALTER TABLE <name> ALTER COLUMN <col> SET TAG
+      <key> = '<value>'` per (column, tag) pair.
+
+    Args:
+        data: A dlt resource (or anything dlt can wrap into one).
+        table_comment: One-line human description of the table. Markdown
+            is not interpreted by Snowflake — keep it short.
+        table_tags: ``{tag_name: value}`` dict. Tag names may be
+            qualified (``governance.cost_center``) or unqualified
+            (resolved in the session's current schema).
+        column_comments: ``{column_name: comment}`` dict. Equivalent
+            to passing ``description`` in a ``columns={...}`` hint, but
+            scoped per the adapter API.
+        column_tags: ``{column_name: {tag_name: value, ...}}`` dict.
+            Same tag semantics as ``table_tags``.
+
+    Returns:
+        The same `DltResource`, with hints applied. Chainable.
+
+    Examples:
+        >>> @dlt.resource
+        ... def orders(): ...
+        >>> snowflake_adapter(
+        ...     orders,
+        ...     table_comment="Shopify orders, one row per checkout",
+        ...     table_tags={"governance.domain": "commerce"},
+        ...     column_comments={"customer_email": "Buyer email (PII)"},
+        ...     column_tags={"customer_email": {"governance.pii_class": "internal"}},
+        ... )
+    """
+    resource = get_resource_for_adapter(data)
+
+    additional_table_hints: Dict[str, TTableHintTemplate[Any]] = {}
+    additional_column_hints: Dict[str, Dict[str, Any]] = {}
+
+    if table_comment is not None:
+        if not isinstance(table_comment, str):
+            raise ValueError("`table_comment` must be a string.")
+        additional_table_hints[TABLE_COMMENT_HINT] = table_comment
+
+    if table_tags is not None:
+        _validate_tags_dict(table_tags, label="table_tags")
+        additional_table_hints[TABLE_TAGS_HINT] = dict(table_tags)
+
+    if column_comments is not None:
+        if not isinstance(column_comments, dict):
+            raise ValueError("`column_comments` must be a dict of {column_name: comment}.")
+        for col, comment in column_comments.items():
+            if not isinstance(col, str) or not col:
+                raise ValueError(f"`column_comments` keys must be non-empty column names. Got: {col!r}")
+            if not isinstance(comment, str):
+                raise ValueError(f"`column_comments[{col!r}]` must be a string.")
+            additional_column_hints.setdefault(col, {"name": col})
+            additional_column_hints[col][COLUMN_COMMENT_HINT] = comment
+
+    if column_tags is not None:
+        if not isinstance(column_tags, dict):
+            raise ValueError(
+                "`column_tags` must be a dict of {column_name: {tag_name: value, ...}}."
+            )
+        for col, tags in column_tags.items():
+            if not isinstance(col, str) or not col:
+                raise ValueError(f"`column_tags` keys must be non-empty column names. Got: {col!r}")
+            _validate_tags_dict(tags, label=f"column_tags[{col!r}]")
+            additional_column_hints.setdefault(col, {"name": col})
+            additional_column_hints[col][COLUMN_TAGS_HINT] = dict(tags)
+
+    if not additional_table_hints and not additional_column_hints:
+        raise ValueError(
+            "`snowflake_adapter` requires at least one of `table_comment`,"
+            " `table_tags`, `column_comments`, or `column_tags`."
+        )
+
+    resource.apply_hints(
+        columns=(
+            cast(TTableSchemaColumns, additional_column_hints)
+            if additional_column_hints
+            else None
+        ),
+        additional_table_hints=additional_table_hints or None,
+    )
+    return resource

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -505,6 +505,64 @@ Above, we set the CSV file format without a header, with **|** as a separator, a
 You'll need these settings when [importing external files](../../general-usage/resource.md#import-external-files).
 :::
 
+### Snowflake adapter — table & column comments and tags
+
+Use `snowflake_adapter` to attach Snowflake-specific table and column metadata
+to a resource. The adapter writes extension hints into the table schema that
+the destination then emits as `COMMENT ON TABLE`, column-level `COMMENT` clauses,
+and `ALTER TABLE … SET TAG` statements after table creation.
+
+```py
+from dlt.destinations.adapters import snowflake_adapter
+
+@dlt.resource
+def orders():
+    ...
+
+snowflake_adapter(
+    orders,
+    table_comment="Shopify orders — one row per checkout",
+    table_tags={
+        "governance.domain": "commerce",
+        "governance.cost_center": "data_eng",
+    },
+    column_comments={
+        "customer_email": "Buyer's email (PII)",
+        "amount_total": "Order grand total in customer's currency",
+    },
+    column_tags={
+        "customer_email": {"governance.pii_class": "internal"},
+    },
+)
+```
+
+Arguments:
+
+* **`table_comment`** (str) — single-line description applied as
+  `COMMENT ON TABLE`. Falls back to the resource's generic `description`
+  hint when not set; equivalent column-level fallback already exists in
+  the destination.
+* **`table_tags`** (dict) — `{tag_name: value}` pairs. Tag names may be
+  qualified (`governance.cost_center`) or unqualified. Values are cast to
+  string by Snowflake. **The tag object must already exist** — issue
+  `CREATE TAG <name>` via your governance/Terraform/Snowcap tooling first.
+  The adapter intentionally does not create tag objects (would require
+  CREATE TAG privilege on the loader role).
+* **`column_comments`** (dict) — `{column_name: comment}`. Equivalent to
+  setting `description` on each column via `apply_hints(columns={...})`.
+* **`column_tags`** (dict of dicts) — `{column_name: {tag_name: value, ...}}`.
+  Same tag semantics as `table_tags`.
+
+Differences from the Databricks adapter:
+
+* **Tags are dicts, not lists.** Snowflake tags are first-class objects
+  with values; the Databricks-style `["pii"]` shape isn't expressible.
+* **No `table_properties` / `cluster` / `partition` arguments.** Snowflake
+  doesn't have TBLPROPERTIES, and clustering is configured via
+  destination-level `create_indexes` + `cluster_by_max_per_table`. Iceberg
+  tables on Snowflake live behind a separate catalog integration, not a
+  CREATE TABLE option.
+
 ### Query tagging
 
 `dlt` [tags sessions](https://docs.snowflake.com/en/sql-reference/parameters#query-tag) used for Snowflake operations with the following properties:

--- a/tests/load/snowflake/test_snowflake_adapter.py
+++ b/tests/load/snowflake/test_snowflake_adapter.py
@@ -1,0 +1,103 @@
+"""Unit tests for snowflake_adapter — validates the API + hint
+propagation without hitting a live Snowflake account.
+
+Integration tests that exercise the full ALTER TABLE/COMMENT/SET TAG
+SQL emission live in test_snowflake_table_builder.py.
+"""
+from tests.utils import skip_if_not_active
+
+skip_if_not_active("snowflake")
+
+from typing import Iterator
+
+import pytest
+
+import dlt
+from dlt.destinations.adapters import snowflake_adapter
+from dlt.destinations.impl.snowflake.snowflake_adapter import (
+    COLUMN_COMMENT_HINT,
+    COLUMN_TAGS_HINT,
+    TABLE_COMMENT_HINT,
+    TABLE_TAGS_HINT,
+)
+
+
+pytestmark = pytest.mark.essential
+
+
+@dlt.resource(columns={"id": {"data_type": "bigint"}})
+def _demo() -> Iterator[dict]:
+    yield {"id": 1}
+
+
+def test_adapter_applies_table_comment() -> None:
+    res = snowflake_adapter(_demo.with_name("a"), table_comment="hello")
+    assert res.compute_table_schema().get(TABLE_COMMENT_HINT) == "hello"
+
+
+def test_adapter_applies_table_tags() -> None:
+    res = snowflake_adapter(
+        _demo.with_name("b"),
+        table_tags={"governance.domain": "commerce", "cost_center": "eng"},
+    )
+    tags = res.compute_table_schema().get(TABLE_TAGS_HINT)
+    assert tags == {"governance.domain": "commerce", "cost_center": "eng"}
+
+
+def test_adapter_applies_column_comments_and_tags() -> None:
+    res = snowflake_adapter(
+        _demo.with_name("c"),
+        column_comments={"id": "primary identifier"},
+        column_tags={"id": {"governance.pii_class": "public"}},
+    )
+    cols = res.compute_table_schema()["columns"]
+    assert cols["id"].get(COLUMN_COMMENT_HINT) == "primary identifier"
+    assert cols["id"].get(COLUMN_TAGS_HINT) == {"governance.pii_class": "public"}
+
+
+def test_adapter_table_tags_must_be_dict() -> None:
+    """Snowflake tags require key=value pairs, not free strings (which
+    Databricks accepts). Reject the list shape early."""
+    with pytest.raises(ValueError, match="table_tags.*must be a dict"):
+        snowflake_adapter(_demo.with_name("d"), table_tags=["foo", "bar"])  # type: ignore[arg-type]
+
+
+def test_adapter_table_tag_value_types() -> None:
+    """Tag values can be string/int/bool/float — reject everything else."""
+    with pytest.raises(ValueError, match="value must be a string"):
+        snowflake_adapter(
+            _demo.with_name("e"),
+            table_tags={"governance.domain": ["nested", "list"]},  # type: ignore[dict-item]
+        )
+
+
+def test_adapter_column_tags_per_column_must_be_dict() -> None:
+    with pytest.raises(ValueError, match="column_tags.*must be a dict"):
+        snowflake_adapter(
+            _demo.with_name("f"),
+            column_tags={"id": ["a", "b"]},  # type: ignore[dict-item]
+        )
+
+
+def test_adapter_no_arguments_raises() -> None:
+    """An empty adapter() call is almost always a bug — surface it."""
+    with pytest.raises(ValueError, match="at least one of"):
+        snowflake_adapter(_demo.with_name("g"))
+
+
+def test_adapter_table_comment_string_only() -> None:
+    with pytest.raises(ValueError, match="table_comment.*must be a string"):
+        snowflake_adapter(_demo.with_name("h"), table_comment=123)  # type: ignore[arg-type]
+
+
+def test_adapter_chains_with_existing_hints() -> None:
+    """The adapter must not clobber column hints set via @dlt.resource()."""
+    res = snowflake_adapter(
+        _demo.with_name("i"),
+        column_comments={"id": "the id column"},
+    )
+    cols = res.compute_table_schema()["columns"]
+    # Original hint from @dlt.resource preserved …
+    assert cols["id"]["data_type"] == "bigint"
+    # … plus the new one stacked on top.
+    assert cols["id"].get(COLUMN_COMMENT_HINT) == "the id column"

--- a/tests/load/snowflake/test_snowflake_table_builder.py
+++ b/tests/load/snowflake/test_snowflake_table_builder.py
@@ -16,6 +16,9 @@ from dlt.destinations.impl.snowflake.snowflake import (
     SnowflakeClient,
     SUPPORTED_HINTS,
     COLUMN_COMMENT_HINT,
+    COLUMN_TAGS_HINT,
+    TABLE_COMMENT_HINT,
+    TABLE_TAGS_HINT,
 )
 from dlt.destinations.impl.snowflake.configuration import (
     SnowflakeClientConfiguration,
@@ -319,6 +322,100 @@ def test_alter_table_with_column_comments(snowflake_client: SnowflakeClient) -> 
     assert add_column_sql.startswith("ALTER TABLE")
     assert "ADD COLUMN" in add_column_sql
     assert "COMMENT 'Added column with comment'" in add_column_sql
+
+
+def test_create_table_with_table_comment(snowflake_client: SnowflakeClient) -> None:
+    """`x-snowflake-table-comment` becomes COMMENT ON TABLE post-CREATE."""
+    mod_update = deepcopy(TABLE_UPDATE[:3])
+    table_name = "event_test_table"
+
+    # Stamp the table-level hint in the schema (mirrors what
+    # snowflake_adapter does for resource-driven loads).
+    snowflake_client.schema.update_table({
+        "name": table_name,
+        TABLE_COMMENT_HINT: "Per-event facts; one row per business event",  # type: ignore[typeddict-unknown-key]
+        "columns": {c["name"]: c for c in mod_update},
+    })
+
+    statements = snowflake_client._get_table_update_sql(table_name, mod_update, False)
+    # CREATE TABLE is statements[0]; the COMMENT ON TABLE is a separate
+    # follow-up statement so attribution is clean if it fails on its own.
+    assert any(s.startswith("COMMENT ON TABLE ") for s in statements)
+    comment_stmt = next(s for s in statements if s.startswith("COMMENT ON TABLE "))
+    assert "Per-event facts" in comment_stmt
+    assert comment_stmt.endswith(
+        "IS 'Per-event facts; one row per business event'"
+    )
+
+
+def test_create_table_comment_falls_back_to_description(
+    snowflake_client: SnowflakeClient,
+) -> None:
+    """Generic `description` table hint is used when no Snowflake-specific
+    hint is set — same fallback the column path already does."""
+    mod_update = deepcopy(TABLE_UPDATE[:2])
+    table_name = "event_test_table"
+    snowflake_client.schema.update_table({
+        "name": table_name,
+        "description": "Generic table description",
+        "columns": {c["name"]: c for c in mod_update},
+    })
+    statements = snowflake_client._get_table_update_sql(table_name, mod_update, False)
+    assert any(
+        "COMMENT ON TABLE" in s and "Generic table description" in s
+        for s in statements
+    )
+
+
+def test_create_table_with_table_tags(snowflake_client: SnowflakeClient) -> None:
+    """`x-snowflake-table-tags` emits one ALTER TABLE SET TAG per pair."""
+    mod_update = deepcopy(TABLE_UPDATE[:2])
+    table_name = "event_test_table"
+    snowflake_client.schema.update_table({
+        "name": table_name,
+        TABLE_TAGS_HINT: {  # type: ignore[typeddict-unknown-key]
+            "governance.domain": "commerce",
+            "governance.cost_center": "data_eng",
+        },
+        "columns": {c["name"]: c for c in mod_update},
+    })
+    statements = snowflake_client._get_table_update_sql(table_name, mod_update, False)
+    tag_statements = [s for s in statements if "SET TAG" in s and "ALTER COLUMN" not in s]
+    assert len(tag_statements) == 2, statements
+    # Tag names must NOT be quoted — Snowflake would treat the quoted form
+    # as a delimited identifier and fail to resolve the tag object.
+    assert any("SET TAG governance.domain = 'commerce'" in s for s in tag_statements)
+    assert any("SET TAG governance.cost_center = 'data_eng'" in s for s in tag_statements)
+
+
+def test_create_table_with_column_tags(snowflake_client: SnowflakeClient) -> None:
+    """`x-snowflake-column-tags` emits ALTER TABLE ALTER COLUMN SET TAG."""
+    mod_update = deepcopy(TABLE_UPDATE[:2])
+    mod_update[0][COLUMN_TAGS_HINT] = {  # type: ignore[typeddict-unknown-key]
+        "governance.pii_class": "internal",
+        "governance.owner": "data_eng",
+    }
+    statements = snowflake_client._get_table_update_sql("event_test_table", mod_update, False)
+    col_tag_statements = [s for s in statements if "ALTER COLUMN" in s and "SET TAG" in s]
+    assert len(col_tag_statements) == 2, statements
+    assert any('"COL1"' in s and "governance.pii_class = 'internal'" in s
+               for s in col_tag_statements)
+    assert any('"COL1"' in s and "governance.owner = 'data_eng'" in s
+               for s in col_tag_statements)
+
+
+def test_table_comment_escaping(snowflake_client: SnowflakeClient) -> None:
+    """Single quotes in the comment value are doubled per Snowflake's
+    literal-escape rules."""
+    table_name = "event_test_table"
+    snowflake_client.schema.update_table({
+        "name": table_name,
+        TABLE_COMMENT_HINT: "isn't it; 'great' \"data\"",  # type: ignore[typeddict-unknown-key]
+        "columns": {c["name"]: c for c in TABLE_UPDATE[:1]},
+    })
+    statements = snowflake_client._get_table_update_sql(table_name, TABLE_UPDATE[:1], False)
+    comment_stmt = next(s for s in statements if s.startswith("COMMENT ON TABLE "))
+    assert "isn''t it; ''great'' \"data\"" in comment_stmt
 
 
 def test_create_table_decfloat(empty_schema: Schema) -> None:


### PR DESCRIPTION
## Summary

Adds `snowflake_adapter` mirroring the pattern shipped for Databricks in #2625. Closes the gap where the dlt-Snowflake destination only honored column-level `COMMENT` (via the `description` column hint) — tables, table tags, and column tags had no documented path.

## What's included

- **`dlt/destinations/impl/snowflake/snowflake_adapter.py`** — new adapter with `table_comment`, `table_tags`, `column_comments`, `column_tags` arguments. Mirrors the `databricks_adapter` / `bigquery_adapter` API shape.
- **`dlt/destinations/impl/snowflake/snowflake.py`** — new `_add_comment_and_tag_sql()` helper called from `_get_table_update_sql`. Emits:
  - `COMMENT ON TABLE <name> IS '…'` from the `x-snowflake-table-comment` hint, with fallback to the generic `description` table hint (matches the existing column-level fallback).
  - `ALTER TABLE <name> SET TAG <k> = '<v>'` per pair from `x-snowflake-table-tags`.
  - `ALTER TABLE <name> ALTER COLUMN <c> SET TAG <k> = '<v>'` from `x-snowflake-column-tags`.
- **`dlt/destinations/adapters.py`** — exports `snowflake_adapter` alongside the others.
- **Tests** (14 new):
  - `tests/load/snowflake/test_snowflake_adapter.py` — 9 unit tests for the adapter API (shape validation, fallback behavior, chaining with existing hints).
  - `tests/load/snowflake/test_snowflake_table_builder.py` — 5 SQL emission tests (table_comment, description fallback, table_tags, column_tags, literal-escape).
- **Docs** — `docs/website/docs/dlt-ecosystem/destinations/snowflake.md` gains a \"Snowflake adapter\" section before the existing Query tagging section.

## Differences from `databricks_adapter`

- **Tags are dicts** (`{name: value}`), not the Databricks list-of-strings shape. Snowflake tags are first-class catalog objects with values; the loose-string form doesn't map.
- **No `table_properties` / `cluster` / `partition` arguments.** Snowflake doesn't have TBLPROPERTIES; clustering is configured via the destination-level `create_indexes` + cluster column hint; iceberg tables live behind a separate catalog integration not a CREATE TABLE option.
- **Adapter does NOT create tag objects.** `CREATE TAG <name>` must already have been run by governance/Terraform tooling. Keeps the loader role's privilege footprint small (no CREATE TAG ACCOUNT-level grant needed).

## Test plan

- [x] 9 unit tests for the adapter API pass (`test_snowflake_adapter.py`).
- [x] 5 new SQL-emission tests + 24 existing tests pass (`test_snowflake_table_builder.py`).
- [ ] Integration tests against a live Snowflake account (I don't have CI access; happy to provide the `databricks_adapter`-style \`@pytest.mark.parametrize(\"destination_config\", destinations_configs(default_sql_configs=True, subset=[\"snowflake\"]))\` pipeline test if you'd like it before merge).

## Context

Originally surfaced by a downstream user needing per-table cost-allocation tags on a Snowflake warehouse + table-level documentation that PowerBI / Snowsight can surface via DESCRIBE TABLE. The Databricks pattern from #2625 fit cleanly; this PR ports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)