### PR TITLE
 Feature: csv encoding as a part of writer configuration

### DIFF
--- a/dlt/common/data_writers/buffered.py
+++ b/dlt/common/data_writers/buffered.py
@@ -31,6 +31,7 @@ class BufferedDataWriter(Generic[TWriter]):
         file_max_items: Optional[int] = None
         file_max_bytes: Optional[int] = None
         disable_compression: bool = False
+        write_encoding: str = "utf-8"
         _caps: Optional[DestinationCapabilitiesContext] = None
 
         __section__: ClassVar[str] = known_sections.DATA_WRITER
@@ -45,6 +46,7 @@ class BufferedDataWriter(Generic[TWriter]):
         file_max_items: int = None,
         file_max_bytes: int = None,
         disable_compression: bool = False,
+        write_encoding: str = "utf-8",
         _caps: DestinationCapabilitiesContext = None,
     ):
         self.writer_spec = writer_spec
@@ -64,6 +66,7 @@ class BufferedDataWriter(Generic[TWriter]):
             self.file_max_bytes = _caps.recommended_file_size
         self.file_max_items = file_max_items
         self.should_compress = self.writer_spec.supports_compression and not disable_compression
+        self.write_encoding = write_encoding
         # the open function is either gzip.open or open
         self.open = gzip.open if self.should_compress else open
 
@@ -243,7 +246,11 @@ class BufferedDataWriter(Generic[TWriter]):
                 if self.writer_spec.is_binary_format:
                     self._file = self.open(self._file_name, "wb")  # type: ignore
                 else:
-                    self._file = self.open(self._file_name, "wt", encoding="utf-8", newline="")
+                    # formats read back by destinations (insert_values, model) must stay utf-8
+                    encoding = (
+                        self.write_encoding if self.writer_spec.supports_encoding else "utf-8"
+                    )
+                    self._file = self.open(self._file_name, "wt", encoding=encoding, newline="")
                 self._writer = self.writer_cls(self._file, caps=self._caps)  # type: ignore[assignment]
                 self._writer.write_header(self._current_columns)
             # swap out buffer before writing so batch references are released

--- a/dlt/common/data_writers/buffered.py
+++ b/dlt/common/data_writers/buffered.py
@@ -1,3 +1,4 @@
+import codecs
 import gzip
 import contextlib
 from typing import ClassVar, Iterator, List, IO, Any, Optional, Type, Generic
@@ -9,6 +10,7 @@ from dlt.common.data_writers.exceptions import (
     DestinationCapabilitiesRequired,
     FileImportNotFound,
     InvalidFileNameTemplateException,
+    InvalidWriteEncoding,
 )
 from dlt.common.data_writers.writers import TWriter, DataWriter, FileWriterSpec, count_rows_in_items
 from dlt.common.schema.typing import TTableSchemaColumns
@@ -66,6 +68,10 @@ class BufferedDataWriter(Generic[TWriter]):
             self.file_max_bytes = _caps.recommended_file_size
         self.file_max_items = file_max_items
         self.should_compress = self.writer_spec.supports_compression and not disable_compression
+        try:
+            codecs.lookup(write_encoding)
+        except LookupError:
+            raise InvalidWriteEncoding(write_encoding)
         self.write_encoding = write_encoding
         # the open function is either gzip.open or open
         self.open = gzip.open if self.should_compress else open

--- a/dlt/common/data_writers/buffered.py
+++ b/dlt/common/data_writers/buffered.py
@@ -1,4 +1,3 @@
-import codecs
 import gzip
 import contextlib
 from typing import ClassVar, Iterator, List, IO, Any, Optional, Type, Generic
@@ -10,7 +9,6 @@ from dlt.common.data_writers.exceptions import (
     DestinationCapabilitiesRequired,
     FileImportNotFound,
     InvalidFileNameTemplateException,
-    InvalidWriteEncoding,
 )
 from dlt.common.data_writers.writers import TWriter, DataWriter, FileWriterSpec, count_rows_in_items
 from dlt.common.schema.typing import TTableSchemaColumns
@@ -33,7 +31,6 @@ class BufferedDataWriter(Generic[TWriter]):
         file_max_items: Optional[int] = None
         file_max_bytes: Optional[int] = None
         disable_compression: bool = False
-        write_encoding: str = "utf-8"
         _caps: Optional[DestinationCapabilitiesContext] = None
 
         __section__: ClassVar[str] = known_sections.DATA_WRITER
@@ -48,7 +45,6 @@ class BufferedDataWriter(Generic[TWriter]):
         file_max_items: int = None,
         file_max_bytes: int = None,
         disable_compression: bool = False,
-        write_encoding: str = "utf-8",
         _caps: DestinationCapabilitiesContext = None,
     ):
         self.writer_spec = writer_spec
@@ -68,11 +64,6 @@ class BufferedDataWriter(Generic[TWriter]):
             self.file_max_bytes = _caps.recommended_file_size
         self.file_max_items = file_max_items
         self.should_compress = self.writer_spec.supports_compression and not disable_compression
-        try:
-            codecs.lookup(write_encoding)
-        except LookupError:
-            raise InvalidWriteEncoding(write_encoding)
-        self.write_encoding = write_encoding
         # the open function is either gzip.open or open
         self.open = gzip.open if self.should_compress else open
 
@@ -252,11 +243,7 @@ class BufferedDataWriter(Generic[TWriter]):
                 if self.writer_spec.is_binary_format:
                     self._file = self.open(self._file_name, "wb")  # type: ignore
                 else:
-                    # formats read back by destinations (insert_values, model) must stay utf-8
-                    encoding = (
-                        self.write_encoding if self.writer_spec.supports_encoding else "utf-8"
-                    )
-                    self._file = self.open(self._file_name, "wt", encoding=encoding, newline="")
+                    self._file = self.open(self._file_name, "wt", encoding="utf-8", newline="")
                 self._writer = self.writer_cls(self._file, caps=self._caps)  # type: ignore[assignment]
                 self._writer.write_header(self._current_columns)
             # swap out buffer before writing so batch references are released

--- a/dlt/common/data_writers/exceptions.py
+++ b/dlt/common/data_writers/exceptions.py
@@ -17,12 +17,22 @@ class InvalidFileNameTemplateException(DataWriterException, ValueError):
         )
 
 
-class InvalidWriteEncoding(DataWriterException, ValueError):
-    def __init__(self, write_encoding: str):
-        self.write_encoding = write_encoding
+class InvalidEncoding(DataWriterException, ValueError):
+    def __init__(self, encoding: str):
+        self.encoding = encoding
         super().__init__(
-            f"Unknown encoding `{write_encoding}` in `write_encoding`. Use a Python codec name,"
+            f"Unknown encoding `{encoding}` in csv format configuration. Use a Python codec name,"
             " e.g. `utf-8`, `utf-8-sig`, `latin-1` or `cp1252`."
+        )
+
+
+class InvalidEncodingErrors(DataWriterException, ValueError):
+    def __init__(self, encoding_errors: str):
+        self.encoding_errors = encoding_errors
+        super().__init__(
+            f"Unknown error handler `{encoding_errors}` in `encoding_errors` of csv format"
+            " configuration. Use a Python error handler name, e.g. `strict`, `replace`,"
+            " `backslashreplace` or `ignore`."
         )
 
 

