### PR TITLE
feat(qol): add useful __repr__ to WorkspaceRunContext

### DIFF
--- a/dlt/_workspace/_workspace_context.py
+++ b/dlt/_workspace/_workspace_context.py
@@ -3,6 +3,7 @@ from types import ModuleType
 from typing import Any, Dict, List, Optional
 
 from dlt.common import known_env
+from dlt.common.utils import simple_repr
 from dlt.common.configuration.container import Container
 from dlt.common.configuration.providers import EnvironProvider
 from dlt.common.configuration.providers.provider import ConfigProvider
@@ -46,7 +47,7 @@ class WorkspaceRunContext(ProfilesRunContext):
         self._config: WorkspaceConfiguration = None
 
     def __repr__(self) -> str:
-        return f"<WorkspaceRunContext(run_dir={self.run_dir!r}, profile={self._profile!r})>"
+        return simple_repr("WorkspaceRunContext", run_dir=self.run_dir, profile=self.profile)
 
     @property
     def name(self) -> str:

--- a/dlt/_workspace/_workspace_context.py
+++ b/dlt/_workspace/_workspace_context.py
@@ -45,6 +45,9 @@ class WorkspaceRunContext(ProfilesRunContext):
         self._global_dir = global_dir()
         self._config: WorkspaceConfiguration = None
 
+    def __repr__(self) -> str:
+        return f"<WorkspaceRunContext(run_dir={self.run_dir!r}, profile={self._profile!r})>"
+
     @property
     def name(self) -> str:
         """Defines workspace name which is (normalized) parent folder name"""

--- a/tests/workspace/test_workspace_context.py
+++ b/tests/workspace/test_workspace_context.py
@@ -345,3 +345,24 @@ def assert_workspace_context(context: WorkspaceRunContext, name_prefix: str, pro
     run_context_unpickled = pickle.loads(pickled_)
     assert dict(context.runtime_config) == dict(run_context_unpickled.runtime_config)
     assert dict(context.config) == dict(run_context_unpickled.config)
+
+
+def test_workspace_run_context_repr() -> None:
+    # Test repr with default profile
+    with isolated_workspace("default") as ctx:
+        result = repr(ctx)
+        # must match the exact format specified in the issue
+        assert result == f"<WorkspaceRunContext(run_dir={ctx.run_dir!r}, profile={ctx._profile!r})>"
+        # must contain the actual values to be useful
+        assert ctx.run_dir in result
+        assert ctx._profile in result
+        # must follow Python convention: < > wrapping means object can't be re-instantiated
+        assert result.startswith("<WorkspaceRunContext(")
+        assert result.endswith(")>")
+
+    # Test repr reflects the correct profile when non-default profile is used
+    with isolated_workspace("default", profile="dev") as ctx:
+        result = repr(ctx)
+        assert "dev" in result
+        assert ctx.run_dir in result
+        assert result == f"<WorkspaceRunContext(run_dir={ctx.run_dir!r}, profile={ctx._profile!r})>"

--- a/tests/workspace/test_workspace_context.py
+++ b/tests/workspace/test_workspace_context.py
@@ -352,10 +352,9 @@ def test_workspace_run_context_repr() -> None:
     with isolated_workspace("default") as ctx:
         result = repr(ctx)
         # must match the exact format specified in the issue
-        assert result == f"<WorkspaceRunContext(run_dir={ctx.run_dir!r}, profile={ctx._profile!r})>"
-        # must contain the actual values to be useful
-        assert ctx.run_dir in result
-        assert ctx._profile in result
+        assert result == f"<WorkspaceRunContext(run_dir={ctx.run_dir!r}, profile={ctx.profile!r})>"
+        # profile must appear as plain string (no escaping needed)
+        assert ctx.profile in result
         # must follow Python convention: < > wrapping means object can't be re-instantiated
         assert result.startswith("<WorkspaceRunContext(")
         assert result.endswith(")>")
@@ -364,5 +363,4 @@ def test_workspace_run_context_repr() -> None:
     with isolated_workspace("default", profile="dev") as ctx:
         result = repr(ctx)
         assert "dev" in result
-        assert ctx.run_dir in result
-        assert result == f"<WorkspaceRunContext(run_dir={ctx.run_dir!r}, profile={ctx._profile!r})>"
+        assert result == f"<WorkspaceRunContext(run_dir={ctx.run_dir!r}, profile={ctx.profile!r})>"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
Added `__repr__` method to `WorkspaceRunContext` to make the object less opaque when inspecting in a REPL or debugger.

Output now shows:
`<WorkspaceRunContext(run_dir='/absolute/path/to/project', profile='dev')>

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues
- Closes #3941


<!--
Provide any additional context about the PR here.
-->
### Additional Context
- Added `__repr__` to `dlt/_workspace/_workspace_context.py` using the codebase's existing `simple_repr` helper
- Added test in `tests/workspace/test_workspace_context.py` covering default and non-default profiles
- Follows Python convention of using `< >` to indicate the object cannot be re-instantiated from its repr

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
