### PR TITLE
fix(athena): scope iceberg staging->target INSERT to current load

### DIFF
--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Sequence,
     Tuple,
+    Type,
     List,
     Dict,
     Iterable,
@@ -42,6 +43,9 @@ from dlt.common.schema.typing import (
 from dlt.common.destination import DestinationCapabilitiesContext, PreparedTableSchema
 from dlt.common.destination.utils import resolve_merge_strategy
 from dlt.common.destination.client import FollowupJobRequest, SupportsStagingDestination, LoadJob
+from dlt.common.schema.typing import C_DLT_LOAD_ID
+from dlt.common.schema.utils import get_columns_names_with_prop
+from dlt.common.storages.load_package import load_package_state as current_load_package
 from dlt.destinations.sql_jobs import (
     SqlStagingCopyFollowupJob,
     SqlStagingReplaceFollowupJob,
@@ -64,6 +68,61 @@ from dlt.destinations.impl.athena.utils import is_s3_tables_catalog
 
 
 boto3_client_lock = Lock()
+
+
+class AthenaIcebergStagingCopyFollowupJob(SqlStagingCopyFollowupJob):
+    """Iceberg-aware ``INSERT INTO ... SELECT *`` that filters the staging
+    external table by the current ``_dlt_load_id``.
+
+    Each staging parquet file is written with a constant ``_dlt_load_id``,
+    so a WHERE clause on that column lets Athena prune non-matching files
+    via parquet row-group min/max statistics. No Hive partition setup is
+    required; query cost stays bounded even when the staging external
+    table accumulates files from older loads (e.g. when the operator
+    deliberately keeps staging for audit and does not enable the
+    ``truncate_iceberg_staging`` flag).
+    """
+
+    @classmethod
+    def _generate_insert_sql(
+        cls,
+        table_chain: Sequence[PreparedTableSchema],
+        sql_client: SqlClientBase[Any],
+        truncate_first: bool,
+    ) -> List[str]:
+        try:
+            current_load_id = current_load_package()["load_id"]
+        except Exception:
+            current_load_id = None
+
+        if not current_load_id:
+            return super()._generate_insert_sql(table_chain, sql_client, truncate_first)
+
+        sql: List[str] = []
+        load_id_literal = sql_client.capabilities.escape_literal(current_load_id)
+        for table in table_chain:
+            with sql_client.with_staging_dataset():
+                staging_table_name = sql_client.make_qualified_table_name(table["name"])
+            table_name = sql_client.make_qualified_table_name(table["name"])
+            column_names = get_columns_names_with_prop(table, "name")
+            columns = ", ".join(map(sql_client.escape_column_name, column_names))
+            if truncate_first:
+                sql.append(sql_client._truncate_table_sql(table_name))
+            if C_DLT_LOAD_ID in column_names:
+                where = (
+                    f" WHERE {sql_client.escape_column_name(C_DLT_LOAD_ID)} ="
+                    f" {load_id_literal}"
+                )
+            else:
+                # Defensive: skip the filter on tables that lack `_dlt_load_id`
+                # for any reason. dlt adds it by default, so this branch should
+                # not be reached on dlt-managed tables.
+                where = ""
+            sql.append(
+                f"INSERT INTO {table_name}({columns})"
+                f" SELECT {columns} FROM {staging_table_name}{where}"
+            )
+        return sql
 
 
 class AthenaMergeJob(SqlMergeFollowupJob):
@@ -428,7 +487,16 @@ class AthenaClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):
         self, table_chain: Sequence[PreparedTableSchema]
     ) -> List[FollowupJobRequest]:
         if self._is_iceberg_table(table_chain[0]):
