### PR TITLE
fix(3979): allow for legacy ducklake migration

### DIFF
--- a/dlt/destinations/impl/ducklake/configuration.py
+++ b/dlt/destinations/impl/ducklake/configuration.py
@@ -140,6 +140,8 @@ class DuckLakeClientConfiguration(WithLocalFiles, DestinationClientDwhWithStagin
     credentials: DuckLakeCredentials = None
     create_indexes: bool = False  # does nothing but required
     override_data_path: bool = False
+    automatic_migration: bool = False
+    """When true, attaches with `AUTOMATIC_MIGRATION true` so DuckDB migrates an older DuckLake catalog schema on attach."""
 
     def fingerprint(self) -> str:
         """Use fingerprint of underlying storage. This is precise to bucket level"""

--- a/dlt/destinations/impl/ducklake/ducklake.py
+++ b/dlt/destinations/impl/ducklake/ducklake.py
@@ -175,6 +175,7 @@ class DuckLakeClient(DuckDbClient):
             credentials=config.credentials,
             capabilities=capabilities,
             override_data_path=config.override_data_path,
+            automatic_migration=config.automatic_migration,
         )
 
     def initialize_storage(self, truncate_tables: Iterable[str] = None) -> None:

--- a/dlt/destinations/impl/ducklake/factory.py
+++ b/dlt/destinations/impl/ducklake/factory.py
@@ -32,6 +32,7 @@ class ducklake(Destination[DuckLakeClientConfiguration, "DuckLakeClient"]):
     def __init__(
         self,
         credentials: Optional[DuckLakeCredentials] = None,
+        automatic_migration: bool = False,
         destination_name: Optional[str] = None,
         environment: Optional[str] = None,
         **kwargs: Any,
@@ -44,6 +45,8 @@ class ducklake(Destination[DuckLakeClientConfiguration, "DuckLakeClient"]):
             credentials(Optional[DuckLakeCredentials]): DuckLake credentials or instantiated connection to a DuckLake
                 client (which is a duckdb instance). The DuckLake credentials include
                 catalog name, catalog, and storage
+            automatic_migration (bool, optional): When true, attaches with `AUTOMATIC_MIGRATION true` so DuckDB migrates
+                an older DuckLake catalog schema on attach. Defaults to False.
             destination_name(Optional[str]): Name of a destination which. May be used as ducklake name, if
                 explicit name is not set in `credentials`.
             environment (Optional[str]): Environment of the destination
@@ -51,6 +54,7 @@ class ducklake(Destination[DuckLakeClientConfiguration, "DuckLakeClient"]):
         """
         super().__init__(
             credentials=credentials,
+            automatic_migration=automatic_migration,
             destination_name=destination_name,
             environment=environment,
             **kwargs,

--- a/dlt/destinations/impl/ducklake/sql_client.py
+++ b/dlt/destinations/impl/ducklake/sql_client.py
@@ -27,11 +27,13 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         credentials: DuckLakeCredentials,
         capabilities: DestinationCapabilitiesContext,
         override_data_path: bool = False,
+        automatic_migration: bool = False,
     ) -> None:
         super().__init__(dataset_name, staging_dataset_name, credentials, capabilities)
         self.credentials: DuckLakeCredentials = credentials
         self._attach_statement: str = None
         self.override_data_path = override_data_path
+        self.automatic_migration = automatic_migration
 
     def create_dataset(self) -> None:
         if self.has_dataset():
@@ -126,6 +128,7 @@ class DuckLakeSqlClient(DuckDbSqlClient):
         catalog: ConnectionStringCredentials,
         storage_url: str,
         override_data_path: bool = False,
+        automatic_migration: bool = False,
     ) -> str:
         attach_params = ""
         metadata_schema = metadata_schema or ducklake_name
@@ -153,7 +156,10 @@ class DuckLakeSqlClient(DuckDbSqlClient):
             raise NotImplementedError(str(catalog))
         attach_statement += f" AS {ducklake_name}"
         override_param = ", OVERRIDE_DATA_PATH true" if override_data_path else ""
-        attach_statement += f" (DATA_PATH '{storage_url}'{attach_params}{override_param})"
+        migration_param = ", AUTOMATIC_MIGRATION true" if automatic_migration else ""
+        attach_statement += (
+            f" (DATA_PATH '{storage_url}'{attach_params}{override_param}{migration_param})"
+        )
         return attach_statement
 
     @property
@@ -168,4 +174,5 @@ class DuckLakeSqlClient(DuckDbSqlClient):
                 catalog=self.credentials.catalog,
                 storage_url=self.credentials.storage_url,
                 override_data_path=self.override_data_path,
+                automatic_migration=self.automatic_migration,
             )

--- a/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/ducklake.md
@@ -180,6 +180,25 @@ destination = dlt.destinations.ducklake(
 
 See the [DuckLake docs on connecting](https://ducklake.select/docs/stable/duckdb/usage/connecting) for more details on `OVERRIDE_DATA_PATH`.
 
+### Automatic migration
+When you attach a catalog that was created by an older `ducklake` extension version, DuckDB raises a catalog version mismatch error. Set `automatic_migration` to `True` to attach with `AUTOMATIC_MIGRATION true`, which makes DuckDB migrate the catalog schema to the installed extension's version on attach. The default is `False`, matching DuckDB's own default.
+
+```toml
+[destination.ducklake]
+automatic_migration=true
+```
+
+Or via environment variable `DESTINATION__DUCKLAKE__AUTOMATIC_MIGRATION=true`, or in code:
+```py
+import dlt
+
+destination = dlt.destinations.ducklake(automatic_migration=True)
+```
+
+:::caution
+Migration mutates the catalog schema irreversibly. This does not help with read-only / pre-release (v0.x) catalogs, which DuckDB cannot migrate in place — migrate those through a writable intermediate catalog instead.
+:::
+
 ### Configure in code
 You can create ducklake destination instance and configure it in code. In most cases you will just set additional options while still using the configuration:
 ```py

--- a/tests/load/ducklake/test_ducklake_client.py
+++ b/tests/load/ducklake/test_ducklake_client.py
@@ -291,6 +291,48 @@ def test_ducklake_attach_statement_with_override_data_path() -> None:
     assert expected_attach_statement == attach_statement
 
 
+def test_ducklake_attach_statement_with_automatic_migration() -> None:
+    # we only assert the option is rendered into the ATTACH statement. the actual catalog
+    # migration triggered by `AUTOMATIC_MIGRATION true` is behavior of the ducklake extension
+    # and is tested upstream in the ducklake repo, not here.
+    expected_attach_statement = (
+        "ATTACH IF NOT EXISTS 'ducklake:postgres:postgres://loader:loader@localhost:5432/dlt_data'"
+        " AS foo (DATA_PATH '/path/to/storage', METADATA_SCHEMA 'foo',"
+        " AUTOMATIC_MIGRATION true)"
+    )
+    attach_statement = DuckLakeSqlClient.build_attach_statement(
+        catalog=ConnectionStringCredentials("postgres://loader:loader@localhost:5432/dlt_data"),
+        ducklake_name="foo",
+        storage_url="/path/to/storage",
+        automatic_migration=True,
+    )
+    assert expected_attach_statement == attach_statement
+    # sqlite/duckdb catalog branch also carries the option
+    sqlite_attach_statement = DuckLakeSqlClient.build_attach_statement(
+        catalog=ConnectionStringCredentials("sqlite:///catalog.sqlite"),
+        ducklake_name="foo",
+        storage_url="/path/to/storage",
+        automatic_migration=True,
+    )
+    assert "AUTOMATIC_MIGRATION true" in sqlite_attach_statement
+
+
+def test_ducklake_attach_statement_without_automatic_migration() -> None:
+    # flag off by default: option absent for both postgres and sqlite/duckdb branches
+    postgres_attach_statement = DuckLakeSqlClient.build_attach_statement(
+        catalog=ConnectionStringCredentials("postgres://loader:loader@localhost:5432/dlt_data"),
+        ducklake_name="foo",
+        storage_url="/path/to/storage",
+    )
+    assert "AUTOMATIC_MIGRATION" not in postgres_attach_statement
+    sqlite_attach_statement = DuckLakeSqlClient.build_attach_statement(
+        catalog=ConnectionStringCredentials("sqlite:///catalog.sqlite"),
+        ducklake_name="foo",
+        storage_url="/path/to/storage",
+    )
+    assert "AUTOMATIC_MIGRATION" not in sqlite_attach_statement
+
+
 def test_ducklake_attach_statement_with_metadata_schema() -> None:
     expected_attach_statement = (
         "ATTACH IF NOT EXISTS 'ducklake:postgres:postgres://loader:loader@localhost:5432/dlt_data'"


### PR DESCRIPTION
- **feat(ducklake): add AUTOMATIC_MIGRATION flag to ducklake**
  # Context
  When attaching a v0.4 ducklake catalog with a v1.x version of the duckb
  ducklake extension with dlt, there is the following error:
  `_duckdb.InvalidInputException: Invalid Input Error: DuckLake catalog
  version mismatch: catalog version is 0.4, but the extension requires
  version 1.0. To automatically migrate, set AUTOMATIC_MIGRATION to TRUE
  when attaching.`
  
  Fortunately [the duckdb docs are quite useful on
  this](https://ducklake.select/docs/stable/duckdb/guides/troubleshooting#connecting-to-an-older-ducklake).
  you just need to attach with the AUTOMATIC_MIGRATION flag as true:
  `ATTACH '...' (AUTOMATIC_MIGRATION);`
  
  # The Change
  Add a (by default off) `AUTOMATIC_MIGRATION` flag to the ducklake
  destination so that users can upgrade legacy catalogs in their pipelines
  with DLT. Off by default means no breaking changes.
  
  # The Benefit
  Users can run their pipelines again even when they upgrade the duckdb
  version/ducklake extension and use a legacy catalog.
  

- **test(ducklake): update test for AUTOMATIC_MIGRATION flag**
  

- **docs(ducklake): add docs to cover AUTOMATIC_MIGRATION flag for ducklake**
  