### PR TITLE
(feat) prunes deps from launcher groups if present in user deps

### DIFF
--- a/dlt/_workspace/cli/dlthub/utils.py
+++ b/dlt/_workspace/cli/dlthub/utils.py
@@ -67,6 +67,7 @@ WORKSPACE_DEPS: List[str] = [
     "pathspec>=0.11.2",
     "pydbml>=1.2.0",
     "croniter>=6.0.0",
+    "s3fs>=2022.4.0",
 ]
 
 

--- a/dlt/_workspace/deployment/requirements.py
+++ b/dlt/_workspace/deployment/requirements.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, BinaryIO, Dict, List, Literal, Optional, Sequence
+from typing import Any, BinaryIO, Dict, List, Literal, Optional, Sequence, Set
 
 import tomlkit
 from packaging.requirements import Requirement
@@ -268,22 +268,12 @@ def build_launcher_requirements() -> Dict[str, List[str]]:
 
 
 def build_dashboard_group() -> List[str]:
-    """Specs for the `DASHBOARD_JOB_REF` group."""
-    return sorted(
-        set(
-            _BASE_LAUNCHER_SPECS
-            + [
-                "botocore",
-                "ibis-framework",
-                "marimo",
-                "numpy",
-                "pandas",
-                "pyarrow",
-                "s3fs",
-                "uvicorn",
-            ]
-        )
-    )
+    """Specs for the `DASHBOARD_JOB_REF` group.
+
+    Matches the dashboard runner's dependency gate plus `s3fs` for artifact access;
+    the launcher baseline (croniter, dlthub, dlt) comes from `launcher_requirements`.
+    """
+    return sorted(["ibis-framework", "marimo", "pyarrow", "s3fs"])
 
 
 def _inject_dlt_into_launchers(launcher_requirements: Dict[str, List[str]]) -> None:
@@ -340,16 +330,20 @@ def export_workspace_requirements(
     else:
         groups = {MAIN_GROUP: []}
 
-    groups[DASHBOARD_JOB_REF] = build_dashboard_group()
-
     resolved_default_groups = list(default_groups) if default_groups else [MAIN_GROUP]
+    # names installed by default groups — always present at runtime, safe to prune against
+    default_names: Set[str] = set()
+    for name in resolved_default_groups:
+        default_names.update(_collect_package_names(groups.get(name, [])))
+    _expand_implied_names(default_names)
+
+    groups[DASHBOARD_JOB_REF] = _prune_specs(build_dashboard_group(), default_names)
 
     launcher_requirements = build_launcher_requirements()
+    for launcher, specs in launcher_requirements.items():
+        launcher_requirements[launcher] = _prune_specs(specs, default_names)
     # inject dlt into every launcher entry unless a default group already names it
-    default_has_dlt = any(
-        _contains_package(groups.get(name, []), DLT_PKG_NAME) for name in resolved_default_groups
-    )
-    if not default_has_dlt:
+    if _normalize_name(DLT_PKG_NAME) not in default_names:
         _inject_dlt_into_launchers(launcher_requirements)
 
     return {
@@ -516,8 +510,8 @@ def _parse_uv_output(text: str) -> List[str]:
     )
 
 
-# PEP 508 leading identifier: first letter/digit then letters/digits/_/-/.
-_LEADING_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.\-]*)")
+# PEP 508 leading identifier: first letter/digit then letters/digits/_/-/., optional extras
+_LEADING_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.\-]*)\s*(?:\[([^\]]*)\])?")
 # PEP 503 normalization: lowercase, runs of `-_.` collapsed to single `-`
 _PEP503_SEP_RE = re.compile(r"[-_.]+")
 
@@ -534,6 +528,53 @@ def _contains_package(specs: Sequence[str], pkg_name: str) -> bool:
         if m and _normalize_name(m.group(1)) == target:
             return True
     return False
