### PR TITLE
Feat/add cdn marimo launcher

### DIFF
--- a/dlt/_workspace/deployment/configuration.py
+++ b/dlt/_workspace/deployment/configuration.py
@@ -23,6 +23,10 @@ class MarimoConfiguration(BaseConfiguration):
     session_ttl: int = 120
     """Seconds before closing an idle session."""
     command: Literal["run", "edit"] = "run"
+    asset_url: Optional[str] = (
+        "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+    )
+    """CDN URL for marimo frontend assets. Marimo substitutes `{version}` from the installed package. Set to empty string to disable and serve assets from the app origin."""
 
 
 @configspec

--- a/dlt/_workspace/deployment/launchers/_launcher.py
+++ b/dlt/_workspace/deployment/launchers/_launcher.py
@@ -1,7 +1,7 @@
 import argparse
+import importlib.util
 import os
 import subprocess
-from importlib import import_module
 from typing import Any, Dict, List, Optional, Tuple
 
 from dlt.common import json
@@ -61,11 +61,14 @@ def get_run_args_base_path(entry_point: TRuntimeEntryPoint) -> str:
 
 
 def resolve_module_path(module_name: str) -> str:
-    """Resolve a Python module name to its file path."""
-    mod = import_module(module_name)
-    file_path: Optional[str] = getattr(mod, "__file__", None)
+    """Resolve a Python module name to its file path without importing it."""
+    spec = importlib.util.find_spec(module_name)
+    if spec is None:
+        raise ValueError(f"module {module_name!r} could not be resolved")
+
+    file_path: Optional[str] = spec.origin
     if file_path is None:
-        raise ValueError(f"module {module_name!r} has no __file__")
+        raise ValueError(f"module {module_name!r} has no origin")
     return file_path
 
 

--- a/dlt/_workspace/deployment/launchers/marimo.py
+++ b/dlt/_workspace/deployment/launchers/marimo.py
@@ -40,6 +40,8 @@ def run(entry_point: TRuntimeEntryPoint) -> None:
     args.extend(["--session-ttl", str(mc.session_ttl)])
     if base_path:
         args.extend(["--base-url", base_path])
+    if mc.asset_url:
+        args.extend(["--asset-url", mc.asset_url])
 
     exec_process(args)
 

--- a/tests/workspace/deployment/test_launchers.py
+++ b/tests/workspace/deployment/test_launchers.py
@@ -1,5 +1,6 @@
 """Tests for job launchers."""
 
+import importlib.util
 import json
 import os
 import signal
@@ -276,6 +277,25 @@ def test_job_launcher_mcp_fallback() -> None:
 
         job_run(entry_point, run_id="test-6", trigger="manual:")
         mock_run_mcp.assert_called_once()
+
+
+def test_resolve_module_path_returns_file_without_importing() -> None:
+    """resolve_module_path must not execute the target module."""
+    module_name = f"{WORKSPACE}.marimo_notebook"
+    expected = importlib.util.find_spec(module_name).origin
+    sys.modules.pop(module_name, None)
+
+    from dlt._workspace.deployment.launchers._launcher import resolve_module_path
+
+    assert resolve_module_path(module_name) == expected
+    assert module_name not in sys.modules
+
+
+def test_resolve_module_path_unknown_module() -> None:
+    from dlt._workspace.deployment.launchers._launcher import resolve_module_path
+
+    with pytest.raises(ValueError, match="could not be resolved"):
+        resolve_module_path("totally_fake_module_abc123")
 
 
 def test_module_launcher_builds_correct_args() -> None:

--- a/tests/workspace/deployment/test_launchers.py
+++ b/tests/workspace/deployment/test_launchers.py
@@ -312,6 +312,11 @@ def test_marimo_launcher_builds_correct_args() -> None:
         assert "0.0.0.0" in cmd
         assert "--headless" in cmd
         assert "--no-token" in cmd
+        assert "--asset-url" in cmd
+        assert (
+            "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+            in cmd
+        )
 
 
 def test_marimo_launcher_with_token() -> None:


### PR DESCRIPTION
## Summary

- Serve marimo frontend assets from jsDelivr CDN via `--asset-url` (configurable, empty string disables).
- Fix launcher path resolution: use `find_spec` instead of `import_module` so marimo/streamlit notebooks aren't executed before `marimo run` / `streamlit run` (~1–1.5s faster port readiness).