### PR TITLE
retry flaky databricks and motherduck remote tests

### DIFF
--- a/.github/workflows/test_destinations_remote.yml
+++ b/.github/workflows/test_destinations_remote.yml
@@ -69,6 +69,7 @@ jobs:
               destinations: "[\"databricks\"]"
               filesystem_drivers: "[\"memory\"]"
               extras: "--extra databricks --extra s3 --extra gs --extra az --extra parquet"
+              rerun_args: "--reruns=2 --reruns-delay=10 --only-rerun=ConnectionResetError --only-rerun=RequestError"
 
             # Filesystem
             - name: filesystem_s3_local
@@ -130,6 +131,11 @@ jobs:
               filesystem_drivers: "[\"memory\"]"
               extras: "--extra motherduck --extra s3 --extra gs --extra az --extra parquet"
               xdist_workers: 1
+              # motherduck tests fail almost exclusively as xdist worker crashes (the worker
+              # segfaults). pytest-rerunfailures always retries worker crashes when
+              # --reruns > 0, independent of --only-rerun. We need --only-rerun sentinel below so
+              # only crashes are retried and genuine failures still fail fast
+              rerun_args: "--reruns=2 --reruns-delay=10 --only-rerun=__worker_crash_only__"
 
             # Ducklake
             - name: ducklake
@@ -257,9 +263,11 @@ jobs:
         run: make test-dest-remote-essential
         env:
           PYTEST_XDIST_N: ${{ matrix.xdist_workers || env.PYTEST_XDIST_N }}
+          PYTEST_ARGS: ${{ matrix.rerun_args || '' }}
 
       - name: Run non-essential tests Linux
         if: ${{ always() && (inputs.run_full_test_suite || matrix.always_run_all_tests) }}
         run: make test-dest-remote-nonessential
         env:
           PYTEST_XDIST_N: ${{ matrix.xdist_workers || env.PYTEST_XDIST_N }}
+          PYTEST_ARGS: ${{ matrix.rerun_args || '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ dev = [
     "pytest-console-scripts>=1.4.1,<2",
     "pytest>=7.4.4,<8",
     "pytest-xdist>=3.5,<4",
+    "pytest-rerunfailures>=14,<16",
     "pytest-timeout>=2.3.1,<3",
     "mypy>=1.11.0",
     "flake8>=7.0.0,<8",

--- a/uv.lock
+++ b/uv.lock
@@ -2838,6 +2838,7 @@ dev = [
     { name = "pytest-forked" },
     { name = "pytest-mock" },
     { name = "pytest-order" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "requests-mock" },
@@ -3076,6 +3077,7 @@ dev = [
     { name = "pytest-forked", specifier = ">=1.3.0" },
     { name = "pytest-mock", specifier = ">=3.14.0,<4" },
     { name = "pytest-order", specifier = ">=1.0.0" },
+    { name = "pytest-rerunfailures", specifier = ">=14,<16" },
     { name = "pytest-timeout", specifier = ">=2.3.1,<3" },
     { name = "pytest-xdist", specifier = ">=3.5,<4" },
     { name = "requests-mock", specifier = ">=1.10.0,<2" },
@@ -9962,6 +9964,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/6b/913e36aa421b35689ec95ed953ff7e8df3f2ee1c7b8ab2a3f1fd39d95faf/pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770", size = 16928, upload-time = "2025-11-24T03:43:22.53Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/61/4d333d8354ea2bea2c2f01bad0a4aa3c1262de20e1241f78e73360e9b620/pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38", size = 16881, upload-time = "2025-11-24T03:43:24.423Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/78/e6e358545537a8e82c4dc91e72ec0d6f80546a3786dd27c76b06ca09db77/pytest_rerunfailures-15.1.tar.gz", hash = "sha256:c6040368abd7b8138c5b67288be17d6e5611b7368755ce0465dda0362c8ece80", size = 26981, upload-time = "2025-05-08T06:36:33.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/30/11d836ff01c938969efa319b4ebe2374ed79d28043a12bfc908577aab9f3/pytest_rerunfailures-15.1-py3-none-any.whl", hash = "sha256:f674c3594845aba8b23c78e99b1ff8068556cc6a8b277f728071fdc4f4b0b355", size = 13274, upload-time = "2025-05-08T06:36:32.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
These two destinations fail every now and then transient and unrelated to the PR being tested. databricks throws ConnectionResetError/RequestError on connect, motherduck crashes the xdist worker (segfault in the duckdb extension).

Adds pytest-rerunfailures and opts in just those two (for now) via rerun_args in the matrix, scoped with --only-rerun so genuine failures still fail fast (motherduck uses a "sentinel" since only the crash needs retrying).

We can also extend this to other remote tests - but I'd keep it scoped