### PR TITLE
fix(extract): start resource progress timer at pipe loop start (#3518)

### DIFF
--- a/dlt/common/runtime/collector.py
+++ b/dlt/common/runtime/collector.py
@@ -174,6 +174,14 @@ class LogCollector(Collector):
             self.messages[counter_key] = message
         self.maybe_log()
 
+    def discard(self, name: str, label: str = None) -> None:
+        """Removes counter `name` (and its info and message) if it exists."""
+        counter_key = f"{name}_{label}" if label else name
+        if counter_key in self.counters:
+            del self.counters[counter_key]
+            del self.counter_info[counter_key]
+            del self.messages[counter_key]
+
     def maybe_log(self) -> None:
         """Check if should report and if so, call self.on_log"""
         current_time = self._clock()

--- a/dlt/common/runtime/collector_base.py
+++ b/dlt/common/runtime/collector_base.py
@@ -60,6 +60,10 @@ class Collector(ABC, SupportsTracking):
         """Stops counting. Should close all counters and release resources ie. screen or push the results to a server."""
         pass
 
+    def discard(self, name: str) -> None:
+        """Removes a counter `name` if it exists. No-op by default."""
+        pass
+
     def __call__(self: TCollector, step: str) -> TCollector:
         """Syntactic sugar for nicer context managers"""
         self.step = step

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -522,6 +522,14 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                 ) as pipes:
                     left_gens = total_gens = len(pipes._sources)
                     collector.update("Resources", 0, total_gens)
+                    # register per resource progress counters before iterating so their
+                    # start_time includes the wait for the first item. without this a slow
+                    # or non paginated request reports an astronomical rate because the
+                    # counter is only created when the first rows arrive (#3518). the
+                    # collector is shared by all extractors and table name normalization is
+                    # identical across them, so any extractor registers the same counter key
+                    for resource in source.resources.selected.values():
+                        extractors["object"].start_resource(resource)
                     for pipe_item in pipes:
                         curr_gens = len(pipes._sources)
                         if left_gens > curr_gens:

--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -130,6 +130,8 @@ class Extractor:
         """Tracks tables that received items"""
         self.tables_with_empty: Set[str] = set()
         """Tracks tables that received empty materialized list"""
+        self._static_resource_counters: Dict[str, str] = {}
+        """Maps resource name to the table name its progress counter was pre-registered on"""
         self.load_id = load_id
         self.item_storage = item_storage
         self._table_contracts: Dict[str, TSchemaContractDict] = {}
@@ -139,6 +141,38 @@ class Extractor:
         self._normalize_table_identifier = lru_cache(maxsize=None)(
             partial(normalize_helpers.normalize_table_identifier, self.schema, self.naming)
         )
+
+    def start_resource(self, resource: DltResource) -> None:
+        """Register the progress counter for a resource before its pipe runs.
+
+        This sets the counter `start_time` up front so the per-resource rate reflects
+        wall-clock time including the wait for the first (possibly only) data item. Without
+        it the counter is created only when the first rows arrive, so a slow or non
+        paginated request reports an astronomical rate over an elapsed time of ~0 (#3518).
+
+        Only resources with a static table name are pre-registered here. Resources with a
+        dynamic table name (`table_name` callable) dispatch rows to tables that depend on
+        individual data items and cannot be keyed up front. Resources that redirect
+        individual items with `dlt.mark.with_table_name` also resolve to their static
+        default name here; the stale pre-registered counter is dropped on first write when
+        rows go to a different table (see `_discard_unused_static_counter`).
+        """
+        if resource.has_dynamic_table_name:
+            return
+        table_name = self._get_static_table_name(resource, None)
+        self._static_resource_counters[resource.name] = table_name
+        self.collector.update(table_name, inc=0)
+
+    def _discard_unused_static_counter(self, resource_name: str, table_name: str) -> None:
+        """Drop a pre-registered static counter if the resource writes elsewhere.
+
+        Keeps the per-resource progress line keyed on the table that actually receives
+        rows and avoids a phantom `name: 0` line for resources that redirect items with
+        `dlt.mark.with_table_name`.
+        """
+        pre_registered = self._static_resource_counters.pop(resource_name, None)
+        if pre_registered is not None and pre_registered != table_name:
+            self.collector.discard(pre_registered)
 
     def write_items(self, resource: DltResource, items: TDataItems, meta: Any) -> None:
         """Write `items` to `resource` optionally computing table schemas and revalidating/filtering data"""
@@ -189,6 +223,7 @@ class Extractor:
         new_rows_count = self.item_storage.write_data_item(
             self.load_id, self.schema.name, table_name, items, columns
         )
+        self._discard_unused_static_counter(resource_name, table_name)
         self.collector.update(table_name, inc=new_rows_count)
         # if there were rows or item was empty arrow table
         if new_rows_count > 0 or self.__class__ is ArrowExtractor:
@@ -211,6 +246,7 @@ class Extractor:
             meta.metrics,
             meta.file_format,
         )