+
+
+_IMPLIED_NAMES: Dict[str, List[str]] = {
+    f"{DLT_PKG_NAME}[hub]": [DLTHUB_PKG_NAME, "croniter"],
+    DLTHUB_PKG_NAME: ["croniter"],
+    DLTHUB_CLIENT_PKG_NAME: ["croniter"],
+    "s3fs": ["botocore"],
+    "marimo": ["uvicorn"],
+    "fastmcp": ["uvicorn"],
+}
+"""Launcher specs pulled in transitively when the key package (or extra) is installed."""
+
+
+def _collect_package_names(specs: Sequence[str]) -> Set[str]:
+    """PEP 503 normalized names of `specs`; extras add one `name[extra]` token each."""
+    names: Set[str] = set()
+    for s in specs:
+        m = _LEADING_NAME_RE.match(s)
+        if not m:
+            continue
+        name = _normalize_name(m.group(1))
+        names.add(name)
+        extras = m.group(2)
+        if extras:
+            for extra in extras.split(","):
+                extra = extra.strip()
+                if extra:
+                    names.add(f"{name}[{_normalize_name(extra)}]")
+    return names
+
+
+def _expand_implied_names(names: Set[str]) -> None:
+    """Add names pulled in transitively by meta-packages in `names`."""
+    for implying, implied in _IMPLIED_NAMES.items():
+        if implying in names:
+            names.update(implied)
+
+
+def _prune_specs(specs: List[str], names: Set[str]) -> List[str]:
+    """Drop specs whose PEP 503 normalized name is in `names`, preserving order."""
+    pruned: List[str] = []
+    for s in specs:
+        m = _LEADING_NAME_RE.match(s)
+        if m and _normalize_name(m.group(1)) in names:
+            continue
+        pruned.append(s)
+    return pruned
 
 
 def _parse_dep_list(entries: Sequence[Any]) -> List[str]:

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -954,32 +954,12 @@ def concat_batches_and_tables_in_order(
 
 def transpose_rows_to_columns(
     rows: TDataItems, column_names: Iterable[str]
-) -> dict[str, Any]:  # dict[str, np.ndarray]
-    """Transpose rows (data items) into columns (numpy arrays). Returns a dictionary of {column_name: column_data}
-
-    Uses pandas if available. Otherwise, use numpy, which is slower
-    """
-    try:
-        from dlt.common.libs.numpy import numpy as np
-    except MissingDependencyException:
-        raise MissingDependencyException(
-            "dlt pyarrow helpers", ["numpy"], "Numpy is required for this pyarrow operation"
-        )
-
-    try:
-        from pandas._libs import lib
-
-        # NOTE: this is part of public interface now via DataFrame.from_records()
-        pivoted_rows = lib.to_object_array_tuples(rows).T
-    except ImportError:
-        logger.info(
-            "Pandas not installed, reverting to numpy.asarray to create a table which is slower"
-        )
-        pivoted_rows = np.asarray(rows, dtype="object", order="K").T
-    return {
-        column_name: data.ravel()
-        for column_name, data in zip(column_names, np.vsplit(pivoted_rows, len(pivoted_rows)))
-    }
+) -> dict[str, Any]:  # dict[str, Sequence[Any]]
+    """Transpose rows (data items) into columns. Returns a dictionary of {column_name: column_data}"""
+    if not rows:
+        return {column_name: () for column_name in column_names}
+    # plain zip benchmarked faster than numpy/pandas object-array pivoting
+    return dict(zip(column_names, zip(*rows)))
 
 
 def uuid_to_string(arr: Any) -> Any:  # pyarrow.Array -> pyarrow.Array
@@ -1039,22 +1019,24 @@ def uuid_to_string(arr: Any) -> Any:  # pyarrow.Array -> pyarrow.Array
     return fsb36.cast(pa.string())
 
 
