### PR TITLE
fix: resolve GCP service-account vs oauth credentials correctly (#3328)

### DIFF
--- a/dlt/common/configuration/specs/gcp_credentials.py
+++ b/dlt/common/configuration/specs/gcp_credentials.py
@@ -1,4 +1,5 @@
 import dataclasses
+import os
 import sys
 from typing import Any, ClassVar, Final, List, Tuple, Union, Dict, Optional
 
@@ -23,9 +24,25 @@ from dlt.common.configuration.specs.base_configuration import (
 )
 from dlt.common.utils import is_interactive
 
-
 # GCS scope required for OAuth2 token requests
 GCS_SCOPE = "https://www.googleapis.com/auth/devstorage.read_write"
+
+
+def _maybe_read_credentials_file(native_value: str) -> str:
+    """Return file contents if ``native_value`` is a path to an existing file.
+
+    Lets users point ``credentials`` at a service-account / oauth json *file*
+    instead of pasting the json itself. Anything that is not an existing file
+    path (json content included) is returned unchanged.
+    """
+    try:
+        if os.path.isfile(native_value):
+            with open(native_value, encoding="utf-8") as f:
+                return f.read()
+    except (OSError, ValueError):
+        # value too long for a path, contains null bytes, etc. -> not a file
+        pass
+    return native_value
 
 
 def _get_pyiceberg_fileio_config(credentials: Any, project_id: Optional[str]) -> Dict[str, Any]:
@@ -134,10 +151,20 @@ class GcpServiceAccountCredentialsWithoutDefaults(GcpCredentials, WithPyicebergC
         if service_dict is None:
             # check if type is str
             GcpCredentials.parse_native_representation(self, native_value)
+            # allow a path to a credentials file in place of the json itself
+            native_value = _maybe_read_credentials_file(native_value)
             # if not instance of service account credentials then check type and try to parse native value
             try:
                 service_dict = json.loads(native_value)
             except Exception:
+                raise InvalidGoogleServicesJson(self.__class__, native_value)
+            # reject oauth client secrets / user info so a credentials union can
+            # fall through to GcpOAuthCredentials instead of mis-parsing here (#3328)
+            if (
+                not isinstance(service_dict, dict)
+                or bool(service_dict.keys() & {"client_secret", "installed", "web"})
+                or service_dict.get("type") == "authorized_user"
+            ):
                 raise InvalidGoogleServicesJson(self.__class__, native_value)
 
         self._from_info_dict(service_dict)
@@ -203,6 +230,8 @@ class GcpOAuthCredentialsWithoutDefaults(GcpCredentials, OAuth2Credentials, With
         if oauth_dict is None:
             # check if type is str
             GcpCredentials.parse_native_representation(self, native_value)
+            # allow a path to a credentials file in place of the json itself
+            native_value = _maybe_read_credentials_file(native_value)
             # if not instance of oauth2 credentials try to parse native value
             try:
                 oauth_dict = json.loads(native_value)
@@ -210,6 +239,12 @@ class GcpOAuthCredentialsWithoutDefaults(GcpCredentials, OAuth2Credentials, With
                 if len(oauth_dict) == 1:
                     oauth_dict = next(iter(oauth_dict.values()))
             except Exception:
+                raise InvalidGoogleOauth2Json(self.__class__, native_value)
+            # reject service account json so a credentials union can fall through
+            # to GcpServiceAccountCredentials instead of mis-parsing here (#3328)
+            if isinstance(oauth_dict, dict) and (
+                oauth_dict.get("type") == "service_account" or "private_key" in oauth_dict
+            ):
                 raise InvalidGoogleOauth2Json(self.__class__, native_value)
         self._from_info_dict(oauth_dict)
 

--- a/tests/common/configuration/test_credentials.py
+++ b/tests/common/configuration/test_credentials.py
@@ -1,9 +1,10 @@
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from unittest.mock import patch
 
 import pytest
 from dlt.common.configuration import resolve_configuration
+from dlt.common.configuration.resolve import initialize_credentials
 from dlt.common.configuration.exceptions import ConfigFieldMissingException
 from dlt.common.configuration.specs import (
     ConnectionStringCredentials,
@@ -26,7 +27,6 @@ from dlt.destinations.impl.snowflake.configuration import SnowflakeCredentials
 from tests.utils import TEST_DICT_CONFIG_PROVIDER, preserve_environ
 from tests.common.utils import json_case_path
 from tests.common.configuration.utils import ConnectionStringCompatCredentials, environment
-
 
 SERVICE_JSON = """
   {
@@ -320,6 +320,76 @@ def test_gcp_oauth_credentials_native_representation(environment) -> None:
     gcpc_3 = GcpOAuthCredentials()
     gcpc_3.parse_native_representation(OAUTH_USER_INFO % '"refresh_token": "refresh_token",')
     assert dict(gcpc_3) == dict(gcpc_2)
+
+
+def test_gcp_oauth_credentials_reject_service_account_json(environment: Any) -> None:
+    # oauth spec must reject a service account json so a credentials union falls
+    # through to GcpServiceAccountCredentials instead of mis-parsing here (#3328)
+    with pytest.raises(InvalidGoogleOauth2Json):
+        GcpOAuthCredentials().parse_native_representation(
+            SERVICE_JSON
+            % '"private_key": "-----BEGIN PRIVATE KEY-----\\n\\n-----END PRIVATE KEY-----\\n",'
+        )
+    # the "type" field identifies it even without a private key
+    with pytest.raises(InvalidGoogleOauth2Json):
+        GcpOAuthCredentialsWithoutDefaults().parse_native_representation(SERVICE_JSON % "")
+
+
+def test_gcp_service_credentials_reject_oauth_json(environment: Any) -> None:
+    # service account spec must reject oauth user/app info so a credentials union
+    # falls through to GcpOAuthCredentials instead of mis-parsing here (#3328)
+    with pytest.raises(InvalidGoogleServicesJson):
+        GcpServiceAccountCredentials().parse_native_representation(
+            OAUTH_APP_USER_INFO % '"refresh_token": "refresh_token",'
+        )
+    with pytest.raises(InvalidGoogleServicesJson):
+        GcpServiceAccountCredentialsWithoutDefaults().parse_native_representation(
+            OAUTH_USER_INFO % '"refresh_token": "refresh_token",'
+        )
+
+
+def test_gcp_credentials_union_resolves_to_correct_type(environment: Any) -> None:
+    # a service account json must resolve to the service account spec and oauth
+    # info to the oauth spec, whatever the order in the union (#3328)
+    hint = Union[GcpServiceAccountCredentials, GcpOAuthCredentials]
+
+    sa = initialize_credentials(
+        hint,
+        SERVICE_JSON
+        % '"private_key": "-----BEGIN PRIVATE KEY-----\\n\\n-----END PRIVATE KEY-----\\n",',
+    )
+    assert isinstance(sa, GcpServiceAccountCredentials)
+    assert sa.client_email == "loader@iam.gserviceaccount.com"
+
+    oauth = initialize_credentials(hint, OAUTH_APP_USER_INFO % '"refresh_token": "refresh_token",')
+    assert isinstance(oauth, GcpOAuthCredentials)
+    assert (
+        oauth.client_id
+        == "921382012504-3mtjaj1s7vuvf53j88mgdq4te7akkjm3.apps.googleusercontent.com"
+    )
+
+
+def test_gcp_credentials_from_file_path(environment: Any, tmp_path: Any) -> None:
+    # credentials given as a path to a json file are read from disk (#3328)
+    sa_file = tmp_path / "service.json"
+    sa_file.write_text(
+        SERVICE_JSON
+        % '"private_key": "-----BEGIN PRIVATE KEY-----\\n\\n-----END PRIVATE KEY-----\\n",',
+        encoding="utf-8",
+    )
+    gcpc = GcpServiceAccountCredentials()
+    gcpc.parse_native_representation(str(sa_file))
+    assert gcpc.client_email == "loader@iam.gserviceaccount.com"
+    assert gcpc.project_id == "chat-analytics"
+
+    oauth_file = tmp_path / "oauth.json"
+    oauth_file.write_text(
+        OAUTH_APP_USER_INFO % '"refresh_token": "refresh_token",', encoding="utf-8"
+    )
+    gcoauth = GcpOAuthCredentials()
+    gcoauth.parse_native_representation(str(oauth_file))
+    assert gcoauth.client_secret == "gOCSPX-XdY5znbrvjSMEG3pkpA_GHuLPPth"
+    assert gcoauth.refresh_token == "refresh_token"
 
 
 def test_needs_scopes_for_refresh_token() -> None:


### PR DESCRIPTION
Closes #3328.

### What's going on

GCS / filesystem credentials are typed as `Union[GcpServiceAccountCredentials, GcpOAuthCredentials]`. When dlt resolves a union it only falls through to the next member if a spec raises `NativeValueError`. The problem: neither GCP spec checked that the JSON actually matched its own type.

- `GcpOAuthCredentials.parse_native_representation` happily `json.loads`-es a *service-account* JSON (a service-account file even has a `client_id`), so resolution can land on oauth.
- When things do fail, the union re-raises the **last** member's error, which is why people see `GcpOAuthCredentials cannot parse the configuration value provided...` even though they supplied a service account. That's both the error in #3328 and the "redirects to the OAuth consent screen instead of using the service account" symptom from the google_sheets source.

### Changes

- `GcpOAuthCredentials` rejects a JSON that looks like a service account (`type == "service_account"` or a `private_key` present) by raising `InvalidGoogleOauth2Json`.
- `GcpServiceAccountCredentials` rejects oauth client-secret / user info (`client_secret` / `installed` / `web` / `type == "authorized_user"`) by raising `InvalidGoogleServicesJson`.
- Both are `NativeValueError` subclasses, so a credentials union now falls through to the correct spec instead of mis-parsing.
- `credentials` may now also be a **path to a json file** — if the value is an existing file it's read from disk, so `credentials = "/path/to/service_account.json"` works (the literal case in the issue).

### Tests

Added to `tests/common/configuration/test_credentials.py`:
- each spec rejects the other's JSON,
- a `Union[...]` resolves a service-account JSON to the service-account spec and oauth info to the oauth spec,
- credentials are read from a file path.

The GCP/oauth credential tests pass locally (9 passed, including the existing ones), `black` and `flake8` are clean, and no existing credential test changed behaviour.
