### PR TITLE
(qol) documents the order of PipelineTasksGroup and dlt.pipeline creation

### DIFF
--- a/dlt/helpers/airflow_helper.py
+++ b/dlt/helpers/airflow_helper.py
@@ -414,12 +414,14 @@ class PipelineTasksGroup(TaskGroup):
             Any: Airflow tasks created in order of creation.
         """
 
-        # make sure that pipeline was created after dag was initialized
+        # make sure that pipeline was created after PipelineTasksGroup was instantiated
         if not pipeline.pipelines_dir.startswith(os.environ[DLT_DATA_DIR]):
             raise ValueError(
-                "Please create your Pipeline instance after AirflowTasks are created. The dlt"
-                f" pipelines directory {pipeline.pipelines_dir} is not set correctly"
-                f" ({os.environ[DLT_DATA_DIR]} expected)."
+                f"Pipeline {pipeline.pipeline_name} has pipelines_dir set to"
+                f" '{pipeline.pipelines_dir}' but a fresh random working directory under"
+                f" '{os.environ[DLT_DATA_DIR]}' is expected. Instantiate PipelineTasksGroup"
+                " BEFORE creating the Pipeline so dlt.pipeline() picks up the per-worker"
+                f" random working directory set by PipelineTasksGroup in {DLT_DATA_DIR}."
             )
 
         with self:

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/deploy-with-airflow-composer.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/deploy-with-airflow-composer.md
@@ -152,7 +152,7 @@ def load_data():
     # Import your source from the pipeline script
     from pipeline_or_source_script import source
 
-    # Modify the pipeline parameters
+    # Create the pipeline after instance of `PipelineTasksGroup` is created
     pipeline = dlt.pipeline(
         pipeline_name='pipeline_name',
         dataset_name='dataset_name',
@@ -224,6 +224,10 @@ load_data()
   ```
 :::tip
 When you run the `load_data` DAG above, Airflow will call the `source` function every 30 seconds (by default) to be able to monitor the tasks. Make sure that your source function does not perform any long-lasting operations, e.g., reflecting the source database. In the case of [sql_database](../../dlt-ecosystem/verified-sources/sql_database/index.md), we added an option to delay database reflection until data is accessed by a resource.
+:::
+
+:::caution
+Always instantiate `PipelineTasksGroup` **before** creating the `dlt.pipeline`. The constructor of `PipelineTasksGroup` overrides the `DLT_DATA_DIR` environment variable to a fresh random per-worker directory so that Airflow workers, which are reused across DAG runs, do not leak pipeline state between runs.
 :::
 
 ### 3. Import sources and move the relevant code from the pipeline script

--- a/tests/helpers/airflow_tests/test_airflow_wrapper.py
+++ b/tests/helpers/airflow_tests/test_airflow_wrapper.py
@@ -1016,3 +1016,36 @@ def test_on_before_run() -> None:
                 mock.call(f'on_before_run test: {pendulum.tomorrow().format("YYYY-MM-DD")}'),
             ]
         )
+
+
+def test_pipeline_created_before_task_group_raises() -> None:
+    # creating dlt.pipeline before PipelineTasksGroup uses a pipelines_dir that does not
+    # match the per-worker random dir set by PipelineTasksGroup. add_run must surface a
+    # clear error pointing at the ordering and the workaround.
+    @dag(schedule=None, start_date=DEFAULT_DATE, catchup=False, default_args=default_args)
+    def dag_wrong_order():
+        early_pipeline = dlt.pipeline(
+            pipeline_name="pipeline_wrong_order",
+            dataset_name="mock_data_" + uniq_id(),
+            destination=dlt.destinations.duckdb(credentials=":pipeline:"),
+        )
+        tasks = PipelineTasksGroup(
+            "pipeline_wrong_order",
+            local_data_folder=get_test_storage_root(),
+            wipe_local_data=False,
+        )
+        with pytest.raises(ValueError) as exc_info:
+            tasks.add_run(
+                early_pipeline,
+                mock_data_source(),
+                decompose="none",
+                trigger_rule="all_done",
+                retries=0,
+            )
+        message = str(exc_info.value)
+        assert "PipelineTasksGroup" in message
+        assert "BEFORE creating the Pipeline" in message
+        assert "DLT_DATA_DIR" in message
+        assert "pipelines_dir" in message
+
+    dag_wrong_order()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
fixes #3938 

I also considered cloning the pipeline into a temp pipelines_dir instead of raising `ValueError` but that may trigger some edge cases and is not worth the minimal QoL increase