+        self._discard_unused_static_counter(resource_name, table_name)
         self.collector.update(table_name, inc=metrics.items_count)
         self.tables_with_items.add(table_name)
 

--- a/tests/common/runtime/test_collector.py
+++ b/tests/common/runtime/test_collector.py
@@ -71,3 +71,50 @@ def test_log_collector_respects_log_period() -> None:
 
     # _stop always emits a final log
     assert buf.getvalue().count("Extract") == 3
+
+
+def test_log_collector_counter_start_time_set_on_registration() -> None:
+    # registering a counter with inc=0 fixes its start_time so a later first
+    # increment after a long wait does not produce an astronomical rate (#3518)
+    clock = [0.0]
+    with LogCollector(dump_system_stats=False)("test") as collector:
+        collector._clock = lambda: clock[0]  # type: ignore[assignment]
+        # register counter at t=0 before any item arrives
+        collector.update("slow_table", inc=0)
+        assert collector.counter_info["slow_table"].start_time == 0.0
+        # simulate a long wait for the first (and only) response
+        clock[0] = 100.0
+        collector.update("slow_table", inc=5)
+        # start_time must still reflect registration time, not first increment
+        assert collector.counter_info["slow_table"].start_time == 0.0
+        info = collector.counter_info["slow_table"]
+        elapsed = collector._clock() - info.start_time
+        assert elapsed == 100.0
+
+
+def test_log_collector_start_time_late_without_registration() -> None:
+    # control: without the inc=0 pre-registration start_time is set on first
+    # increment, which is the buggy behavior the fix avoids
+    clock = [0.0]
+    with LogCollector(dump_system_stats=False)("test") as collector:
+        collector._clock = lambda: clock[0]  # type: ignore[assignment]
+        clock[0] = 100.0
+        collector.update("slow_table", inc=5)
+        assert collector.counter_info["slow_table"].start_time == 100.0
+
+
+def test_collector_discard_is_noop_by_default() -> None:
+    # the base Collector exposes discard() so extractors can call it on any
+    # collector implementation; only LogCollector actually removes a counter
+    with DictCollector()("test") as collector:
+        collector.update("some_table", inc=1)
+        collector.discard("some_table")
+        assert collector.counters["some_table"] == 1
+
+    with LogCollector(dump_system_stats=False)("test") as collector:
+        collector.update("some_table", inc=1)
+        collector.discard("some_table")
+        assert "some_table" not in collector.counters
+        assert "some_table" not in collector.counter_info
+        # discarding an unknown counter is a no-op, not a KeyError
+        collector.discard("never_registered")

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -14,6 +14,7 @@ from dlt.common.storages import (
     NormalizeStorageConfiguration,
 )
 from dlt.common.storages.schema_storage import SchemaStorage
+from dlt.common.runtime.collector import LogCollector
 from dlt.common.schema.typing import TColumnSchema, TWriteDisposition
 from dlt.common.typing import TTableNames, TDataItems
 from dlt.common.utils import uniq_id
@@ -2102,3 +2103,104 @@ def test_resource_inputs_reject_invalid_location() -> None:
     with pytest.raises(TypeErrorWithKnownTypes):
         resource.add_input("not a location", replace=True)  # type: ignore[arg-type]
     assert len(resource.inputs) == 1
