### PR TITLE
fix(sql_database): warn when type_adapter_callback returns None and clarify docs

### DIFF
--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -94,7 +94,12 @@ def sql_database(
         include_views (bool): Reflect views as well as tables. Note view names included in `table_names` are always included regardless of this setting.
 
         type_adapter_callback (Optional[TTypeAdapter]): Callable to override type inference when reflecting columns.
-            Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type, or `None` (type will be inferred from data)
+            Argument is a single sqlalchemy data type (`TypeEngine` instance). Return another sqlalchemy
+            data type to override it, return the argument unchanged to keep the reflected type, or return
+            `None` to drop the reflected type and infer the data type from the data.
+            Warning: for a selective override, return the unchanged argument for types you do not adapt.
+            Returning `None` discards the reflected type, and with the `pyarrow`/`pandas` backends the
+            inferred type may differ across batches (e.g. decimal precision), which can fail the load.
 
         query_adapter_callback (Optional[TQueryAdapter]): Callable to override the SELECT query used to fetch data from the table.
             The callback receives the sqlalchemy `Select` and corresponding `Table`, 'Incremental` and `Engine` objects and should return the modified `Select` or `Text`.
@@ -248,7 +253,12 @@ def sql_table(
         backend_kwargs (Dict[str, Any], optional): kwargs passed to table backend ie. "conn" is used to pass specialized connection string to connectorx.
 
         type_adapter_callback (Optional[TTypeAdapter]): Callable to override type inference when reflecting columns.
-            Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type, or `None` (type will be inferred from data)
+            Argument is a single sqlalchemy data type (`TypeEngine` instance). Return another sqlalchemy
+            data type to override it, return the argument unchanged to keep the reflected type, or return
+            `None` to drop the reflected type and infer the data type from the data.
+            Warning: for a selective override, return the unchanged argument for types you do not adapt.
+            Returning `None` discards the reflected type, and with the `pyarrow`/`pandas` backends the
+            inferred type may differ across batches (e.g. decimal precision), which can fail the load.
 
         included_columns (Optional[List[str]]): List of column names to select from the table. If not provided, all columns are loaded.
 

--- a/dlt/sources/sql_database/schema_types.py
+++ b/dlt/sources/sql_database/schema_types.py
@@ -123,7 +123,18 @@ def sqla_col_to_column_schema(
             sql_t = sql_t()
 
     if sql_t is None:
-        # Column ignored by callback
+        # `type_adapter_callback` returned None: drop the reflected type and let the
+        # backend infer the data type from the data (documented behavior). Warn because
+        # inference is per-batch for the `pyarrow`/`pandas` backends, so a column like
+        # NUMERIC(7, 2) can yield incompatible decimal types across batches and fail the
+        # load. Return the SQL type unchanged from the callback to keep the reflected type.
+        logger.warning(
+            f"`type_adapter_callback` returned None for column {sql_col.name} of reflected type"
+            f" {sql_col.type}. dlt will drop the reflected type and infer the data type from the"
+            " data. With the `pyarrow` and `pandas` backends inference happens per batch, so"
+            " types may differ across batches and the load may fail. Return the SQL type"
+            " unchanged from the callback to keep the reflected type."
+        )
         return col
 
     add_precision = reflection_level == "full_with_precision"

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
@@ -184,12 +184,19 @@ most of the coercion problems.
 
 ### Adapt reflected types to your needs
 
-You can also override the SQL type by passing a `type_adapter_callback` function. This function takes a `SQLAlchemy` data type as input and returns a new type (or `None` to force the column to be inferred from the data) as output.
+You can also override the SQL type by passing a `type_adapter_callback` function. This function takes a `SQLAlchemy` data type as input and returns:
+- a new `SQLAlchemy` type to override it,
+- the input type unchanged to keep the reflected type,
+- or `None` to drop the reflected type and have `dlt` infer the data type from the data.
 
 This is useful, for example, when:
 - You're loading a data type that is not supported by the destination (e.g., you need JSON type columns to be coerced to string).
 - You're using a sqlalchemy dialect that uses custom types that don't inherit from standard sqlalchemy types.
 - For certain types, you prefer `dlt` to infer the data type from the data and you return `None`.
+
+:::warning
+For a selective override, return the **input type unchanged** for the types you don't adapt (as in the example below). Returning `None` is not a "no change" signal: it discards the reflected type. With the `pyarrow` and `pandas` backends the data type is then inferred per batch, so a column such as `NUMERIC(7, 2)` can produce incompatible types across batches (e.g. `decimal128(5, 2)` vs `decimal128(2, 2)`) and fail the load with `Table schema does not match schema used to create file`.
+:::
 
 In the following example, when loading timestamps from Snowflake, you ensure that they get translated into standard sqlalchemy `timestamp` columns in the resultant schema:
 

--- a/tests/sources/sql_database/test_schema_types.py
+++ b/tests/sources/sql_database/test_schema_types.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 import sqlalchemy as sa
 from sqlalchemy.dialects.mssql import DATETIMEOFFSET, UNIQUEIDENTIFIER
@@ -10,6 +12,8 @@ from dlt.sources.sql_database.schema_types import (
     sqla_col_to_column_schema,
     _is_uuid_type,
 )
+
+from tests.utils import capture_dlt_logger
 
 
 @pytest.mark.parametrize(
@@ -103,6 +107,38 @@ def test_datetime_timezone_mapping(sql_type: sa.types.TypeEngine, expected_tz: b
     col_schema = sqla_col_to_column_schema(table.c.col, "full")
     assert col_schema is not None
     assert col_schema["timezone"] is expected_tz
+
+
+def test_type_adapter_unchanged_keeps_reflected_type() -> None:
+    """Returning the argument unchanged from the callback is the 'no change' pattern: the
+    reflected type is mapped as usual."""
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("price", sa.Numeric(7, 2)))
+
+    col_schema = sqla_col_to_column_schema(
+        table.c.price, "full_with_precision", type_adapter_callback=lambda sql_t: sql_t
+    )
+    assert col_schema is not None
+    assert col_schema["data_type"] == "decimal"
+    assert col_schema["precision"] == 7
+    assert col_schema["scale"] == 2
+
+
+def test_type_adapter_none_drops_type_and_warns(caplog: Any) -> None:
+    """Returning None from the callback drops the reflected type (inferred from data) and warns
+    so the behavior is not silent."""
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("price", sa.Numeric(7, 2)))
+
+    with capture_dlt_logger(caplog):
+        col_schema = sqla_col_to_column_schema(
+            table.c.price, "full_with_precision", type_adapter_callback=lambda sql_t: None
+        )
+    assert col_schema is not None
+    assert "data_type" not in col_schema
+    assert any(
+        "price" in r.message and "returned None for column" in r.message for r in caplog.records
+    )
 
 
 def test_get_table_references() -> None:


### PR DESCRIPTION
Closes #4032.

When `type_adapter_callback` returns `None`, dlt drops the reflected `data_type` for that column. That's documented behaviour ("infer the type from data"), but it bites under `backend="pyarrow"`/`"pandas"`: pyarrow then infers the type per batch, so a `NUMERIC(7,2)` column comes out as `decimal128(5,2)` in one batch and `decimal128(2,2)` in another. `ArrowToParquetWriter` opens the file with the first batch's schema, the next batch doesn't match, and the extract dies mid-run with:

```
ValueError: Table schema does not match schema used to create file
```

The catch is that the natural "no change" pattern looks like `return None`, when it actually has to be `return sql_type`.

### What I did

I kept the `None` behaviour rather than flipping it to mean "keep the reflected type". Returning `None` to force data inference is intentional and documented (it's the escape hatch for custom dialect types that don't map onto standard SQLAlchemy types), so changing it would be a breaking change. Instead this makes the footgun loud:

- Log a warning when the callback returns `None` and the reflected type is dropped, naming the column and explaining the per-batch inference risk.
- Clarify the `sql_database`/`sql_table` docstrings and the `advanced.md` docs: return the input unchanged for the "no change" case, `None` discards the type.
- Tests in `tests/sources/sql_database/test_schema_types.py` for both the warning path and the pass-through (`return sql_type`) path.

### Out of scope

This doesn't touch the deeper behaviour where any `data_type=None` column infers per batch (that also hits unknown reflected types, not just the callback). Happy to follow up on that separately if you'd like it addressed.