-            return [SqlStagingCopyFollowupJob.from_table_chain(table_chain, self.sql_client)]
+            # `scope_iceberg_staging_insert_to_load` defaults to True so the
+            # staging→iceberg copy stays scoped to the current load. Setting
+            # the flag to False restores the legacy unbounded SELECT for
+            # operators who rely on the historical accumulation semantic.
+            job_cls: Type[SqlStagingCopyFollowupJob] = (
+                AthenaIcebergStagingCopyFollowupJob
+                if self.config.scope_iceberg_staging_insert_to_load is not False
+                else SqlStagingCopyFollowupJob
+            )
+            return [job_cls.from_table_chain(table_chain, self.sql_client)]
         return super()._create_append_followup_jobs(table_chain)
 
     def _create_replace_followup_jobs(

--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -99,7 +99,10 @@ class AthenaIcebergStagingCopyFollowupJob(SqlStagingCopyFollowupJob):
             return super()._generate_insert_sql(table_chain, sql_client, truncate_first)
 
         sql: List[str] = []
-        load_id_literal = sql_client.capabilities.escape_literal(current_load_id)
+        escape_lit = sql_client.capabilities.escape_literal
+        if escape_lit is None:
+            escape_lit = DestinationCapabilitiesContext.generic_capabilities().escape_literal
+        load_id_literal = escape_lit(current_load_id)
         for table in table_chain:
             with sql_client.with_staging_dataset():
                 staging_table_name = sql_client.make_qualified_table_name(table["name"])

--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -99,10 +99,12 @@ class AthenaIcebergStagingCopyFollowupJob(SqlStagingCopyFollowupJob):
             return super()._generate_insert_sql(table_chain, sql_client, truncate_first)
 
         sql: List[str] = []
-        escape_lit = sql_client.capabilities.escape_literal
-        if escape_lit is None:
-            escape_lit = DestinationCapabilitiesContext.generic_capabilities().escape_literal
-        load_id_literal = escape_lit(current_load_id)
+        # `_dlt_load_id` is a VARCHAR column; always quote as a string literal
+        # so Athena's parquet reader can prune row-groups via min/max stats.
+        # Using a generic numeric/typed escape_literal would render a load_id
+        # like "1780238139.7988734" as a DOUBLE literal and trigger
+        # `TYPE_MISMATCH: Cannot apply operator: varchar = double`.
+        load_id_literal = "'" + current_load_id.replace("'", "''") + "'"
         for table in table_chain:
             with sql_client.with_staging_dataset():
                 staging_table_name = sql_client.make_qualified_table_name(table["name"])

--- a/dlt/destinations/impl/athena/configuration.py
+++ b/dlt/destinations/impl/athena/configuration.py
@@ -29,6 +29,15 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
     force_iceberg: Optional[bool] = None
     table_location_layout: Optional[str] = DEFAULT_TABLE_LOCATION_LAYOUT
     table_properties: Optional[Dict[str, str]] = None
+    scope_iceberg_staging_insert_to_load: Optional[bool] = None
+    """When True (default), the staging→iceberg ``INSERT INTO`` copy is
+    scoped to the current load via ``WHERE _dlt_load_id = '<load_id>'``.
+    Each staging parquet file is written with a constant ``_dlt_load_id``,
+    so Athena prunes non-matching files at the parquet row-group reader
+    via column min/max statistics — no Hive partition is required and
+    query cost stays bounded even when the staging external table
+    accumulates files from older loads. Set to False to restore the
+    legacy unbounded ``SELECT *`` behaviour."""
     lakeformation_config: Optional[LakeformationConfig] = None
     info_tables_query_threshold: int = 90
     # athena slows down when this value is too high, see for context:
@@ -40,6 +49,7 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
         "athena_work_group",
         "aws_data_catalog",
         "info_tables_query_threshold",
+        "scope_iceberg_staging_insert_to_load",
     ]
 
     def to_connector_params(self, use_catalog_name: bool = True) -> Dict[str, Any]:

