### PR TITLE
(feat) lance write optimizations - namespace caching, atomic commit and truncation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,9 +45,7 @@ jobs:
         run: uv sync --all-extras --no-extra hub --group airflow --group providers --group pipeline --group sources --group sentry-sdk --group dbt
 
       - name: Run make lint
-        run: |
-          export PATH=$PATH:"/c/Program Files/usr/bin" # needed for Windows
-          make lint
+        run: make lint
 
       - name: Check filesizes
         uses: ppremk/lfs-warning@v3.2

--- a/dlt/_workspace/deployment/configuration.py
+++ b/dlt/_workspace/deployment/configuration.py
@@ -23,9 +23,7 @@ class MarimoConfiguration(BaseConfiguration):
     session_ttl: int = 120
     """Seconds before closing an idle session."""
     command: Literal["run", "edit"] = "run"
-    asset_url: Optional[str] = (
-        "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
-    )
+    asset_url: Optional[str] = "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
     """CDN URL for marimo frontend assets. Marimo substitutes `{version}` from the installed package. Set to empty string to disable and serve assets from the app origin."""
 
 

--- a/dlt/common/libs/deltalake.py
+++ b/dlt/common/libs/deltalake.py
@@ -153,6 +153,11 @@ def merge_delta_table(
         )
 
 
+def truncate_delta_table(table: DeltaTable) -> None:
+    """Deletes all rows in a single transactional commit, preserving schema and version history."""
+    table.delete()
+
+
 def get_delta_tables(
     pipeline: Pipeline, *tables: str, schema_name: str = None, include_dlt_tables: bool = False
 ) -> Dict[str, DeltaTable]:

--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -794,6 +794,18 @@ def columns_to_arrow(
     )
 
 
+def get_local_dataset_reader(file_paths: Sequence[str]) -> pyarrow.RecordBatchReader:
+    """Streams local data files with bounded readahead to limit memory use over throughput."""
+    # NOTE: import inline, pyarrow.dataset pulls heavy dependencies
+    import pyarrow.dataset
+
+    return (
+        pyarrow.dataset.dataset(file_paths)
+        .scanner(batch_size=65536, batch_readahead=2, fragment_readahead=1)
+        .to_reader()
+    )
+
+
 def get_parquet_metadata(parquet_file: TFileOrPath) -> Tuple[int, pyarrow.Schema]:
     """Gets parquet file metadata (including row count and schema)
 

--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -29,6 +29,7 @@ try:
     from pyiceberg.table import Table as IcebergTable
     from pyiceberg.catalog import Catalog as IcebergCatalog
     from pyiceberg.exceptions import NoSuchTableError
+    from pyiceberg.expressions import AlwaysTrue
     from pyiceberg.partitioning import (
         UNPARTITIONED_PARTITION_SPEC,
         PartitionSpec as IcebergPartitionSpec,
@@ -383,6 +384,32 @@ def get_catalog(
         "No catalog configuration found, using in-memory SQLite catalog (backward compatibility)"
     )
     return get_sql_catalog(iceberg_catalog_name, "sqlite:///:memory:", credentials)
+
+
+def is_ephemeral_catalog(catalog: IcebergCatalog) -> bool:
+    """In-memory catalogs are rebuilt per client and lose table registrations between loads."""
+    return ":memory:" in catalog.properties.get("uri", "")
+
+
+def truncate_iceberg_table(table: IcebergTable) -> None:
+    """Deletes all rows in a single transactional commit, keeping the table registered with snapshot history."""
+    table.delete(delete_filter=AlwaysTrue())
+
+
+def drop_iceberg_table(catalog: IcebergCatalog, table_id: str) -> bool:
+    """Drops `table_id` from `catalog`, purging its files when the catalog supports it.
+
+    Returns False when the table is not registered in `catalog`.
+    """
+    try:
+        try:
+            catalog.purge_table(table_id)
+        except NotImplementedError:
+            # not all catalogs implement purge, drop leaves files in place
+            catalog.drop_table(table_id)
+        return True
+    except NoSuchTableError:
+        return False
 
 
 def evolve_table(

--- a/dlt/common/libs/pyiceberg.py
+++ b/dlt/common/libs/pyiceberg.py
@@ -28,7 +28,7 @@ try:
     import pyiceberg
     from pyiceberg.table import Table as IcebergTable
     from pyiceberg.catalog import Catalog as IcebergCatalog
-    from pyiceberg.exceptions import NoSuchTableError
+    from pyiceberg.exceptions import NoSuchTableError, BadRequestError, ForbiddenError
     from pyiceberg.expressions import AlwaysTrue
     from pyiceberg.partitioning import (
         UNPARTITIONED_PARTITION_SPEC,
@@ -396,17 +396,25 @@ def truncate_iceberg_table(table: IcebergTable) -> None:
     table.delete(delete_filter=AlwaysTrue())
 
 
-def drop_iceberg_table(catalog: IcebergCatalog, table_id: str) -> bool:
-    """Drops `table_id` from `catalog`, purging its files when the catalog supports it.
+def drop_iceberg_table(catalog: IcebergCatalog, table_id: str, purge: bool = True) -> bool:
+    """Drops `table_id` from `catalog`, purging its files when `purge` is set and the catalog
+    supports it.
 
     Returns False when the table is not registered in `catalog`.
     """
     try:
-        try:
-            catalog.purge_table(table_id)
-        except NotImplementedError:
-            # not all catalogs implement purge, drop leaves files in place
-            catalog.drop_table(table_id)
+        if purge:
+            try:
+                catalog.purge_table(table_id)
+                return True
+            except (NotImplementedError, BadRequestError, ForbiddenError) as ex:
+                # purge is not implemented (hive) or rejected by the catalog server (e.g. Polaris
+                # returns 403 unless DROP_WITH_PURGE_ENABLED), drop leaves files in place
+                logger.info(
+                    f"Catalog {catalog.name} rejected purge of iceberg table {table_id}: {ex}."
+                    " Falling back to drop, table files are left in place."
+                )
+        catalog.drop_table(table_id)
         return True
     except NoSuchTableError:
         return False

