### PR TITLE
fix(athena): add truncate_iceberg_staging opt-in to clear staging across loads

### DIFF
--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -465,9 +465,15 @@ class AthenaClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):
         return super().should_load_data_to_staging_dataset(table_name)
 
     def should_truncate_table_before_load_on_staging_destination(self, table_name: str) -> bool:
-        # on athena we only truncate replace tables that are not iceberg
         table = self.prepare_load_table(table_name)
-        if table["write_disposition"] == "replace" and not self._is_iceberg_table(table):
+        if self._is_iceberg_table(table):
+            # Iceberg targets get their data copied out of the staging external
+            # table with ``INSERT INTO target SELECT * FROM staging``. Without
+            # an opt-in truncate, parquet files accumulate in the staging
+            # location across loads and every subsequent ``INSERT`` re-copies
+            # the older loads' rows into the iceberg target.
+            return bool(self.config.truncate_iceberg_staging)
+        if table["write_disposition"] == "replace":
             return True
         return False
 

--- a/dlt/destinations/impl/athena/configuration.py
+++ b/dlt/destinations/impl/athena/configuration.py
@@ -29,6 +29,11 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
     force_iceberg: Optional[bool] = None
     table_location_layout: Optional[str] = DEFAULT_TABLE_LOCATION_LAYOUT
     table_properties: Optional[Dict[str, str]] = None
+    truncate_iceberg_staging: Optional[bool] = None
+    """When True, the staging external table that backs each iceberg target is
+    truncated before each load, regardless of write disposition. Required when
+    appending into iceberg tables to keep the staging→iceberg copy scoped to the
+    current load. Defaults to False to preserve existing behaviour."""
     lakeformation_config: Optional[LakeformationConfig] = None
     info_tables_query_threshold: int = 90
     # athena slows down when this value is too high, see for context:
@@ -40,6 +45,7 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
         "athena_work_group",
         "aws_data_catalog",
         "info_tables_query_threshold",
+        "truncate_iceberg_staging",
     ]
 
     def to_connector_params(self, use_catalog_name: bool = True) -> Dict[str, Any]:

--- a/tests/load/athena_iceberg/test_athena_iceberg.py
+++ b/tests/load/athena_iceberg/test_athena_iceberg.py
@@ -166,3 +166,40 @@ def test_iceberg_location_tag(destination_config: DestinationTestConfiguration) 
     pipeline.run([7, 8, 9], table_name="digits", refresh="drop_sources")
     data = [s[0] for s in pipeline.dataset().digits.fetchall()]
     assert set(data) == set([7, 8, 9])
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_sql_configs=True,
+        with_table_format="iceberg",
+        subset=["athena"],
+        aws_data_catalog=None,
+    ),
+    ids=lambda x: x.name,
+)
+def test_iceberg_staging_truncate_flag(destination_config: DestinationTestConfiguration) -> None:
+    """``truncate_iceberg_staging=True`` opts the iceberg staging external table
+    into a pre-load truncate, so subsequent appends do not re-copy older loads
+    into the iceberg target via the staging ``INSERT INTO ... SELECT *``.
+    """
+    from dlt.destinations import athena
+
+    destination = athena(truncate_iceberg_staging=True)
+    pipeline = destination_config.setup_pipeline(
+        "test_iceberg_staging_truncate_flag", dev_mode=True, destination=destination,
+    )
+
+    @dlt.resource(name="items_iceberg", write_disposition="append", table_format="iceberg")
+    def items(start: int, count: int):
+        for i in range(start, start + count):
+            yield {"id": i, "name": f"item-{i}"}
+
+    pipeline.run(items(0, 3))
+    pipeline.run(items(100, 2))
+
+    # 3 from first load + 2 from second; without the flag the second load also
+    # re-inserts the first load's 3 rows (= 8 total) because the staging table
+    # accumulates parquet files across loads.
+    counts = load_table_counts(pipeline, "items_iceberg")
+    assert counts["items_iceberg"] == 5


### PR DESCRIPTION
## Summary

The Athena destination unconditionally returns `False` from `should_truncate_table_before_load_on_staging_destination` for iceberg tables (`dlt/destinations/impl/athena/athena.py:467-472`), so the generic `truncate_tables_on_staging_destination_before_load` flag introduced in #1717 has no effect on iceberg targets.

Combined with the unbounded `INSERT INTO target SELECT * FROM staging` in `SqlStagingFollowupJob` (`dlt/destinations/sql_jobs.py:88-110`), appending into an iceberg target re-copies every previous load's rows on each subsequent load: storage and Athena-scan cost grow quadratically and the iceberg table accumulates duplicates.

This PR adds an explicit opt-in config flag on `AthenaClientConfiguration` so operators can request a per-load truncate of the iceberg staging external table. Default value preserves existing behaviour.

## Closes

- #4005

## Behaviour matrix

| table_format | write_disposition | `truncate_iceberg_staging` | truncate? |
|---|---|---|---|
| non-iceberg | replace | any | True (unchanged) |
| non-iceberg | append | any | False (unchanged) |
| iceberg | any | None / False | False (unchanged) |
| iceberg | any | True | **True (new)** |

## Tests

- `tests/load/athena_iceberg/test_athena_iceberg.py::test_iceberg_staging_truncate_flag` — two appends of disjoint payloads with `truncate_iceberg_staging=True`; asserts target row count == sum of payloads (without the flag the second load would also re-insert the first load's rows).

## Lint

```
$ uv run ruff check dlt/destinations/impl/athena/configuration.py dlt/destinations/impl/athena/athena.py tests/load/athena_iceberg/test_athena_iceberg.py
All checks passed!
$ uv run mypy dlt/destinations/impl/athena/configuration.py dlt/destinations/impl/athena/athena.py
(no output)
```

Test requires the Athena CI credentials label.

## Related

- #1717 — original truncate flag, which this PR extends for iceberg
- Follow-up: a separate PR will scope the staging→iceberg `INSERT INTO` to the current load via `_dlt_load_id`, as defence-in-depth for users who keep accumulated staging on purpose (e.g. audit). Filed as a sibling issue.