### PR TITLE
Preserve timezone=False for naive Arrow timestamps

### DIFF
--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -330,7 +330,8 @@ def adjust_column_schema_to_capabilities(
 ) -> TColumnSchema:
     """Modify column schema in place according to destination capabilities.
     * timestamp and time precision are limited by min(destination max, parquet writer max)
-    * timezone is always removed (enables default behavior)
+    * timezone=False inferred from naive Arrow timestamps is preserved, other timezone hints fall back
+      to default behavior
     * default timestamp precision for destination is removed
     """
     data_type = column.get("data_type")
@@ -347,8 +348,9 @@ def adjust_column_schema_to_capabilities(
             ),
         )
 
-        # remove timezone flag to fallback to default tz-aware and let normalizer to correct the data
-        column.pop("timezone", None)
+        # preserve explicit timezone=False inferred from naive Arrow timestamps
+        if column.get("timezone") is not False:
+            column.pop("timezone", None)
 
         # do not write default precision
         if precision == caps.timestamp_precision:

--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -503,7 +503,8 @@ class ArrowExtractor(Extractor):
                     arrow_table = copy(computed_table)
                 try:
                     # generate dlt schema from arrow schema and adjust to capabilities
-                    # drop timezones and honor only explicit settings like the regular normalizer
+                    # keep naive Arrow timestamps as timezone=False and let other timezone hints
+                    # fall back to default behavior like the regular normalizer
                     arrow_table["columns"] = adjust_schema_to_capabilities(
                         pyarrow.py_arrow_to_table_schema_columns(item.schema),
                         self._caps,

--- a/tests/destinations/test_capabilities.py
+++ b/tests/destinations/test_capabilities.py
@@ -63,18 +63,25 @@ def test_timestamp_default_precision_removed(data_type: TDataType) -> None:
     assert "precision" not in column
 
 
-@pytest.mark.parametrize(
-    "timezone_value", [True, False, None], ids=["tz-true", "tz-false", "tz-missing"]
-)
-def test_timestamp_timezone_handling(timezone_value: bool) -> None:
-    """Test timezone is always removed from timestamp/time columns regardless of capabilities"""
+@pytest.mark.parametrize("timezone_value", [True, None], ids=["tz-true", "tz-missing"])
+def test_timestamp_timezone_true_or_missing_removed(timezone_value: bool) -> None:
+    """Test timezone=True or missing falls back to default timestamp behavior."""
     caps = _create_default_caps()
 
     column = _create_timestamp_column(timezone=timezone_value)
     adjust_column_schema_to_capabilities(column, caps)
 
-    # timezone should always be removed (or remain absent)
     assert "timezone" not in column
+
+
+def test_timestamp_timezone_false_preserved() -> None:
+    """Test timezone=False survives capabilities adjustment for naive Arrow timestamps."""
+    caps = _create_default_caps()
+
+    column = _create_timestamp_column(timezone=False)
+    adjust_column_schema_to_capabilities(column, caps)
+
+    assert column["timezone"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/libs/pyarrow/test_pyarrow.py
+++ b/tests/libs/pyarrow/test_pyarrow.py
@@ -79,6 +79,18 @@ def test_py_arrow_to_table_schema_columns():
     assert result == dlt_schema
 
 
+def test_py_arrow_naive_timestamp_survives_capabilities_adjustment():
+    caps = DestinationCapabilitiesContext.generic_capabilities()
+    arrow_schema = pa.schema([pa.field("ts_col", pa.timestamp("us"))])
+
+    columns = py_arrow_to_table_schema_columns(arrow_schema)
+    adjust_schema_to_capabilities(columns, caps)
+    roundtrip_schema = columns_to_arrow(columns, caps)
+
+    assert columns["ts_col"]["timezone"] is False
+    assert roundtrip_schema.field("ts_col").type == pa.timestamp("us")
+
+
 @pytest.mark.parametrize("supports_nested_types", (True, False))
 def test_py_arrow_to_table_schema_columns_nested_types(supports_nested_types: bool):
     """Test py_arrow_to_table_schema_columns with various nested types, including dictionary and deeply nested structures."""


### PR DESCRIPTION
### Description

This PR fixes a regression where DLT dropped the explicit timezone=False hint inferred from naive Arrow timestamps during capabilities adjustment.

Previously, Arrow input with naive timestamps was normalized as if the timezone hint were absent, which caused downstream loading to convert values to UTC-aware timestamps instead of keeping them naive. This affected [pass-through behavior](https://dlthub.com/docs/general-usage/schema#handling-of-timestamp-and-time-zones) for sources that already expose naive Arrow timestamps, including ConnectorX-based extraction.

The fix preserves timezone=False when it is explicitly present on a column, while continuing to strip other timezone values so the default behavior remains unchanged where no explicit hint is set.

### Related Issues

- Fixes #4015

### Additional Context

- Added or updated tests covering naive Arrow timestamps and timezone-aware timestamps.
- Verified the fix with ConnectorX in both arrow and arrow_stream modes.
- Confirmed naive timestamps stay naive in Parquet output and timestamptz values remain UTC-aware.
