### PR TITLE
fix: increase marimo cell timeout in dashboard tests

### DIFF
--- a/tests/e2e/helpers/dashboard/test_e2e.py
+++ b/tests/e2e/helpers/dashboard/test_e2e.py
@@ -135,7 +135,7 @@ def test_multi_schema_selection(page: Page, multi_schema_pipeline: Any):
         expect(schema_selector).to_have_value(schema_name)
         # allow marimo reactivity to process
         page.wait_for_timeout(500)
-        expect(page.get_by_text(expected, exact=True).nth(0)).to_be_visible(timeout=15000)
+        expect(page.get_by_text(expected, exact=True).nth(0)).to_be_visible(timeout=30000)
         for table in not_expected:
             expect(page.get_by_text(table, exact=True)).to_have_count(0, timeout=10000)
 


### PR DESCRIPTION
The dashboard tests can take longer than 15s on the lowest-direct CI matrix causing test_multi_schema_selection to flake. Bumping to 30s. 

Some previous failures:

- feat/3747-explicit-joins: https://github.com/dlt-hub/dlt/actions/runs/26559638756/job/78239428084
- devel: https://github.com/dlt-hub/dlt/actions/runs/26529597837/job/78164724331
- devel: https://github.com/dlt-hub/dlt/actions/runs/26524233227/job/78123875858