+
+
+def _make_log_collector_extract_step(collector: LogCollector) -> Extract:
+    schema_storage = SchemaStorage(
+        SchemaStorageConfiguration(
+            schema_volume_path=os.path.join(get_test_storage_root(), "schemas")
+        ),
+        makedirs=True,
+    )
+    return Extract(schema_storage, NormalizeStorageConfiguration(), collector=collector)
+
+
+def _collector_capturing_final_state(collector: LogCollector, captured: Dict[str, Any]) -> None:
+    # counters and counter_info are reset to None on _stop, so snapshot them just
+    # before the collector context closes at the end of _extract_single_source
+    original_stop = collector._stop
+
+    def capturing_stop() -> None:
+        captured["counters"] = dict(collector.counters)
+        captured["counter_info"] = dict(collector.counter_info)
+        original_stop()
+
+    collector._stop = capturing_stop  # type: ignore[method-assign]
+
+
+def test_static_resource_progress_timer_started_before_wait() -> None:
+    # a slow single table resource must report a progress rate based on wall clock
+    # time including the wait for the first item, not from when the first row
+    # arrives. the per resource counter start_time is set at pipe loop start (#3518)
+    clean_test_storage(init_normalize=True)
+    clock = [0.0]
+    collector = LogCollector(dump_system_stats=False)
+    collector._clock = lambda: clock[0]  # type: ignore[assignment]
+    captured: Dict[str, Any] = {}
+    _collector_capturing_final_state(collector, captured)
+    extract_step = _make_log_collector_extract_step(collector)
+
+    @dlt.resource(name="slow_resource")
+    def slow_resource():
+        # advance the clock to simulate waiting for the first and only response
+        clock[0] = 100.0
+        yield [{"id": 1}, {"id": 2}, {"id": 3}]
+
+    source = DltSource(dlt.Schema("slow"), "module", [slow_resource])
+    load_id = extract_step.extract_storage.create_load_package(source.discover_schema())
+    extract_step._extract_single_source(load_id, source, max_parallel_items=5, workers=1)
+
+    # the counter is keyed on the normalized table name (== resource name here)
+    info = captured["counter_info"]["slow_resource"]
+    # start_time was set at pipe loop start (t=0), before the wait
+    assert info.start_time == 0.0
+    # so elapsed reflects the full wall clock time, not ~0
+    assert clock[0] - info.start_time == 100.0
+    assert captured["counters"]["slow_resource"] == 3
+    # no stray per resource counter keyed on something other than the table name
+    assert set(captured["counters"].keys()) == {"Resources", "slow_resource"}
+
+
+def test_dynamic_resource_progress_not_preregistered() -> None:
+    # resources that redirect items with dlt.mark.with_table_name resolve to their
+    # static default name when pre-registered, but rows go to other tables. the stale
+    # counter must be dropped so no phantom "name: 0" line remains (#3518)
+    clean_test_storage(init_normalize=True)
+    collector = LogCollector(dump_system_stats=False)
+    captured: Dict[str, Any] = {}
+    _collector_capturing_final_state(collector, captured)
+    extract_step = _make_log_collector_extract_step(collector)
+
+    @dlt.resource(name="dyn_resource")
+    def dyn_resource():
+        yield dlt.mark.with_table_name({"id": 1}, "tab_a")
+        yield dlt.mark.with_table_name({"id": 2}, "tab_b")
+
+    source = DltSource(dlt.Schema("dyn"), "module", [dyn_resource])
+    load_id = extract_step.extract_storage.create_load_package(source.discover_schema())
+    extract_step._extract_single_source(load_id, source, max_parallel_items=5, workers=1)
+
+    # only the real per table counters exist, plus aggregate Resources
+    assert "dyn_resource" not in captured["counters"]
+    assert set(captured["counters"].keys()) == {"Resources", "tab_a", "tab_b"}
+
+
+def test_dynamic_table_name_callable_not_preregistered() -> None:
+    # resources with a table_name callable have a dynamic table name and must not be
+    # pre-registered at all, since the table is unknown until items arrive (#3518)
+    clean_test_storage(init_normalize=True)
+    collector = LogCollector(dump_system_stats=False)
+    captured: Dict[str, Any] = {}
+    _collector_capturing_final_state(collector, captured)
+    extract_step = _make_log_collector_extract_step(collector)
+
+    @dlt.resource(name="lambda_resource", table_name=lambda i: f"tab_{i['id']}")
+    def lambda_resource():
+        yield [{"id": 1}, {"id": 2}]
+
+    source = DltSource(dlt.Schema("lam"), "module", [lambda_resource])
+    load_id = extract_step.extract_storage.create_load_package(source.discover_schema())
+    extract_step._extract_single_source(load_id, source, max_parallel_items=5, workers=1)
+
+    assert "lambda_resource" not in captured["counters"]
+    assert set(captured["counters"].keys()) == {"Resources", "tab_1", "tab_2"}


### PR DESCRIPTION
## fix: per resource progress rate shows astronomical value for slow resources (#3518)

### the bug
for a rest_api (or any) resource whose request is slow or non paginated, the per
resource line in LogCollector reports a rate of millions/s. the total extract time is
correct, only the per resource rate is wrong.

cause: LogCollector creates a counter lazily on the first update for a given key and
sets its start_time at that moment. the per resource counter is keyed on the table name
and is only updated when the first rows arrive (extractors.py _write_item / _import_item).
for a slow single response that first update happens after the whole wait, so start_time
is set late, elapsed time is ~0, and count/elapsed blows up. the aggregate "Resources"
counter is registered at pipe loop start so its timer is correct.

### the fix
register each selected resource's progress counter with inc=0 at pipe loop start, right
where the "Resources" counter is registered. this sets start_time before the request goes
out, so elapsed time includes the wait and the rate is sane.

### the table vs resource keying
the per resource line is keyed on the normalized table name, not the resource name. three
cases:

- static single table resource (the reported case): the static table name is known up
  front and equals where rows land, so pre-registration uses the same key as the row
  update. fixed.
- dynamic table name (table_name callable): table is unknown until items arrive, so it is
  not pre-registered. nothing changes for these.
- per item redirect via dlt.mark.with_table_name: these have no dynamic table name flag,
  so they resolve to their static default name when pre-registered, but rows actually go
  elsewhere. to avoid a phantom "name: 0" line that never advances, the stale
  pre-registered counter is dropped on the first write that targets a different table.

### tests
- collector unit tests assert start_time is fixed at registration and elapsed reflects a
  later clock jump (and a control showing the buggy late start_time without registration).
- extract integration tests with an injected clock assert the static resource counter
  start_time is set before a simulated wait, and that neither the with_table_name redirect
  case nor the table_name callable case leaves a phantom counter line.

closes #3518
