### PR TITLE
fix(sftp): cap paramiko<5 in sftp extra (#3931)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,8 @@ hf = [
     "pyarrow>=21.0.0",  # minimum version that supports CDC (https://huggingface.co/blog/parquet-cdc)
 ]
 sftp = [
-    "paramiko>=3.3.0"
+    # paramiko 5.0.0 dropped GSSAPI support and broke SFTP filesystem (#3931). cap until upgrade evaluated.
+    "paramiko>=3.3.0,<5"
 ]
 http = [
     "aiohttp>3.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2855,7 +2855,7 @@ requires-dist = [
     { name = "orjson", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'", specifier = ">=3.6.7,!=3.9.11,!=3.9.12,!=3.9.13,!=3.9.14,!=3.10.1,<4" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'", specifier = ">=3.10.1" },
     { name = "packaging", specifier = ">=21.1" },
-    { name = "paramiko", marker = "extra == 'sftp'", specifier = ">=3.3.0" },
+    { name = "paramiko", marker = "extra == 'sftp'", specifier = ">=3.3.0,<5" },
     { name = "pathvalidate", specifier = ">=2.5.2" },
     { name = "pendulum", specifier = ">=2.1.2" },
     { name = "pendulum", marker = "python_full_version >= '3.14'", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary

Closes #3931.

paramiko 5.0.0 (released 2026-05-09) [removed GSSAPI support](https://www.paramiko.org/changelog.html) and changed several public APIs. The `sftp` extra currently has an open bound (`"paramiko>=3.3.0"`), so fresh `pip install dlt[sftp]` picks up paramiko 5.x and breaks the SFTP filesystem destination.

Cap the constraint at `paramiko>=3.3.0,<5` until 5.x compat is evaluated explicitly. `uv.lock` regenerated to match.

## What I ran locally

```
$ # before — open bound
$ grep paramiko pyproject.toml
    "paramiko>=3.3.0"

$ uv pip install --dry-run ".[sftp]" 2>&1 | grep paramiko
 + paramiko==5.0.0
```

After applying the cap:

```
$ uv pip install --dry-run ".[sftp]" 2>&1 | grep paramiko
 + paramiko==4.0.0   # the latest paramiko before 5.x — resolver picks the highest allowed
```

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# BEFORE — on devel: resolver picks up paramiko 5.x, which has the breaking GSSAPI removal
git checkout origin/devel
uv pip install --dry-run ".[sftp]" 2>&1 | grep paramiko
# Expected: `+ paramiko==5.0.0` (or higher)

# AFTER — on this branch: capped to <5
git checkout fix/3931-cap-paramiko-below-5
uv pip install --dry-run ".[sftp]" 2>&1 | grep paramiko
# Expected: `+ paramiko==4.0.0`
```

## Edge cases

| Scenario | Before | After |
|---|---|---|
| New `pip install dlt[sftp]` | resolves paramiko 5.x, breaks at import on the SFTP path | resolves paramiko 4.x, works |
| Existing install with paramiko 3.x or 4.x pinned | unaffected | unaffected |
| `types-paramiko` dev dep | already pinned at `>=3.5.0.20250708`, no change | no change |

## Notes for reviewers

- This is a conservative, time-bounded cap — once paramiko 5.x support is reviewed (probably via the GSSAPI removal note in their 5.0 changelog plus any other API delta), the cap can be relaxed in a follow-up. I did not attempt to make dlt compatible with 5.x in this PR.
- Reporter's original diagnosis in #3931 is accurate; this implements exactly the suggested fix.

---

*Generated with assistance from Claude Code (Anthropic). Investigation and resolver verification were done by me (jbbqqf, data engineer GCP/Python); all commands above were run locally before submission.*
