### PR TITLE
fix(aws): omit static key/secret/token for RefreshableCredentials in …

### DIFF
--- a/dlt/common/configuration/specs/aws_credentials.py
+++ b/dlt/common/configuration/specs/aws_credentials.py
@@ -132,23 +132,14 @@ class AwsCredentials(AwsCredentialsWithoutDefaults, CredentialsWithDefault):
         return super().to_session_credentials()
 
     def to_s3fs_credentials(self) -> Dict[str, Optional[str]]:
-        """When the underlying credentials come from a refreshable provider
-        (ECS task role, EKS IRSA, EC2 instance profile, assumed role, SSO),
-        omit the static ``key``/``secret``/``token`` so that ``s3fs`` falls back
-        to its own ``aiobotocore`` default chain. The aiobotocore session honors
-        the same refreshable provider, preventing ``ExpiredToken`` errors on
-        long-running S3 writes once the temporary token rotates mid-process.
-
-        Static credentials (env vars, explicit IAM user keys) are passed through
-        unchanged.
-        """
+        """Omit static key/secret/token when underlying provider is refreshable
+        so s3fs uses its own aiobotocore default chain and rotates the token."""
         creds = super().to_s3fs_credentials()
         if self.has_default_credentials():
             try:
                 from botocore.credentials import RefreshableCredentials
 
-                underlying = self.default_credentials().get_credentials()
-                if isinstance(underlying, RefreshableCredentials):
+                if isinstance(self.default_credentials().get_credentials(), RefreshableCredentials):
                     for k in ("key", "secret", "token"):
                         creds.pop(k, None)
             except ImportError:

--- a/dlt/common/configuration/specs/aws_credentials.py
+++ b/dlt/common/configuration/specs/aws_credentials.py
@@ -131,6 +131,30 @@ class AwsCredentials(AwsCredentialsWithoutDefaults, CredentialsWithDefault):
             )
         return super().to_session_credentials()
 
+    def to_s3fs_credentials(self) -> Dict[str, Optional[str]]:
+        """When the underlying credentials come from a refreshable provider
+        (ECS task role, EKS IRSA, EC2 instance profile, assumed role, SSO),
+        omit the static ``key``/``secret``/``token`` so that ``s3fs`` falls back
+        to its own ``aiobotocore`` default chain. The aiobotocore session honors
+        the same refreshable provider, preventing ``ExpiredToken`` errors on
+        long-running S3 writes once the temporary token rotates mid-process.
+
+        Static credentials (env vars, explicit IAM user keys) are passed through
+        unchanged.
+        """
+        creds = super().to_s3fs_credentials()
+        if self.has_default_credentials():
+            try:
+                from botocore.credentials import RefreshableCredentials
+
+                underlying = self.default_credentials().get_credentials()
+                if isinstance(underlying, RefreshableCredentials):
+                    for k in ("key", "secret", "token"):
+                        creds.pop(k, None)
+            except ImportError:
+                pass
+        return creds
+
     def to_sts_credentials(self) -> Dict[str, str]:
         """Return session credentials with a session token, generating one via STS if needed."""
         sess_creds = self.to_session_credentials()

--- a/tests/load/filesystem/test_aws_credentials.py
+++ b/tests/load/filesystem/test_aws_credentials.py
@@ -161,6 +161,51 @@ def test_aws_credentials_with_endpoint_url(environment: Dict[str, str]) -> None:
     assert "config_kwargs" in s3fs_creds
 
 
+def test_aws_credentials_to_s3fs_omits_refreshable_token() -> None:
+    """Refreshable credentials must not be frozen into s3fs static kwargs.
+
+    When the underlying provider is ``RefreshableCredentials`` (ECS task role,
+    EKS IRSA, EC2 instance profile, assumed role, SSO), ``to_s3fs_credentials``
+    must omit ``key``/``secret``/``token`` so that s3fs falls back to its own
+    aiobotocore default chain and refreshes the token before expiry. Otherwise
+    long-running S3 writes die with ``ExpiredToken`` once the provider rotates
+    the temporary credentials. Static credentials are unaffected (covered by
+    other tests in this module). See issue #4003.
+    """
+    import botocore.session
+    from botocore.credentials import RefreshableCredentials
+
+    def _refresh() -> Dict[str, str]:
+        return {
+            "access_key": "refreshable_access_key",
+            "secret_key": "refreshable_secret_key",
+            "token": "refreshable_session_token",
+            "expiry_time": "2099-01-01T00:00:00Z",
+        }
+
+    refreshable = RefreshableCredentials.create_from_metadata(
+        metadata=_refresh(),
+        refresh_using=_refresh,
+        method="custom",
+    )
+
+    session = botocore.session.get_session()
+    session._credentials = refreshable
+    session.set_config_variable("region", "eu-central-1")
+
+    c = AwsCredentials.from_session(session)
+    assert c.has_default_credentials()
+
+    s3fs_creds = c.to_s3fs_credentials()
+    # static key/secret/token must NOT be present so s3fs uses its own
+    # refreshable default chain instead of frozen strings.
+    assert "key" not in s3fs_creds
+    assert "secret" not in s3fs_creds
+    assert "token" not in s3fs_creds
+    # non-credential kwargs are preserved.
+    assert s3fs_creds["client_kwargs"] == {"region_name": "eu-central-1"}
+
+
 def test_explicit_filesystem_credentials() -> None:
     import dlt
     from dlt.destinations import filesystem

--- a/tests/load/filesystem/test_aws_credentials.py
+++ b/tests/load/filesystem/test_aws_credentials.py
@@ -162,16 +162,7 @@ def test_aws_credentials_with_endpoint_url(environment: Dict[str, str]) -> None:
 
 
 def test_aws_credentials_to_s3fs_omits_refreshable_token() -> None:
-    """Refreshable credentials must not be frozen into s3fs static kwargs.
-
-    When the underlying provider is ``RefreshableCredentials`` (ECS task role,
-    EKS IRSA, EC2 instance profile, assumed role, SSO), ``to_s3fs_credentials``
-    must omit ``key``/``secret``/``token`` so that s3fs falls back to its own
-    aiobotocore default chain and refreshes the token before expiry. Otherwise
-    long-running S3 writes die with ``ExpiredToken`` once the provider rotates
-    the temporary credentials. Static credentials are unaffected (covered by
-    other tests in this module). See issue #4003.
-    """
+    """RefreshableCredentials must not freeze into s3fs static kwargs (#4003)."""
     import botocore.session
     from botocore.credentials import RefreshableCredentials
 


### PR DESCRIPTION
…to_s3fs_credentials

When the underlying boto3 default chain returns RefreshableCredentials (ECS task role, EKS IRSA, EC2 instance profile, assumed role, SSO), extracting access_key/secret_key/session_token into plain strings and passing them as static s3fs kwargs freezes the credentials at pipeline init time. After the provider rotates the temporary token mid-process, dlt keeps sending the stale snapshot and S3 PutObject dies with ExpiredToken on long-running writes.

Detect the RefreshableCredentials case and omit key/secret/token so s3fs falls back to its own aiobotocore default chain, which honors the same provider and refreshes transparently before expiry.

Static credentials (env vars, explicit IAM user keys) are passed through unchanged.

Closes #4003

<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description


<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #...
- Closes #...
- Resolves #...

<!--
Provide any additional context about the PR here.
-->
### Additional Context

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