--- a/dlt/common/data_writers/exceptions.py
+++ b/dlt/common/data_writers/exceptions.py
@@ -17,6 +17,15 @@ class InvalidFileNameTemplateException(DataWriterException, ValueError):
         )
 
 
+class InvalidWriteEncoding(DataWriterException, ValueError):
+    def __init__(self, write_encoding: str):
+        self.write_encoding = write_encoding
+        super().__init__(
+            f"Unknown encoding `{write_encoding}` in `write_encoding`. Use a Python codec name,"
+            " e.g. `utf-8`, `utf-8-sig`, `latin-1` or `cp1252`."
+        )
+
+
 class BufferedDataWriterClosed(DataWriterException):
     def __init__(self, file_name: str):
         self.file_name = file_name

--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -1,5 +1,7 @@
 import abc
+import codecs
 import csv
+import io
 from packaging.version import Version
 from typing import (
     IO,
@@ -14,6 +16,7 @@ from typing import (
     Type,
     NamedTuple,
     TypeVar,
+    Union,
     cast,
 )
 
@@ -25,6 +28,8 @@ from dlt.common.data_writers.exceptions import (
     FileFormatForItemFormatNotFound,
     FileSpecNotFound,
     InvalidDataItem,
+    InvalidEncoding,
+    InvalidEncodingErrors,
 )
 from dlt.common.destination.configuration import (
     CsvFormatConfiguration,
@@ -62,8 +67,6 @@ class FileWriterSpec(NamedTuple):
     supports_compression: bool = False
     file_max_items: Optional[int] = None
     """Set an upper limit on the number of items in one file"""
-    supports_encoding: bool = False
-    """Text format may be written with a custom encoding set via `write_encoding`. Formats that destinations read back as utf-8 must not set it."""
 
 
 EMPTY_DATA_WRITER_METRICS = DataWriterMetrics("", 0, 0, 2**32, 0.0)
@@ -409,6 +412,64 @@ class ParquetDataWriter(DataWriter):
         )
 
 
+def canonical_encoding(encoding: str) -> str:
+    """Validates `encoding` against the Python codec registry and returns its canonical name."""
+    try:
+        return codecs.lookup(encoding).name
+    except LookupError:
+        raise InvalidEncoding(encoding)
+
+
+def validated_encoding_errors(encoding_errors: str) -> str:
+    """Validates `encoding_errors` against registered Python codec error handlers."""
+    try:
+        codecs.lookup_error(encoding_errors)
+    except LookupError:
+        raise InvalidEncodingErrors(encoding_errors)
+    return encoding_errors
+
+
+class Utf8TranscodingWrapper:
+    """Binary sink wrapper that transcodes utf-8 bytes written to it into `encoding`.
+
+    Closing the wrapper flushes the transcoder state but does not close the wrapped stream.
+    """
+
+    def __init__(self, f: IO[bytes], encoding: str, encoding_errors: str = "strict") -> None:
+        self._f = f
+        self._decoder = codecs.getincrementaldecoder("utf-8")()
+        self._encoder = codecs.getincrementalencoder(encoding)(encoding_errors)
+        self._closed = False
+
+    def write(self, b: Union[bytes, memoryview]) -> int:
+        if isinstance(b, memoryview):
+            b = b.tobytes()
+        # decoder buffers a trailing partial multi-byte sequence until the next write
+        text = self._decoder.decode(b)
+        if text:
+            self._f.write(self._encoder.encode(text))
+        return len(b)
+
+    def flush(self) -> None:
+        self._f.flush()
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            if text := self._decoder.decode(b"", True):
+                self._f.write(self._encoder.encode(text, True))
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def writable(self) -> bool:
+        return True
+
+    def tell(self) -> int:
+        return self._f.tell()
+
+
 class CsvWriter(DataWriter):
     @with_config(spec=CsvFormatConfiguration)
     def __init__(
@@ -420,6 +481,8 @@ class CsvWriter(DataWriter):
         include_header: bool = True,
         quoting: CsvQuoting = "quote_needed",
         lineterminator: str = "\n",
+        encoding: str = "utf-8",
+        encoding_errors: str = "strict",
         bytes_encoding: str = "utf-8",
     ) -> None:
         super().__init__(f, caps)
@@ -428,7 +491,14 @@ class CsvWriter(DataWriter):
         self.quoting: CsvQuoting = quoting
         self.lineterminator = lineterminator
         self.writer: csv.DictWriter[str] = None
+        self.encoding = canonical_encoding(encoding)
+        self.encoding_errors = validated_encoding_errors(encoding_errors)
         self.bytes_encoding = bytes_encoding
+        # csv module writes text, encode it into the binary stream with the configured encoding
+        self._text_f: Optional[io.TextIOWrapper] = io.TextIOWrapper(
+            f, encoding=encoding, errors=encoding_errors, newline="", write_through=True
+        )
+        self._f = self._text_f
 
     def write_header(self, columns_schema: TTableSchemaColumns) -> None:
         self._columns_schema = columns_schema
@@ -485,13 +555,26 @@ class CsvWriter(DataWriter):
                                 " type as binary.",
                             )
 
-        self.writer.writerows(items)
+        try:
+            self.writer.writerows(items)
+        except UnicodeEncodeError as enc_ex:
+            raise InvalidDataItem(
+                "csv",
+                "object",
+                "Data contains string values with characters that cannot be encoded with the"
+                f" configured `{self.encoding}` encoding: {enc_ex}. Set `encoding_errors` option"
+                " e.g. to `replace` to write such characters anyway.",
+            )
         # count rows that got written
         self.items_count += sum(len(row) for row in items)
 
     def close(self) -> None:
         self.writer = None
         self._first_schema = None
+        if self._text_f is not None:
+            # flush and release the underlying binary stream which is closed by the caller
+            self._text_f.detach()
+            self._text_f = None
 
     @classmethod
     def writer_spec(cls) -> FileWriterSpec:
@@ -499,11 +582,10 @@ class CsvWriter(DataWriter):
             "csv",
             "object",
             file_extension="csv",
-            is_binary_format=False,
+            is_binary_format=True,
             supports_schema_changes="False",
             requires_destination_capabilities=False,
             supports_compression=True,
-            supports_encoding=True,
         )
 
 
@@ -567,12 +649,19 @@ class ArrowToCsvWriter(DataWriter):
         delimiter: str = ",",
         include_header: bool = True,
         quoting: CsvQuoting = "quote_needed",
+        encoding: str = "utf-8",
+        encoding_errors: str = "strict",
     ) -> None:
         super().__init__(f, caps)
         self.delimiter = delimiter
         self._delimiter_b = delimiter.encode("ascii")
         self.include_header = include_header
         self.quoting: CsvQuoting = quoting
+        self.encoding = canonical_encoding(encoding)
+        self.encoding_errors = validated_encoding_errors(encoding_errors)
+        if self.encoding != "utf-8":
+            # pyarrow csv writer emits only utf-8, transcode into the requested encoding
+            self._f = cast(IO[Any], Utf8TranscodingWrapper(f, encoding, encoding_errors))
         self.writer: Any = None
 
     def write_header(self, columns_schema: TTableSchemaColumns) -> None:
