### PR TITLE
fix(cli): sort top-level subparser registrations alphabetically (#3454)

### DIFF
--- a/dlt/_workspace/cli/_dlt.py
+++ b/dlt/_workspace/cli/_dlt.py
@@ -247,8 +247,9 @@ def _create_parser(
 
     installed_commands: Dict[str, _compose.ComposedExecutable] = {}
 
-    # install top level commands
-    for name, group in top_groups.items():
+    # install top level commands. iterate sorted so subcommand order is deterministic
+    # regardless of plugin discovery order (varies across interpreter / install set, #3454)
+    for name, group in sorted(top_groups.items()):
         command_parser = subparsers.add_parser(
             name,
             help=group[0].help_string,
@@ -256,8 +257,8 @@ def _create_parser(
         )
         installed_commands[name] = _compose.configure_parser(command_parser, group)
 
-    # attach sub commands to commands
-    for (parent_name, sub_name), sub_group in sub_groups.items():
+    # attach sub commands to commands (also sorted for deterministic rendering, #3454)
+    for (parent_name, sub_name), sub_group in sorted(sub_groups.items()):
         if parent_name not in installed_commands:
             warnings.warn(
                 f"sub-subcommand {sub_name!r} skipped: parent {parent_name!r} is not"

--- a/tests/workspace/cli/common/test_cli_invoke.py
+++ b/tests/workspace/cli/common/test_cli_invoke.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 import pytest
@@ -91,6 +92,26 @@ def test_create_parser_filters_none_hookimpls() -> None:
     assert "init" in installed
     # parser was built without raising
     assert parser is not None
+
+
+@pytest.mark.parametrize("host", ["dlt", "dlthub"], ids=["dlt", "dlthub"])
+def test_top_level_subcommands_are_alphabetically_ordered(host: str) -> None:
+    """Top-level subcommands must render in a stable, alphabetical order — see #3454.
+
+    Plugin discovery order varies across systems (interpreter version, installed package set,
+    entry point registration order), which previously made `dlt --help` and the generated CLI
+    docs non-deterministic.
+    """
+    parser, _pre, _installed = _create_parser(host)
+    top_subparsers = next(
+        (a for a in parser._actions if isinstance(a, argparse._SubParsersAction)),
+        None,
+    )
+    assert top_subparsers is not None, "expected top-level subparsers action"
+    choices = list(top_subparsers.choices.keys())
+    assert choices == sorted(choices), (
+        f"top-level CLI subcommands are not alphabetically ordered: {choices!r}"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Closes #3454.

Top-level CLI subcommands (`dlt ai | dashboard | deploy | init | pipeline | schema | telemetry`) currently render in plugin-discovery order, which depends on pluggy entry-point registration and varies across systems (interpreter version, installed package set, dict iteration semantics across Python builds). That makes `dlt --help` non-deterministic and is the root cause #3454 calls out for the CLI docs renderer.

Fix iterates `sorted(top_groups.items())` and `sorted(sub_groups.items())` in `_create_parser` before adding subparsers so the output is stable. The change is local to `dlt/_workspace/cli/_dlt.py`; `group_commands` itself stays insertion-order to preserve the contract its callers expect for compose/extend semantics.

## What I ran locally

```
$ uv pip install -e ".[hub]" pytest pytest-console-scripts pytest-mock --quiet
$ python -m pytest tests/workspace/cli/common/test_cli_invoke.py::test_top_level_subcommands_are_alphabetically_ordered \
    tests/workspace/cli/common/test_cli_compose.py -v
...
tests/workspace/cli/common/test_cli_invoke.py::test_top_level_subcommands_are_alphabetically_ordered[dlt] PASSED
tests/workspace/cli/common/test_cli_invoke.py::test_top_level_subcommands_are_alphabetically_ordered[dlthub] PASSED
... 9 passed in test_cli_compose.py
```

Also ran the wider `tests/workspace/cli/common/` suite — the only failures are 9 pre-existing tests requiring `ibis-framework` (dashboard helpers), and they fail identically on `origin/devel` without my patch.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# from a fresh clone with the venv already prepared
PR_BRANCH=fix/3454-deterministic-cli-subparser-order

# BEFORE — on devel: regression test fails because subcommand order is plugin-discovery dependent
git checkout origin/devel
python -m pytest tests/workspace/cli/common/test_cli_invoke.py::test_top_level_subcommands_are_alphabetically_ordered -v
# Expected: 2 FAILED with `AssertionError: top-level CLI subcommands are not alphabetically ordered`

# AFTER — on this branch: deterministic, alphabetical
git checkout $PR_BRANCH
python -m pytest tests/workspace/cli/common/test_cli_invoke.py::test_top_level_subcommands_are_alphabetically_ordered -v
# Expected: 2 passed
```

The exact failing assertion on `origin/devel` (recorded locally before the fix):

```
AssertionError: top-level CLI subcommands are not alphabetically ordered:
  ['telemetry', 'schema', 'pipeline', 'init', 'deploy', 'dashboard', 'ai']
```

## Edge cases

| Scenario | Before | After |
|---|---|---|
| `dlt --help` on stock install | order depends on entry-point discovery | always alphabetical |
| `dlthub --help` | same non-determinism (#3913 split surface) | alphabetical |
| Sub-subcommands (`dlt pipeline show / info / drop`) | unsorted insertion order | also sorted (cosmetic, fixes nested sections in generated docs) |
| Plugin compose modes (`replace`/`extend`/`additive`) | unaffected | unaffected — `group_commands` and `configure_parser` are untouched |

## Notes for reviewers

- I deliberately left `group_commands` returning insertion-ordered dicts because `configure_parser` and the `ComposedExecutable.primary` selection rely on "first plugin wins" semantics. Sorting at the registration site keeps that contract intact while making the rendered surface deterministic.
- The new test lives next to the existing `_create_parser` tests in `test_cli_invoke.py` and is parametrised over both hosts (`dlt`, `dlthub`) since both invoke the same composition path.

---

*Generated with assistance from Claude Code (Anthropic). Investigation, fix implementation and the regression test were authored by me (jbbqqf, data engineer GCP/Python); all assertions were verified locally before submission.*