-def convert_numpy_to_arrow(
-    column_data: Any,  # 1-dimensional np.ndarray
+def convert_array_to_arrow(
+    column_data: Any,  # 1-dimensional sequence of column values
     caps: DestinationCapabilitiesContext,
     column_schema: TColumnSchema,
     tz: str,
     safe_arrow_conversion: bool,
+    arrow_type: Optional[Any] = None,
 ) -> Any:  # pyarrow.Array
-    """Convert a numpy array to a pyarrow array.
+    """Convert a sequence of column values to a pyarrow array.
 
     Args:
-        rows: data items
+        column_data: column values
         caps: capabilities of the storage backend
-        columns: dlt hints about the table columns (e.g., data type, nullabe)
+        column_schema: dlt hints about the column (e.g., data type, nullable)
         tz: time zone identifier
         safe_arrow_conversion: if False, truncation and loss of precision is allowed
             ref: https://arrow.apache.org/docs/python/generated/pyarrow.compute.CastOptions.html#pyarrow.compute.CastOptions
+        arrow_type: precomputed target arrow type, derived from `column_schema` when None
 
     Returns:
         an arrow Array
@@ -1063,7 +1045,9 @@ def convert_numpy_to_arrow(
 
     dlt_data_type = column_schema.get("data_type")
     inferred_arrow_type = (
-        get_py_arrow_datatype(column_schema, caps, tz) if dlt_data_type is not None else None
+        arrow_type
+        if arrow_type is not None
+        else (get_py_arrow_datatype(column_schema, caps, tz) if dlt_data_type is not None else None)
     )
     inferred_array = None
 
@@ -1402,6 +1386,36 @@ def cast_arrow_as_columns_schema(
     return item.__class__.from_arrays(arrays_out, schema=new_schema)
 
 
+def _row_tuples_to_arrow_struct(
+    rows: TDataItems,
+    columns: TTableSchemaColumns,
+    arrow_types: Dict[str, Optional[Any]],
+) -> Optional[Any]:  # Optional[pyarrow.Table]
+    """Converts row tuples to an arrow table in a single pass via a `StructArray`."""
+    from dlt.common.libs.pyarrow import pyarrow as pa
+
+    # json values typically need serialization fallbacks which fail the whole struct
+    if any(
+        arrow_types[name] is None or column.get("data_type") == "json"
+        for name, column in columns.items()
+    ):
+        return None
+    try:
+        struct_fields = [pa.field(name, arrow_types[name]) for name in columns]
+        arrays = pa.array(rows, type=pa.struct(struct_fields)).flatten()
+    except Exception as e:
+        logger.debug(
+            "Single-pass arrow conversion not possible, using per-column fallbacks:"
+            f" {type(e).__name__}: {e}"
+        )
+        return None
+    schema = pa.schema(
+        pa.field(field.name, field.type, nullable=columns[field.name].get("nullable", True))
+        for field in struct_fields
+    )
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
 def row_tuples_to_arrow(
     rows: TDataItems,
     caps: DestinationCapabilitiesContext,
@@ -1428,16 +1442,30 @@ def row_tuples_to_arrow(
     """
     from dlt.common.libs.pyarrow import pyarrow as pa
 
-    columnar = transpose_rows_to_columns(rows, column_names=columns.keys())
+    # compute target arrow types once; None when the type must be inferred from data
+    arrow_types: Dict[str, Optional[Any]] = {
+        name: get_py_arrow_datatype(column, caps, tz) if column.get("data_type") else None
+        for name, column in columns.items()
+    }
+
+    if (arrow_table := _row_tuples_to_arrow_struct(rows, columns, arrow_types)) is not None:
+        return arrow_table
+
+    transposed_rows = transpose_rows_to_columns(rows, column_names=columns.keys())
 
     arrow_arrays = []
     arrow_fields = []
-    for column_name, column_data in columnar.items():
+    for column_name, column_data in transposed_rows.items():
         column_schema = columns[column_name]
 
         try:
-            arrow_array = convert_numpy_to_arrow(
-                column_data, caps, column_schema, tz, safe_arrow_conversion
+            arrow_array = convert_array_to_arrow(
+                column_data,
+                caps,
+                column_schema,
+                tz,
+                safe_arrow_conversion,
+                arrow_types[column_name],
             )
         # TODO if converting to arrow fail, should we raise or skip column?
         except PyToArrowConversionException as e:

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -1442,6 +1442,11 @@ def row_tuples_to_arrow(
     """
     from dlt.common.libs.pyarrow import pyarrow as pa
 
+    # pyarrow struct conversion accepts only tuples and dicts, and tuple iteration is
+    # ~3x faster than driver row objects (e.g. sqlalchemy Row) in the transpose below
+    if rows and not isinstance(rows[0], (tuple, dict)):
+        rows = [tuple(row) for row in rows]
+
     # compute target arrow types once; None when the type must be inferred from data
     arrow_types: Dict[str, Optional[Any]] = {
         name: get_py_arrow_datatype(column, caps, tz) if column.get("data_type") else None

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -332,8 +332,9 @@ class TableLoader(BaseTableLoader):
                 # positional mapping (self.columns may be in schema order
                 # after merge_columns reordering)
                 cursor_columns = {c: self.columns[c] for c in columns}
+                # extract tuples to speed up arrow conversion
                 table = row_tuples_to_arrow(
-                    partition,
+                    [row._data for row in partition],
                     columns=cursor_columns,
                     tz=backend_kwargs.get("tz", "UTC"),
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,7 @@ workspace-deps = [
     "pathspec>=0.11.2",
     "pydbml>=1.2.0",
     "croniter>=6.0.0",
+    "s3fs>=2022.4.0",
 ]
 
 [project.entry-points.dlt]

--- a/tests/libs/pyarrow/test_row_tuples_to_arrow.py
+++ b/tests/libs/pyarrow/test_row_tuples_to_arrow.py
@@ -16,7 +16,7 @@ from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.libs.pyarrow import (
     PyToArrowConversionException,
     transpose_rows_to_columns,
-    convert_numpy_to_arrow,
+    convert_array_to_arrow,
     row_tuples_to_arrow,
     serialize_type,
     uuid_to_string,
@@ -139,7 +139,7 @@ def test_row_tuples_to_arrow_unknown_types(all_unknown: bool, leading_nulls: boo
 
 
 def test_convert_to_arrow_json_is_string():
-    """json data_type should be serialized to string by row_tuples_to_arrow and convert_numpy_to_arrow."""
+    """json data_type should be serialized to string by row_tuples_to_arrow and convert_array_to_arrow."""
     column_name = "json_col"
     columns_schema: TTableSchemaColumns = {column_name: {"name": column_name, "data_type": "json"}}
     value1 = {"foo": "bar"}
@@ -154,7 +154,7 @@ def test_convert_to_arrow_json_is_string():
     column = columns[column_name]
     assert_equal(columns[column_name], (expected_column))
 
-    arrow_array = convert_numpy_to_arrow(
+    arrow_array = convert_array_to_arrow(
         column,
         DestinationCapabilitiesContext().generic_capabilities(),
         columns_schema[column_name],
@@ -257,14 +257,14 @@ def test_uuid_to_string_python_fallback_matches_numpy(monkeypatch: pytest.Monkey
 
 
 def test_convert_uuid_is_string() -> None:
-    """convert_numpy_to_arrow yields a string array for UUID columns regardless of pyarrow version."""
+    """convert_array_to_arrow yields a string array for UUID columns regardless of pyarrow version."""
     column_name = "uuid_col"
     columns_schema: TTableSchemaColumns = {column_name: {"name": column_name}}
     uuids = [uuid4(), uuid4(), uuid4()]
     rows = [(u,) for u in uuids]
 
     columns = transpose_rows_to_columns(rows, columns_schema)
-    arrow_array = convert_numpy_to_arrow(
+    arrow_array = convert_array_to_arrow(
         columns[column_name],
         DestinationCapabilitiesContext().generic_capabilities(),
         columns_schema[column_name],
@@ -290,7 +290,7 @@ def test_convert_to_arrow_null_column_is_not_removed():
     rows = [(1, None), (2, None)]
 
     columns = transpose_rows_to_columns(rows, columns_schema)
-    arrow_array = convert_numpy_to_arrow(
+    arrow_array = convert_array_to_arrow(
         columns[column_name],
         DestinationCapabilitiesContext().generic_capabilities(),
         columns_schema[column_name],
@@ -313,7 +313,7 @@ def test_convert_to_arrow_null_column_with_data_type_is_not_removed():
     rows = [(1, None), (2, None)]
 
     columns = transpose_rows_to_columns(rows, columns_schema)
-    arrow_array = convert_numpy_to_arrow(
+    arrow_array = convert_array_to_arrow(
         columns[column_name],
         DestinationCapabilitiesContext().generic_capabilities(),
         columns_schema[column_name],
@@ -336,7 +336,7 @@ def test_convert_to_arrow_cast_string_to_decimal():
     rows = [("2.00001",), (None,), ("3.00001",)]
 
     columns = transpose_rows_to_columns(rows, columns_schema)
-    arrow_array = convert_numpy_to_arrow(
+    arrow_array = convert_array_to_arrow(
         columns[column_name],
         DestinationCapabilitiesContext().generic_capabilities(),
         columns_schema[column_name],
@@ -357,7 +357,7 @@ def test_convert_to_arrow_cast_float_to_decimal():
     rows = [(2.00001,), (None,), (3.00001,)]
 
     columns = transpose_rows_to_columns(rows, columns_schema)
-    arrow_array = convert_numpy_to_arrow(
+    arrow_array = convert_array_to_arrow(
         columns[column_name],
         DestinationCapabilitiesContext().generic_capabilities(),
         columns_schema[column_name],
@@ -679,7 +679,7 @@ def test_row_tuples_to_arrow_detects_range_type() -> None:
 def test_json_fallback_to_string_for_non_coercible_nested_objects() -> None:
     """ensure json columns fall back to string when nested values cannot be coerced to a uniform nested type.
 
-    this exercises convert_numpy_to_arrow fallback case 2: values are encoded to json strings.
+    this exercises convert_array_to_arrow fallback case 2: values are encoded to json strings.
     """
     # mix incompatible python container types across rows: list in one row, dict in another
     rows = [([1, 2, 3],), (None,), ({"a": 1},)]
@@ -728,3 +728,85 @@ def test_json_with_nested_type_hint_produces_real_nested_type() -> None:
     assert pa.types.is_struct(col_type)
     # ensure it is exactly the hinted type
     assert col_type == hinted_type
+
+
+def test_row_tuples_to_arrow_struct_fast_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fully typed schemas use the single-pass struct conversion and produce
+    the same table as the per-column path."""
+    import dlt.common.libs.pyarrow as pyarrow_libs
+
+    columns: TTableSchemaColumns = {
+        "int_col": {"name": "int_col", "data_type": "bigint"},
+        "float_col": {"name": "float_col", "data_type": "double"},
+        "text_col": {"name": "text_col", "data_type": "text"},
+        "bool_col": {"name": "bool_col", "data_type": "bool", "nullable": False},
+        "ts_col": {"name": "ts_col", "data_type": "timestamp"},
+        "date_col": {"name": "date_col", "data_type": "date"},
+        "dec_col": {"name": "dec_col", "data_type": "decimal", "precision": 10, "scale": 2},
+    }
+    rows = [
+        (
+            1,
+            1.5,
+            "a",
+            True,
+            datetime(2024, 1, 1, tzinfo=timezone.utc),
+            date(2024, 1, 1),
+            Decimal("1.23"),
+        ),
+        (None, None, None, True, None, None, None),
+    ]
+
+    # reference result from the per-column path
+    with monkeypatch.context() as m:
+        m.setattr(pyarrow_libs, "_row_tuples_to_arrow_struct", lambda *args: None)
+        expected = row_tuples_to_arrow(rows, _caps(), columns, "UTC")
+
+    # fast path must not transpose
+    def _no_transpose(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("per-column path used")
+
+    with monkeypatch.context() as m:
+        m.setattr(pyarrow_libs, "transpose_rows_to_columns", _no_transpose)
+        tbl = row_tuples_to_arrow(rows, _caps(), columns, "UTC")
+
+    assert tbl.schema == expected.schema
+    assert tbl.equals(expected)
+
+
+def test_row_tuples_to_arrow_struct_fallback_to_per_column() -> None:
+    """json columns (struct path ineligible) and values failing the fused
+    conversion (struct path aborts) use per-column strategies."""
+    # json columns skip the struct path
+    columns: TTableSchemaColumns = {
+        "int_col": {"name": "int_col", "data_type": "bigint"},
+        "json_col": {"name": "json_col", "data_type": "json"},
+    }
+    rows = [(1, {"k": 1}), (2, {"k": 2})]
+    tbl = row_tuples_to_arrow(rows, _caps(), columns, "UTC")
+    assert tbl["int_col"].to_pylist() == [1, 2]
+    assert pa.types.is_string(tbl["json_col"].type)
+    assert tbl["json_col"].to_pylist() == [json_to_str({"k": 1}), json_to_str({"k": 2})]
+
+    # numeric strings fail the fused conversion to double, per-column infer+cast converts them
+    columns = {"float_col": {"name": "float_col", "data_type": "double"}}
+    tbl = row_tuples_to_arrow([("1.5",), ("2.5",)], _caps(), columns, "UTC")
+    assert tbl["float_col"].type == pa.float64()
+    assert tbl["float_col"].to_pylist() == [1.5, 2.5]
+
+
+@pytest.mark.parametrize("typed", [True, False], ids=["typed_schema", "untyped_schema"])
+def test_row_tuples_to_arrow_empty_rows(typed: bool) -> None:
+    """Empty result sets produce an empty table with all schema columns present."""
+    columns: TTableSchemaColumns = {
+        "a": {"name": "a", "data_type": "bigint"} if typed else {"name": "a"},
+        "b": {"name": "b", "data_type": "text"} if typed else {"name": "b"},
+    }
+
+    tbl = row_tuples_to_arrow([], _caps(), columns, "UTC")
+
+    assert tbl.num_rows == 0
+    assert tbl.column_names == ["a", "b"]
+    if typed:
+        assert tbl.schema.field("a").type == pa.int64()
+        assert tbl.schema.field("b").type == pa.string()

--- a/tests/libs/pyarrow/test_row_tuples_to_arrow.py
+++ b/tests/libs/pyarrow/test_row_tuples_to_arrow.py
@@ -795,6 +795,53 @@ def test_row_tuples_to_arrow_struct_fallback_to_per_column() -> None:
     assert tbl["float_col"].to_pylist() == [1.5, 2.5]
 
 
+class _DriverRow:
+    """Mimics a non-tuple driver row (e.g. sqlalchemy Row): sequence protocol only."""
+
+    def __init__(self, *values: Any) -> None:
+        self._values = values
+
+    def __iter__(self) -> Any:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __getitem__(self, idx: int) -> Any:
+        return self._values[idx]
+
+
+@pytest.mark.parametrize("row_shape", ["list", "driver_row"], ids=["list-rows", "driver-rows"])
+def test_row_tuples_to_arrow_non_tuple_rows_use_struct_path(
+    row_shape: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-tuple row shapes are normalized to tuples and take the single-pass
+    struct conversion, producing the same table as plain tuple rows."""
+    import dlt.common.libs.pyarrow as pyarrow_libs
+
+    columns: TTableSchemaColumns = {
+        "int_col": {"name": "int_col", "data_type": "bigint"},
+        "text_col": {"name": "text_col", "data_type": "text"},
+    }
+    base_rows = [(1, "a"), (2, None)]
+    rows: List[Any] = (
+        [list(r) for r in base_rows] if row_shape == "list" else [_DriverRow(*r) for r in base_rows]
+    )
+
+    expected = row_tuples_to_arrow(base_rows, _caps(), columns, "UTC")
+
+    # normalized rows must take the struct path, not the transpose
+    def _no_transpose(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("per-column path used")
+
+    with monkeypatch.context() as m:
+        m.setattr(pyarrow_libs, "transpose_rows_to_columns", _no_transpose)
+        tbl = row_tuples_to_arrow(rows, _caps(), columns, "UTC")
+
+    assert tbl.schema == expected.schema
+    assert tbl.equals(expected)
+
+
 @pytest.mark.parametrize("typed", [True, False], ids=["typed_schema", "untyped_schema"])
 def test_row_tuples_to_arrow_empty_rows(typed: bool) -> None:
     """Empty result sets produce an empty table with all schema columns present."""

--- a/tests/workspace/deployment/test_requirements.py
+++ b/tests/workspace/deployment/test_requirements.py
@@ -35,7 +35,7 @@ from dlt._workspace.deployment.requirements import (
     migrate_requirements,
     python_version,
     save_requirements,
-    _collect_package_names
+    _collect_package_names,
 )
 from dlt._workspace.deployment.typing import DASHBOARD_JOB_REF
 

--- a/tests/workspace/deployment/test_requirements.py
+++ b/tests/workspace/deployment/test_requirements.py
@@ -18,6 +18,8 @@ from dlt._workspace.deployment.launchers import (
     LAUNCHER_MODULE,
     LAUNCHER_STREAMLIT,
 )
+from dlt._workspace.cli.dlthub._init_command import init_dlthub_workspace
+from dlt._workspace.cli.dlthub.utils import fetch_init_plan
 from dlt._workspace.deployment.manifest import default_dashboard_job
 from dlt._workspace.deployment.requirements import (
     MAIN_GROUP,
@@ -33,6 +35,7 @@ from dlt._workspace.deployment.requirements import (
     migrate_requirements,
     python_version,
     save_requirements,
+    _collect_package_names
 )
 from dlt._workspace.deployment.typing import DASHBOARD_JOB_REF
 
@@ -328,22 +331,8 @@ def test_export_skips_dlt_injection_when_present_in_default_group() -> None:
 
 def test_dashboard_group_always_present() -> None:
     dashboard_specs = build_dashboard_group()
-    expected = sorted(
-        set(
-            _BASE_LAUNCHER_SPECS
-            + [
-                "botocore",
-                "ibis-framework",
-                "marimo",
-                "numpy",
-                "pandas",
-                "pyarrow",
-                "s3fs",
-                "uvicorn",
-            ]
-        )
-    )
-    assert dashboard_specs == expected
+    # dashboard runner gate (marimo, pyarrow, ibis-framework) + s3fs for artifacts
+    assert dashboard_specs == sorted(["ibis-framework", "marimo", "pyarrow", "s3fs"])
 
     # present in every export path
     with isolated_workspace("deps_none") as ctx:
@@ -434,6 +423,169 @@ def test_contains_package_name_normalization(spec: str, needle: str, expected: b
     from dlt._workspace.deployment.requirements import _contains_package
 
     assert _contains_package([spec], needle) is expected
+
+
+@pytest.mark.parametrize(
+    "spec, names, kept",
+    [
+        ("s3fs", {"s3fs"}, False),
+        ("s3fs==2024.1", {"s3fs"}, False),
+        ("ibis-framework[duckdb]", {"ibis-framework"}, False),
+        ("ibis_framework>=12", {"ibis-framework"}, False),
+        ('s3fs ; python_version > "3.8"', {"s3fs"}, False),
+        ("Pandas", {"pandas"}, False),
+        ("marimo", {"s3fs"}, True),
+        ("croniter", set(), True),
+        ("", {"s3fs"}, True),
+        ("# comment", {"s3fs"}, True),
+    ],
+    ids=[
+        "bare-name",
+        "pinned",
+        "extras",
+        "underscore-separator",
+        "marker",
+        "case-insensitive",
+        "no-match",
+        "empty-set",
+        "empty-line",
+        "comment-line",
+    ],
+)
+def test_prune_specs_normalization(spec: str, names: Set[str], kept: bool) -> None:
+    from dlt._workspace.deployment.requirements import _prune_specs
+
+    assert _prune_specs([spec], names) == ([spec] if kept else [])
+
+
+def test_export_prunes_launcher_specs_against_default_group() -> None:
+    # deps_requirements_in declares dlt + s3fs in main
+    with isolated_workspace("deps_requirements_in") as ctx:
+        with patch(_SHUTIL_WHICH, return_value=None):
+            result = export_workspace_requirements(Path(ctx.run_dir))
+    lreq = result["launcher_requirements"]
+    for launcher in (LAUNCHER_JOB, LAUNCHER_MODULE):
+        assert "s3fs" not in lreq[launcher]
+        # botocore is implied by s3fs and pruned with it
+        assert "botocore" not in lreq[launcher]
+    # dlt in main — no dlt spec injected anywhere
+    for specs in lreq.values():
+        assert not any(Requirement(s).name == "dlt" for s in specs)
+        assert specs == sorted(specs)
+    # dashboard group pruned against main too
+    dashboard = result["groups"][DASHBOARD_JOB_REF]
+    assert "s3fs" not in dashboard
+    assert "marimo" in dashboard
+    assert "pyarrow" in dashboard
+
+
+def test_export_prunes_dashboard_group_with_normalized_names() -> None:
+    with isolated_workspace("deps_none") as ctx:
+        Path(ctx.run_dir, "requirements.txt").write_text(
+            "ibis_framework>=12\nPandas\nnumpy>=1.24\n"
+        )
+        with patch(_SHUTIL_WHICH, return_value=None):
+            result = export_workspace_requirements(Path(ctx.run_dir))
+    dashboard = result["groups"][DASHBOARD_JOB_REF]
+    assert "ibis-framework" not in dashboard
+    # rest of the synthesized group survives
+    for kept in ("marimo", "pyarrow", "s3fs"):
+        assert kept in dashboard
+    # launcher lists share none of these names — untouched except dlt injection
+    dlt_spec = get_dlt_requirement_spec()
+    assert result["launcher_requirements"][LAUNCHER_JOB] == sorted(
+        set(["botocore", "s3fs", dlt_spec] + _BASE_LAUNCHER_SPECS)
+    )
+
+
+@pytest.mark.parametrize(
+    "default_groups, pyarrow_pruned",
+    [(None, False), (["main", "extras"], True)],
+    ids=["main-only", "main-and-extras"],
+)
+def test_export_prunes_only_against_default_groups(
+    default_groups: List[str], pyarrow_pruned: bool
+) -> None:
+    with isolated_workspace("deps_none") as ctx:
+        Path(ctx.run_dir, "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "deps-groups"\n'
+            'version = "0.0.1"\n'
+            'dependencies = ["requests>=2.0"]\n'
+            "\n"
+            "[dependency-groups]\n"
+            'extras = ["pyarrow>=16.0.0"]\n'
+        )
+        result = export_workspace_requirements(Path(ctx.run_dir), default_groups=default_groups)
+    dashboard = result["groups"][DASHBOARD_JOB_REF]
+    assert ("pyarrow" not in dashboard) is pyarrow_pruned
+    # user groups are never modified by pruning
+    assert result["groups"]["extras"] == ["pyarrow>=16.0.0"]
+
+
+@pytest.mark.parametrize(
+    "spec, expected",
+    [
+        ("dlt>=1.0", {"dlt"}),
+        ("dlt[hub]==1.2", {"dlt", "dlt[hub]"}),
+        ("dlt[Hub , providers]>=1.0", {"dlt", "dlt[hub]", "dlt[providers]"}),
+        ("dlt[hub] @ https://example.com/dlt.zip", {"dlt", "dlt[hub]"}),
+    ],
+    ids=["no-extras", "single-extra", "multiple-extras-normalized", "extras-with-direct-ref"],
+)
+def test_collect_package_names_extras_tokens(spec: str, expected: Set[str]) -> None:
+    assert _collect_package_names([spec]) == expected
+
+
+@pytest.mark.parametrize(
+    "spec, pruned, kept, dlt_injected",
+    [
+        ("dlt[hub]>=1.0", {"dlthub", "croniter"}, set(), False),
+        ("dlthub>=0.1", {"dlthub", "croniter"}, set(), True),
+        ("dlthub-client", {"croniter"}, {"dlthub"}, True),
+        ("dlt>=1.0", set(), {"dlthub", "croniter"}, False),
+    ],
+    ids=["dlt-hub-extra", "dlthub", "dlthub-client", "plain-dlt"],
+)
+def test_export_prunes_implied_packages(
+    spec: str, pruned: Set[str], kept: Set[str], dlt_injected: bool
+) -> None:
+    """`dlt[hub]` pulls dlthub + croniter; dlthub / dlthub-client pull croniter."""
+    with isolated_workspace("deps_none") as ctx:
+        Path(ctx.run_dir, "requirements.txt").write_text(f"{spec}\n")
+        with patch(_SHUTIL_WHICH, return_value=None):
+            result = export_workspace_requirements(Path(ctx.run_dir))
+    job_specs = result["launcher_requirements"][LAUNCHER_JOB]
+    for name in pruned:
+        assert name not in job_specs
+    for name in kept:
+        assert name in job_specs
+    has_dlt = any(Requirement(s).name == "dlt" for s in job_specs)
+    assert has_dlt is dlt_injected
+
+
+def test_export_scaffolded_workspace_prunes_all_launcher_specs() -> None:
+    """A `dlthub init` workspace declares every launcher dep except streamlit."""
+    with isolated_workspace("deps_none") as ctx:
+        plan = fetch_init_plan(ctx.run_dir, dependencies="pyproject")
+        init_dlthub_workspace(plan)
+        result = export_workspace_requirements(Path(ctx.run_dir))
+    for launcher, specs in result["launcher_requirements"].items():
+        if launcher == LAUNCHER_STREAMLIT:
+            assert specs == ["streamlit"]
+        else:
+            assert specs == [], f"{launcher!r} not fully pruned: {specs}"
+    assert result["groups"][DASHBOARD_JOB_REF] == []
+
+
+def test_export_prunes_marker_guarded_specs() -> None:
+    """Marker-guarded user specs count toward the prune set — name-level only."""
+    with isolated_workspace("deps_none") as ctx:
+        Path(ctx.run_dir, "requirements.txt").write_text('s3fs ; python_version >= "3.8"\n')
+        with patch(_SHUTIL_WHICH, return_value=None):
+            result = export_workspace_requirements(Path(ctx.run_dir))
+    assert "s3fs" not in result["launcher_requirements"][LAUNCHER_JOB]
+    assert "s3fs" not in result["groups"][DASHBOARD_JOB_REF]
 
 
 def test_python_version_shape() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2917,6 +2917,7 @@ workspace-deps = [
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydbml" },
+    { name = "s3fs" },
 ]
 
 [package.metadata]
@@ -3140,6 +3141,7 @@ workspace-deps = [
     { name = "pathspec", specifier = ">=0.11.2" },
     { name = "pyarrow", specifier = ">=16.0.0" },
     { name = "pydbml", specifier = ">=1.2.0" },
+    { name = "s3fs", specifier = ">=2022.4.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
* duplicate deps are eliminated
* numpy and pandas got removed from rows to arrow conversion and from dashboard deps
* row conversion above uses fast-path (pure arrow) that could be to 2x faster or Python zip that is as good as pandas