@@ -624,6 +713,15 @@ class ArrowToCsvWriter(DataWriter):
                 # write headers only on the first write
                 try:
                     self.writer.write(item)
+                except UnicodeEncodeError as enc_ex:
+                    raise InvalidDataItem(
+                        "csv",
+                        "arrow",
+                        "Arrow data contains string columns with characters that cannot be"
+                        f" encoded with the configured `{self.encoding}` encoding: {enc_ex}. Set"
+                        " `encoding_errors` option e.g. to `replace` to write such characters"
+                        " anyway.",
+                    )
                 except pyarrow.ArrowInvalid as inv_ex:
                     if "Invalid UTF8 payload" in str(inv_ex):
                         raise InvalidDataItem(
@@ -659,6 +757,8 @@ class ArrowToCsvWriter(DataWriter):
             self.writer.close()
             self.writer = None
             self._first_schema = None
+        if isinstance(self._f, Utf8TranscodingWrapper):
+            self._f.close()
 
     @classmethod
     def writer_spec(cls) -> FileWriterSpec:

--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -73,6 +73,15 @@ EMPTY_DATA_WRITER_METRICS = DataWriterMetrics("", 0, 0, 2**32, 0.0)
 
 
 class DataWriter(abc.ABC):
+    """Writes data items of a particular format into an open file `f`.
+
+    Implementations must follow the contract that allows `BufferedDataWriter` to recover from
+    failures without leaking the file handle:
+    * `__init__` must not raise - any logic that may raise must be in `write_header`.
+    * `close` must not raise, must be idempotent and must not close `f` which is owned by
+      the buffered writer.
+    """
+
     def __init__(self, f: IO[Any], caps: DestinationCapabilitiesContext = None) -> None:
         self._f = f
         self._caps = caps
@@ -440,14 +449,24 @@ class Utf8TranscodingWrapper:
         self._decoder = codecs.getincrementaldecoder("utf-8")()
         self._encoder = codecs.getincrementalencoder(encoding)(encoding_errors)
         self._closed = False
+        self._broken = False
 
     def write(self, b: Union[bytes, memoryview]) -> int:
         if isinstance(b, memoryview):
             b = b.tobytes()
-        # decoder buffers a trailing partial multi-byte sequence until the next write
-        text = self._decoder.decode(b)
-        if text:
-            self._f.write(self._encoder.encode(text))
+        if self._broken:
+            # a previous write failed and raised, the file is abandoned - ignore trailing
+            # writes from the wrapped writer flushing its buffers on close
+            return len(b)
+        try:
+            # decoder buffers a trailing partial multi-byte sequence until the next write
+            text = self._decoder.decode(b)
+            if text:
+                self._f.write(self._encoder.encode(text))
+        except Exception:
+            # prevent writing to transcoder when flushing or closing
+            self._broken = True
+            raise
         return len(b)
 
     def flush(self) -> None:
@@ -456,8 +475,9 @@ class Utf8TranscodingWrapper:
     def close(self) -> None:
         if not self._closed:
             self._closed = True
-            if text := self._decoder.decode(b"", True):
-                self._f.write(self._encoder.encode(text, True))
+            if not self._broken:
+                if text := self._decoder.decode(b"", True):
+                    self._f.write(self._encoder.encode(text, True))
 
     @property
     def closed(self) -> bool:
@@ -491,17 +511,15 @@ class CsvWriter(DataWriter):
         self.quoting: CsvQuoting = quoting
         self.lineterminator = lineterminator
         self.writer: csv.DictWriter[str] = None
-        self.encoding = canonical_encoding(encoding)
-        self.encoding_errors = validated_encoding_errors(encoding_errors)
+        self.encoding = encoding
+        self.encoding_errors = encoding_errors
         self.bytes_encoding = bytes_encoding
-        # csv module writes text, encode it into the binary stream with the configured encoding
-        self._text_f: Optional[io.TextIOWrapper] = io.TextIOWrapper(
-            f, encoding=encoding, errors=encoding_errors, newline="", write_through=True
-        )
-        self._f = self._text_f
+        self._text_f: Optional[io.TextIOWrapper] = None
 
     def write_header(self, columns_schema: TTableSchemaColumns) -> None:
         self._columns_schema = columns_schema
+        self.encoding = canonical_encoding(self.encoding)
+        self.encoding_errors = validated_encoding_errors(self.encoding_errors)
         if self.quoting == "quote_needed":
             quoting: Literal[0, 1, 2, 3] = csv.QUOTE_NONNUMERIC
         elif self.quoting == "quote_all":
@@ -513,6 +531,15 @@ class CsvWriter(DataWriter):
         else:
             raise ValueError(self.quoting)
 
+        # csv module writes text, encode it into the binary stream with the configured encoding
+        self._text_f = io.TextIOWrapper(
+            self._f,
+            encoding=self.encoding,
+            errors=self.encoding_errors,
+            newline="",
+            write_through=True,
+        )
+        self._f = self._text_f
         self.writer = csv.DictWriter(
             self._f,
             fieldnames=list(columns_schema.keys()),
@@ -654,18 +681,23 @@ class ArrowToCsvWriter(DataWriter):
     ) -> None:
         super().__init__(f, caps)
         self.delimiter = delimiter
-        self._delimiter_b = delimiter.encode("ascii")
+        self._delimiter_b: bytes = None
         self.include_header = include_header
         self.quoting: CsvQuoting = quoting
-        self.encoding = canonical_encoding(encoding)
-        self.encoding_errors = validated_encoding_errors(encoding_errors)
-        if self.encoding != "utf-8":
-            # pyarrow csv writer emits only utf-8, transcode into the requested encoding
-            self._f = cast(IO[Any], Utf8TranscodingWrapper(f, encoding, encoding_errors))
+        self.encoding = encoding
+        self.encoding_errors = encoding_errors
         self.writer: Any = None
 
     def write_header(self, columns_schema: TTableSchemaColumns) -> None:
         self._columns_schema = columns_schema
+        self._delimiter_b = self.delimiter.encode("ascii")
+        self.encoding = canonical_encoding(self.encoding)
+        self.encoding_errors = validated_encoding_errors(self.encoding_errors)
+        if self.encoding != "utf-8":
+            # pyarrow csv writer emits only utf-8, transcode into the requested encoding
+            self._f = cast(
+                IO[Any], Utf8TranscodingWrapper(self._f, self.encoding, self.encoding_errors)
+            )
 
     def write_data(self, items: Sequence[TDataItem]) -> None:
         from dlt.common.libs.pyarrow import pyarrow

--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -62,6 +62,8 @@ class FileWriterSpec(NamedTuple):
     supports_compression: bool = False
     file_max_items: Optional[int] = None
     """Set an upper limit on the number of items in one file"""
+    supports_encoding: bool = False
+    """Text format may be written with a custom encoding set via `write_encoding`. Formats that destinations read back as utf-8 must not set it."""
 
 
 EMPTY_DATA_WRITER_METRICS = DataWriterMetrics("", 0, 0, 2**32, 0.0)
@@ -501,6 +503,7 @@ class CsvWriter(DataWriter):
             supports_schema_changes="False",
             requires_destination_capabilities=False,
             supports_compression=True,
+            supports_encoding=True,
         )
 
 

