### PR TITLE
Fix retry after zero

### DIFF
--- a/dlt/sources/helpers/requests/retry.py
+++ b/dlt/sources/helpers/requests/retry.py
@@ -89,6 +89,8 @@ class wait_exponential_retry_after(wait_exponential):
                 return None
             retry_date = mktime_tz(retry_date_tuple)
             seconds = retry_date - time.time()
+        if seconds <= 0:
+            return None
         return max(self.min, min(self.max, seconds))
 
     def _get_retry_after(self, retry_state: RetryCallState) -> Optional[float]:

--- a/tests/sources/helpers/test_requests.py
+++ b/tests/sources/helpers/test_requests.py
@@ -200,7 +200,7 @@ def test_wait_retry_after_int(mock_sleep: mock.MagicMock) -> None:
 
 @pytest.mark.parametrize(
     "retry_after_value",
-    ["0", "-1", "  0  "],
+    ["0", "Tue, 10 Jun 2025 00:00:00 GMT", "  0  "],
 )
 def test_wait_retry_after_zero_falls_through_to_backoff(
     mock_sleep: mock.MagicMock, retry_after_value: str

--- a/tests/sources/helpers/test_requests.py
+++ b/tests/sources/helpers/test_requests.py
@@ -198,6 +198,49 @@ def test_wait_retry_after_int(mock_sleep: mock.MagicMock) -> None:
     assert 4 <= mock_sleep.call_args[0][0] <= 5  # Adds jitter up to 1s
 
 
+@pytest.mark.parametrize(
+    "retry_after_value",
+    ["0", "-1", "  0  "],
+)
+def test_wait_retry_after_zero_falls_through_to_backoff(
+    mock_sleep: mock.MagicMock, retry_after_value: str
+) -> None:
+    """Retry-After: 0 (or negative) must fall through to exponential backoff, not retry instantly."""
+    session = Client(request_backoff_factor=1, request_max_attempts=3).session
+    url = "https://example.com/data"
+    m = requests_mock.Adapter()
+    session.mount("https://", m)
+    responses: List[Dict[str, Any]] = [
+        dict(text="error", headers={"retry-after": retry_after_value}, status_code=429),
+        dict(text="success"),
+    ]
+    m.register_uri("GET", url, responses)
+    session.get(url)
+
+    # exponential backoff must have fired — sleep called with a positive value
+    mock_sleep.assert_called_once()
+    assert mock_sleep.call_args[0][0] > 0
+
+
+def test_wait_retry_after_zero_then_nonzero_uses_header(mock_sleep: mock.MagicMock) -> None:
+    """After falling back to backoff on Retry-After: 0, a subsequent non-zero header is respected."""
+    session = Client(request_backoff_factor=0, request_max_attempts=4).session
+    url = "https://example.com/data"
+    m = requests_mock.Adapter()
+    session.mount("https://", m)
+    responses: List[Dict[str, Any]] = [
+        dict(text="error", headers={"retry-after": "0"}, status_code=429),
+        dict(text="error", headers={"retry-after": "10"}, status_code=429),
+        dict(text="success"),
+    ]
+    m.register_uri("GET", url, responses)
+    session.get(url)
+
+    assert mock_sleep.call_count == 2
+    assert mock_sleep.call_args_list[0][0][0] == 0  # Retry-After: 0 → backoff, but backoff_factor=0
+    assert 10 <= mock_sleep.call_args_list[1][0][0] <= 11 # Retry-After: 10 → wait for 10
+
+
 def test_init_default_client() -> None:
     """Test that the default client config is updated from runtime configuration.
     Run twice. 1. Clean start with no existing session attached.


### PR DESCRIPTION
### Description

When an API returns 429 Too Many Requests with Retry-After: 0, dlt retries immediately with 0s wait on every subsequent attempt. 

Fix:

Treat seconds <= 0 as "no actionable hint" and return None, letting tenacity's exponential backoff take over

### Related Issues

- Fixes #4036 