### PR TITLE
fix: propagate _dlt_root_id to child tables for scd2 merge strategy

### DIFF
--- a/dlt/common/normalizers/json/helpers.py
+++ b/dlt/common/normalizers/json/helpers.py
@@ -138,7 +138,7 @@ def requires_root_key(
     """Checks if table chain containing `table` requires root_key to propagate.
 
     1. if there's any table with `root_key` in table chain already - we always propagate
-    2. if write disposition is merge and merge strategy is "delete-insert", "upsert" and root_key_propagation is not False
+    2. if write disposition is merge and merge strategy is "delete-insert", "upsert", "scd2" and root_key_propagation is not False
     3. root_key_propagation is True
     """
     table_name = root_table["name"]
@@ -148,7 +148,7 @@ def requires_root_key(
     else:
         merge_strategy = resolve_merge_strategy(schema.tables, root_table)
         merge_requires = (
-            merge_strategy in ["delete-insert", "upsert", "insert-only"]
+            merge_strategy in ["delete-insert", "upsert", "insert-only", "scd2"]
             if root_key_propagation is None
             else root_key_propagation
         )

--- a/tests/common/normalizers/test_json_relational.py
+++ b/tests/common/normalizers/test_json_relational.py
@@ -980,7 +980,7 @@ def test_caching_perf(norm: RelationalNormalizer) -> None:
         ("delete-insert", None, False, True),
         ("upsert", None, False, True),
         ("insert-only", None, False, True),
-        ("scd2", None, False, False),
+        ("scd2", None, False, True),
         ("append", None, False, False),
         ("replace", None, False, False),
         # Test with root_key_propagation explicitly True (should always be True)
@@ -1016,7 +1016,7 @@ def test_caching_perf(norm: RelationalNormalizer) -> None:
         "delete-insert_default_no-nested_requires-key",
         "upsert_default_no-nested_requires-key",
         "insert-only_default_no-nested_requires-key",
-        "scd2_default_no-nested_no-key-required",
+        "scd2_default_no-nested_requires-key",
         "append_default_no-nested_no-key-required",
         "replace_default_no-nested_no-key-required",
         # Names for explicit True tests


### PR DESCRIPTION
requires_root_key() had a whitelist of strategies that auto-enable root key propagation: delete-insert, upsert, insert-only. scd2 was missing, so nested tables silently lost the _dlt_root_id column — breaking parent-version linkage.

Added "scd2" to the whitelist. Updated the corresponding test expectation.

Fixes #4047