### PR TITLE
feat(athena): allow separate bucket for iceberg target via iceberg_bucket_url

### DIFF
--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -332,7 +332,11 @@ class AthenaClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):
     def _get_table_update_sql(
         self, table_name: str, new_columns: Sequence[TColumnSchema], generate_alter: bool
     ) -> List[str]:
-        bucket = self.config.staging_config.bucket_url
+        staging_bucket = self.config.staging_config.bucket_url
+        # Iceberg targets may live in a dedicated bucket independent of the
+        # staging external tables; fall back to staging bucket when not set
+        # (preserves prior behaviour). See https://github.com/dlt-hub/dlt/issues/3823
+        iceberg_bucket = self.config.iceberg_bucket_url or staging_bucket
         dataset = self.sql_client.dataset_name
 
         sql: List[str] = []
@@ -374,7 +378,7 @@ class AthenaClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):
                     # create unique tag for iceberg table so it is never recreated in the same folder
                     # athena requires some kind of special cleaning (or that is a bug) so we cannot refresh
                     # iceberg tables without it, by default tag is not added
-                    location = f"{bucket}/" + table_location_layout.format(
+                    location = f"{iceberg_bucket}/" + table_location_layout.format(
                         dataset_name=dataset,
                         table_name=table_prefix.rstrip("/"),
                         location_tag=uniq_id(6),
@@ -387,7 +391,7 @@ class AthenaClient(SqlJobClientWithStagingDataset, SupportsStagingDestination):
                 sql.append(stmt)
             else:
                 # external tables always here
-                location = f"{bucket}/{dataset}/{table_prefix}"
+                location = f"{staging_bucket}/{dataset}/{table_prefix}"
                 logger.info(f"Will create EXTERNAL table {table_name} from {location}")
                 sql.append(f"""CREATE EXTERNAL TABLE {qualified_table_name}
                         ({columns})

--- a/dlt/destinations/impl/athena/configuration.py
+++ b/dlt/destinations/impl/athena/configuration.py
@@ -29,6 +29,14 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
     force_iceberg: Optional[bool] = None
     table_location_layout: Optional[str] = DEFAULT_TABLE_LOCATION_LAYOUT
     table_properties: Optional[Dict[str, str]] = None
+    iceberg_bucket_url: Optional[str] = None
+    """Optional S3 root for the final iceberg table ``LOCATION``. When set, the
+    iceberg target lives at ``{iceberg_bucket_url}/{table_location_layout}``
+    while staging external tables stay under ``staging_config.bucket_url``.
+    Defaults to ``None`` -- iceberg targets fall back to the staging bucket,
+    preserving existing behaviour. Useful when staging and final-table prefixes
+    sit under different IAM policies, lifecycle rules, or bucket-level
+    encryption keys. See https://github.com/dlt-hub/dlt/issues/3823."""
     lakeformation_config: Optional[LakeformationConfig] = None
     info_tables_query_threshold: int = 90
     # athena slows down when this value is too high, see for context:
@@ -40,6 +48,7 @@ class AthenaClientConfiguration(DestinationClientDwhWithStagingConfiguration):
         "athena_work_group",
         "aws_data_catalog",
         "info_tables_query_threshold",
+        "iceberg_bucket_url",
     ]
 
     def to_connector_params(self, use_catalog_name: bool = True) -> Dict[str, Any]:

--- a/tests/load/athena_iceberg/test_athena_configuration.py
+++ b/tests/load/athena_iceberg/test_athena_configuration.py
@@ -62,3 +62,25 @@ def test_query_result_bucket_optional() -> None:
         athena_config.query_result_bucket = None
         connector_params = athena_config.to_connector_params()
         assert connector_params["s3_staging_dir"] is None
+
+
+def test_iceberg_bucket_url_optional() -> None:
+    # iceberg_bucket_url is Optional[str] so it should be resolved even when None.
+    # see: https://github.com/dlt-hub/dlt/issues/3823
+    hints = AthenaClientConfiguration.get_resolvable_fields()
+    assert AthenaClientConfiguration.is_field_resolved(None, hints["iceberg_bucket_url"])
+
+    # default: iceberg target falls back to staging_config.bucket_url
+    with cm_yield_client("athena", "dummy_dataset", enter_client=False) as client:
+        athena_config = cast(AthenaClientConfiguration, client.config)
+        assert athena_config.iceberg_bucket_url is None
+
+    # explicit override: the override round-trips through resolved config
+    with cm_yield_client(
+        "athena",
+        "dummy_dataset",
+        {"iceberg_bucket_url": "s3://my-iceberg-target"},
+        enter_client=False,
+    ) as client:
+        athena_config = cast(AthenaClientConfiguration, client.config)
+        assert athena_config.iceberg_bucket_url == "s3://my-iceberg-target"


### PR DESCRIPTION
## Summary

The Athena destination derives the iceberg target table `LOCATION` from `self.config.staging_config.bucket_url` (`dlt/destinations/impl/athena/athena.py:393, :437`). Hive external staging tables and final iceberg data therefore have to share an S3 root. Deployments with prefix-scoped IAM policies, per-prefix lifecycle rules, or bucket-level KMS keys cannot separate the short-lived staging zone from the durable iceberg storage today.

This PR adds an optional `iceberg_bucket_url` config field. When set, the iceberg table `LOCATION` uses it as the root; staging external tables continue to live under `staging_config.bucket_url`. Default value preserves existing behaviour.

## Closes

- #3823

## Behaviour

| `iceberg_bucket_url` | Iceberg `LOCATION` root | Hive external (staging) | S3 Tables Catalog |
|---|---|---|---|
| None (default) | `staging_config.bucket_url` (unchanged) | `staging_config.bucket_url` | catalog-managed |
| explicit S3 URL | configured value | `staging_config.bucket_url` (unchanged) | catalog-managed (unchanged) |

S3 Tables Catalog is intentionally unaffected — the catalog manages its own locations, same as `table_location_layout` is ignored on that path today.

## Tests

- `tests/load/athena_iceberg/test_athena_configuration.py::test_iceberg_bucket_url_optional`
  - `iceberg_bucket_url=None` resolves to `None` (default, no AWS call needed).
  - Explicit `s3://my-iceberg-target` round-trips through resolved config.

Local run:
```
$ uv run pytest tests/load/athena_iceberg/test_athena_configuration.py::test_iceberg_bucket_url_optional -xvs
... 1 passed in 0.65s
```

## Lint

```
$ uv run ruff check dlt/destinations/impl/athena/ tests/load/athena_iceberg/
All checks passed!
$ uv run mypy dlt/destinations/impl/athena/configuration.py dlt/destinations/impl/athena/athena.py
(no errors)
```

## Scope

Strictly Athena destination. Only the iceberg `LOCATION` is decoupled — no changes to staging path, query result bucket, merge/replace jobs, or other destinations. No data migration required; existing tables continue to resolve to their stored `LOCATION` so this PR is purely additive for new tables.