--- a/tests/load/athena_iceberg/test_athena_iceberg.py
+++ b/tests/load/athena_iceberg/test_athena_iceberg.py
@@ -166,3 +166,39 @@ def test_iceberg_location_tag(destination_config: DestinationTestConfiguration) 
     pipeline.run([7, 8, 9], table_name="digits", refresh="drop_sources")
     data = [s[0] for s in pipeline.dataset().digits.fetchall()]
     assert set(data) == set([7, 8, 9])
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_sql_configs=True,
+        with_table_format="iceberg",
+        subset=["athena"],
+        aws_data_catalog=None,
+    ),
+    ids=lambda x: x.name,
+)
+def test_iceberg_staging_insert_scoped_to_load(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Two consecutive appends into the same iceberg table must not duplicate
+    earlier loads' rows in the target. The staging external table accumulates
+    parquet files across loads (default behaviour); the WHERE filter on
+    ``_dlt_load_id`` keeps the staging→iceberg copy scoped to the current load.
+    """
+    pipeline = destination_config.setup_pipeline(
+        "test_iceberg_staging_insert_scoped_to_load", dev_mode=True,
+    )
+
+    @dlt.resource(name="items_iceberg", write_disposition="append", table_format="iceberg")
+    def items(start: int, count: int):
+        for i in range(start, start + count):
+            yield {"id": i, "name": f"item-{i}"}
+
+    pipeline.run(items(0, 3))
+    pipeline.run(items(100, 2))
+
+    counts = load_table_counts(pipeline, "items_iceberg")
+    # 3 from first load + 2 from second; the legacy unbounded SELECT would yield
+    # 8 because the second load re-copies the accumulated staging files.
+    assert counts["items_iceberg"] == 5


### PR DESCRIPTION
## Summary

For Athena iceberg targets the staging external table accumulates parquet files across loads (`should_truncate_table_before_load_on_staging_destination` hardcodes False, see #4005). Each subsequent `INSERT INTO target SELECT * FROM staging` in `SqlStagingFollowupJob` therefore re-copies older loads' rows into the iceberg target — duplicates accumulate and Athena scan cost grows quadratically.

This PR overrides the staging copy followup job for iceberg targets with a `WHERE _dlt_load_id = '<current load_id>'` clause. The current load id is resolved via `dlt.common.storages.load_package.load_package_state` (the same mechanism the merge followup job already uses at `dlt/destinations/sql_jobs.py:22,950`).

## Closes

- #4007

## Query cost

Athena's parquet reader applies predicate pushdown using row-group min/max statistics. Every staging parquet written by a single load has a constant `_dlt_load_id`, so the WHERE clause prunes non-matching files at the row-group reader stage — effectively per-load scoping without a Hive partition setup. No filesystem-side layout changes, no per-load `ALTER ADD PARTITION`, no cross-destination behaviour change.

## Opt-out

`AthenaClientConfiguration.scope_iceberg_staging_insert_to_load` (Optional[bool], default None / safe path). Set to `False` to restore the legacy unbounded `SELECT *` behaviour for operators who deliberately rely on the staging accumulation semantic.

Defensive fallback to the unbounded `SELECT` when `_dlt_load_id` is not on the table or the load package state is unavailable.

## Behaviour matrix

| iceberg | `scope_iceberg_staging_insert_to_load` | INSERT shape |
|---|---|---|
| no | any | unchanged — non-iceberg path |
| yes | None / True (default) | `INSERT ... SELECT cols FROM staging WHERE _dlt_load_id = '<load>'` |
| yes | False | `INSERT ... SELECT cols FROM staging` (legacy) |

## Scope

Strictly Athena iceberg followup. Other destinations consuming `SqlStagingFollowupJob` (BigQuery, ClickHouse, Databricks, Dremio, Fabric, Synapse, MS SQL, Postgres, Redshift, Snowflake) keep their current behaviour. No changes to merge or replace followups.

## Tests

- `tests/load/athena_iceberg/test_athena_iceberg.py::test_iceberg_staging_insert_scoped_to_load` — two consecutive appends of disjoint payloads; asserts target row count == sum of payloads (without the fix the second load would yield 8 rows because of duplicate copy).

## Lint

```
$ uv run ruff check dlt/destinations/impl/athena/configuration.py dlt/destinations/impl/athena/athena.py tests/load/athena_iceberg/test_athena_iceberg.py
All checks passed!
$ uv run mypy dlt/destinations/impl/athena/athena.py
(no errors)
```

Test requires the Athena CI credentials label.

## Related

- #4005 / PR #4006 — sibling truncate flag. The two PRs are complementary: this one is correct on its own, and works as defence-in-depth even when the operator also enables the truncate flag (orphan parquets, eventual-consistency races during lifecycle expiry, manual uploads).