--- a/dlt/destinations/impl/filesystem/configuration.py
+++ b/dlt/destinations/impl/filesystem/configuration.py
@@ -39,6 +39,10 @@ class FilesystemDestinationClientConfiguration(FilesystemConfigurationWithLocalF
     """Default Iceberg table properties applied to all tables; per-table adapter properties take precedence."""
     iceberg_namespace_properties: Optional[Dict[str, str]] = None
     """Properties passed to the Iceberg catalog when creating the namespace."""
+    iceberg_use_catalog_purge: bool = False
+    """When true, dropped iceberg tables are purged via the persistent catalog which may leave
+    files in place (e.g. rejected purge, deferred GC). When false, the table is dropped from
+    the catalog and dlt deletes the table files itself."""
 
     @resolve_type("credentials")
     def resolve_credentials_type(self) -> Type[CredentialsConfiguration]:

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -705,15 +705,15 @@ class FilesystemClient(
                 self._delete_file(filename)
 
     def _drop_open_table_in_catalog(self, table_name: str) -> bool:
-        """Returns True when a persistent catalog handled the drop and owns file deletion;
-        caller deletes table files otherwise."""
+        """Drops iceberg tables from a persistent catalog. Returns True when the catalog also
+        handles file deletion; caller deletes table files otherwise."""
         if table_name in self.schema.tables:
             if not self.is_open_table("iceberg", table_name):
                 return False
         else:
             # dropped tables may be gone from the schema, detect iceberg via the metadata dir
-            location = self.get_open_table_location("iceberg", table_name)
-            if not self.fs_client.exists(f"{location.rstrip('/')}/metadata"):
+            metadata_dir = self.pathlib.join(self.get_table_dir(table_name), "metadata")
+            if not self.fs_client.exists(metadata_dir):
                 return False
         try:
             from dlt.common.libs.pyiceberg import is_ephemeral_catalog, drop_iceberg_table
@@ -723,7 +723,13 @@ class FilesystemClient(
         catalog = self.get_open_table_catalog("iceberg")
         if is_ephemeral_catalog(catalog):
             return False
-        return drop_iceberg_table(catalog, f"{self.dataset_name}.{table_name}")
+        dropped = drop_iceberg_table(
+            catalog,
+            f"{self.dataset_name}.{table_name}",
+            purge=self.config.iceberg_use_catalog_purge,
+        )
+        # without catalog purge dlt deletes the table files itself
+        return dropped and self.config.iceberg_use_catalog_purge
 
     def get_storage_tables(
         self, table_names: Iterable[str]

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Tuple,
     Sequence,
+    Set,
     cast,
     Any,
     Dict,
@@ -78,6 +79,7 @@ from dlt.common.destination.exceptions import (
     OpenTableCatalogNotSupported,
     OpenTableFormatNotSupported,
 )
+from dlt.common.exceptions import MissingDependencyException
 from dlt.common.schema.exceptions import SchemaCorruptedException
 from dlt.destinations.job_impl import (
     ReferenceFollowupJobRequest,
@@ -201,8 +203,7 @@ class TableFormatLoadFilesystemJob(ReferenceFollowupJob):
 
 class DeltaLoadFilesystemJob(TableFormatLoadFilesystemJob):
     def run(self) -> None:
-        # create Arrow dataset from Parquet files
-        from dlt.common.libs.pyarrow import pyarrow as pa
+        from dlt.common.libs.pyarrow import pyarrow as pa, get_local_dataset_reader
         from dlt.common.libs.deltalake import (
             write_delta_table,
             merge_delta_table,
@@ -214,7 +215,6 @@ class DeltaLoadFilesystemJob(TableFormatLoadFilesystemJob):
             f"Will copy file(s) {self.file_paths} to delta table {self.make_remote_url()} [arrow"
             f" buffer: {pa.total_allocated_bytes()}]"
         )
-        source_ds = self.arrow_dataset
         storage_options = deltalake_storage_options(
             self._job_client.config.credentials,
             self._job_client.config.deltalake_storage_options,
@@ -226,7 +226,7 @@ class DeltaLoadFilesystemJob(TableFormatLoadFilesystemJob):
         except DestinationUndefinedEntity:
             delta_table = None
 
-        with source_ds.scanner().to_reader() as arrow_rbr:  # RecordBatchReader
+        with get_local_dataset_reader(self.file_paths) as arrow_rbr:  # RecordBatchReader
             if self._load_table["write_disposition"] == "merge" and delta_table is not None:
                 merge_delta_table(
                     table=delta_table,
@@ -246,7 +246,6 @@ class DeltaLoadFilesystemJob(TableFormatLoadFilesystemJob):
                     configuration=self._job_client.config.deltalake_configuration,
                 )
         # release memory ASAP by deleting objects explicitly
-        del source_ds
         del delta_table
         logger.info(
             f"Copied {self.file_paths} to delta table {self.make_remote_url()} [arrow buffer:"
@@ -532,6 +531,10 @@ class FilesystemClient(
         self._sql_client: SqlClientBase[Any] = None
         # iceberg catalog
         self._catalog: Any = None
+        # dataset names with namespaces created in the catalog
+        self._catalog_namespaces: Set[str] = set()
+        # tables receiving data files in this load, set in `verify_schema`
+        self._tables_with_jobs: Set[str] = set()
 
         # storage versions
         self._cached_initial_storage_version: int = None
@@ -605,8 +608,12 @@ class FilesystemClient(
         if truncate_tables and self.fs_client.isdir(self.dataset_path):
             # get all dirs with table data to delete. the table data are guaranteed to be files in those folders
             # TODO: when we do partitioning it is no longer the case and we may remove folders below instead
-            logger.info(f"Will truncate tables {truncate_tables}")
-            self.truncate_tables(list(truncate_tables))
+            truncate_names = [
+                t for t in truncate_tables if not self._replaced_atomically_in_load(t)
+            ]
+            if truncate_names:
+                logger.info(f"Will truncate tables {truncate_names}")
+                self.truncate_tables(truncate_names)
 
         # check if init file already exists
         if self.fs_client.exists(self.init_file_path):
@@ -687,13 +694,36 @@ class FilesystemClient(
         return initial_version, current_version
 
     def drop_tables(self, *tables: str, delete_schema: bool = True) -> None:
-        self.truncate_tables(list(tables))
+        wipe_names = [t for t in tables if not self._drop_open_table_in_catalog(t)]
+        if wipe_names:
+            self._delete_table_files(wipe_names)
         if not delete_schema:
             return
         # Delete all stored schemas
         for filename, fileparts in self._iter_stored_schema_files():
             if fileparts[0] == self.schema.name:
                 self._delete_file(filename)
+
+    def _drop_open_table_in_catalog(self, table_name: str) -> bool:
+        """Returns True when a persistent catalog handled the drop and owns file deletion;
+        caller deletes table files otherwise."""
+        if table_name in self.schema.tables:
+            if not self.is_open_table("iceberg", table_name):
+                return False
+        else:
+            # dropped tables may be gone from the schema, detect iceberg via the metadata dir
+            location = self.get_open_table_location("iceberg", table_name)
+            if not self.fs_client.exists(f"{location.rstrip('/')}/metadata"):
+                return False
+        try:
+            from dlt.common.libs.pyiceberg import is_ephemeral_catalog, drop_iceberg_table
+        except MissingDependencyException:
+            return False
+
+        catalog = self.get_open_table_catalog("iceberg")
+        if is_ephemeral_catalog(catalog):
+            return False
+        return drop_iceberg_table(catalog, f"{self.dataset_name}.{table_name}")
 
     def get_storage_tables(
         self, table_names: Iterable[str]
@@ -718,8 +748,60 @@ class FilesystemClient(
     def get_storage_table(self, table_name: str) -> Tuple[str, TTableSchemaColumns]:
         return list(self.get_storage_tables([table_name]))[0]
 
+    def _replaced_atomically_in_load(self, table_name: str) -> bool:
+        """Open tables with data jobs and replace disposition are overwritten atomically by
+        their load job and must not be truncated up front."""
+        if table_name not in self._tables_with_jobs:
+            return False
+        try:
+            table = self.prepare_load_table(table_name)
+        except TableNotFound:
+            return False
+        return (
+            table.get("table_format") in ("delta", "iceberg")
+            and table["write_disposition"] == "replace"
+        )
+
     def truncate_tables(self, table_names: List[str]) -> None:
-        """Truncate a set of regular tables with given `table_names`"""
+        """Truncates tables. Delta tables and iceberg tables in a persistent catalog are emptied
+        with a transactional delete that preserves the table and its history; all other tables
+        get their files deleted."""
+        wipe_names: List[str] = []
+        for table_name in table_names:
+            truncated = False
+            for table_format in ("delta", "iceberg"):
+                if self.is_open_table(table_format, table_name):
+                    truncated = self._truncate_open_table(table_format, table_name)
+                    break
+            if not truncated:
+                wipe_names.append(table_name)
+        if wipe_names:
+            self._delete_table_files(wipe_names)
+
+    def _truncate_open_table(self, table_format: TTableFormat, table_name: str) -> bool:
+        """Returns False when transactional truncate does not apply so caller falls back to
+        deleting table files."""
+        if table_format == "iceberg":
+            from dlt.common.libs.pyiceberg import is_ephemeral_catalog, truncate_iceberg_table
+
+            # ephemeral catalog tables are not tracked between loads, delete files instead
+            if is_ephemeral_catalog(self.get_open_table_catalog("iceberg")):
+                return False
+        try:
+            table = self.load_open_table(table_format, table_name)
+        except DestinationUndefinedEntity:
+            return False
+        if table_format == "delta":
+            from dlt.common.libs.deltalake import truncate_delta_table
+
+            truncate_delta_table(table)
+        else:
+            truncate_iceberg_table(table)
+        return True
+
+    def _delete_table_files(self, table_names: List[str]) -> None:
+        """Deletes all files belonging to `table_names`, including open table metadata and
+        transaction logs."""
         table_dirs = set(self.get_table_dirs(table_names))
         table_prefixes = [self.get_table_prefix(t) for t in table_names]
         for table_dir in table_dirs:
@@ -772,6 +854,7 @@ class FilesystemClient(
     def verify_schema(
         self, only_tables: Iterable[str] = None, new_jobs: Iterable[ParsedLoadJobFileName] = None
     ) -> List[PreparedTableSchema]:
+        self._tables_with_jobs = {job.table_name for job in new_jobs or ()}
         loaded_tables = super().verify_schema(only_tables, new_jobs)
         # TODO: finetune verify_schema_merge_disposition ie. hard deletes are not supported
         if exceptions := verify_schema_merge_disposition(
@@ -999,13 +1082,6 @@ class FilesystemClient(
 
     def should_load_data_to_staging_dataset(self, table_name: str) -> bool:
         return False
-
-    def should_truncate_table_before_load(self, table_name: str) -> bool:
-        table = self.prepare_load_table(table_name)
-        return table["write_disposition"] == "replace" and not table.get("table_format") in (
-            "delta",
-            "iceberg",
-        )  # Delta/Iceberg can do a logical replace
 
     #
     # state stuff
@@ -1258,9 +1334,7 @@ class FilesystemClient(
                     file_name = FileStorage.get_file_name_from_file_path(job_file_paths[0])
                     jobs.append(ReferenceFollowupJobRequest(file_name, job_file_paths))
                 else:
-                    # file_name = ParsedLoadJobFileName(table["name"], "empty", 0, "reference").file_name()
-                    # TODO: if we implement removal od orphaned rows, we may need to propagate such job without files
-                    # to the delta load job
+                    # jobless tables in replace chains are truncated in `initialize_storage`
                     pass
             return jobs
 
@@ -1319,33 +1393,30 @@ class FilesystemClient(
         if table_format != "iceberg":
             raise OpenTableCatalogNotSupported(table_format, "filesystem")
 
-        if self._catalog:
-            return self._catalog
+        if not self._catalog:
+            from dlt.common.libs.pyiceberg import get_catalog
 
-        from dlt.common.libs.pyiceberg import get_catalog, IcebergCatalog
-        from pyiceberg.exceptions import NamespaceAlreadyExistsError
-
-        catalog: IcebergCatalog
-
-        # Try to load catalog using new function
-        catalog = self._catalog = get_catalog(
-            iceberg_catalog_name=catalog_name or ConfigValue,
-            credentials=self.config.credentials,
-        )
-
-        logger.info(f"Successfully loaded catalog '{catalog.name}' ")
-
-        # Create namespace
-        try:
-            catalog.create_namespace(
-                self.dataset_name,
-                properties=self.config.iceberg_namespace_properties or {},
+            self._catalog = get_catalog(
+                iceberg_catalog_name=catalog_name or ConfigValue,
+                credentials=self.config.credentials,
             )
-            logger.info(f"Created Iceberg namespace: {self.dataset_name}")
-        except NamespaceAlreadyExistsError as e:
-            logger.debug(f"Namespace {self.dataset_name} already exists or error: {e}")
+            logger.info(f"Successfully loaded catalog '{self._catalog.name}' ")
 
-        return catalog
+        # create namespace for the active dataset, main and staging dataset share the catalog
+        if self.dataset_name not in self._catalog_namespaces:
+            from pyiceberg.exceptions import NamespaceAlreadyExistsError
+
+            try:
+                self._catalog.create_namespace(
+                    self.dataset_name,
+                    properties=self.config.iceberg_namespace_properties or {},
+                )
+                logger.info(f"Created Iceberg namespace: {self.dataset_name}")
+            except NamespaceAlreadyExistsError as e:
+                logger.debug(f"Namespace {self.dataset_name} already exists or error: {e}")
+            self._catalog_namespaces.add(self.dataset_name)
+
+        return self._catalog
 
     def get_open_table_location(
         self, table_format: TTableFormat, table_name: str, schema_name: Optional[str] = None

--- a/dlt/destinations/impl/lance/configuration.py
+++ b/dlt/destinations/impl/lance/configuration.py
@@ -305,6 +305,13 @@ class LanceClientConfiguration(WithLocalFiles, DestinationClientDwhConfiguration
     def storage_options(self) -> Optional[Dict[str, str]]:
         return self.storage.options if self.storage else None
 
+    @property
+    def manifest_enabled(self) -> Optional[bool]:
+        """Manifest mode setting of the catalog, `None` when the catalog has no such setting."""
+        if isinstance(self.capabilities, DirectoryCatalogCapabilities):
+            return self.capabilities.manifest_enabled
+        return None
+
     @resolve_type("credentials")
     def resolve_credentials_type(self) -> Type[CredentialsConfiguration]:
         return self.CATALOG_CREDENTIALS.get(self.catalog_type) or CredentialsConfiguration

--- a/dlt/destinations/impl/lance/configuration.py
+++ b/dlt/destinations/impl/lance/configuration.py
@@ -290,13 +290,7 @@ class LanceNamespaceHandle(NamedTuple):
 
 
 class LanceNamespacePool:
-    """Dispenses a shared namespace, session and storage options to job clients.
-
-    Piggybacks on the configuration being a singleton in the load step, like
-    `DuckDbConnectionPool`. The handle is rebuilt when rotatable storage credentials
-    change so refreshed tokens are picked up; it is retained at zero borrows to be
-    reused across load steps.
-    """
+    """Dispenses a shared namespace, session and storage options to job clients."""
 
     def __init__(self, config: "LanceClientConfiguration") -> None:
         self.config = config
@@ -309,6 +303,8 @@ class LanceNamespacePool:
         import lance
 
         with self._lock:
+            # refreshes default credentials on each borrow
+            # TODO: offload default credential chain to rust crate and remove this
             fresh_creds = self.config._fresh_storage_creds()
             if self._handle is None or fresh_creds != self._handle_creds:
                 storage_options = dict(self.config.storage_options or {}) | (fresh_creds or {})

--- a/dlt/destinations/impl/lance/configuration.py
+++ b/dlt/destinations/impl/lance/configuration.py
@@ -2,13 +2,28 @@ from __future__ import annotations
 
 import dataclasses
 import os
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Final, ClassVar, List, Type, Union
+import threading
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Literal,
+    NamedTuple,
+    Optional,
+    Final,
+    ClassVar,
+    List,
+    Type,
+    Union,
+)
 
 from dlt.common import logger
 from dlt.common.configuration import configspec
 from dlt.common.configuration.specs.base_configuration import (
     BaseConfiguration,
     CredentialsConfiguration,
+    CredentialsWithDefault,
+    NotResolved,
     resolve_type,
 )
 from dlt.common.configuration.specs.mixins import WithObjectStoreRsCredentials
@@ -19,8 +34,10 @@ from dlt.common.storages.configuration import (
     FilesystemConfigurationWithLocalFiles,
     WithLocalFiles,
 )
+from dlt.common.typing import Annotated
 
 if TYPE_CHECKING:
+    from lance import Session
     from lance_namespace import LanceNamespace
     from lancedb.embeddings import EmbeddingFunction, EmbeddingFunctionRegistry
 
@@ -266,6 +283,49 @@ class LanceEmbeddingsConfiguration(BaseConfiguration):
             )
 
 
+class LanceNamespaceHandle(NamedTuple):
+    namespace: "LanceNamespace"
+    session: "Session"
+    storage_options: Optional[Dict[str, str]]
+
+
+class LanceNamespacePool:
+    """Dispenses a shared namespace, session and storage options to job clients.
+
+    Piggybacks on the configuration being a singleton in the load step, like
+    `DuckDbConnectionPool`. The handle is rebuilt when rotatable storage credentials
+    change so refreshed tokens are picked up; it is retained at zero borrows to be
+    reused across load steps.
+    """
+
+    def __init__(self, config: "LanceClientConfiguration") -> None:
+        self.config = config
+        self._lock = threading.RLock()
+        self._borrows = 0
+        self._handle: Optional[LanceNamespaceHandle] = None
+        self._handle_creds: Optional[Dict[str, str]] = None
+
+    def borrow(self) -> LanceNamespaceHandle:
+        import lance
+
+        with self._lock:
+            fresh_creds = self.config._fresh_storage_creds()
+            if self._handle is None or fresh_creds != self._handle_creds:
+                storage_options = dict(self.config.storage_options or {}) | (fresh_creds or {})
+                self._handle = LanceNamespaceHandle(
+                    namespace=self.config.make_namespace(fresh_creds),
+                    session=lance.Session(),
+                    storage_options=storage_options or None,
+                )
+                self._handle_creds = fresh_creds
+            self._borrows += 1
+            return self._handle
+
+    def return_handle(self, handle: LanceNamespaceHandle) -> None:
+        with self._lock:
+            self._borrows = max(0, self._borrows - 1)
+
+
 @configspec
 class LanceClientConfiguration(WithLocalFiles, DestinationClientDwhConfiguration):
     destination_type: Final[str] = dataclasses.field(  # type: ignore
@@ -300,10 +360,29 @@ class LanceClientConfiguration(WithLocalFiles, DestinationClientDwhConfiguration
     always_refresh_views: bool = False
     """Recreate the duckdb scanner views on each query. Enable it to also pick up schema
     changes (new columns) through an already-open connection."""
+    namespace_pool: Annotated[Optional[LanceNamespacePool], NotResolved()] = None
 
     @property
     def storage_options(self) -> Optional[Dict[str, str]]:
         return self.storage.options if self.storage else None
+
+    def _fresh_storage_creds(self) -> Optional[Dict[str, str]]:
+        """Refreshed object-store credentials when backed by a default provider chain,
+        `None` for static credentials."""
+        creds = self.storage.credentials if self.storage else None
+        if (
+            isinstance(creds, CredentialsWithDefault)
+            and creds.has_default_credentials()
+            and isinstance(creds, WithObjectStoreRsCredentials)
+        ):
+            return creds.to_object_store_rs_credentials()
+        return None
+
+    def copy(self) -> "LanceClientConfiguration":
+        new_obj = super().copy()
+        # the pool holds threading state that must not be shared across copies
+        new_obj.namespace_pool = LanceNamespacePool(new_obj) if self.namespace_pool else None
+        return new_obj
 
     @property
     def manifest_enabled(self) -> Optional[bool]:
@@ -351,7 +430,9 @@ class LanceClientConfiguration(WithLocalFiles, DestinationClientDwhConfiguration
                 # explicit catalog location may be relative — re-run normalization under local_dir
                 self.credentials.normalize_bucket_url()
 
-    def make_namespace(self) -> "LanceNamespace":
+        self.namespace_pool = LanceNamespacePool(self)
+
+    def make_namespace(self, fresh_creds: Optional[Dict[str, str]] = None) -> "LanceNamespace":
         from lance_namespace import connect
 
         props: Dict[str, str] = {}
@@ -360,7 +441,9 @@ class LanceClientConfiguration(WithLocalFiles, DestinationClientDwhConfiguration
             assert isinstance(self.capabilities, DirectoryCatalogCapabilities)
             props["manifest_enabled"] = str(self.capabilities.manifest_enabled).lower()
             props["dir_listing_enabled"] = str(self.capabilities.dir_listing_enabled).lower()
-            for k, v in (self.credentials.options or {}).items():
+            # fresh credentials replace the options baked in at resolve time
+            options = dict(self.credentials.options or {}) | (fresh_creds or {})
+            for k, v in options.items():
                 if v is not None:
                     props[f"storage.{k}"] = str(v)
         elif isinstance(self.credentials, RestCatalogCredentials):

--- a/dlt/destinations/impl/lance/exceptions.py
+++ b/dlt/destinations/impl/lance/exceptions.py
@@ -1,6 +1,6 @@
 from functools import wraps
 import re
-from typing import Any, List
+from typing import Any, List, Optional
 
 from dlt.common.destination.exceptions import (
     DestinationException,
@@ -19,6 +19,7 @@ LANCE_MANIFEST_MODE = r"manifest\s+mode\s+is\s+enabled"
 LANCE_UNDEFINED_ENTITY_PATTERN = re.compile(
     rf"(?i){LANCE_NOT_FOUND}|{LANCE_DOES_NOT_EXIST}|{LANCE_MANIFEST_MODE}"
 )
+LANCE_MANIFEST_MODE_PATTERN = re.compile(rf"(?i){LANCE_MANIFEST_MODE}")
 
 
 class LanceEmbeddingsConfigurationMissing(DestinationTerminalException):
@@ -31,15 +32,39 @@ class LanceEmbeddingsConfigurationMissing(DestinationTerminalException):
         )
 
 
-def is_lance_undefined_entity_exception(e: Exception) -> bool:
+class LanceManifestMisconfiguration(DestinationTerminalException):
+    def __init__(self, original: Exception) -> None:
+        super().__init__(
+            "Manifest namespace failed to initialize and lance fell back to directory listing"
+            " while manifest mode is enabled in the configuration. Check storage credentials"
+            f" and connectivity. Original error: {original}"
+        )
+
+
+def is_lance_manifest_misconfiguration(e: Exception, manifest_enabled: Optional[bool]) -> bool:
+    """Tells if lance reports manifest mode as disabled while the configuration enables it,
+    which happens when the manifest namespace fails to initialize (eg. bad credentials)."""
+    return manifest_enabled is True and bool(LANCE_MANIFEST_MODE_PATTERN.search(str(e)))
+
+
+def is_lance_undefined_entity_exception(
+    e: Exception, manifest_enabled: Optional[bool] = None
+) -> bool:
     """Returns True if exception indicates an undefined entity (e.g. missing namespace, table, or branch).
 
-    Used to work around:
+    The message check covers untyped lance core errors:
     - bug: https://github.com/lance-format/lance/issues/6240
-    - fact that `LanceDataset.checkout_version()` raises `ValueError` with "not found" message if
-    version does not exist
+    - `checkout_version()` raises `ValueError` for a missing branch and `OSError` for a
+      missing version, both with "not found" messages
     """
-    return isinstance(e, (RuntimeError, ValueError)) and bool(
+    if is_lance_manifest_misconfiguration(e, manifest_enabled):
+        return False
+
+    from lance_namespace.errors import LanceNamespaceError
+
+    if isinstance(e, LanceNamespaceError):
+        return type(e).__name__.endswith("NotFoundError")
+    return isinstance(e, (RuntimeError, ValueError, OSError)) and bool(
         LANCE_UNDEFINED_ENTITY_PATTERN.search(str(e))
     )
 
@@ -53,7 +78,10 @@ def raise_destination_error(f: TFun) -> TFun:
             # already converted (eg. raised by a nested decorated call)
             raise
         except Exception as e:
-            if is_lance_undefined_entity_exception(e):
+            manifest_enabled = getattr(self.config, "manifest_enabled", None)
+            if is_lance_manifest_misconfiguration(e, manifest_enabled):
+                raise LanceManifestMisconfiguration(e) from e
+            if is_lance_undefined_entity_exception(e, manifest_enabled):
                 raise DestinationUndefinedEntity(e) from e
             raise DestinationTransientException(e) from e
 

--- a/dlt/destinations/impl/lance/jobs.py
+++ b/dlt/destinations/impl/lance/jobs.py
@@ -77,7 +77,7 @@ class LanceLoadJob(RunnableLoadJob):
 
     @staticmethod
     def _get_file_reader(file_path: str) -> pa.RecordBatchReader:
-        parquet_file = pa.parquet.ParquetFile(file_path)
-        return pa.RecordBatchReader.from_batches(
-            parquet_file.schema_arrow, parquet_file.iter_batches()
-        )
+        import pyarrow.dataset
+
+        # native reader: batches are pulled in the writer without per-batch GIL round trips
+        return pyarrow.dataset.dataset(file_path).scanner().to_reader()

--- a/dlt/destinations/impl/lance/jobs.py
+++ b/dlt/destinations/impl/lance/jobs.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, List
 
 from dlt.common import json
 from dlt.common.destination.client import HasFollowupJobs, RunnableLoadJob
-from dlt.common.libs.pyarrow import pyarrow as pa
+from dlt.common.libs.pyarrow import pyarrow as pa, get_local_dataset_reader
 from dlt.common.schema.typing import TTableSchema
 from dlt.common.schema.utils import is_nested_table
 from dlt.common.storages.load_package import (
@@ -28,10 +28,8 @@ LANCE_FRAGMENTS_STATE_KEY = "lance_fragments"
 
 
 def _get_file_reader(file_paths: List[str]) -> pa.RecordBatchReader:
-    import pyarrow.dataset
-
     # native reader: batches are pulled in the writer without per-batch GIL round trips
-    return pyarrow.dataset.dataset(file_paths).scanner().to_reader()
+    return get_local_dataset_reader(file_paths)
 
 
 class LanceLoadJob(RunnableLoadJob, HasFollowupJobs):

--- a/dlt/destinations/impl/lance/jobs.py
+++ b/dlt/destinations/impl/lance/jobs.py
@@ -1,21 +1,42 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
-from dlt.common.destination.client import RunnableLoadJob
+from dlt.common import json
+from dlt.common.destination.client import HasFollowupJobs, RunnableLoadJob
 from dlt.common.libs.pyarrow import pyarrow as pa
 from dlt.common.schema.typing import TTableSchema
 from dlt.common.schema.utils import is_nested_table
+from dlt.common.storages.load_package import (
+    ParsedLoadJobFileName,
+    commit_load_package_state,
+    destination_state,
+)
 from dlt.destinations.impl.lance.lance_adapter import REMOVE_ORPHANS_HINT
 from dlt.destinations.impl.lance.utils import (
     get_canonical_vector_database_doc_id_merge_key,
     create_in_filter,
 )
+from dlt.destinations.job_impl import ReferenceFollowupJobRequest
 from dlt.destinations.sql_jobs import SqlMergeFollowupJob
 
 if TYPE_CHECKING:
+    from lance import LanceDataset, LanceOperation
+    from lance.fragment import FragmentMetadata
+
     from dlt.destinations.impl.lance.lance_client import LanceClient
 
+LANCE_FRAGMENTS_STATE_KEY = "lance_fragments"
 
-class LanceLoadJob(RunnableLoadJob):
+
+def _get_file_reader(file_paths: List[str]) -> pa.RecordBatchReader:
+    import pyarrow.dataset
+
+    # native reader: batches are pulled in the writer without per-batch GIL round trips
+    return pyarrow.dataset.dataset(file_paths).scanner().to_reader()
+
+
+class LanceLoadJob(RunnableLoadJob, HasFollowupJobs):
+    """Writes data files as uncommitted lance fragments, `LanceCommitLoadJob` commits them."""
+
     def __init__(
         self,
         file_path: str,
@@ -26,29 +47,101 @@ class LanceLoadJob(RunnableLoadJob):
         self._table_schema: TTableSchema = table_schema
 
     def run(self) -> None:
+        from lance.fragment import write_fragments
+
+        table_name: str = self._table_schema["name"]
+        ds = self._job_client.open_lance_dataset(
+            table_name, branch_name=self._job_client.config.branch_name
+        )
+        records = self._job_client.prepare_records(_get_file_reader([self._file_path]), ds.schema)
+        # fragments are not visible until committed, concurrent jobs do not conflict
+        fragments = write_fragments(records, ds)
+        table_state = (
+            destination_state().setdefault(LANCE_FRAGMENTS_STATE_KEY, {}).setdefault(table_name, {})
+        )
+        # keyed by job id so a retried job replaces its own fragments
+        table_state[self._parsed_file_name.job_id()] = [f.to_json() for f in fragments]
+        commit_load_package_state()
+
+
+class LanceCommitLoadJob(RunnableLoadJob):
+    """Completes a table in a single lance commit: appends or overwrites the fragments
+    written by `LanceLoadJob`, or merges all job files at once."""
+
+    def __init__(self, file_path: str, table_schema: TTableSchema, restore: bool = False) -> None:
+        super().__init__(file_path)
+        self._job_client: LanceClient = None
+        self._table_schema: TTableSchema = table_schema
+        self._restore = restore
+        self.file_paths: List[str] = ReferenceFollowupJobRequest.resolve_references(file_path)
+
+    def run(self) -> None:
+        from lance import LanceDataset, LanceOperation
+
         table_name: str = self._table_schema["name"]
         write_disposition = self._load_table.get("write_disposition", "append")
+        ds = self._job_client.open_lance_dataset(
+            table_name, branch_name=self._job_client.config.branch_name
+        )
 
-        merge_key: str = None
-        when_not_matched_by_source_delete_expr: str = None
         if write_disposition == "merge":
-            # use deterministic and unique id as a merge column (to perform classical upsert)
-            # NOTE: upsert strategy generates deterministic row_key both for root and nested tables
-            merge_key = SqlMergeFollowupJob.get_row_key_col(
-                [self._load_table],
-                self._load_table,
-                self._job_client.dataset_name,
-                self._job_client.dataset_name,
+            self._merge(ds)
+            return
+
+        fragments = self._collect_fragments(table_name)
+        if write_disposition == "replace":
+            # a single Overwrite commit replaces the data, no truncate round trip.
+            # re-running it on job resume yields the same result
+            operation: "LanceOperation.BaseOperation" = LanceOperation.Overwrite(
+                ds.schema, fragments
             )
+        elif fragments:
+            # only a re-run job may have already committed: a crash or transient error
+            # between a successful commit and completing the job would duplicate the append
+            is_rerun = self._restore or self._parsed_file_name.retry_count > 0
+            if is_rerun and self._fragments_committed(ds, fragments):
+                return
+            operation = LanceOperation.Append(fragments)
+        else:
+            return
+        LanceDataset.commit(ds, operation, read_version=ds.version)
 
-            if self._load_table[REMOVE_ORPHANS_HINT]:  # type: ignore[literal-required]
-                when_not_matched_by_source_delete_expr = self._build_remove_orphans_scope_expr()
+    @staticmethod
+    def _fragments_committed(ds: "LanceDataset", fragments: List["FragmentMetadata"]) -> bool:
+        pending_file = fragments[0].files[0].path
+        return any(
+            pending_file == f.path for frag in ds.get_fragments() for f in frag.metadata.files
+        )
 
-        self._job_client.write_records(
-            self._get_file_reader(self._file_path),
-            table_name,
-            branch_name=self._job_client.config.branch_name,
-            write_disposition=write_disposition,
+    def _collect_fragments(self, table_name: str) -> List["FragmentMetadata"]:
+        from lance.fragment import FragmentMetadata
+
+        table_state = destination_state().get(LANCE_FRAGMENTS_STATE_KEY, {}).get(table_name, {})
+        job_ids = [ParsedLoadJobFileName.parse(p).job_id() for p in self.file_paths]
+        return [
+            FragmentMetadata.from_json(json.dumps(fragment))
+            for job_id in job_ids
+            for fragment in table_state.get(job_id, [])
+        ]
+
+    def _merge(self, ds: "LanceDataset") -> None:
+        # use deterministic and unique id as a merge column (to perform classical upsert)
+        # NOTE: upsert strategy generates deterministic row_key both for root and nested tables
+        merge_key = SqlMergeFollowupJob.get_row_key_col(
+            [self._load_table],
+            self._load_table,
+            self._job_client.dataset_name,
+            self._job_client.dataset_name,
+        )
+        when_not_matched_by_source_delete_expr: str = None
+        if self._load_table[REMOVE_ORPHANS_HINT]:  # type: ignore[literal-required]
+            when_not_matched_by_source_delete_expr = self._build_remove_orphans_scope_expr()
+
+        records = self._job_client.prepare_records(_get_file_reader(self.file_paths), ds.schema)
+        self._job_client._write_records(
+            ds,
+            records,
+            write_disposition="merge",
             merge_key=merge_key,
             when_not_matched_by_source_delete_expr=when_not_matched_by_source_delete_expr,
         )
@@ -72,12 +165,7 @@ class LanceLoadJob(RunnableLoadJob):
         )
         # unfortunately we need to load data into memory here before the write, but at least we can
         # scope it to just the key column
-        keys = pa.parquet.read_table(self._file_path, columns=[key_col])[key_col]
+        keys = pa.concat_tables(
+            pa.parquet.read_table(path, columns=[key_col]) for path in self.file_paths
+        )[key_col]
         return create_in_filter(key_col, keys)
-
-    @staticmethod
-    def _get_file_reader(file_path: str) -> pa.RecordBatchReader:
-        import pyarrow.dataset
-
-        # native reader: batches are pulled in the writer without per-batch GIL round trips
-        return pyarrow.dataset.dataset(file_path).scanner().to_reader()

--- a/dlt/destinations/impl/lance/lance_client.py
+++ b/dlt/destinations/impl/lance/lance_client.py
@@ -24,6 +24,7 @@ from lance.namespace import (
     NamespaceExistsRequest,
     TableExistsRequest,
 )
+from lance_namespace import LanceNamespace
 from lancedb.table import LanceTable, _append_vector_columns
 from lancedb.embeddings import EmbeddingFunctionConfig, EmbeddingFunctionRegistry
 from lancedb.namespace import LanceNamespaceDBConnection
@@ -59,6 +60,8 @@ from dlt.common.schema.utils import (
 from dlt.common.storages import ParsedLoadJobFileName
 from dlt.destinations.impl.lance.configuration import (
     LanceClientConfiguration,
+    LanceNamespaceHandle,
+    LanceNamespacePool,
 )
 from dlt.destinations.impl.lance.exceptions import (
     LanceEmbeddingsConfigurationMissing,
@@ -94,10 +97,10 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
         self.config: LanceClientConfiguration = config
         self.type_mapper = self.capabilities.get_type_mapper()
         self.dataset_name = self.config.normalize_dataset_name(self.schema)
-        self.namespace = self.config.make_namespace()
         self.embedding_function = (
             self.config.embeddings.create_embedding_function() if self.config.embeddings else None
         )
+        self._namespace_handle: Optional[LanceNamespaceHandle] = None
         self._sql_client: SqlClientBase[Any] = None
 
     def __enter__(self) -> LanceClient:
@@ -106,7 +109,23 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
     def __exit__(
         self, exc_type: Type[BaseException], exc_val: BaseException, exc_tb: TracebackType
     ) -> None:
-        pass
+        if self._namespace_handle is not None:
+            self.config.namespace_pool.return_handle(self._namespace_handle)
+            self._namespace_handle = None
+
+    @property
+    def namespace_handle(self) -> LanceNamespaceHandle:
+        """Borrows the shared namespace handle on first access, returned in `__exit__`."""
+        if self._namespace_handle is None:
+            if self.config.namespace_pool is None:
+                # hand-built configs that skipped resolution
+                self.config.namespace_pool = LanceNamespacePool(self.config)
+            self._namespace_handle = self.config.namespace_pool.borrow()
+        return self._namespace_handle
+
+    @property
+    def namespace(self) -> LanceNamespace:
+        return self.namespace_handle.namespace
 
     @property
     def sql_client_class(self) -> Type[LanceSQLClient]:  # type: ignore[override]
@@ -171,7 +190,7 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
             schema.empty_table(),
             namespace_client=self.namespace,
             table_id=self.make_table_id(table_name),
-            storage_options=self.config.storage_options,
+            storage_options=self.namespace_handle.storage_options,
         )
 
     @raise_destination_error
@@ -255,7 +274,8 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
         return lance.dataset(
             namespace_client=self.namespace,
             table_id=self.make_table_id(table_name),
-            storage_options=self.config.storage_options,
+            storage_options=self.namespace_handle.storage_options,
+            session=self.namespace_handle.session,
         ).checkout_version((branch_name, version_number))
 
     def open_lancedb_table(self, table_name: str) -> LanceTable:
@@ -263,7 +283,9 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
 
         This provides access to LanceDB-specific features like vector search.
         """
-        db = LanceNamespaceDBConnection(self.namespace, storage_options=self.config.storage_options)
+        db = LanceNamespaceDBConnection(
+            self.namespace, storage_options=self.namespace_handle.storage_options
+        )
         return db.open_table(table_name, namespace=self.make_namespace_id())
 
     @raise_destination_error

--- a/dlt/destinations/impl/lance/lance_client.py
+++ b/dlt/destinations/impl/lance/lance_client.py
@@ -160,7 +160,7 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
             self.namespace.namespace_exists(NamespaceExistsRequest(id=self.make_namespace_id()))
             return True
         except Exception as e:
-            if is_lance_undefined_entity_exception(e):
+            if is_lance_undefined_entity_exception(e, self.config.manifest_enabled):
                 return False
             raise
 
@@ -169,7 +169,7 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
         """Creates empty lance dataset from provided PyArrow schema."""
         lance.write_dataset(
             schema.empty_table(),
-            namespace=self.namespace,
+            namespace_client=self.namespace,
             table_id=self.make_table_id(table_name),
             storage_options=self.config.storage_options,
         )
@@ -185,7 +185,7 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
             self.namespace.table_exists(TableExistsRequest(id=self.make_table_id(table_name)))
             return True
         except Exception as e:
-            if is_lance_undefined_entity_exception(e):
+            if is_lance_undefined_entity_exception(e, self.config.manifest_enabled):
                 return False
             raise
 
@@ -253,7 +253,7 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
             LanceDataset: The dataset checked out at the specified branch and version.
         """
         return lance.dataset(
-            namespace=self.namespace,
+            namespace_client=self.namespace,
             table_id=self.make_table_id(table_name),
             storage_options=self.config.storage_options,
         ).checkout_version((branch_name, version_number))
@@ -405,7 +405,7 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
             # `open_lance_dataset` already mapped a missing table/namespace to this exception
             return False, table_schema
         except Exception as e:
-            if is_lance_undefined_entity_exception(e):
+            if is_lance_undefined_entity_exception(e, self.config.manifest_enabled):
                 return False, table_schema
             raise
 

--- a/dlt/destinations/impl/lance/lance_client.py
+++ b/dlt/destinations/impl/lance/lance_client.py
@@ -293,10 +293,18 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
 
         This provides access to LanceDB-specific features like vector search.
         """
+        # NOTE: the pooled `lance.Session` cannot be shared here, lancedb requires its own
+        # session type
         db = LanceNamespaceDBConnection(
             self.namespace, storage_options=self.namespace_handle.storage_options
         )
-        table = db.open_table(table_name, namespace_path=self.make_namespace_id())
+        # storage options must be repeated per call: connection-level options are not
+        # applied when the namespace connection opens the table dataset
+        table = db.open_table(
+            table_name,
+            namespace_path=self.make_namespace_id(),
+            storage_options=self.namespace_handle.storage_options,
+        )
         # lancedb bug: `LanceTable._dataset_uri` reads the connection `_uri` which namespace
         # connections never set, unlike `_dataset_path` which honors the table location.
         # seed the cached property with the real table uri

--- a/dlt/destinations/impl/lance/lance_client.py
+++ b/dlt/destinations/impl/lance/lance_client.py
@@ -6,6 +6,8 @@ from typing import (
     Dict,
     List,
     Any,
+    Sequence,
+    Set,
     Union,
     Tuple,
     Iterable,
@@ -38,6 +40,7 @@ from dlt.common.destination.exceptions import (
     DestinationTerminalException,
 )
 from dlt.common.destination.client import (
+    FollowupJobRequest,
     JobClientBase,
     PreparedTableSchema,
     WithStateSync,
@@ -45,6 +48,8 @@ from dlt.common.destination.client import (
     StateInfo,
     LoadJob,
 )
+from dlt.common.storages import FileStorage
+from dlt.common.storages.load_package import LoadJobInfo
 from dlt.common.schema import Schema, TSchemaTables
 from dlt.common.schema.typing import (
     C_DLT_LOADS_TABLE_LOAD_ID,
@@ -68,7 +73,11 @@ from dlt.destinations.impl.lance.exceptions import (
     is_lance_undefined_entity_exception,
     raise_destination_error,
 )
-from dlt.destinations.impl.lance.jobs import LanceLoadJob
+from dlt.destinations.impl.lance.jobs import LanceCommitLoadJob, LanceLoadJob
+from dlt.destinations.job_impl import (
+    FinalizedLoadJobWithFollowupJobs,
+    ReferenceFollowupJobRequest,
+)
 from dlt.destinations.impl.lance.lance_adapter import (
     DEFAULT_REMOVE_ORPHANS,
     VECTORIZE_HINT,
@@ -101,6 +110,7 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
             self.config.embeddings.create_embedding_function() if self.config.embeddings else None
         )
         self._namespace_handle: Optional[LanceNamespaceHandle] = None
+        self._tables_with_jobs: Set[str] = set()
         self._sql_client: SqlClientBase[Any] = None
 
     def __enter__(self) -> LanceClient:
@@ -286,7 +296,12 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
         db = LanceNamespaceDBConnection(
             self.namespace, storage_options=self.namespace_handle.storage_options
         )
-        return db.open_table(table_name, namespace=self.make_namespace_id())
+        table = db.open_table(table_name, namespace_path=self.make_namespace_id())
+        # lancedb bug: `LanceTable._dataset_uri` reads the connection `_uri` which namespace
+        # connections never set, unlike `_dataset_path` which honors the table location.
+        # seed the cached property with the real table uri
+        table.__dict__["_dataset_uri"] = self.get_table_uri(table_name)
+        return table
 
     @raise_destination_error
     def _write_records(
@@ -309,6 +324,13 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
                 )
             merge_builder.execute(records)
 
+    def prepare_records(
+        self, records: pa.RecordBatchReader, schema: pa.Schema
+    ) -> pa.RecordBatchReader:
+        """Adds embedding columns and casts records to the target dataset schema."""
+        records = _append_vector_columns(records, schema=schema)
+        return _cast_to_target_types(records, schema)
+
     def write_records(
         self,
         records: Union[pa.RecordBatchReader, List[Dict[str, Any]]],
@@ -324,8 +346,7 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
         ds = self.open_lance_dataset(table_name, branch_name=branch_name)
 
         if isinstance(records, pa.RecordBatchReader):
-            records = _append_vector_columns(records, schema=ds.schema)
-            records = _cast_to_target_types(records, ds.schema)
+            records = self.prepare_records(records, ds.schema)
 
         self._write_records(
             ds,
@@ -340,6 +361,13 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
             self.create_dataset_namespace()
         elif truncate_tables:
             for table_name in truncate_tables:
+                if (
+                    table_name in self._tables_with_jobs
+                    and self.prepare_load_table(table_name)["write_disposition"] == "replace"
+                ):
+                    # replaced atomically by the single Overwrite commit of the table chain.
+                    # append tables truncated via refresh still need the truncation
+                    continue
                 if not self.table_exists(table_name):
                     continue
                 self.truncate_table(table_name)
@@ -350,6 +378,8 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
     def verify_schema(
         self, only_tables: Iterable[str] = None, new_jobs: Iterable[ParsedLoadJobFileName] = None
     ) -> List[PreparedTableSchema]:
+        # tables receiving data files are not truncated in `initialize_storage`
+        self._tables_with_jobs = {job.table_name for job in new_jobs or ()}
         loaded_tables = super().verify_schema(only_tables, new_jobs)
 
         for load_table in loaded_tables:
@@ -642,4 +672,30 @@ class LanceClient(JobClientBase, WithStateSync, WithSqlClient):
     def create_load_job(
         self, table: PreparedTableSchema, file_path: str, load_id: str, restore: bool = False
     ) -> LoadJob:
+        if ReferenceFollowupJobRequest.is_reference_job(file_path):
+            return LanceCommitLoadJob(file_path, table, restore=restore)
+        if table["write_disposition"] == "merge":
+            # all job files of the table merge in one commit in `LanceCommitLoadJob`
+            return FinalizedLoadJobWithFollowupJobs(file_path)
         return LanceLoadJob(file_path, table)
+
+    def create_table_chain_completed_followup_jobs(
+        self,
+        table_chain: Sequence[PreparedTableSchema],
+        completed_table_chain_jobs: Optional[Sequence[LoadJobInfo]] = None,
+    ) -> List[FollowupJobRequest]:
+        assert completed_table_chain_jobs is not None
+        jobs = super().create_table_chain_completed_followup_jobs(
+            table_chain, completed_table_chain_jobs
+        )
+        # one commit job per table over all its completed job files
+        for table in table_chain:
+            file_paths = [
+                job.file_path
+                for job in completed_table_chain_jobs
+                if job.job_file_info.table_name == table["name"]
+            ]
+            if file_paths:
+                file_name = FileStorage.get_file_name_from_file_path(file_paths[0])
+                jobs.append(ReferenceFollowupJobRequest(file_name, file_paths))
+        return jobs

--- a/docs/website/docs/dlt-ecosystem/destinations/delta-iceberg.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/delta-iceberg.md
@@ -80,6 +80,9 @@ delta_tables["another_delta_table"].optimize.z_order(["col_a", "col_b"])
 # etc.
 ```
 
+## Table truncation
+When dlt truncates a Delta table — with [`refresh="drop_data"`](../../general-usage/pipeline.md#refresh-pipeline-data-and-state) or for tables in a `replace` chain that receive no data — it runs a transactional delete that commits a new table version with no rows. The table, its schema, and version history stay intact, so readers are never exposed to a partially deleted table. Physical Parquet files are retained for time travel until you run `vacuum`.
+
 ## Google Cloud Storage authentication
 
 Note that not all authentication methods are supported when using Delta table format on Google Cloud Storage:

--- a/docs/website/docs/dlt-ecosystem/destinations/iceberg.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/iceberg.md
@@ -98,8 +98,12 @@ That's it!
 ## Table truncation and drop
 How dlt empties or drops Iceberg tables depends on the catalog:
 
-- **Persistent catalog** (configured as above): truncation — with [`refresh="drop_data"`](../../general-usage/pipeline.md#refresh-pipeline-data-and-state) or for tables in a `replace` chain that receive no data — is a transactional delete that keeps the table registered and its snapshot history intact. Dropping a table (e.g. with `refresh="drop_sources"`) delegates to the catalog's `purge_table`, which removes the table from the catalog and deletes its files. Catalogs that do not support purging fall back to `drop_table` and leave the files in place.
+- **Persistent catalog** (configured as above): truncation — with [`refresh="drop_data"`](../../general-usage/pipeline.md#refresh-pipeline-data-and-state) or for tables in a `replace` chain that receive no data — is a transactional delete that keeps the table registered and its snapshot history intact. Dropping a table (e.g. with `refresh="drop_sources"`) removes it from the catalog and dlt deletes the table files itself. Set `destination.filesystem.iceberg_use_catalog_purge` to `true` to delegate file deletion to the catalog's `purge_table` instead — note that catalogs may then leave files in place (Polaris rejects purge unless `DROP_WITH_PURGE_ENABLED` is set, Nessie defers file cleanup to its GC, others purge asynchronously).
 - **Ephemeral catalog** (the default in-memory fallback): dlt deletes the table files directly, removing the table entirely; it is recreated on the next load.
+
+:::caution
+With `iceberg_use_catalog_purge` enabled, dlt recreates dropped tables at the same name and location while the catalog may still be cleaning them up. Behavior depends on the catalog: when files are left in place (Nessie, rejected purge) the next load re-registers the old table metadata and resurrects its data; catalogs with soft deletes or asynchronous cleanup may reject the recreation with a conflict (Lakekeeper, Gravitino) or, for Lakekeeper hard deletes, purge the recreated table's files. Keep `iceberg_use_catalog_purge` disabled unless you understand your catalog's drop semantics.
+:::
 
 ## Set table format
 

--- a/docs/website/docs/dlt-ecosystem/destinations/iceberg.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/iceberg.md
@@ -95,6 +95,12 @@ s3.region = "eu-fr-1"                                 # DLT_ICEBERG_CATALOG__ICE
 
 That's it!
 
+## Table truncation and drop
+How dlt empties or drops Iceberg tables depends on the catalog:
+
+- **Persistent catalog** (configured as above): truncation — with [`refresh="drop_data"`](../../general-usage/pipeline.md#refresh-pipeline-data-and-state) or for tables in a `replace` chain that receive no data — is a transactional delete that keeps the table registered and its snapshot history intact. Dropping a table (e.g. with `refresh="drop_sources"`) delegates to the catalog's `purge_table`, which removes the table from the catalog and deletes its files. Catalogs that do not support purging fall back to `drop_table` and leave the files in place.
+- **Ephemeral catalog** (the default in-memory fallback): dlt deletes the table files directly, removing the table entirely; it is recreated on the next load.
+
 ## Set table format
 
 Set the `table_format` argument to `iceberg` when defining your resource:

--- a/docs/website/docs/dlt-ecosystem/destinations/lance.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/lance.md
@@ -182,6 +182,10 @@ dir_listing_enabled = true
 
 **When to disable `manifest_enabled`**: if many writers hit the same catalog root concurrently (for example, multiple pipelines or parallel jobs sharing one `bucket_url`/`namespace_name`), conflicting commits to the shared `__manifest` table on S3/GCS can cause contention and retries. Disabling the manifest eliminates the shared write point at the cost of slower listing and no nested-namespace support. If you disable it, give each pipeline run its own `namespace_name` to isolate datasets.
 
+:::note
+You can disable `manifest_enabled` only when the pipeline does not use a `dataset_name`: dlt creates the dataset as a child namespace, which requires manifest mode (loads fail with `Child namespaces are only supported when manifest mode is enabled`). Without a `dataset_name`, tables live in the root namespace and the catalog works with plain directory listing — no `__manifest` commits on table creation and no manifest reads when opening tables, which also makes loads noticeably faster on object stores.
+:::
+
 ### REST Namespace (experimental)
 
 :::warning

--- a/docs/website/docs/dlt-ecosystem/destinations/lance.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/lance.md
@@ -30,6 +30,8 @@ The `lancedb` destination will be phased out in favor of `lance`.
 pip install "dlt[lance]"
 ```
 
+The `lance` extra requires Python 3.10+ and installs `pylance>=6.0.1`.
+
 ### Quick start
 
 ```py
@@ -248,17 +250,26 @@ Any field left empty under `credentials` falls back to the corresponding `storag
 
 All [write dispositions](../../general-usage/incremental-loading.md#choosing-a-write-disposition) are supported.
 
+Each table receives a single lance commit per load, regardless of how many job files the
+load produces: load jobs write data fragments in parallel without committing and a followup
+job commits them in one atomic version. Readers never observe a partially loaded table and
+parallel jobs do not contend on dataset versions.
+
 ### Append
 
 The default. Inserts all records without updating or deleting existing data.
 
 ### Replace
 
-Replaces all data in the table using a truncate-and-insert strategy:
+Replaces all data in the table with a single overwrite commit:
 
 ```py
 info = pipeline.run(movies, table_name="movies", write_disposition="replace")
 ```
+
+Tables of a replaced resource that receive no data in a load (e.g. a nested table absent
+from the current run) are truncated before loading; tables receiving data are replaced
+atomically by their overwrite commit, without an intermediate truncation.
 
 ### Merge (upsert)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,8 +187,8 @@ lancedb = [
     "ibis-framework>=12.0.0 ; python_version >= '3.10'"
 ]
 lance = [
-    "pylance>=4.0.0",
-    "lancedb>=0.22.0",
+    "pylance>=6.0.1,<8 ; python_version >= '3.10'",
+    "lancedb>=0.33.0 ; python_version >= '3.10'",
     "pyarrow>=16.0.0",
     "duckdb>=1.4.3",
     "ibis-framework>=12.0.0 ; python_version >= '3.10'"

--- a/tests/common/libs/test_pyiceberg.py
+++ b/tests/common/libs/test_pyiceberg.py
@@ -10,13 +10,15 @@ from dlt.common.typing import ConfigValue
 # Skip entire module if SQLAlchemy 2.0 is not installed (required by pyiceberg)
 sqlalchemy = pytest.importorskip("sqlalchemy", minversion="2.0")
 
+import pyarrow as pa
+
 from dlt.common.libs.pyiceberg import (
     get_catalog,
+    get_sql_catalog,
+    is_ephemeral_catalog,
+    truncate_iceberg_table,
+    drop_iceberg_table,
 )
-
-# ============================================================================
-# HELPER FUNCTIONS
-# ============================================================================
 
 
 def is_service_available(host: str, port: int, timeout: float = 1.0) -> bool:
@@ -26,11 +28,6 @@ def is_service_available(host: str, port: int, timeout: float = 1.0) -> bool:
             return True
     except (socket.timeout, OSError):
         return False
-
-
-# ============================================================================
-# FIXTURES
-# ============================================================================
 
 
 @pytest.fixture
@@ -156,9 +153,54 @@ def test_persistence_of_sqlite_catalog(tmp_path):
     assert test_namespace in [ns[0] if isinstance(ns, tuple) else ns for ns in namespaces2]
 
 
-# ============================================================================
-# INTEGRATION / SMOKE TESTS
-# ============================================================================
+def test_is_ephemeral_catalog(tmp_path):
+    assert is_ephemeral_catalog(get_sql_catalog("eph", "sqlite:///:memory:", None))
+    assert not is_ephemeral_catalog(
+        get_sql_catalog("persistent", f"sqlite:///{tmp_path / 'cat.db'}", None)
+    )
+
+
+def test_truncate_and_drop_iceberg_table(sqlite_catalog_config, monkeypatch):
+    from pyiceberg.exceptions import NoSuchTableError
+
+    catalog = get_catalog("truncate_drop_catalog", iceberg_catalog_config=sqlite_catalog_config)
+    catalog.create_namespace("test_ns")
+    data = pa.table({"id": [1, 2, 3]})
+    table = catalog.create_table("test_ns.items", schema=data.schema)
+    table.append(data)
+    assert table.scan().to_arrow().num_rows == 3
+    snapshot_count = len(table.metadata.snapshots)
+
+    # truncate keeps the table registered with a new snapshot
+    truncate_iceberg_table(table)
+    table = catalog.load_table("test_ns.items")
+    assert table.scan().to_arrow().num_rows == 0
+    assert len(table.metadata.snapshots) > snapshot_count
+
+    # drop purges files and unregisters the table
+    table_dir = table.location().removeprefix("file://")
+    assert drop_iceberg_table(catalog, "test_ns.items") is True
+    with pytest.raises(NoSuchTableError):
+        catalog.load_table("test_ns.items")
+    assert not any(f.endswith((".parquet", ".json")) for f in _list_files(table_dir))
+    # dropping unregistered table reports False
+    assert drop_iceberg_table(catalog, "test_ns.items") is False
+
+    # purge not implemented falls back to drop which leaves files in place
+    table = catalog.create_table("test_ns.kept_files", schema=data.schema)
+    table.append(data)
+    table_dir = table.location().removeprefix("file://")
+    monkeypatch.setattr(
+        catalog, "purge_table", mock.Mock(side_effect=NotImplementedError), raising=True
+    )
+    assert drop_iceberg_table(catalog, "test_ns.kept_files") is True
+    with pytest.raises(NoSuchTableError):
+        catalog.load_table("test_ns.kept_files")
+    assert any(f.endswith(".parquet") for f in _list_files(table_dir))
+
+
+def _list_files(root: str):
+    return [os.path.join(dir_, f) for dir_, _, files in os.walk(root) for f in files]
 
 
 def test_priority_explicit_config_over_pyiceberg(tmp_path, monkeypatch):

--- a/tests/common/libs/test_pyiceberg.py
+++ b/tests/common/libs/test_pyiceberg.py
@@ -1,5 +1,7 @@
 import os
 import socket
+from pathlib import Path
+
 import yaml
 import pytest
 from unittest import mock
@@ -166,7 +168,11 @@ def test_truncate_and_drop_iceberg_table(sqlite_catalog_config, monkeypatch):
     catalog = get_catalog("truncate_drop_catalog", iceberg_catalog_config=sqlite_catalog_config)
     catalog.create_namespace("test_ns")
     data = pa.table({"id": [1, 2, 3]})
-    table = catalog.create_table("test_ns.items", schema=data.schema)
+    warehouse = Path(sqlite_catalog_config["warehouse"])
+    items_dir = warehouse / "items"
+    table = catalog.create_table(
+        "test_ns.items", schema=data.schema, location=_table_location(items_dir)
+    )
     table.append(data)
     assert table.scan().to_arrow().num_rows == 3
     snapshot_count = len(table.metadata.snapshots)
@@ -178,28 +184,51 @@ def test_truncate_and_drop_iceberg_table(sqlite_catalog_config, monkeypatch):
     assert len(table.metadata.snapshots) > snapshot_count
 
     # drop purges files and unregisters the table
-    table_dir = table.location().removeprefix("file://")
     assert drop_iceberg_table(catalog, "test_ns.items") is True
     with pytest.raises(NoSuchTableError):
         catalog.load_table("test_ns.items")
-    assert not any(f.endswith((".parquet", ".json")) for f in _list_files(table_dir))
+    assert not any(f.endswith((".parquet", ".json")) for f in _list_files(items_dir))
     # dropping unregistered table reports False
     assert drop_iceberg_table(catalog, "test_ns.items") is False
 
-    # purge not implemented falls back to drop which leaves files in place
-    table = catalog.create_table("test_ns.kept_files", schema=data.schema)
-    table.append(data)
-    table_dir = table.location().removeprefix("file://")
-    monkeypatch.setattr(
-        catalog, "purge_table", mock.Mock(side_effect=NotImplementedError), raising=True
+    # drop with purge disabled leaves files in place
+    no_purge_dir = warehouse / "no_purge"
+    table = catalog.create_table(
+        "test_ns.no_purge", schema=data.schema, location=_table_location(no_purge_dir)
     )
-    assert drop_iceberg_table(catalog, "test_ns.kept_files") is True
+    table.append(data)
+    assert drop_iceberg_table(catalog, "test_ns.no_purge", purge=False) is True
     with pytest.raises(NoSuchTableError):
-        catalog.load_table("test_ns.kept_files")
-    assert any(f.endswith(".parquet") for f in _list_files(table_dir))
+        catalog.load_table("test_ns.no_purge")
+    assert any(f.endswith(".parquet") for f in _list_files(no_purge_dir))
+
+    # rejected purge falls back to drop which leaves files in place: NotImplementedError is
+    # raised by python catalogs (hive), 400/403 by REST catalog servers (glue, polaris)
+    from pyiceberg.exceptions import BadRequestError, ForbiddenError
+
+    for idx, purge_error in enumerate((NotImplementedError, BadRequestError, ForbiddenError)):
+        table_name = f"test_ns.kept_files_{idx}"
+        table_dir = warehouse / f"kept_files_{idx}"
+        table = catalog.create_table(
+            table_name, schema=data.schema, location=_table_location(table_dir)
+        )
+        table.append(data)
+        monkeypatch.setattr(
+            catalog, "purge_table", mock.Mock(side_effect=purge_error), raising=True
+        )
+        assert drop_iceberg_table(catalog, table_name) is True
+        with pytest.raises(NoSuchTableError):
+            catalog.load_table(table_name)
+        assert any(f.endswith(".parquet") for f in _list_files(table_dir))
 
 
-def _list_files(root: str):
+def _table_location(path) -> str:
+    uri = path.as_uri()
+    # pyiceberg cannot deal with windows absolute file urls
+    return uri.replace("file:///", "file://") if os.name == "nt" else uri
+
+
+def _list_files(root):
     return [os.path.join(dir_, f) for dir_, _, files in os.walk(root) for f in files]
 
 

--- a/tests/libs/test_ibis.py
+++ b/tests/libs/test_ibis.py
@@ -16,9 +16,6 @@ import dlt
 from dlt.common.libs.ibis import _DltBackend
 from dlt.common.libs.pyarrow import pyarrow as pa
 
-from tests.load.lance_utils import (
-    module_lance_rest_server,  # consumed by `populated_pipeline` fixture
-)
 from tests.load.test_read_interfaces import (
     populated_pipeline,
     preserve_module_environ_per_destination_config,

--- a/tests/load/conftest.py
+++ b/tests/load/conftest.py
@@ -3,7 +3,6 @@ from typing import Iterator
 
 import pytest
 
-from tests.load.lance_utils import lance_rest_server, cleanup_lance_namespace_root
 from tests.load.utils import (
     ALL_BUCKETS,
     DEFAULT_BUCKETS,

--- a/tests/load/conftest.py
+++ b/tests/load/conftest.py
@@ -3,7 +3,7 @@ from typing import Iterator
 
 import pytest
 
-from tests.load.lance_utils import lance_rest_server
+from tests.load.lance_utils import lance_rest_server, cleanup_lance_namespace_root
 from tests.load.utils import (
     ALL_BUCKETS,
     DEFAULT_BUCKETS,

--- a/tests/load/lance/conftest.py
+++ b/tests/load/lance/conftest.py
@@ -1,0 +1,1 @@
+from tests.load.lance.lance_utils import lance_rest_server, cleanup_lance_namespace_root

--- a/tests/load/lance/lance_utils.py
+++ b/tests/load/lance/lance_utils.py
@@ -2,19 +2,20 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 import os
-from typing import TYPE_CHECKING, Iterator, Optional
+from typing import Iterator, List, Optional
 import pytest
 
-from dlt.common.utils import uniq_id
 from dlt.common.configuration.resolve import resolve_configuration
 from dlt.common.storages.configuration import FilesystemConfiguration
 from dlt.common.storages.fsspec_filesystem import fsspec_from_config
 
-from tests.load.utils import FILE_BUCKET, OBJECT_STORE_RS_BUCKETS
-from tests.utils import get_test_storage_root, get_test_worker_id, get_test_worker_idx
-
-if TYPE_CHECKING:
-    from tests.load.utils import DestinationTestConfiguration
+from tests.load.utils import (
+    FILE_BUCKET,
+    OBJECT_STORE_RS_BUCKETS,
+    DestinationTestConfiguration,
+    get_lance_namespace_name,
+)
+from tests.utils import get_test_storage_root, get_test_worker_idx
 
 
 _LANCE_REST_SERVER_ACTIVE = False
@@ -56,14 +57,21 @@ class LanceRestServerConfig:
         }
 
 
-# random per test session: a shared root accumulates a `__manifest` version per namespace
-# mutation, slowing all namespace operations down with every test run
-_LANCE_ROOT_SUFFIX = uniq_id(4)
+def lance_rest_destination_configs() -> List[DestinationTestConfiguration]:
+    """REST namespace lance configs backed by the in-process test REST server.
 
-
-def get_lance_namespace_name() -> str:
-    # isolate per xdist worker — Lance __manifest writes conflict on S3
-    return f"dlt_lance_root_{get_test_worker_id()}_{_LANCE_ROOT_SUFFIX}"
+    Only local storage-backed REST namespaces are included: `RestAdapter` (our test REST
+    Namespace server) does not vend credentials, so cloud-bucket REST namespaces are excluded.
+    """
+    return [
+        DestinationTestConfiguration(
+            destination_type="lance",
+            extra_info=f"rest-{FilesystemConfiguration.parse_protocol(bucket)}",
+            env_vars=LanceRestServerConfig.get_destination_test_configuration_env_vars(),
+        )
+        for bucket in OBJECT_STORE_RS_BUCKETS
+        if bucket == FILE_BUCKET
+    ]
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -96,8 +104,6 @@ def extract_destination_test_configuration(
     if "destination_config" in request.fixturenames:
         return request.getfixturevalue("destination_config")
 
-    from tests.load.utils import DestinationTestConfiguration
-
     callspec = getattr(request.node, "callspec", None)
     if callspec is None:
         return None
@@ -119,14 +125,12 @@ def maybe_lance_rest_server(
     """Starts ephemeral in-process Lance REST server if not already active and `destination_config` needs it."""
     global _LANCE_REST_SERVER_ACTIVE
 
-    # NOTE: the module-scoped fixture may have already started the server for the entire module, in
-    # which case we can skip starting it again for the auto-used function-scoped fixture
+    # guard against re-entry if the server is already running for the current test
     if _LANCE_REST_SERVER_ACTIVE or not LanceRestServerConfig.needs_fixture(destination_config):
         yield
         return
 
     from lance.namespace import RestAdapter
-    from tests.load.utils import FILE_BUCKET
 
     root = os.path.join(get_test_storage_root(), FILE_BUCKET, get_lance_namespace_name())
     _LANCE_REST_SERVER_ACTIVE = True
@@ -146,13 +150,4 @@ def maybe_lance_rest_server(
 def lance_rest_server(request: pytest.FixtureRequest) -> Iterator[None]:
     """Starts function-scoped ephemeral in-process Lance REST server if needed."""
     with maybe_lance_rest_server(extract_destination_test_configuration(request)):
-        yield
-
-
-@pytest.fixture(scope="module")
-def module_lance_rest_server(
-    destination_config: Optional[DestinationTestConfiguration],
-) -> Iterator[None]:
-    """Starts module-scoped ephemeral in-process Lance REST server if needed."""
-    with maybe_lance_rest_server(destination_config):
         yield

--- a/tests/load/lance/test_lance_client.py
+++ b/tests/load/lance/test_lance_client.py
@@ -33,6 +33,23 @@ def client_with_storage() -> Iterator[LanceClient]:
     yield from cast(Iterator[LanceClient], yield_client_with_storage("lance"))
 
 
+def test_lance_client_borrows_shared_namespace(client: LanceClient) -> None:
+    client_namespace = client.namespace
+    pool = client.config.namespace_pool
+    base_borrows = pool._borrows
+
+    other = LanceClient(client.schema, client.config, client.capabilities)
+    # namespace borrowed lazily from the shared pool
+    assert other.namespace is client_namespace
+    assert pool._borrows == base_borrows + 1
+
+    # handle returned on context exit and re-borrowed on next access
+    other.__exit__(None, None, None)
+    assert other._namespace_handle is None
+    assert pool._borrows == base_borrows
+    assert other.namespace is client_namespace
+
+
 def test_lance_client_dataset_namespace_and_table_methods(client: LanceClient) -> None:
     # create dataset namespace
     assert not client.dataset_namespace_exists()

--- a/tests/load/lance/test_lance_client.py
+++ b/tests/load/lance/test_lance_client.py
@@ -147,7 +147,7 @@ def test_lance_client_write_records_into_branch(client_with_storage: LanceClient
 
 
 def test_lance_client_write_records_matches_lancedb_table_add(
-    client_with_storage: LanceClient, tmp_path: str
+    client_with_storage: LanceClient, tmp_path: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Asserts `write_records` produces same table as `lancedb.Table.add()`.
 
@@ -155,6 +155,8 @@ def test_lance_client_write_records_matches_lancedb_table_add(
     """
     client = client_with_storage
 
+    # the shell-provided NAME env var leaks into the `name` config field as last resort lookup
+    monkeypatch.delenv("NAME", raising=False)
     # configure embeddings on client
     embeddings_config = resolve_configuration(
         LanceEmbeddingsConfiguration(),

--- a/tests/load/lance/test_lance_configuration.py
+++ b/tests/load/lance/test_lance_configuration.py
@@ -1,8 +1,9 @@
 import os
-from typing import Optional
+from typing import Dict, Optional
 
 import pytest
 from lance.namespace import DirectoryNamespace, RestNamespace
+from lance_namespace import LanceNamespace
 from lancedb.embeddings import CohereEmbeddingFunction, OllamaEmbeddings, OpenAIEmbeddings
 
 import dlt
@@ -21,6 +22,7 @@ from dlt.destinations.impl.lance.configuration import (
     LanceClientConfiguration,
     LanceEmbeddingsConfiguration,
     LanceEmbeddingsCredentials,
+    LanceNamespacePool,
     RestCatalogCapabilities,
     RestCatalogCredentials,
     LanceStorageConfiguration,
@@ -342,3 +344,74 @@ def test_lance_follows_local_dir(
     else:
         expected_catalog = os.path.join(abs_local_dir, catalog_bucket_url)
         assert c.credentials.bucket_url == f"file://{expected_catalog}"
+
+
+def _resolved_config() -> LanceClientConfiguration:
+    return resolve_configuration(
+        LanceClientConfiguration()._bind_dataset_name(dataset_name="test_dataset"),
+        sections=("destination", "lance"),
+    )
+
+
+def test_lance_namespace_pool_shared_handle() -> None:
+    c = _resolved_config()
+    assert isinstance(c.namespace_pool, LanceNamespacePool)
+
+    handle_1 = c.namespace_pool.borrow()
+    handle_2 = c.namespace_pool.borrow()
+    # same namespace and session dispensed to all borrowers
+    assert handle_1.namespace is handle_2.namespace
+    assert handle_1.session is handle_2.session
+    assert c.namespace_pool._borrows == 2
+
+    c.namespace_pool.return_handle(handle_1)
+    c.namespace_pool.return_handle(handle_2)
+    assert c.namespace_pool._borrows == 0
+    # handle retained at zero borrows for reuse across load steps
+    assert c.namespace_pool.borrow().namespace is handle_1.namespace
+
+
+def test_lance_namespace_pool_copy_isolation() -> None:
+    c = _resolved_config()
+    handle = c.namespace_pool.borrow()
+
+    c_copy = c.copy()
+    assert c_copy.namespace_pool is not c.namespace_pool
+    assert c_copy.namespace_pool.borrow().namespace is not handle.namespace
+
+
+def test_lance_namespace_pool_rebuilds_on_credential_rotation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = _resolved_config()
+
+    creds = {"value": {"aws_access_key_id": "key_1"}}
+    monkeypatch.setattr(
+        LanceClientConfiguration, "_fresh_storage_creds", lambda self: dict(creds["value"])
+    )
+    builds = []
+    orig_make_namespace = LanceClientConfiguration.make_namespace
+
+    def counting_make_namespace(
+        self: LanceClientConfiguration, fresh_creds: Optional[Dict[str, str]] = None
+    ) -> "LanceNamespace":
+        builds.append(fresh_creds)
+        # build without the fake creds, the local object store does not accept them
+        return orig_make_namespace(self)
+
+    monkeypatch.setattr(LanceClientConfiguration, "make_namespace", counting_make_namespace)
+
+    # same snapshot borrows the same handle
+    handle_1 = c.namespace_pool.borrow()
+    handle_2 = c.namespace_pool.borrow()
+    assert len(builds) == 1
+    assert handle_1.namespace is handle_2.namespace
+
+    # rotated credentials rebuild the handle and overlay storage options
+    creds["value"] = {"aws_access_key_id": "key_2"}
+    handle_3 = c.namespace_pool.borrow()
+    assert len(builds) == 2
+    assert builds[-1] == {"aws_access_key_id": "key_2"}
+    assert handle_3.namespace is not handle_1.namespace
+    assert handle_3.session is not handle_1.session
+    assert handle_3.storage_options["aws_access_key_id"] == "key_2"

--- a/tests/load/lance/test_lance_exceptions.py
+++ b/tests/load/lance/test_lance_exceptions.py
@@ -1,22 +1,34 @@
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional, Type
 
 import pytest
 from lance.namespace import DirectoryNamespace
 from lance_namespace import NamespaceExistsRequest, TableExistsRequest
+from lance_namespace.errors import (
+    NamespaceNotFoundError,
+    PermissionDeniedError,
+    TableNotFoundError,
+)
 
+from dlt.common.destination.exceptions import (
+    DestinationTransientException,
+    DestinationUndefinedEntity,
+)
 from dlt.destinations.impl.lance.exceptions import (
-    LANCE_DOES_NOT_EXIST,
-    LANCE_MANIFEST_MODE,
-    LANCE_NOT_FOUND,
+    LanceManifestMisconfiguration,
     is_lance_undefined_entity_exception,
+    raise_destination_error,
 )
 
 
 pytestmark = pytest.mark.essential
 
+MANIFEST_MODE_MSG = "Child namespaces are only supported when manifest mode is enabled"
 
-def test_lance_exists_methods_raise_runtime_error(tmp_path: Path) -> None:
-    """Asserts namespace_exists() / table_exists() raise RuntimeError with expected message if namespace / table does not exist.
+
+def test_lance_exists_methods_raise(tmp_path: Path) -> None:
+    """Asserts namespace_exists() / table_exists() raise NotFound errors if namespace / table does not exist.
 
     This is a known bug: https://github.com/lance-format/lance/issues/6240.
 
@@ -26,16 +38,84 @@ def test_lance_exists_methods_raise_runtime_error(tmp_path: Path) -> None:
     ns = DirectoryNamespace(root=str(tmp_path))
 
     # missing namespace
-    with pytest.raises(RuntimeError, match=LANCE_NOT_FOUND) as exc_info:
+    with pytest.raises(NamespaceNotFoundError) as exc_info:
         ns.namespace_exists(NamespaceExistsRequest(id=["nonexistent_namespace"]))
     assert is_lance_undefined_entity_exception(exc_info.value)
 
     # missing table: single-level table id
-    with pytest.raises(RuntimeError, match=LANCE_DOES_NOT_EXIST) as exc_info:
+    with pytest.raises(TableNotFoundError) as table_exc_info:
         ns.table_exists(TableExistsRequest(id=["nonexistent_table"]))
-    assert is_lance_undefined_entity_exception(exc_info.value)
+    assert is_lance_undefined_entity_exception(table_exc_info.value)
 
     # missing table: multi-level table id
-    with pytest.raises(RuntimeError, match=LANCE_MANIFEST_MODE) as exc_info:
+    with pytest.raises(TableNotFoundError) as table_exc_info:
         ns.table_exists(TableExistsRequest(id=["nonexistent_namespace", "nonexistent_table"]))
-    assert is_lance_undefined_entity_exception(exc_info.value)
+    assert is_lance_undefined_entity_exception(table_exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("exc", "manifest_enabled", "expected"),
+    [
+        pytest.param(
+            NamespaceNotFoundError("Namespace not found: x"), None, True, id="typed-namespace"
+        ),
+        pytest.param(TableNotFoundError("Table not found: x"), None, True, id="typed-table"),
+        pytest.param(PermissionDeniedError("denied"), None, False, id="typed-not-a-not-found"),
+        pytest.param(
+            RuntimeError("Namespace error: Table does not exist: x"), None, True, id="untyped"
+        ),
+        pytest.param(
+            ValueError("Not found: t.lance/tree/b/_versions"), None, True, id="missing-branch"
+        ),
+        pytest.param(
+            OSError("Dataset at path t.lance/_versions/9.manifest was not found"),
+            None,
+            True,
+            id="missing-version",
+        ),
+        pytest.param(RuntimeError("boom"), None, False, id="unrelated"),
+        # configured manifest mode reported as disabled means broken storage, not a missing entity
+        pytest.param(
+            NamespaceNotFoundError(MANIFEST_MODE_MSG), True, False, id="contradiction-typed"
+        ),
+        pytest.param(RuntimeError(MANIFEST_MODE_MSG), True, False, id="contradiction-untyped"),
+        pytest.param(RuntimeError(MANIFEST_MODE_MSG), False, True, id="manifest-off"),
+        pytest.param(RuntimeError(MANIFEST_MODE_MSG), None, True, id="manifest-unknown"),
+    ],
+)
+def test_is_lance_undefined_entity_exception(
+    exc: Exception, manifest_enabled: Optional[bool], expected: bool
+) -> None:
+    assert is_lance_undefined_entity_exception(exc, manifest_enabled) is expected
+
+
+@pytest.mark.parametrize(
+    ("manifest_enabled", "raised", "expected"),
+    [
+        pytest.param(
+            True,
+            RuntimeError(MANIFEST_MODE_MSG),
+            LanceManifestMisconfiguration,
+            id="misconfiguration",
+        ),
+        pytest.param(
+            False,
+            RuntimeError(MANIFEST_MODE_MSG),
+            DestinationUndefinedEntity,
+            id="undefined-entity",
+        ),
+        pytest.param(True, RuntimeError("boom"), DestinationTransientException, id="transient"),
+    ],
+)
+def test_raise_destination_error_classification(
+    manifest_enabled: bool, raised: Exception, expected: Type[Exception]
+) -> None:
+    class _Client:
+        config = SimpleNamespace(manifest_enabled=manifest_enabled)
+
+        @raise_destination_error
+        def probe(self) -> None:
+            raise raised
+
+    with pytest.raises(expected):
+        _Client().probe()

--- a/tests/load/lance/test_lance_pipeline.py
+++ b/tests/load/lance/test_lance_pipeline.py
@@ -12,14 +12,22 @@ from dlt.destinations.impl.lance.lance_client import LanceClient
 from dlt.pipeline.exceptions import PipelineStepFailed
 
 from tests.load.utils import destinations_configs, DestinationTestConfiguration
+from tests.load.lance.lance_utils import lance_rest_destination_configs
 
 
 pytestmark = pytest.mark.essential
 
+# directory namespace configs (from `destinations_configs`) plus the local REST namespace config
+# that runs against the in-process REST server fixture
+lance_destination_configs = [
+    *destinations_configs(default_vector_configs=True, subset=("lance",)),
+    *lance_rest_destination_configs(),
+]
+
 
 @pytest.mark.parametrize(
     "destination_config",
-    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    lance_destination_configs,
     ids=lambda x: x.name,
 )
 def test_lance_pipeline_raises_on_embed_column_without_embeddings_config(
@@ -49,7 +57,7 @@ def test_lance_pipeline_raises_on_embed_column_without_embeddings_config(
 
 @pytest.mark.parametrize(
     "destination_config",
-    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    lance_destination_configs,
     ids=lambda x: x.name,
 )
 def test_lance_pipeline_branching(
@@ -128,7 +136,7 @@ def test_lance_pipeline_branching(
 
 @pytest.mark.parametrize(
     "destination_config",
-    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    lance_destination_configs,
     ids=lambda x: x.name,
 )
 def test_lance_pipeline_replace_in_branch(
@@ -174,7 +182,7 @@ def test_lance_pipeline_replace_in_branch(
 
 @pytest.mark.parametrize(
     "destination_config",
-    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    lance_destination_configs,
     ids=lambda x: x.name,
 )
 def test_lance_pipeline_branching_root_namespace(
@@ -224,7 +232,7 @@ def test_lance_pipeline_branching_root_namespace(
 
 @pytest.mark.parametrize(
     "destination_config",
-    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    lance_destination_configs,
     ids=lambda x: x.name,
 )
 def test_lance_pipeline_single_commit_per_table(
@@ -291,7 +299,7 @@ def test_lance_pipeline_single_commit_per_table(
 
 @pytest.mark.parametrize(
     "destination_config",
-    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    lance_destination_configs,
     ids=lambda x: x.name,
 )
 def test_lance_pipeline_replace_truncates_jobless_nested_table(
@@ -329,7 +337,7 @@ def test_lance_pipeline_replace_truncates_jobless_nested_table(
 
 @pytest.mark.parametrize(
     "destination_config",
-    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    lance_destination_configs,
     ids=lambda x: x.name,
 )
 def test_lance_pipeline_refresh_drop_data(
@@ -368,7 +376,7 @@ def test_lance_pipeline_refresh_drop_data(
 
 @pytest.mark.parametrize(
     "destination_config",
-    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    lance_destination_configs,
     ids=lambda x: x.name,
 )
 def test_lance_commit_job_retry_idempotency(

--- a/tests/load/lance_utils.py
+++ b/tests/load/lance_utils.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from contextlib import contextmanager
 import os
 from typing import TYPE_CHECKING, Iterator, Optional
-
 import pytest
 
 from dlt.common.utils import uniq_id
+from dlt.common.configuration.resolve import resolve_configuration
+from dlt.common.storages.configuration import FilesystemConfiguration
+from dlt.common.storages.fsspec_filesystem import fsspec_from_config
 
+from tests.load.utils import FILE_BUCKET, OBJECT_STORE_RS_BUCKETS
 from tests.utils import get_test_storage_root, get_test_worker_id, get_test_worker_idx
 
 if TYPE_CHECKING:
@@ -67,11 +70,6 @@ def get_lance_namespace_name() -> str:
 def cleanup_lance_namespace_root() -> Iterator[None]:
     """Deletes this session's lance namespace root from remote buckets."""
     yield
-    from dlt.common.configuration.resolve import resolve_configuration
-    from dlt.common.storages.configuration import FilesystemConfiguration
-    from dlt.common.storages.fsspec_filesystem import fsspec_from_config
-
-    from tests.load.utils import FILE_BUCKET, OBJECT_STORE_RS_BUCKETS
 
     name = get_lance_namespace_name()
     for bucket in OBJECT_STORE_RS_BUCKETS:

--- a/tests/load/lance_utils.py
+++ b/tests/load/lance_utils.py
@@ -100,7 +100,7 @@ def maybe_lance_rest_server(
     try:
         with RestAdapter(
             "dir",
-            namespace_properties={"root": root},
+            namespace_client_properties={"root": root},
             host=LanceRestServerConfig.HOST,
             port=LanceRestServerConfig.get_port(),
         ):

--- a/tests/load/lance_utils.py
+++ b/tests/load/lance_utils.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Iterator, Optional
 
 import pytest
 
+from dlt.common.utils import uniq_id
+
 from tests.utils import get_test_storage_root, get_test_worker_id, get_test_worker_idx
 
 if TYPE_CHECKING:
@@ -51,9 +53,42 @@ class LanceRestServerConfig:
         }
 
 
+# random per test session: a shared root accumulates a `__manifest` version per namespace
+# mutation, slowing all namespace operations down with every test run
+_LANCE_ROOT_SUFFIX = uniq_id(4)
+
+
 def get_lance_namespace_name() -> str:
     # isolate per xdist worker — Lance __manifest writes conflict on S3
-    return f"dlt_lance_root_{get_test_worker_id()}"
+    return f"dlt_lance_root_{get_test_worker_id()}_{_LANCE_ROOT_SUFFIX}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_lance_namespace_root() -> Iterator[None]:
+    """Deletes this session's lance namespace root from remote buckets."""
+    yield
+    from dlt.common.configuration.resolve import resolve_configuration
+    from dlt.common.storages.configuration import FilesystemConfiguration
+    from dlt.common.storages.fsspec_filesystem import fsspec_from_config
+
+    from tests.load.utils import FILE_BUCKET, OBJECT_STORE_RS_BUCKETS
+
+    name = get_lance_namespace_name()
+    for bucket in OBJECT_STORE_RS_BUCKETS:
+        # local files live in the test storage and are cleaned with it
+        if bucket == FILE_BUCKET:
+            continue
+        try:
+            cfg = resolve_configuration(
+                FilesystemConfiguration(bucket_url=bucket), sections=("destination", "filesystem")
+            )
+            fs, path = fsspec_from_config(cfg)
+            root = f"{path}/{name}"
+            if fs.exists(root):
+                fs.rm(root, recursive=True)
+        except Exception:
+            # best effort: no credentials or bucket not used in this session
+            pass
 
 
 def extract_destination_test_configuration(

--- a/tests/load/lancedb/test_merge.py
+++ b/tests/load/lancedb/test_merge.py
@@ -120,10 +120,14 @@ def test_lancedb_remove_nested_orphaned_records(
         child_tbl = open_lance_table(client, "parent__child")
         grandchild_tbl = open_lance_table(client, "parent__child__grandchild")
 
-        actual_parent_df = parent_tbl.to_pandas().sort_values(by="id").reset_index(drop=True)
-        actual_child_df = child_tbl.to_pandas().sort_values(by="bar").reset_index(drop=True)
+        actual_parent_df = (
+            parent_tbl.to_arrow().to_pandas().sort_values(by="id").reset_index(drop=True)
+        )
+        actual_child_df = (
+            child_tbl.to_arrow().to_pandas().sort_values(by="bar").reset_index(drop=True)
+        )
         actual_grandchild_df = (
-            grandchild_tbl.to_pandas().sort_values(by="baz").reset_index(drop=True)
+            grandchild_tbl.to_arrow().to_pandas().sort_values(by="baz").reset_index(drop=True)
         )
 
         expected_parent_data = expected_parent_data.sort_values(by="id").reset_index(drop=True)
@@ -200,7 +204,10 @@ def test_lancedb_remove_orphaned_records_root_table(
         tbl = open_lance_table(client, "root")
 
         actual_root_df: DataFrame = (
-            tbl.to_pandas().sort_values(by=["doc_id", "chunk_hash"]).reset_index(drop=True)
+            tbl.to_arrow()
+            .to_pandas()
+            .sort_values(by=["doc_id", "chunk_hash"])
+            .reset_index(drop=True)
         )[["doc_id", "chunk_hash"]]
 
         assert_frame_equal(actual_root_df, expected_root_table_df)
@@ -269,7 +276,10 @@ def test_lancedb_remove_orphaned_records_root_table_string_doc_id(
         tbl = open_lance_table(client, "root")
 
         actual_root_df: DataFrame = (
-            tbl.to_pandas().sort_values(by=["doc_id", "chunk_hash"]).reset_index(drop=True)
+            tbl.to_arrow()
+            .to_pandas()
+            .sort_values(by=["doc_id", "chunk_hash"])
+            .reset_index(drop=True)
         )[["doc_id", "chunk_hash"]]
 
         assert_frame_equal(actual_root_df, expected_root_table_df)
@@ -351,7 +361,7 @@ def test_lancedb_root_table_remove_orphaned_records_with_real_embeddings(
     with pipeline.destination_client() as client:
         client = cast(TLanceDestinationClient, client)
         tbl = open_lance_table(client, "document")
-        df = tbl.to_pandas()
+        df = tbl.to_arrow().to_pandas()
 
         # Check (non-empty) embeddings as present, and that orphaned embeddings have been discarded.
         assert len(df) == 21
@@ -418,7 +428,10 @@ def test_lancedb_compound_merge_key_root_table(
         tbl = open_lance_table(client, "root")
 
         actual_root_df: DataFrame = (
-            tbl.to_pandas().sort_values(by=["doc_id", "chunk_hash", "foo"]).reset_index(drop=True)
+            tbl.to_arrow()
+            .to_pandas()
+            .sort_values(by=["doc_id", "chunk_hash", "foo"])
+            .reset_index(drop=True)
         )[["doc_id", "chunk_hash", "foo"]]
 
         assert_frame_equal(actual_root_df, expected_root_table_df)
@@ -430,9 +443,9 @@ def test_lancedb_compound_merge_key_root_table(
         )
 
         child_tbl = open_lance_table(client, "root__child")
-        actual_child_df = (child_tbl.to_pandas().sort_values(by="val").reset_index(drop=True))[
-            ["val"]
-        ]
+        actual_child_df = (
+            child_tbl.to_arrow().to_pandas().sort_values(by="val").reset_index(drop=True)
+        )[["val"]]
 
         assert_frame_equal(actual_child_df, expected_child_df)
 

--- a/tests/load/lancedb/test_pipeline.py
+++ b/tests/load/lancedb/test_pipeline.py
@@ -657,7 +657,7 @@ def test_bring_your_own_vector(destination_config: DestinationTestConfiguration)
         assert results.iloc[0]["id"] == 1
 
         # Check that all rows were loaded
-        assert len(tbl.to_pandas()) == num_rows
+        assert len(tbl.to_arrow().to_pandas()) == num_rows
 
 
 @pytest.mark.parametrize(
@@ -850,7 +850,7 @@ def test_lancedb_remove_nested_orphaned_records_with_chunks(
         }
 
         tbl = open_lance_table(client, "document__embeddings")
-        df = tbl.to_pandas()
+        df = tbl.to_arrow().to_pandas()
         assert set(df["chunk_text"]) == expected_text
 
 

--- a/tests/load/pipeline/test_drop.py
+++ b/tests/load/pipeline/test_drop.py
@@ -175,11 +175,6 @@ def test_drop_command_resources_and_state(
 ) -> None:
     """Test the drop command with resource and state path options and
     verify correct data is deleted from destination and locally"""
-    if destination_config.destination_type == "filesystem" and destination_config.table_format:
-        pytest.skip(
-            "Cannot run this test on filesystem with open tables enabled, dlt tables are not open"
-            " tables"
-        )
     source: Any = droppable_source()
     if not in_source:
         source = list(source.selected_resources.values())

--- a/tests/load/pipeline/test_lance.py
+++ b/tests/load/pipeline/test_lance.py
@@ -1,12 +1,16 @@
 import dlt
 import pytest
 
-from typing import Any, cast
+from typing import Any, List, cast
 
 from dlt.common.utils import uniq_id
+from dlt.common.destination.exceptions import DestinationTransientException
+
 from dlt.destinations.impl.lance.exceptions import LanceEmbeddingsConfigurationMissing
 from dlt.destinations.impl.lance.lance_adapter import lance_adapter
+from dlt.destinations.impl.lance.lance_client import LanceClient
 from dlt.pipeline.exceptions import PipelineStepFailed
+
 from tests.load.utils import destinations_configs, DestinationTestConfiguration
 
 
@@ -227,8 +231,6 @@ def test_lance_pipeline_single_commit_per_table(
     destination_config: DestinationTestConfiguration,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from dlt.destinations.impl.lance.lance_client import LanceClient
-
     # rotate job files so each table loads from multiple parquet files
     monkeypatch.setenv("NORMALIZE__DATA_WRITER__FILE_MAX_ITEMS", "10")
     pipe = destination_config.setup_pipeline(
@@ -362,3 +364,59 @@ def test_lance_pipeline_refresh_drop_data(
         snap_ds = client.open_lance_dataset("snap")
         assert [r["id"] for r in snap_ds.to_table().to_pylist()] == [20]
         assert len(snap_ds.versions()) == snap_versions + 1
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    ids=lambda x: x.name,
+)
+def test_lance_commit_job_retry_idempotency(
+    destination_config: DestinationTestConfiguration,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A commit job retried after its lance commit succeeded must not apply the commit
+    twice: a re-run append detects its fragments in the dataset and skips, a re-run
+    replace repeats the Overwrite commit with the same fragments."""
+    import lance
+    from dlt.destinations.impl.lance.lance_client import LanceClient
+
+    pipe = destination_config.setup_pipeline(
+        pipeline_name="test_lance_commit_retry",
+        dev_mode=True,
+    )
+    pipe.run([{"id": i} for i in range(10)], table_name="items")
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        versions_after_first = len(client.open_lance_dataset("items").versions())
+
+    # crash the items commit job once, right between a successful commit and job completion
+    orig_commit = lance.LanceDataset.commit
+    crashed: List[bool] = []
+
+    def crash_once_after_commit(ds: Any, *args: Any, **kwargs: Any) -> Any:
+        result = orig_commit(ds, *args, **kwargs)
+        if "items" in ds.uri and not crashed:
+            crashed.append(True)
+            raise DestinationTransientException("crash between commit and job completion")
+        return result
+
+    monkeypatch.setattr(lance.LanceDataset, "commit", crash_once_after_commit)
+
+    # append: the retried job must skip the already applied commit, one new version only
+    pipe.run([{"id": i} for i in range(10, 20)], table_name="items")
+    assert crashed
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        ds = client.open_lance_dataset("items")
+        assert ds.count_rows() == 20
+        assert len(ds.versions()) == versions_after_first + 1
+
+    # replace: the retried job repeats the Overwrite commit, same rows come out
+    crashed.clear()
+    pipe.run([{"id": i} for i in range(5)], table_name="items", write_disposition="replace")
+    assert crashed
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        ds = client.open_lance_dataset("items")
+        assert sorted(r["id"] for r in ds.to_table().to_pylist()) == list(range(5))

--- a/tests/load/pipeline/test_lance.py
+++ b/tests/load/pipeline/test_lance.py
@@ -1,7 +1,7 @@
 import dlt
 import pytest
 
-from typing import cast
+from typing import Any, cast
 
 from dlt.common.utils import uniq_id
 from dlt.destinations.impl.lance.exceptions import LanceEmbeddingsConfigurationMissing
@@ -216,3 +216,149 @@ def test_lance_pipeline_branching_root_namespace(
         assert "a_new_column" in dev_ds.schema.names
         assert "a_new_column" not in main_ds.schema.names
         assert "a_new_column" not in staging_ds.schema.names
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    ids=lambda x: x.name,
+)
+def test_lance_pipeline_single_commit_per_table(
+    destination_config: DestinationTestConfiguration,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dlt.destinations.impl.lance.lance_client import LanceClient
+
+    # rotate job files so each table loads from multiple parquet files
+    monkeypatch.setenv("NORMALIZE__DATA_WRITER__FILE_MAX_ITEMS", "10")
+    pipe = destination_config.setup_pipeline(
+        pipeline_name="test_lance_single_commit",
+        dev_mode=True,
+    )
+    pipe.run([{"id": i} for i in range(35)], table_name="items")
+
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        assert client.open_lance_dataset("items").count_rows() == 35
+        versions_after_first = len(client.open_lance_dataset("items").versions())
+
+    # append: all job files of a load commit as one version
+    info = pipe.run([{"id": i} for i in range(35, 70)], table_name="items")
+    items_jobs = [
+        j
+        for j in info.load_packages[0].jobs["completed_jobs"]
+        if j.job_file_info.table_name == "items" and j.job_file_info.file_format == "parquet"
+    ]
+    assert len(items_jobs) > 1
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        ds = client.open_lance_dataset("items")
+        assert ds.count_rows() == 70
+        assert len(ds.versions()) == versions_after_first + 1
+        versions_after_second = len(ds.versions())
+
+    # replace: a single Overwrite commit replaces all rows
+    pipe.run([{"id": i} for i in range(15)], table_name="items", write_disposition="replace")
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        ds = client.open_lance_dataset("items")
+        assert ds.count_rows() == 15
+        assert len(ds.versions()) == versions_after_second + 1
+
+    # merge: multiple job files merge in one operation, updates and inserts apply
+    pipe.run(
+        [{"id": i, "v": "old"} for i in range(25)],
+        table_name="merge_items",
+        write_disposition="merge",
+        primary_key="id",
+    )
+    pipe.run(
+        [{"id": i, "v": "new"} for i in range(15, 40)],
+        table_name="merge_items",
+        write_disposition="merge",
+        primary_key="id",
+    )
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        ds = client.open_lance_dataset("merge_items")
+        table = ds.to_table()
+        assert table.num_rows == 40
+        updated = {r["id"]: r["v"] for r in table.to_pylist()}
+        assert updated[10] == "old" and updated[20] == "new" and updated[39] == "new"
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    ids=lambda x: x.name,
+)
+def test_lance_pipeline_replace_truncates_jobless_nested_table(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    from dlt.destinations.impl.lance.lance_client import LanceClient
+
+    pipe = destination_config.setup_pipeline(
+        pipeline_name="test_lance_replace_nested",
+        dev_mode=True,
+    )
+
+    # nested lists create a nested table in the replace chain
+    pipe.run(
+        [{"id": 1, "kids": [{"k": 1}, {"k": 2}]}],
+        table_name="items",
+        write_disposition="replace",
+    )
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        assert client.open_lance_dataset("items").count_rows() == 1
+        assert client.open_lance_dataset("items__kids").count_rows() == 2
+        items_versions = len(client.open_lance_dataset("items").versions())
+
+    # no nested data: the jobless nested table is truncated, the parent is replaced
+    # atomically in a single Overwrite commit without an intermediate truncation
+    pipe.run([{"id": 2}, {"id": 3}], table_name="items", write_disposition="replace")
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        ds = client.open_lance_dataset("items")
+        assert sorted(r["id"] for r in ds.to_table().to_pylist()) == [2, 3]
+        assert len(ds.versions()) == items_versions + 1
+        assert client.open_lance_dataset("items__kids").count_rows() == 0
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_vector_configs=True, subset=("lance",)),
+    ids=lambda x: x.name,
+)
+def test_lance_pipeline_refresh_drop_data(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    from dlt.destinations.impl.lance.lance_client import LanceClient
+
+    pipe = destination_config.setup_pipeline(
+        pipeline_name="test_lance_refresh_drop",
+        dev_mode=True,
+    )
+
+    @dlt.source
+    def two_tables(events: Any, snap: Any) -> Any:
+        return [
+            dlt.resource(events, name="events", write_disposition="append"),
+            dlt.resource(snap, name="snap", write_disposition="replace"),
+        ]
+
+    pipe.run(two_tables([{"id": 1}, {"id": 2}], [{"id": 10}]))
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        snap_versions = len(client.open_lance_dataset("snap").versions())
+
+    # drop_data must truncate the append table even though it receives a data file,
+    # the replace table is still overwritten in a single commit
+    pipe.run(two_tables([{"id": 3}], [{"id": 20}]), refresh="drop_data")
+    with pipe.destination_client() as client:
+        client = cast(LanceClient, client)
+        events = sorted(r["id"] for r in client.open_lance_dataset("events").to_table().to_pylist())
+        assert events == [3]
+        snap_ds = client.open_lance_dataset("snap")
+        assert [r["id"] for r in snap_ds.to_table().to_pylist()] == [20]
+        assert len(snap_ds.versions()) == snap_versions + 1

--- a/tests/load/pipeline/test_open_table_pipeline.py
+++ b/tests/load/pipeline/test_open_table_pipeline.py
@@ -41,6 +41,7 @@ from tests.load.utils import (
 )
 from tests.pipeline.utils import (
     load_table_counts,
+    assert_empty_tables,
     assert_load_info,
     load_tables_to_dicts,
     users_materialize_table_schema,
@@ -1243,6 +1244,136 @@ def test_iceberg_namespace_properties(
         assert ns_props["description"] == "test namespace"
     finally:
         del os.environ["DESTINATION__FILESYSTEM__ICEBERG_NAMESPACE_PROPERTIES"]
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(table_format_local_configs=True, with_table_format="delta"),
+    ids=lambda x: x.name,
+)
+def test_delta_transactional_truncate_on_refresh(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Refresh `drop_data` empties a delta table with a transactional delete that keeps the
+    table, its schema and version history."""
+    from dlt.common.libs.deltalake import get_delta_tables
+
+    pipeline = destination_config.setup_pipeline("delta_truncate", dev_mode=True)
+
+    @dlt.resource(write_disposition="append")
+    def items(emit: bool):
+        if emit:
+            yield [{"id": 1, "value": "a"}, {"id": 2, "value": "b"}]
+
+    info = pipeline.run(items(True), **destination_config.run_kwargs)
+    assert_load_info(info)
+    dt = get_delta_tables(pipeline, "items")["items"]
+    version = dt.version()
+    assert dt.to_pyarrow_table().num_rows == 2
+
+    info = pipeline.run(items(False), refresh="drop_data", **destination_config.run_kwargs)
+    assert_load_info(info)
+    # table survived truncation with a new version and no rows
+    dt = get_delta_tables(pipeline, "items")["items"]
+    assert dt.version() > version
+    arrow_table = dt.to_pyarrow_table()
+    assert arrow_table.num_rows == 0
+    assert {"id", "value"} <= set(arrow_table.column_names)
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(table_format_local_configs=True, with_table_format="iceberg"),
+    ids=lambda x: x.name,
+)
+def test_iceberg_ephemeral_catalog_truncate_deletes_files(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """With the default in-memory catalog, refresh `drop_data` deletes the table files."""
+    pipeline = destination_config.setup_pipeline("iceberg_truncate", dev_mode=True)
+
+    @dlt.resource(write_disposition="append")
+    def items(emit: bool):
+        if emit:
+            yield [{"id": 1}]
+
+    info = pipeline.run(items(True), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    info = pipeline.run(items(False), refresh="drop_data", **destination_config.run_kwargs)
+    assert_load_info(info)
+    client: FilesystemClient = pipeline.destination_client()  # type: ignore[assignment]
+    assert client.list_table_files("items") == []
+    assert_empty_tables(pipeline, "items")
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(table_format_local_configs=True, with_table_format="iceberg"),
+    ids=lambda x: x.name,
+)
+def test_iceberg_persistent_catalog_truncate_and_drop(
+    destination_config: DestinationTestConfiguration, tmp_path: Path
+) -> None:
+    """With a persistent catalog, refresh `drop_data` empties tables with a transactional delete
+    keeping them registered, while refresh `drop_sources` purges them from the catalog which also
+    deletes their files."""
+    from pyiceberg.exceptions import NoSuchTableError
+
+    os.environ["ICEBERG_CATALOG__ICEBERG_CATALOG_CONFIG"] = json.dumps(
+        {
+            "type": "sql",
+            "uri": f"sqlite:///{tmp_path / 'catalog.db'}",
+            "warehouse": str(tmp_path / "warehouse"),
+        }
+    )
+    try:
+        pipeline = destination_config.setup_pipeline("iceberg_catalog_refresh", dev_mode=True)
+
+        @dlt.source
+        def src(emit: bool):
+            @dlt.resource(write_disposition="append")
+            def items():
+                if emit:
+                    yield [{"id": 1}, {"id": 2}]
+
+            @dlt.resource
+            def keep():
+                yield [{"id": 1}]
+
+            return items, keep
+
+        info = pipeline.run(src(True), **destination_config.run_kwargs)
+        assert_load_info(info)
+
+        client: FilesystemClient = pipeline.destination_client()  # type: ignore[assignment]
+        catalog = client.get_open_table_catalog("iceberg")
+        items_id = f"{client.dataset_name}.items"
+        table = catalog.load_table(items_id)
+        assert table.scan().to_arrow().num_rows == 2
+        snapshot_count = len(table.metadata.snapshots)
+
+        # drop_data truncates transactionally: table stays registered with a new snapshot
+        info = pipeline.run(src(False), refresh="drop_data", **destination_config.run_kwargs)
+        assert_load_info(info)
+        table = catalog.load_table(items_id)
+        assert table.scan().to_arrow().num_rows == 0
+        assert len(table.metadata.snapshots) > snapshot_count
+        assert len(client.list_table_files("items")) > 0
+
+        # drop_sources purges dropped tables from the catalog which deletes their files
+        info = pipeline.run(
+            src(True).with_resources("keep"),
+            refresh="drop_sources",
+            **destination_config.run_kwargs,
+        )
+        assert_load_info(info)
+        with pytest.raises(NoSuchTableError):
+            catalog.load_table(items_id)
+        assert client.list_table_files("items") == []
+        assert load_table_counts(pipeline, "keep") == {"keep": 1}
+    finally:
+        del os.environ["ICEBERG_CATALOG__ICEBERG_CATALOG_CONFIG"]
 
 
 @pytest.mark.parametrize(

--- a/tests/load/pipeline/test_open_table_pipeline.py
+++ b/tests/load/pipeline/test_open_table_pipeline.py
@@ -1,12 +1,7 @@
-import csv
 import os
-import posixpath
 from pathlib import Path
-from typing import Any, Callable, List, Dict, cast, Tuple
-from importlib.metadata import version as pkg_version
-from packaging.version import Version
+from typing import Any, List, Tuple
 
-from pytest_mock import MockerFixture
 import dlt
 import pytest
 
@@ -16,15 +11,10 @@ from dlt.common.storages.configuration import (
     FilesystemConfiguration,
     FilesystemConfigurationWithLocalFiles,
 )
-from dlt.common.storages.load_package import ParsedLoadJobFileName
-from dlt.common.utils import uniq_id
 from dlt.common.schema.typing import TWriteDisposition, TTableFormat
-from dlt.common.configuration.exceptions import ConfigurationValueError
 
-from dlt.destinations import filesystem
 from dlt.destinations.impl.duckdb.exceptions import IcebergViewException
 from dlt.destinations.impl.filesystem.filesystem import FilesystemClient
-from dlt.destinations.impl.filesystem.typing import TExtraPlaceholders
 from dlt.pipeline.exceptions import PipelineStepFailed
 from dlt.load.exceptions import LoadClientJobRetry
 
@@ -36,8 +26,6 @@ from tests.load.utils import (
     DestinationTestConfiguration,
     MEMORY_BUCKET,
     FILE_BUCKET,
-    AZ_BUCKET,
-    SFTP_BUCKET,
 )
 from tests.pipeline.utils import (
     load_table_counts,
@@ -1312,12 +1300,17 @@ def test_iceberg_ephemeral_catalog_truncate_deletes_files(
     destinations_configs(table_format_local_configs=True, with_table_format="iceberg"),
     ids=lambda x: x.name,
 )
+@pytest.mark.parametrize(
+    "iceberg_use_catalog_purge", [True, False], ids=["catalog-purge", "dlt-purge"]
+)
 def test_iceberg_persistent_catalog_truncate_and_drop(
-    destination_config: DestinationTestConfiguration, tmp_path: Path
+    destination_config: DestinationTestConfiguration,
+    iceberg_use_catalog_purge: bool,
+    tmp_path: Path,
 ) -> None:
     """With a persistent catalog, refresh `drop_data` empties tables with a transactional delete
-    keeping them registered, while refresh `drop_sources` purges them from the catalog which also
-    deletes their files."""
+    keeping them registered, while refresh `drop_sources` drops them from the catalog and deletes
+    their files: via catalog purge or by dlt itself depending on `iceberg_use_catalog_purge`."""
     from pyiceberg.exceptions import NoSuchTableError
 
     os.environ["ICEBERG_CATALOG__ICEBERG_CATALOG_CONFIG"] = json.dumps(
@@ -1327,53 +1320,59 @@ def test_iceberg_persistent_catalog_truncate_and_drop(
             "warehouse": str(tmp_path / "warehouse"),
         }
     )
-    try:
-        pipeline = destination_config.setup_pipeline("iceberg_catalog_refresh", dev_mode=True)
+    os.environ["DESTINATION__FILESYSTEM__ICEBERG_USE_CATALOG_PURGE"] = str(
+        iceberg_use_catalog_purge
+    )
 
-        @dlt.source
-        def src(emit: bool):
-            @dlt.resource(write_disposition="append")
-            def items():
-                if emit:
-                    yield [{"id": 1}, {"id": 2}]
+    pipeline = destination_config.setup_pipeline("iceberg_catalog_refresh", dev_mode=True)
 
-            @dlt.resource
-            def keep():
-                yield [{"id": 1}]
+    @dlt.source
+    def src(emit: bool):
+        @dlt.resource(write_disposition="append")
+        def items():
+            if emit:
+                yield [{"id": 1}, {"id": 2}]
 
-            return items, keep
+        @dlt.resource
+        def keep():
+            yield [{"id": 1}]
 
-        info = pipeline.run(src(True), **destination_config.run_kwargs)
-        assert_load_info(info)
+        return items, keep
 
-        client: FilesystemClient = pipeline.destination_client()  # type: ignore[assignment]
-        catalog = client.get_open_table_catalog("iceberg")
-        items_id = f"{client.dataset_name}.items"
-        table = catalog.load_table(items_id)
-        assert table.scan().to_arrow().num_rows == 2
-        snapshot_count = len(table.metadata.snapshots)
+    info = pipeline.run(src(True), **destination_config.run_kwargs)
+    assert_load_info(info)
 
-        # drop_data truncates transactionally: table stays registered with a new snapshot
-        info = pipeline.run(src(False), refresh="drop_data", **destination_config.run_kwargs)
-        assert_load_info(info)
-        table = catalog.load_table(items_id)
-        assert table.scan().to_arrow().num_rows == 0
-        assert len(table.metadata.snapshots) > snapshot_count
-        assert len(client.list_table_files("items")) > 0
+    client: FilesystemClient = pipeline.destination_client()  # type: ignore[assignment]
+    catalog = client.get_open_table_catalog("iceberg")
+    items_id = f"{client.dataset_name}.items"
+    table = catalog.load_table(items_id)
+    assert table.scan().to_arrow().num_rows == 2
+    snapshot_count = len(table.metadata.snapshots)
 
-        # drop_sources purges dropped tables from the catalog which deletes their files
-        info = pipeline.run(
-            src(True).with_resources("keep"),
-            refresh="drop_sources",
-            **destination_config.run_kwargs,
-        )
-        assert_load_info(info)
-        with pytest.raises(NoSuchTableError):
-            catalog.load_table(items_id)
-        assert client.list_table_files("items") == []
-        assert load_table_counts(pipeline, "keep") == {"keep": 1}
-    finally:
-        del os.environ["ICEBERG_CATALOG__ICEBERG_CATALOG_CONFIG"]
+    # drop_data truncates transactionally: table stays registered with a new snapshot, data
+    # files of past snapshots and table metadata stay in place
+    info = pipeline.run(src(False), refresh="drop_data", **destination_config.run_kwargs)
+    assert_load_info(info)
+    table = catalog.load_table(items_id)
+    assert table.scan().to_arrow().num_rows == 0
+    assert len(table.metadata.snapshots) > snapshot_count
+    table_files = client.list_table_files("items")
+    assert any(f.endswith(".metadata.json") for f in table_files)
+    assert any(f.endswith(".parquet") for f in table_files)
+
+    # drop_sources drops tables from the catalog. pyiceberg purge deletes data files of all
+    # snapshots, manifests and metadata files; dlt file wipe deletes the same when purge is
+    # disabled, so the table dir is empty either way
+    info = pipeline.run(
+        src(True).with_resources("keep"),
+        refresh="drop_sources",
+        **destination_config.run_kwargs,
+    )
+    assert_load_info(info)
+    with pytest.raises(NoSuchTableError):
+        catalog.load_table(items_id)
+    assert client.list_table_files("items") == []
+    assert load_table_counts(pipeline, "keep") == {"keep": 1}
 
 
 @pytest.mark.parametrize(

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -525,3 +525,98 @@ def test_snowflake_atomic_swap_replace(
     info = pipeline.run(load_items_empty(), **destination_config.run_kwargs)
     assert_load_info(info)
     assert_empty_tables(pipeline, "items", "items__sub_items")
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_sql_configs=True,
+        local_filesystem_configs=True,
+        table_format_local_configs=True,
+        subset=["duckdb", "filesystem"],
+    ),
+    ids=lambda x: x.name,
+)
+def test_replace_chain_jobless_nested_tables(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Nested tables of a replace resource that receive no data in a run get no load job and
+    must still be emptied."""
+    pipeline = destination_config.setup_pipeline("replace_jobless", dev_mode=True)
+
+    @dlt.resource(name="items", write_disposition="replace")
+    def items(children: bool):
+        if children:
+            yield {"id": 1, "children": [{"cid": 1}, {"cid": 2}]}
+        else:
+            yield {"id": 2}
+
+    info = pipeline.run(items(True), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(pipeline, "items", "items__children") == {
+        "items": 1,
+        "items__children": 2,
+    }
+
+    info = pipeline.run(items(False), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(pipeline, "items") == {"items": 1}
+    assert_empty_tables(pipeline, "items__children")
+    if destination_config.table_format == "delta":
+        from dlt.common.libs.deltalake import get_delta_tables
+
+        # delta truncation is transactional: the nested table is kept and empty
+        dt = get_delta_tables(pipeline, "items__children")["items__children"]
+        assert dt.to_pyarrow_table().num_rows == 0
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(table_format_local_configs=True, with_table_format="delta"),
+    ids=lambda x: x.name,
+)
+def test_replace_chain_truncate_consistent_with_package_jobs(
+    destination_config: DestinationTestConfiguration, mocker: MockerFixture
+) -> None:
+    """Locks the contract the truncation skip in `initialize_storage` relies on: `verify_schema`
+    receives exactly the new jobs stored in the load package, so tables with data jobs and replace
+    disposition are left to their atomic overwrite while jobless chain tables are truncated.
+    """
+    from dlt.destinations.impl.filesystem.filesystem import FilesystemClient
+
+    verify_spy = mocker.spy(FilesystemClient, "verify_schema")
+    truncate_spy = mocker.spy(FilesystemClient, "truncate_tables")
+
+    pipeline = destination_config.setup_pipeline("replace_chain_contract", dev_mode=True)
+
+    @dlt.resource(name="items", write_disposition="replace")
+    def items(children: bool):
+        if children:
+            yield {"id": 1, "children": [{"cid": 1}, {"cid": 2}]}
+        else:
+            yield {"id": 2}
+
+    info = pipeline.run(items(True), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    verify_spy.reset_mock()
+    truncate_spy.reset_mock()
+    info = pipeline.run(items(False), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    # verify_schema got the very same new jobs that the load step executed from the package
+    assert verify_spy.call_count == 1
+    spied_jobs = {job.job_id() for job in verify_spy.call_args.kwargs["new_jobs"]}
+    package_jobs = {
+        job.job_file_info.job_id()
+        for jobs in pipeline.get_load_package_info(info.loads_ids[0]).jobs.values()
+        for job in jobs
+        # reference jobs are followups created while the package runs
+        if job.job_file_info.file_format != "reference"
+    }
+    assert spied_jobs == package_jobs
+
+    # the root replace table has a data job and is overwritten atomically, only the jobless
+    # nested table is truncated
+    assert truncate_spy.call_count == 1
+    assert truncate_spy.call_args.args[1] == ["items__children"]

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -24,7 +24,6 @@ from dlt.extract.incremental import Incremental
 from dlt.extract.source import DltSource
 from dlt.dataset.exceptions import LineageFailedException
 
-from tests.load.lance_utils import module_lance_rest_server
 from tests.load.utils import (
     DestinationTestConfiguration,
     MEMORY_BUCKET,
@@ -171,7 +170,6 @@ def preserve_module_environ_per_destination_config(
 @pytest.fixture(scope="module")
 def populated_pipeline(
     destination_config: DestinationTestConfiguration,
-    module_lance_rest_server: None,
     auto_module_test_storage,
     preserve_module_environ_per_destination_config,
     auto_module_test_run_context,
@@ -1675,7 +1673,6 @@ def _src_gamma():
 @pytest.fixture(scope="module")
 def overlap_pipeline(
     destination_config: DestinationTestConfiguration,
-    module_lance_rest_server: None,
     auto_module_test_storage,
     preserve_module_environ_per_destination_config,
     auto_module_test_run_context,
@@ -1782,6 +1779,7 @@ def test_multi_schema_ibis(overlap_pipeline: Pipeline) -> None:
     if overlap_pipeline.destination.destination_type not in (
         "dlt.destinations.duckdb",
         "dlt.destinations.filesystem",
+        "dlt.destinations.lance",
     ):
         pytest.skip("ibis multi-schema test only on duckdb and filesystem")
 

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -69,7 +69,6 @@ from dlt.destinations.impl.filesystem.configuration import FilesystemDestination
 from dlt.destinations.sql_client import SqlClientBase
 from dlt.destinations.job_client_impl import SqlJobClientBase
 
-from tests.load.lance_utils import LanceRestServerConfig, get_lance_namespace_name
 from tests.utils import (
     ACTIVE_DESTINATIONS,
     ACTIVE_TABLE_FORMATS,
@@ -148,6 +147,16 @@ OBJECT_STORE_RS_BUCKETS = [
     for bucket in (FILE_BUCKET, AWS_BUCKET, GCS_BUCKET, AZ_BUCKET)
     if FilesystemDestinationClientConfiguration.parse_protocol(bucket) in ALL_FILESYSTEM_DRIVERS
 ]
+
+# random per test session: a shared lance namespace root accumulates a `__manifest` version per
+# namespace mutation, slowing all namespace operations down with every test run
+_LANCE_ROOT_SUFFIX = uniq_id(4)
+
+
+def get_lance_namespace_name() -> str:
+    # isolate per xdist worker — Lance __manifest writes conflict on S3
+    return f"dlt_lance_root_{get_test_worker_id()}_{_LANCE_ROOT_SUFFIX}"
+
 
 # Add r2 in extra buckets so it's not run for all tests
 R2_BUCKET_CONFIG = dict(
@@ -478,33 +487,16 @@ def destinations_configs(
         cid_configs_by_cid["athena-iceberg"],
         cid_configs_by_cid["athena-s3-tables"],
     ]
-
     lance_configs = [
-        # directory namespace configs
-        *[
-            DestinationTestConfiguration(
-                destination_type="lance",
-                extra_info=f"dir-{FilesystemConfiguration.parse_protocol(bucket)}",
-                env_vars={
-                    "DESTINATION__STORAGE__BUCKET_URL": bucket,
-                    "DESTINATION__STORAGE__NAMESPACE_NAME": get_lance_namespace_name(),
-                },
-            )
-            for bucket in OBJECT_STORE_RS_BUCKETS
-        ],
-        # REST namespace configs
-        # NOTE: we exclude cloud storage-backed REST namespaces here because `RestAdapter` (which
-        # we use as test REST Namespace server) does not vend credentials — we only include a
-        # local storage-backed REST namespace, which does not need credentials
-        *[
-            DestinationTestConfiguration(
-                destination_type="lance",
-                extra_info=f"rest-{FilesystemConfiguration.parse_protocol(bucket)}",
-                env_vars=LanceRestServerConfig.get_destination_test_configuration_env_vars(),
-            )
-            for bucket in OBJECT_STORE_RS_BUCKETS
-            if bucket == FILE_BUCKET
-        ],
+        DestinationTestConfiguration(
+            destination_type="lance",
+            extra_info=f"dir-{FilesystemConfiguration.parse_protocol(bucket)}",
+            env_vars={
+                "DESTINATION__STORAGE__BUCKET_URL": bucket,
+                "DESTINATION__STORAGE__NAMESPACE_NAME": get_lance_namespace_name(),
+            },
+        )
+        for bucket in OBJECT_STORE_RS_BUCKETS
     ]
 
     # default non staging sql based configs, one per destination

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -56,7 +56,11 @@ from dlt.common.storages import SchemaStorage, FileStorage, SchemaStorageConfigu
 from dlt.common.schema.utils import new_table, normalize_table_identifiers
 from dlt.common.storages import ParsedLoadJobFileName, LoadStorage, PackageStorage
 from dlt.common.storages.configuration import FilesystemConfiguration
-from dlt.common.storages.load_package import LoadJobInfo, create_load_id
+from dlt.common.storages.load_package import (
+    LoadJobInfo,
+    LoadPackageStateInjectableContext,
+    create_load_id,
+)
 from dlt.common.typing import StrAny
 from dlt.common.utils import uniq_id
 
@@ -1213,26 +1217,34 @@ def expect_load_file(
 
         return job
 
-    if isinstance(client, WithStagingDataset) and client.should_load_data_to_staging_dataset(
-        table_name
+    # jobs may use load package state (e.g. lance fragments) - inject it like the loader does
+    package_storage = PackageStorage(
+        FileStorage(os.path.join(file_storage.storage_path, "normalized_" + load_id)), "normalized"
+    )
+    package_storage.create_package(load_id)
+    with Container().injectable_context(
+        LoadPackageStateInjectableContext(storage=package_storage, load_id=load_id)
     ):
-        # load to staging dataset on merge
-        with client.with_staging_dataset():
+        if isinstance(client, WithStagingDataset) and client.should_load_data_to_staging_dataset(
+            table_name
+        ):
+            # load to staging dataset on merge
+            with client.with_staging_dataset():
+                job = _run_job(file_name)
+        else:
             job = _run_job(file_name)
-    else:
-        job = _run_job(file_name)
-    # execute table chain job
-    if chain_jobs := client.create_table_chain_completed_followup_jobs(
-        [table], [LoadJobInfo("completed_jobs", full_path, 0, 0, 0, job.job_file_info(), "")]  # type: ignore[arg-type]
-    ):
-        assert len(chain_jobs) == 1, "can't execute more than 1 chain job in this test"
-
-        _run_job(chain_jobs[0].new_file_path())
-
-    if isinstance(job, HasFollowupJobs):
-        if chain_jobs := job.create_followup_jobs("completed"):
+        # execute table chain job
+        if chain_jobs := client.create_table_chain_completed_followup_jobs(
+            [table], [LoadJobInfo("completed_jobs", full_path, 0, 0, 0, job.job_file_info(), "")]  # type: ignore[arg-type]
+        ):
             assert len(chain_jobs) == 1, "can't execute more than 1 chain job in this test"
+
             _run_job(chain_jobs[0].new_file_path())
+
+        if isinstance(job, HasFollowupJobs):
+            if chain_jobs := job.create_followup_jobs("completed"):
+                assert len(chain_jobs) == 1, "can't execute more than 1 chain job in this test"
+                _run_job(chain_jobs[0].new_file_path())
 
     return job
 

--- a/tests/sources/helpers/test_requests.py
+++ b/tests/sources/helpers/test_requests.py
@@ -238,7 +238,7 @@ def test_wait_retry_after_zero_then_nonzero_uses_header(mock_sleep: mock.MagicMo
 
     assert mock_sleep.call_count == 2
     assert mock_sleep.call_args_list[0][0][0] == 0  # Retry-After: 0 → backoff, but backoff_factor=0
-    assert 10 <= mock_sleep.call_args_list[1][0][0] <= 11 # Retry-After: 10 → wait for 10
+    assert 10 <= mock_sleep.call_args_list[1][0][0] <= 11  # Retry-After: 10 → wait for 10
 
 
 def test_init_default_client() -> None:

--- a/tests/workspace/deployment/test_launchers.py
+++ b/tests/workspace/deployment/test_launchers.py
@@ -333,10 +333,7 @@ def test_marimo_launcher_builds_correct_args() -> None:
         assert "--headless" in cmd
         assert "--no-token" in cmd
         assert "--asset-url" in cmd
-        assert (
-            "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
-            in cmd
-        )
+        assert "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist" in cmd
 
 
 def test_marimo_launcher_with_token() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2709,15 +2709,16 @@ hub = [
 lance = [
     { name = "duckdb" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10'" },
-    { name = "lancedb" },
+    { name = "lancedb", version = "0.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pylance" },
+    { name = "pylance", marker = "python_full_version >= '3.10'" },
 ]
 lancedb = [
     { name = "duckdb" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10'" },
-    { name = "lancedb" },
+    { name = "lancedb", version = "0.26.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "lancedb", version = "0.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -2965,7 +2966,7 @@ requires-dist = [
     { name = "ibis-framework", marker = "python_full_version >= '3.10' and extra == 'lance'", specifier = ">=12.0.0" },
     { name = "ibis-framework", marker = "python_full_version >= '3.10' and extra == 'lancedb'", specifier = ">=12.0.0" },
     { name = "jsonpath-ng", specifier = ">=1.5.3,<1.8" },
-    { name = "lancedb", marker = "extra == 'lance'", specifier = ">=0.22.0" },
+    { name = "lancedb", marker = "python_full_version >= '3.10' and extra == 'lance'", specifier = ">=0.33.0" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.22.0" },
     { name = "oracledb", marker = "extra == 'oracle'", specifier = ">=3.4.1" },
     { name = "orjson", marker = "python_full_version >= '3.14'", specifier = ">=3.11.0" },
@@ -3001,7 +3002,7 @@ requires-dist = [
     { name = "pydbml", marker = "extra == 'dbml'" },
     { name = "pyiceberg", marker = "extra == 'pyiceberg'", specifier = ">=0.9.1" },
     { name = "pyiceberg-core", marker = "extra == 'pyiceberg'", specifier = ">=0.6.0" },
-    { name = "pylance", marker = "extra == 'lance'", specifier = ">=4.0.0" },
+    { name = "pylance", marker = "python_full_version >= '3.10' and extra == 'lance'", specifier = ">=6.0.1,<8" },
     { name = "pyodbc", marker = "extra == 'fabric'", specifier = ">=4.0.39" },
     { name = "pyodbc", marker = "extra == 'mssql'", specifier = ">=4.0.39" },
     { name = "pyodbc", marker = "extra == 'synapse'", specifier = ">=4.0.39" },
@@ -5042,19 +5043,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.6.1"
+version = "0.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/9f/7906ba4117df8d965510285eaf07264a77de2fd283b9d44ec7fc63a4a57a/lance_namespace-0.6.1.tar.gz", hash = "sha256:f0deea442bd3f1056a8e2fed056ae2778e3356517ec2e680db049058b824d131", size = 10666, upload-time = "2026-03-17T17:55:44.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/5c/9822af615fc1bd3ee1073994696c739aecde377be32435ec3303aed1bc5d/lance_namespace-0.7.7.tar.gz", hash = "sha256:d00b525f2e26993a6c61668e798bca6c808605ab8a79f29f86a1a1af92d91ae2", size = 10754, upload-time = "2026-05-20T17:32:59.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/91/aee1c0a04d17f2810173bd304bd444eb78332045df1b0c1b07cebd01f530/lance_namespace-0.6.1-py3-none-any.whl", hash = "sha256:9699c9e3f12236e5e08ea979cc4e036a8e3c67ed2f37ae6f25c5353ab908e1be", size = 12498, upload-time = "2026-03-17T17:55:44.062Z" },
+    { url = "https://files.pythonhosted.org/packages/11/43/186acc1156da20c351db196e2b6241b2453b16dc1b4cc8e0a626667ca471/lance_namespace-0.7.7-py3-none-any.whl", hash = "sha256:477a7ca6b5e1f673a2c9ba52f42d6e8e3ff7c27a601392a21eb90fba98d0309b", size = 12581, upload-time = "2026-05-20T17:32:57.389Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.6.1"
+version = "0.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -5064,28 +5065,32 @@ dependencies = [
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/a1/8706a2be25bd184acccc411e48f1a42a4cbf3b6556cba15b9fcf4c15cfcc/lance_namespace_urllib3_client-0.6.1.tar.gz", hash = "sha256:31fbd058ce1ea0bf49045cdeaa756360ece0bc61e9e10276f41af6d217debe87", size = 182567, upload-time = "2026-03-17T17:55:46.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/95/38ab81ccc1e09beeecd8ddfc61b8bc73831dc5053db1e3f9021f64a4896b/lance_namespace_urllib3_client-0.7.7.tar.gz", hash = "sha256:4d8c066628c17c6a10cf643b51a7f7ae1bfb8a614d9cc54a5af38a4ba2b4b102", size = 202930, upload-time = "2026-05-20T17:32:58.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/c7/cb9580602dec25f0fdd6005c1c9ba1d4c8c0c3dc8d543107e5a9f248bba8/lance_namespace_urllib3_client-0.6.1-py3-none-any.whl", hash = "sha256:b9c103e1377ad46d2bd70eec894bfec0b1e2133dae0964d7e4de543c6e16293b", size = 317111, upload-time = "2026-03-17T17:55:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/35/96/5483e48e40433b1d078183c15a92c99e59a156041b0260e7f18ee34e7c08/lance_namespace_urllib3_client-0.7.7-py3-none-any.whl", hash = "sha256:9221c3e00fd89f0c811953d94b32d2ea527765280460a174f5872dc8a74c0ed6", size = 334767, upload-time = "2026-05-20T17:32:55.883Z" },
 ]
 
 [[package]]
 name = "lancedb"
 version = "0.26.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version < '3.10' and os_name == 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version < '3.10' and os_name != 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version < '3.10' and os_name == 'nt' and sys_platform == 'emscripten'",
+    "python_full_version < '3.10' and os_name != 'nt' and sys_platform == 'emscripten'",
+]
 dependencies = [
-    { name = "deprecation" },
-    { name = "lance-namespace" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
-    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "overrides", marker = "python_full_version < '3.12'" },
-    { name = "packaging" },
+    { name = "deprecation", marker = "python_full_version < '3.10'" },
+    { name = "lance-namespace", marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "overrides", marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "tqdm" },
+    { name = "tqdm", marker = "python_full_version < '3.10'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/b5/110651418ceb1fa4ff2eb74ce4bad911ecf49dc765b134f0201d5564aab8/lancedb-0.26.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:b1c4389134ede49e4be0497b9719f573f447e627426bb9e6fc1b642db11fb22d", size = 43416143, upload-time = "2026-01-02T17:57:07.232Z" },
@@ -5094,6 +5099,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/13/d8db83335ddf28afe1fb814ca995da7f67826f337d547e54471d7d425dd1/lancedb-0.26.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2941c9f8aa22244002307c4da5d19f12ab77dcb0569eb4f8a48b60e9c4fdee79", size = 45318771, upload-time = "2026-01-02T18:04:26.429Z" },
     { url = "https://files.pythonhosted.org/packages/08/94/10e9d4b5ba49eeba72024d310dc42e0c24feb8d5676f48e989198121a8a0/lancedb-0.26.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0d5f125b98836a49095c492085f5ecf3a78906fafcab59c367d9347eb372a4cc", size = 48425627, upload-time = "2026-01-02T18:11:57.443Z" },
     { url = "https://files.pythonhosted.org/packages/17/5d/d7a834ce8dd9c5e6ef7a0e308c7de5f87bb8f04c0944a1bea617d9d42dc7/lancedb-0.26.1-cp39-abi3-win_amd64.whl", hash = "sha256:9338d34c6e7472c97e49fd6b2638b29d3d087e8b002d92cafdbb46a8b0b1480e", size = 53214501, upload-time = "2026-01-02T22:34:06.836Z" },
+]
+
+[[package]]
+name = "lancedb"
+version = "0.33.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and os_name == 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and os_name != 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version >= '3.14' and os_name == 'nt' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and os_name != 'nt' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.13.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.12.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.11.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.13.*' and os_name == 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.13.*' and os_name != 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.12.*' and os_name == 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.11.*' and os_name == 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.10.*' and os_name == 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.12.*' and os_name != 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.11.*' and os_name != 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.10.*' and os_name != 'nt' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.13.*' and os_name == 'nt' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and os_name != 'nt' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and os_name == 'nt' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and os_name == 'nt' and sys_platform == 'emscripten'",
+    "python_full_version == '3.10.*' and os_name == 'nt' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and os_name != 'nt' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and os_name != 'nt' and sys_platform == 'emscripten'",
+    "python_full_version == '3.10.*' and os_name != 'nt' and sys_platform == 'emscripten'",
+]
+dependencies = [
+    { name = "deprecation", marker = "python_full_version >= '3.10'" },
+    { name = "lance-namespace", marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "overrides", marker = "python_full_version >= '3.10' and python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "tqdm", marker = "python_full_version >= '3.10'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/2f/d5a4b2a5bb1f800936c76a6d8a4daf127a86fcab621eeb70b574a5adc774/lancedb-0.33.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4eaf6fa7c2eac619208f1d396f4de635ee0f535673067118a31c1181575c48b", size = 48338115, upload-time = "2026-05-28T20:37:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/07/12/31787b93a856b2c31382c7771dc22fb05575b70b87c9efe454269f4f0948/lancedb-0.33.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c6c2402ed2744245ae76c4167c0461da0a7a80f1608e0ec491c1548ea2b4302", size = 51162262, upload-time = "2026-05-28T20:37:59.101Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/081cc29f8e06bf12191b99ab3fe702aceebdb0914476b821a8c0445cacc8/lancedb-0.33.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ebf1ffad811e6254a93931a79489ba1f21f48564bdfa06abae846f5fcaaf3e8", size = 54381368, upload-time = "2026-05-28T20:38:02.2Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/bd/e0f4bd621f10ecf96a801b0166e87799ed7ca5a9dbabcef9a6c766a58ef3/lancedb-0.33.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:13da39f80adfea59e5831fe64e4166b2d70a2f843e6507bf644c4fe4c350087c", size = 51188986, upload-time = "2026-05-28T20:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/1a/a8647a432ac6aa59cdce1fc061a7050ea4278bcab364539b78af2ecf72d2/lancedb-0.33.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:21b712825f0a00225e8974a41352c4ea84b0899ef8c23b17f672fadc38bd8346", size = 54440958, upload-time = "2026-05-28T20:38:08.474Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6c/d0cc8da784cd7ed3b4940a5d1f3e7702e2d99a0a348ba81a376eed782810/lancedb-0.33.0-cp39-abi3-win_amd64.whl", hash = "sha256:4ba78c6202b0f6c2ce8edc7aa470e550d2da56271c7cbdd10428613f1f7126f9", size = 58751944, upload-time = "2026-05-28T20:38:11.549Z" },
 ]
 
 [[package]]
@@ -9578,23 +9640,22 @@ crypto = [
 
 [[package]]
 name = "pylance"
-version = "4.0.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lance-namespace" },
-    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')" },
+    { name = "lance-namespace", marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*' or python_full_version == '3.13.*'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pyarrow", version = "23.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/29/5152da1261a628c293876917b6185538bd68f4cf1420da6265b5be79d09b/pylance-4.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7310892f3089eeddb1af1fe5c398b71cc483a3015646caceaa2f62fc92b227b2", size = 54420876, upload-time = "2026-03-30T18:18:37.525Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ae/7edbbfc18c3be43eedb886e74a17826c09fdf35588b35912f2733779ea43/pylance-4.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57f6a521b1b4b77a62d791850213a854093719c7d76b9641e8abcd445eb73e56", size = 56752552, upload-time = "2026-03-30T18:24:21.331Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/88/6d8bda83224bac52806f09d3e211d8886b81500384948a753c4b24c11f35/pylance-4.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e433d6bddd66de99c58e472bc3e8ed1590c7ff4ff7948479254c1c2111a601a8", size = 60305704, upload-time = "2026-03-30T18:35:23.425Z" },
-    { url = "https://files.pythonhosted.org/packages/52/f3/8d8369c756c4173ea070f6964213f9b622ac278bd04a058c48d00a549177/pylance-4.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f36dce83c11cd5d598cb0f64bad7c51fc21ed43df868b9029184a385c6bf4d84", size = 56771233, upload-time = "2026-03-30T18:25:40.012Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e6/53e0713440685b1c76e20d72755eca2e531cc182ea9a612b4cb6a15abe50/pylance-4.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9ca03f97f22e0b75f06378c4006d587aba26408122fd066f0e43e2b7a019c67e", size = 60260813, upload-time = "2026-03-30T18:36:07.976Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/04/5f22b88c8965d3982f68f67bfe24d756e7b788e10392d2bec6f97f5eb0e3/pylance-4.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:9261c32d3bd6aaab33025a45b20c2f2554804e1bc2a1ec2bfcb06f0c9d2e59b9", size = 65137830, upload-time = "2026-03-30T18:37:33.048Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/2f64921bf346e7075aef24a72595db44821724a3d89a9a92dd24e79632aa/pylance-7.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:98422021975be76e72b1572f41b8c9abb3bee5bdc9bfa5e9ce731110a65ed4d1", size = 62134146, upload-time = "2026-05-27T21:59:37.459Z" },
+    { url = "https://files.pythonhosted.org/packages/73/1c/c5a01bee0160b55d9a98895cbd33091d038f0a0995b121ab72e629008d02/pylance-7.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4bec86ee5b6fbd8bfc493e653f0a1fba0303cfe5492b9b46fc25ab908edc7183", size = 65373684, upload-time = "2026-05-27T22:04:01.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/da/1fe8b8f7dbfe734d76af76acc994fc360a0d0c79a4874ef69f5a72a58fe3/pylance-7.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:881491432c53184e52f8d1db8d5f872f39a03f36fb104bec77b33d379519d8b5", size = 69458555, upload-time = "2026-05-27T22:16:50.567Z" },
+    { url = "https://files.pythonhosted.org/packages/76/f0/dd505cf3fd0226ab9d94759acd713125af1d3bfacfd80bbd52e3b9f89509/pylance-7.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:18453999e7fff4f76b16d6b7882c9df0628bd142ff95e2461bd7dd5ee3fe0af3", size = 65394430, upload-time = "2026-05-27T22:05:30.923Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ba/2357b81034f28eb00790e258ed140289a6a887a7468ca9df6349fd186b27/pylance-7.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:04a58051d408c60fe76d41a220dcaf8fea8fb6d1aa0ca78a709b60bc3cc8d19a", size = 69473470, upload-time = "2026-05-27T22:17:18.935Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ec/5c00b6303a67d787f9475141832cbdc513d674ac3dcaeef8a7b169905e65/pylance-7.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:467d4864af047eaab4e1370e2f1e88e2c6f507c079874421116cb41d78bc3629", size = 74792863, upload-time = "2026-05-27T22:19:23.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## ⚠️ Breaking changes

- **`refresh="drop_data"` on Delta and persistent-catalog Iceberg no longer frees storage.** Truncation is now a transactional delete that keeps the table, schema, version history, and data files (retained for time travel until `vacuum`). Previously the files were deleted. (this is **bugfix** that changes previous erroneous behavior)

## Bug fixes

- **Fixes #3800** — Iceberg tables left in the catalog after `refresh="drop_sources"` caused `409 Table already exists` on the next run. `drop_tables` now drops the table from a persistent catalog. Supersedes #3801, and handles the case #3801 misses (tables already removed from the schema, detected via the on-storage `metadata/` dir).
- **Stale nested-table data in `replace` chains** — nested tables of a replaced resource that receive no data in a run got no load job and were never emptied (the old "logical replace" left stale rows). They are now truncated.
- **Lance credential expiry on long loads** — same class as #4003 (but for the lance/`object_store` path, not the s3fs path that #4003/#4004 cover): the namespace pool re-resolves and rebuilds the handle when rotatable storage tokens change, avoiding `ExpiredToken`.
- **Lance `replace` is now a single `Overwrite` commit** instead of truncate-and-insert. Readers never observe a partially-replaced table; a mid-load failure leaves the old data intact (previously left an empty table).

## Lance destination

- **Namespace/session pooling** (`LanceNamespacePool`/`LanceNamespaceHandle`): one shared `LanceNamespace` + `lance.Session` + storage options dispensed to all job clients, retained across load steps, rebuilt only on credential rotation.
- **Atomic single-commit-per-table:** `LanceLoadJob` writes uncommitted fragments in parallel (no version contention); a per-table followup `LanceCommitLoadJob` commits them in one version — `Append` for append, `Overwrite` for replace, one `upsert` over all files for merge.
- **Commit-job idempotency** on retry/resume: a re-run append detects its already-committed fragments and skips; a re-run replace repeats the same deterministic `Overwrite`.
- **Typed exception classification:** uses `lance_namespace.errors` typed not-found exceptions where available, with a string-match fallback for pylance-core errors (which expose no typed not-found exceptions).
- **New `LanceManifestMisconfiguration`** terminal error: distinguishes "manifest mode configured but storage/creds broken" from a genuinely missing entity.

## Filesystem (Delta / Iceberg)

- **Transactional truncate** for Delta (`truncate_delta_table`) and persistent-catalog Iceberg (`truncate_iceberg_table`); ephemeral (in-memory) Iceberg catalogs and all other tables still delete files.
- **Atomic replace** skips the up-front truncate for Delta/Iceberg tables that have data jobs (their load job overwrites atomically); jobless chain tables are still truncated. `should_truncate_table_before_load` override removed.
- **Iceberg catalog drop integration** with new config `iceberg_use_catalog_purge` (default `False`): when off, dlt deletes table files itself; when on, delegates to `catalog.purge_table` with fallbacks for rejected purges (`NotImplementedError`/400/403).
- **Iceberg namespace caching fix:** namespace creation is now tracked per active `dataset_name` (`_catalog_namespaces`) instead of once-per-catalog, so the staging dataset's namespace is created and there's no `create_namespace` round trip on every catalog access.