--- a/dlt/common/destination/configuration.py
+++ b/dlt/common/destination/configuration.py
@@ -13,10 +13,13 @@ class CsvFormatConfiguration(BaseConfiguration):
     include_header: bool = True
     quoting: CsvQuoting = "quote_needed"
     lineterminator: str = "\n"
+    encoding: str = "utf-8"
+    """Encoding used to write csv files and to decode them when a destination loads them."""
+    encoding_errors: str = "strict"
+    """How characters not representable in `encoding` are treated when writing csv files: a Python error handler name, e.g. `strict` (default, raises), `replace` or `backslashreplace`."""
 
     # read options
     on_error_continue: bool = False
-    encoding: str = "utf-8"
 
     __section__: ClassVar[str] = known_sections.DATA_WRITER
 

--- a/docs/website/docs/dlt-ecosystem/file-formats.md
+++ b/docs/website/docs/dlt-ecosystem/file-formats.md
@@ -148,8 +148,9 @@ with standard settings:
 
 * `delimiter`: change the delimiting character (default: ',')
 * `include_header`: include the header row (default: True)
-* `lineterminator`: specify the string used to terminate lines (default: `\n` - UNIX line endings, use `\r\n` for Windows line endings)
-* `write_encoding`: encoding used to write `csv` files (default: `utf-8`). Use, e.g., `utf-8-sig` to add a BOM for older Excel or `latin-1`/`cp1252` for legacy importers. Applies to the Python CSV writer only; the PyArrow writer always writes `utf-8`
+* `lineterminator`: specify the string used to terminate lines (default: `\n` - UNIX line endings, use `\r\n` for Windows line endings). Applies to the Python CSV writer only; the PyArrow writer always uses `\n`
+* `encoding`: encoding used to write `csv` files (default: `utf-8`). Use, e.g., `utf-8-sig` to add a BOM for older Excel or `latin-1`/`cp1252` for legacy importers. Both writers honor it
+* `encoding_errors`: how characters that cannot be represented in `encoding` are treated (default: `strict` - the load fails). Use a [Python error handler name](https://docs.python.org/3/library/codecs.html#error-handlers), e.g., `replace` to substitute them with `?` or `backslashreplace` to keep them as escape sequences
 * `quoting`: controls when quotes should be generated around field values. Available options:
 
     - `quote_needed` (default): quote only values that need quoting, i.e., non-numeric values
@@ -169,7 +170,7 @@ delimiter="|"
 include_header=false
 quoting="quote_all"
 lineterminator="\r\n"
-write_encoding="latin-1"
+encoding="latin-1"
 ```
 
 Or using environment variables:
@@ -179,7 +180,7 @@ NORMALIZE__DATA_WRITER__DELIMITER=|
 NORMALIZE__DATA_WRITER__INCLUDE_HEADER=False
 NORMALIZE__DATA_WRITER__QUOTING=quote_all
 NORMALIZE__DATA_WRITER__LINETERMINATOR=$"\r\n"
-NORMALIZE__DATA_WRITER__WRITE_ENCODING=latin-1
+NORMALIZE__DATA_WRITER__ENCODING=latin-1
 ```
 
 Note the `"$"` prefix before `"\r\n"` to escape the newline character when using environment variables.
@@ -193,16 +194,19 @@ delimiter="|"
 encoding="latin-1"
 ```
 
-Two options are used only when reading:
-* `encoding`: encoding used to decode the `csv` file (default: `utf-8`)
+When reading, `encoding` tells the destination how to decode the `csv` file (default: `utf-8`) and one option is used only when reading:
 * `on_error_continue`: skip lines with errors (only Snowflake)
 
-`csv_format` also accepts the write settings above (except `write_encoding`) - set them when the file being loaded deviates from the defaults, e.g., uses a different delimiter or has no header row.
-
-You'll typically need these settings when [importing external files](../general-usage/resource.md#import-external-files) that `dlt` did not write.
+`csv_format` also accepts the write settings above - set them when the file being loaded deviates from the defaults, e.g., uses a different delimiter or has no header row.
 
 :::caution
-`write_encoding` and `encoding` are two different settings with different purposes: `write_encoding` controls the encoding `dlt` uses to **write** `csv` files during normalize, while `encoding` tells the destination how to **decode** a `csv` file it loads - setting one does not affect the other. With the `filesystem` destination, files are uploaded as-is, so `write_encoding` alone is enough. If the files are instead copied into **postgres** or **snowflake**, also set `encoding` in the destination `csv_format` to the same value - otherwise the destination will decode them as `utf-8` and the load will fail or garble non-ASCII characters.
+Write settings (`[normalize.data_writer]`) and destination read settings (`[destination.<name>.csv_format]`) are resolved independently - which one to set depends on who writes and who reads the files:
+
+* **dlt does both** - in the standard flow (e.g. loading into **postgres** or **snowflake**), `dlt` writes the files and the destination copies them right back. Keep the defaults on both sides: the files exist only as an internal transport format and there is no reason to change how it is encoded.
+* **External systems read the files** - with the `filesystem` destination as the final target, the files are the product. Set the `[normalize.data_writer]` options to whatever the consumer expects, e.g. `encoding="utf-8-sig"` for older Excel or `cp1252` for a legacy importer.
+* **dlt did not write the files** - when [importing external files](../general-usage/resource.md#import-external-files), describe them in `[destination.<name>.csv_format]` so the destination can decode them. Mind that `encoding` goes verbatim into the destination's COPY statement, so it must be an encoding name the destination accepts - and those names do not always match Python's (e.g. `latin-1` vs `ISO_8859_1`).
+
+If you nevertheless combine a custom write encoding with a database destination, mirror the value in the destination `csv_format` - otherwise the destination decodes the files as `utf-8` and the load fails or garbles non-ASCII characters.
 :::
 
 ### Limitations
@@ -210,7 +214,6 @@ You'll typically need these settings when [importing external files](../general-
 
 * binary columns are supported only if they contain valid UTF-8 characters
 * json (nested, struct) types are not supported
-* `write_encoding` is ignored, files are always written as `utf-8`
 
 **csv writer**
 * binary columns are supported only if they contain valid UTF-8 characters (easy to add more encodings)

--- a/docs/website/docs/dlt-ecosystem/file-formats.md
+++ b/docs/website/docs/dlt-ecosystem/file-formats.md
@@ -35,7 +35,7 @@ pip install "dlt[parquet]"
 Under the hood, `dlt` uses the [pyarrow parquet writer](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html) to create the files. The following options can be used to change the behavior of the writer:
 
 - `flavor`: Sanitize schema or set other compatibility options to work with various target systems. Defaults to None, which is the **pyarrow** default.
-- `version`: Determine which Parquet logical types are available for use, whether the reduced set from the Parquet 1.x.x format or the expanded logical types added in later format versions. Defaults to "2.6".
+- `version`: Determine which Parquet logical types are available for use, whether the reduced set from the Parquet 1.x.x format or the expanded logical types added in later format versions. `dlt` defaults to "2.4".
 - `data_page_size`: Set a target threshold for the approximate encoded size of data pages within a column chunk (in bytes). Defaults to None, which is the **pyarrow** default.
 - `row_group_size`: Set the number of rows in a row group. [See here](#row-group-size) how this can optimize parallel processing of queries on your destination over the default setting of `pyarrow`.
 - `timestamp_timezone`: A string specifying the timezone, default is UTC.
@@ -48,6 +48,7 @@ Under the hood, `dlt` uses the [pyarrow parquet writer](https://arrow.apache.org
 :::tip
 The default parquet version used by `dlt` is 2.4. It coerces timestamps to microseconds and truncates nanoseconds silently. Such a setting
 provides the best interoperability with database systems, including loading pandas DataFrames which have nanosecond resolution by default.
+Set `version="2.6"` if you need to preserve nanosecond precision timestamps.
 :::
 
 Read the [pyarrow parquet docs](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html) to learn more about these settings.
@@ -56,7 +57,7 @@ Example:
 
 ```toml
 [data_writer]
-# the default values
+# example values
 flavor="spark"
 version="2.4"
 data_page_size=1048576
@@ -116,9 +117,9 @@ The `row_group_size` configuration setting has limited utility with the `pyarrow
 **CSV** is the most basic file format for storing tabular data, where all values are strings and are separated by a delimiter (typically a comma).
 `dlt` uses it for specific use cases - mostly for performance and compatibility reasons.
 
-Internally, we use two implementations:
-- [Python standard library CSV writer](https://docs.python.org/3/library/csv.html)
-- PyArrow CSV writer - a very fast, multithreaded writer for [Arrow tables](./verified-sources/arrow-pandas.md)
+Internally, we use two implementations, picked based on the shape of the data items:
+- [Python standard library CSV writer](https://docs.python.org/3/library/csv.html) - used when resources yield Python objects (dicts)
+- PyArrow CSV writer - a very fast, multithreaded writer, used when resources yield [Arrow tables, pandas DataFrames, or polars DataFrames](./verified-sources/arrow-pandas.md)
 
 ### Settings
 `dlt` attempts to make both writers generate similarly looking files:
@@ -139,14 +140,16 @@ A,,""
 In the last row, both `text2` and `text3` values are NULL. The Python `csv` writer
 is not able to write unquoted `None` values, so we had to settle for `""`.
 
-Note: all destinations capable of writing CSVs must support it.
+Note: all destinations that support the `csv` format accept files written with the standard settings above.
 
-You can change basic `csv` settings; this may be handy when working with the `filesystem` destination. Other destinations are tested
+#### Write settings
+The settings below control how `dlt` writes `csv` files during **normalize** and are configured in the `[normalize.data_writer]` section. Changing them may be handy when working with the `filesystem` destination. Other destinations are tested
 with standard settings:
 
 * `delimiter`: change the delimiting character (default: ',')
 * `include_header`: include the header row (default: True)
 * `lineterminator`: specify the string used to terminate lines (default: `\n` - UNIX line endings, use `\r\n` for Windows line endings)
+* `write_encoding`: encoding used to write `csv` files (default: `utf-8`). Use, e.g., `utf-8-sig` to add a BOM for older Excel or `latin-1`/`cp1252` for legacy importers. Applies to the Python CSV writer only; the PyArrow writer always writes `utf-8`
 * `quoting`: controls when quotes should be generated around field values. Available options:
 
     - `quote_needed` (default): quote only values that need quoting, i.e., non-numeric values
@@ -166,6 +169,7 @@ delimiter="|"
 include_header=false
 quoting="quote_all"
 lineterminator="\r\n"
+write_encoding="latin-1"
 ```
 
 Or using environment variables:
@@ -175,16 +179,30 @@ NORMALIZE__DATA_WRITER__DELIMITER=|
 NORMALIZE__DATA_WRITER__INCLUDE_HEADER=False
 NORMALIZE__DATA_WRITER__QUOTING=quote_all
 NORMALIZE__DATA_WRITER__LINETERMINATOR=$"\r\n"
+NORMALIZE__DATA_WRITER__WRITE_ENCODING=latin-1
 ```
 
 Note the `"$"` prefix before `"\r\n"` to escape the newline character when using environment variables.
 
-A few additional settings are available when copying `csv` to destination tables:
-* **on_error_continue** - skip lines with errors (only Snowflake)
-* **encoding** - encoding of the `csv` file
+#### Read settings
+Destinations that copy `csv` files into tables (**postgres** and **snowflake**) read them according to their own `csv_format` configuration. These settings do not change how `dlt` writes files - they describe the file the destination is loading and are set on the destination, e.g.:
 
-:::tip
-You'll need these settings when [importing external files](../general-usage/resource.md#import-external-files).
+```toml
+[destination.postgres.csv_format]
+delimiter="|"
+encoding="latin-1"
+```
+
+Two options are used only when reading:
+* `encoding`: encoding used to decode the `csv` file (default: `utf-8`)
+* `on_error_continue`: skip lines with errors (only Snowflake)
+
+`csv_format` also accepts the write settings above (except `write_encoding`) - set them when the file being loaded deviates from the defaults, e.g., uses a different delimiter or has no header row.
+
+You'll typically need these settings when [importing external files](../general-usage/resource.md#import-external-files) that `dlt` did not write.
+
+:::caution
+`write_encoding` and `encoding` are two different settings with different purposes: `write_encoding` controls the encoding `dlt` uses to **write** `csv` files during normalize, while `encoding` tells the destination how to **decode** a `csv` file it loads - setting one does not affect the other. With the `filesystem` destination, files are uploaded as-is, so `write_encoding` alone is enough. If the files are instead copied into **postgres** or **snowflake**, also set `encoding` in the destination `csv_format` to the same value - otherwise the destination will decode them as `utf-8` and the load will fail or garble non-ASCII characters.
 :::
 
 ### Limitations
@@ -192,6 +210,7 @@ You'll need these settings when [importing external files](../general-usage/reso
 
 * binary columns are supported only if they contain valid UTF-8 characters
 * json (nested, struct) types are not supported
+* `write_encoding` is ignored, files are always written as `utf-8`
 
 **csv writer**
 * binary columns are supported only if they contain valid UTF-8 characters (easy to add more encodings)

--- a/tests/extract/data_writers/test_buffered_writer.py
+++ b/tests/extract/data_writers/test_buffered_writer.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import time
 from typing import Iterator, Type
+from unittest.mock import patch
 from uuid import uuid4
 
 from dlt.common.data_writers.exceptions import BufferedDataWriterClosed
@@ -467,6 +468,20 @@ def test_rotation_on_destination_caps_recommended_file_size(
         assert all(closed_file.file_path.endswith(".gz") for closed_file in writer.closed_files)
     else:
         assert not any(closed_file.file_path.endswith(".gz") for closed_file in writer.closed_files)
+
+
+def test_write_header_failure_releases_file() -> None:
+    """When write_header raises, buffered writer recovers via writer.close() without leaking the file handle."""
+    c1 = new_column("col1", "text")
+    with patch.object(JsonlWriter, "write_header", side_effect=ValueError("header failed")):
+        writer = get_writer(JsonlWriter, disable_compression=True)
+        with pytest.raises(ValueError, match="header failed"):
+            with writer:
+                writer.write_data_item([{"col1": "a"}], {"col1": c1})
+    # file handle released so the file can be deleted on Windows
+    assert writer._file is None
+    assert writer._writer is None
+    os.remove(writer.closed_files[-1].file_path)
 
 
 def test_encoding_ignored_by_non_csv_formats() -> None:

--- a/tests/extract/data_writers/test_buffered_writer.py
+++ b/tests/extract/data_writers/test_buffered_writer.py
@@ -4,7 +4,7 @@ import time
 from typing import Iterator, Type
 from uuid import uuid4
 
-from dlt.common.data_writers.exceptions import BufferedDataWriterClosed
+from dlt.common.data_writers.exceptions import BufferedDataWriterClosed, InvalidWriteEncoding
 from dlt.common.data_writers.writers import (
     DataWriter,
     InsertValuesWriter,
@@ -477,3 +477,10 @@ def test_write_encoding_ignored_by_non_supporting_formats() -> None:
     # insert files are read back as utf-8 by destinations so encoding setting must not apply
     with open(writer.closed_files[0].file_path, "r", encoding="utf-8") as f:
         assert "æøå" in f.read()
+
+
+def test_invalid_write_encoding() -> None:
+    with custom_environ({"DATA_WRITER__WRITE_ENCODING": "no-such-encoding"}):
+        with pytest.raises(InvalidWriteEncoding) as exc_info:
+            get_writer(InsertValuesWriter)
+    assert "no-such-encoding" in str(exc_info.value)

--- a/tests/extract/data_writers/test_buffered_writer.py
+++ b/tests/extract/data_writers/test_buffered_writer.py
@@ -4,7 +4,7 @@ import time
 from typing import Iterator, Type
 from uuid import uuid4
 
-from dlt.common.data_writers.exceptions import BufferedDataWriterClosed, InvalidWriteEncoding
+from dlt.common.data_writers.exceptions import BufferedDataWriterClosed
 from dlt.common.data_writers.writers import (
     DataWriter,
     InsertValuesWriter,
@@ -469,18 +469,11 @@ def test_rotation_on_destination_caps_recommended_file_size(
         assert not any(closed_file.file_path.endswith(".gz") for closed_file in writer.closed_files)
 
 
-def test_write_encoding_ignored_by_non_supporting_formats() -> None:
+def test_encoding_ignored_by_non_csv_formats() -> None:
     c1 = new_column("col1", "text")
-    with custom_environ({"DATA_WRITER__WRITE_ENCODING": "latin-1"}):
+    with custom_environ({"DATA_WRITER__ENCODING": "latin-1"}):
         with get_writer(InsertValuesWriter, disable_compression=True) as writer:
             writer.write_data_item([{"col1": "æøå"}], {"col1": c1})
-    # insert files are read back as utf-8 by destinations so encoding setting must not apply
+    # insert files are read back as utf-8 by destinations so csv encoding setting must not apply
     with open(writer.closed_files[0].file_path, "r", encoding="utf-8") as f:
         assert "æøå" in f.read()
-
-
-def test_invalid_write_encoding() -> None:
-    with custom_environ({"DATA_WRITER__WRITE_ENCODING": "no-such-encoding"}):
-        with pytest.raises(InvalidWriteEncoding) as exc_info:
-            get_writer(InsertValuesWriter)
-    assert "no-such-encoding" in str(exc_info.value)

--- a/tests/extract/data_writers/test_buffered_writer.py
+++ b/tests/extract/data_writers/test_buffered_writer.py
@@ -17,6 +17,7 @@ from dlt.common.schema.utils import new_column
 from dlt.common.storages.file_storage import FileStorage
 
 from dlt.common.typing import DictStrAny
+from dlt.common.utils import custom_environ
 
 from tests.common.data_writers.utils import get_writer, ALL_OBJECT_WRITERS
 
@@ -466,3 +467,13 @@ def test_rotation_on_destination_caps_recommended_file_size(
         assert all(closed_file.file_path.endswith(".gz") for closed_file in writer.closed_files)
     else:
         assert not any(closed_file.file_path.endswith(".gz") for closed_file in writer.closed_files)
+
+
+def test_write_encoding_ignored_by_non_supporting_formats() -> None:
+    c1 = new_column("col1", "text")
+    with custom_environ({"DATA_WRITER__WRITE_ENCODING": "latin-1"}):
+        with get_writer(InsertValuesWriter, disable_compression=True) as writer:
+            writer.write_data_item([{"col1": "æøå"}], {"col1": c1})
+    # insert files are read back as utf-8 by destinations so encoding setting must not apply
+    with open(writer.closed_files[0].file_path, "r", encoding="utf-8") as f:
+        assert "æøå" in f.read()

--- a/tests/libs/test_csv_writer.py
+++ b/tests/libs/test_csv_writer.py
@@ -1,13 +1,19 @@
 import csv
+import gzip
 from copy import copy
 from typing import Any, Dict, Type
 from unittest.mock import Mock, patch
 import pytest
+import pyarrow as pa
 import pyarrow.parquet as pq
 
 from dlt.common import json
 from dlt.common.destination.configuration import CsvQuoting
-from dlt.common.data_writers.exceptions import InvalidDataItem
+from dlt.common.data_writers.exceptions import (
+    InvalidDataItem,
+    InvalidEncoding,
+    InvalidEncodingErrors,
+)
 from dlt.common.data_writers.writers import (
     ArrowToCsvWriter,
     CsvWriter,
@@ -341,20 +347,26 @@ def test_csv_lineterminator(test_case: Dict[str, str]) -> None:
             assert content == expected
 
 
+@pytest.mark.parametrize("item_type", ["object", "arrow"])
 @pytest.mark.parametrize("encoding", ["latin-1", "cp1252", "utf-8-sig"])
-def test_csv_write_encoding(encoding: str) -> None:
+def test_csv_encoding(item_type: TestDataItemFormat, encoding: str) -> None:
     schema: TTableSchemaColumns = {"name": {"name": "name", "data_type": "text"}}
     # use characters that encode differently in utf-8 and latin-1/cp1252
-    data = [{"name": "æøå"}, {"name": "Ünïcödé"}]
+    values = ["æøå", "Ünïcödé"]
 
-    with custom_environ({"DATA_WRITER__WRITE_ENCODING": encoding}):
-        with get_writer(CsvWriter, disable_compression=True) as writer:
-            writer.write_data_item(data, schema)
+    with custom_environ({"DATA_WRITER__ENCODING": encoding}):
+        if item_type == "object":
+            with get_writer(CsvWriter, disable_compression=True) as writer:
+                writer.write_data_item([{"name": value} for value in values], schema)
+        else:
+            with get_writer(ArrowToCsvWriter, disable_compression=True) as arrow_writer:
+                arrow_writer.write_data_item(pa.table({"name": values}), schema)
+            writer = arrow_writer  # type: ignore[assignment]
 
     file_path = writer.closed_files[0].file_path
     with open(file_path, "r", encoding=encoding, newline="") as f:
         rows = list(csv.DictReader(f, dialect=csv.unix_dialect))
-    assert [r["name"] for r in rows] == ["æøå", "Ünïcödé"]
+    assert [r["name"] for r in rows] == values
 
     with open(file_path, "rb") as f:
         raw = f.read()
@@ -365,6 +377,86 @@ def test_csv_write_encoding(encoding: str) -> None:
         # single byte encodings produce sequences that are not valid utf-8
         with pytest.raises(UnicodeDecodeError):
             raw.decode("utf-8")
+
+
+@pytest.mark.parametrize("writer_type", [CsvWriter, ArrowToCsvWriter])
+def test_csv_encoding_with_compression(writer_type: Type[DataWriter]) -> None:
+    schema: TTableSchemaColumns = {"name": {"name": "name", "data_type": "text"}}
+    values = ["æøå", "Ünïcödé"]
+
+    with custom_environ({"DATA_WRITER__ENCODING": "latin-1"}):
+        if writer_type is CsvWriter:
+            with get_writer(CsvWriter) as writer:
+                writer.write_data_item([{"name": value} for value in values], schema)
+            file_path = writer.closed_files[0].file_path
+        else:
+            with get_writer(ArrowToCsvWriter) as arrow_writer:
+                arrow_writer.write_data_item(pa.table({"name": values}), schema)
+            file_path = arrow_writer.closed_files[0].file_path
+
+    assert file_path.endswith(".gz")
+    with gzip.open(file_path, "rt", encoding="latin-1", newline="") as f:
+        rows = list(csv.DictReader(f, dialect=csv.unix_dialect))
+    assert [r["name"] for r in rows] == values
+
+
+@pytest.mark.parametrize("writer_type", [CsvWriter, ArrowToCsvWriter])
+def test_csv_encoding_errors(writer_type: Type[DataWriter]) -> None:
+    schema: TTableSchemaColumns = {"name": {"name": "name", "data_type": "text"}}
+    # "żółw" is not representable in latin-1
+
+    # strict (default): non-encodable characters fail the writer
+    with custom_environ({"DATA_WRITER__ENCODING": "latin-1"}):
+        with pytest.raises(InvalidDataItem) as inv_info:
+            if writer_type is CsvWriter:
+                with get_writer(CsvWriter, disable_compression=True) as writer:
+                    writer.write_data_item([{"name": "żółw"}], schema)
+            else:
+                with get_writer(ArrowToCsvWriter, disable_compression=True) as arrow_writer:
+                    arrow_writer.write_data_item(pa.table({"name": ["żółw"]}), schema)
+    assert "latin-1" in str(inv_info.value)
+
+    # replace: non-encodable characters are replaced with ?
+    with custom_environ(
+        {"DATA_WRITER__ENCODING": "latin-1", "DATA_WRITER__ENCODING_ERRORS": "replace"}
+    ):
+        if writer_type is CsvWriter:
+            with get_writer(CsvWriter, disable_compression=True) as writer:
+                writer.write_data_item([{"name": "żółw"}], schema)
+            file_path = writer.closed_files[0].file_path
+        else:
+            with get_writer(ArrowToCsvWriter, disable_compression=True) as arrow_writer:
+                arrow_writer.write_data_item(pa.table({"name": ["żółw"]}), schema)
+            file_path = arrow_writer.closed_files[0].file_path
+
+    with open(file_path, "r", encoding="latin-1", newline="") as f:
+        rows = list(csv.DictReader(f, dialect=csv.unix_dialect))
+    assert [r["name"] for r in rows] == ["?ó?w"]
+
+
+@pytest.mark.parametrize("writer_type", [CsvWriter, ArrowToCsvWriter])
+def test_csv_invalid_encoding(writer_type: Type[DataWriter]) -> None:
+    schema: TTableSchemaColumns = {"name": {"name": "name", "data_type": "text"}}
+
+    with custom_environ({"DATA_WRITER__ENCODING": "no-such-encoding"}):
+        with pytest.raises(InvalidEncoding) as exc_info:
+            if writer_type is CsvWriter:
+                with get_writer(CsvWriter, disable_compression=True) as writer:
+                    writer.write_data_item([{"name": "a"}], schema)
+            else:
+                with get_writer(ArrowToCsvWriter, disable_compression=True) as arrow_writer:
+                    arrow_writer.write_data_item(pa.table({"name": ["a"]}), schema)
+    assert "no-such-encoding" in str(exc_info.value)
+
+    with custom_environ({"DATA_WRITER__ENCODING_ERRORS": "no-such-handler"}):
+        with pytest.raises(InvalidEncodingErrors) as err_info:
+            if writer_type is CsvWriter:
+                with get_writer(CsvWriter, disable_compression=True) as writer:
+                    writer.write_data_item([{"name": "a"}], schema)
+            else:
+                with get_writer(ArrowToCsvWriter, disable_compression=True) as arrow_writer:
+                    arrow_writer.write_data_item(pa.table({"name": ["a"]}), schema)
+    assert "no-such-handler" in str(err_info.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/libs/test_csv_writer.py
+++ b/tests/libs/test_csv_writer.py
@@ -1,5 +1,6 @@
 import csv
 import gzip
+import os
 from copy import copy
 from typing import Any, Dict, Type
 from unittest.mock import Mock, patch
@@ -30,7 +31,7 @@ from tests.cases import (
     arrow_table_all_data_types,
     table_update_and_row,
 )
-from tests.utils import TestDataItemFormat
+from tests.utils import TestDataItemFormat, get_test_storage_root
 
 
 def test_csv_arrow_writer_all_data_fields() -> None:
@@ -407,14 +408,17 @@ def test_csv_encoding_errors(writer_type: Type[DataWriter]) -> None:
 
     # strict (default): non-encodable characters fail the writer
     with custom_environ({"DATA_WRITER__ENCODING": "latin-1"}):
+        failed_writer = get_writer(writer_type, disable_compression=True)
         with pytest.raises(InvalidDataItem) as inv_info:
-            if writer_type is CsvWriter:
-                with get_writer(CsvWriter, disable_compression=True) as writer:
-                    writer.write_data_item([{"name": "żółw"}], schema)
-            else:
-                with get_writer(ArrowToCsvWriter, disable_compression=True) as arrow_writer:
-                    arrow_writer.write_data_item(pa.table({"name": ["żółw"]}), schema)
+            with failed_writer:
+                if writer_type is CsvWriter:
+                    failed_writer.write_data_item([{"name": "żółw"}], schema)
+                else:
+                    failed_writer.write_data_item(pa.table({"name": ["żółw"]}), schema)
     assert "latin-1" in str(inv_info.value)
+    # file handle must be released so the file can be deleted on Windows
+    assert failed_writer._file is None
+    assert failed_writer._writer is None
 
     # replace: non-encodable characters are replaced with ?
     with custom_environ(
@@ -438,25 +442,54 @@ def test_csv_encoding_errors(writer_type: Type[DataWriter]) -> None:
 def test_csv_invalid_encoding(writer_type: Type[DataWriter]) -> None:
     schema: TTableSchemaColumns = {"name": {"name": "name", "data_type": "text"}}
 
+    def _write_one_item(failed_writer: Any) -> None:
+        if writer_type is CsvWriter:
+            failed_writer.write_data_item([{"name": "a"}], schema)
+        else:
+            failed_writer.write_data_item(pa.table({"name": ["a"]}), schema)
+
     with custom_environ({"DATA_WRITER__ENCODING": "no-such-encoding"}):
+        failed_writer = get_writer(writer_type, disable_compression=True)
         with pytest.raises(InvalidEncoding) as exc_info:
-            if writer_type is CsvWriter:
-                with get_writer(CsvWriter, disable_compression=True) as writer:
-                    writer.write_data_item([{"name": "a"}], schema)
-            else:
-                with get_writer(ArrowToCsvWriter, disable_compression=True) as arrow_writer:
-                    arrow_writer.write_data_item(pa.table({"name": ["a"]}), schema)
+            with failed_writer:
+                _write_one_item(failed_writer)
     assert "no-such-encoding" in str(exc_info.value)
+    # writer constructor failed: file handle must be released so the file can be deleted on Windows
+    assert failed_writer._file is None
+    assert failed_writer._writer is None
 
     with custom_environ({"DATA_WRITER__ENCODING_ERRORS": "no-such-handler"}):
+        failed_writer = get_writer(writer_type, disable_compression=True)
         with pytest.raises(InvalidEncodingErrors) as err_info:
-            if writer_type is CsvWriter:
-                with get_writer(CsvWriter, disable_compression=True) as writer:
-                    writer.write_data_item([{"name": "a"}], schema)
-            else:
-                with get_writer(ArrowToCsvWriter, disable_compression=True) as arrow_writer:
-                    arrow_writer.write_data_item(pa.table({"name": ["a"]}), schema)
+            with failed_writer:
+                _write_one_item(failed_writer)
     assert "no-such-handler" in str(err_info.value)
+    assert failed_writer._file is None
+    assert failed_writer._writer is None
+
+
+@pytest.mark.parametrize("writer_type", [CsvWriter, ArrowToCsvWriter])
+def test_csv_writer_close_contract(writer_type: Type[DataWriter]) -> None:
+    """Writer close must not raise, be idempotent and keep the file open, also after a failed write."""
+    schema: TTableSchemaColumns = {"name": {"name": "name", "data_type": "text"}}
+    os.makedirs(get_test_storage_root(), exist_ok=True)
+    file_path = os.path.join(get_test_storage_root(), f"close_contract_{writer_type.__name__}.csv")
+    with open(file_path, "wb") as f:
+        writer = writer_type(f, encoding="latin-1")  # type: ignore[call-arg]
+        writer.write_header(schema)
+        # "żółw" is not representable in latin-1, the write fails mid file
+        with pytest.raises(InvalidDataItem):
+            if writer_type is CsvWriter:
+                writer.write_data([{"name": "żółw"}])
+            else:
+                writer.write_data([pa.table({"name": ["żółw"]})])
+        writer.close()
+        writer.close()
+        # the file is owned by the caller and must stay open
+        assert not f.closed
+        f.tell()
+    # the handle was released with the owner close, the file can be deleted on Windows
+    os.remove(file_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/libs/test_csv_writer.py
+++ b/tests/libs/test_csv_writer.py
@@ -341,6 +341,32 @@ def test_csv_lineterminator(test_case: Dict[str, str]) -> None:
             assert content == expected
 
 
+@pytest.mark.parametrize("encoding", ["latin-1", "cp1252", "utf-8-sig"])
+def test_csv_write_encoding(encoding: str) -> None:
+    schema: TTableSchemaColumns = {"name": {"name": "name", "data_type": "text"}}
+    # use characters that encode differently in utf-8 and latin-1/cp1252
+    data = [{"name": "æøå"}, {"name": "Ünïcödé"}]
+
+    with custom_environ({"DATA_WRITER__WRITE_ENCODING": encoding}):
+        with get_writer(CsvWriter, disable_compression=True) as writer:
+            writer.write_data_item(data, schema)
+
+    file_path = writer.closed_files[0].file_path
+    with open(file_path, "r", encoding=encoding, newline="") as f:
+        rows = list(csv.DictReader(f, dialect=csv.unix_dialect))
+    assert [r["name"] for r in rows] == ["æøå", "Ünïcödé"]
+
+    with open(file_path, "rb") as f:
+        raw = f.read()
+    if encoding == "utf-8-sig":
+        # BOM must be written so Excel detects utf-8
+        assert raw.startswith(b"\xef\xbb\xbf")
+    else:
+        # single byte encodings produce sequences that are not valid utf-8
+        with pytest.raises(UnicodeDecodeError):
+            raw.decode("utf-8")
+
+
 @pytest.mark.parametrize(
     "quoting,delimiter,schema,test_data_dict,expected_header,expected_data_rows",
     [


### PR DESCRIPTION
### Description

Adds a `write_encoding` option that lets users choose the encoding of csv files written by dlt (default: utf-8), e.g. utf-8-sig for a BOM that older Excel needs, or latin-1/cp1252 for legacy importers and partner file specs.
```
[normalize.data_writer]
write_encoding="latin-1"
```
Implementation:
- `write_encoding` added to `BufferedDataWriterConfiguration` and applied when opening text-mode files in `BufferedDataWriter`.
- New `supports_encoding` flag on `FileWriterSpec`, set only on `CsvWriter` — other text formats (`insert_values`, `model`) stay utf-8, since destinations read them back with hardcoded utf-8 and would fail to load otherwise.
- The encoding name is validated with `codecs.lookup()` at writer creation and raises `InvalidWriteEncoding` on a typo, instead of a raw `LookupError` mid-normalize.
- Tests: round-trip for `latin-1/cp1252/utf-8-sig` (incl. BOM bytes assertion), insert files stay utf-8 when the option is set, invalid encoding fails fast.
- Docs: `file-formats.md` restructured into Write settings vs Read settings with a caution explaining how the two relate.

### Related Issues

- Closes #3977 

### Additional Context

Two points to discuss @burnash:

1. We now have two encoding configurations. 
- `write_encoding` (`normalize.data_writer`) controls how dlt writes csv; 
- the pre-existing `encoding` (`destination.<name>.csv_format`) tells postgres/snowflake how to decode csv they load. 

  They don't know about each other, so a user writing `latin-1` csv into postgres must set both. Also, dlt does not validate or translate `csv_format.encoding`, the value goes straight into the destination's COPY statement, so it must be an encoding name the destination accepts, and those names don't always match Python's (e.g. ISO-8859-1 vs latin-1). The docs caution covers it, but should we unify these (e.g. default the read side from the write side), or keep them separate since `csv_format.encoding` also serves [external file imports](https://dlthub.com/docs/general-usage/resource#import-external-files)?


2. The PyArrow csv writer ignores `write_encoding` entirely. It's a binary-format writer and pyarrow only emits utf-8 (`WriteOptions` has no encoding parameter), so resources yielding arrow tables / pandas / polars frames silently produce utf-8 files regardless of the setting. Documented as a limitation, and supporting it would require a transcoding wrapper around the binary sink. 
 
   @VioletM  For the users requesting this feature: what shape is their data? Python objects or arrow/pandas? If the latter, this PR won't solve their case yet and we should prioritize the arrow follow-up. 
