### PR TITLE
Fix typos: wether -> whether, invididual -> individual

### DIFF
--- a/dlt/dataset/dataset.py
+++ b/dlt/dataset/dataset.py
@@ -163,7 +163,7 @@ class Dataset:
     def sqlglot_schema(self) -> SQLGlotSchema:
         """SQLGlot schema of the dataset derived from all dlt schemas."""
         # NOTE: no cache for now, it is probably more expensive to compute the current schema hash
-        # to see wether this is stale than to compute a new sqlglot schema
+        # to see whether this is stale than to compute a new sqlglot schema
         return lineage.create_sqlglot_schema(
             {self.dataset_name: list(self.schemas)}, dialect=self.destination_dialect
         )

--- a/dlt/destinations/impl/dremio/sql_client.py
+++ b/dlt/destinations/impl/dremio/sql_client.py
@@ -158,7 +158,7 @@ class DremioSqlClient(SqlClientBase[pydremio.DremioConnection]):
         return isinstance(ex, (pyarrow.lib.ArrowInvalid, pydremio.MalformedQueryError))
 
     def create_dataset(self) -> None:
-        # We create a sentinel table which defines wether we consider the dataset created
+        # We create a sentinel table which defines whether we consider the dataset created
         sentinel_table_name = self.make_qualified_table_name(self.SENTINEL_TABLE_NAME)
         self.execute_sql(f"CREATE TABLE {sentinel_table_name} (_dlt_id BIGINT)")
 

--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -212,12 +212,12 @@ class DltResourceHints:
 
     @property
     def has_dynamic_table_name(self) -> bool:
-        """Tells the extractor wether computed table name may change based on invididual data items"""
+        """Tells the extractor whether computed table name may change based on individual data items"""
         return self._table_name_hint_fun is not None
 
     @property
     def has_other_dynamic_hints(self) -> bool:
-        """Tells the extractor wether computed hints may change based on invididual data items"""
+        """Tells the extractor whether computed hints may change based on individual data items"""
         return self._table_has_other_dynamic_hints
 
     @property


### PR DESCRIPTION
Spotted while reading through the code:

- 4x `wether` -> `whether` in [dataset.py](dlt/dataset/dataset.py), [dremio/sql_client.py](dlt/destinations/impl/dremio/sql_client.py), and [extract/hints.py](dlt/extract/hints.py)
- 2x `invididual` -> `individual` in [extract/hints.py](dlt/extract/hints.py)

Comments and docstrings only, no behavior change.