### PR TITLE
fix(hf): don't print huggingface_hub progress bars by default

### DIFF
--- a/dlt/destinations/impl/filesystem/configuration.py
+++ b/dlt/destinations/impl/filesystem/configuration.py
@@ -63,6 +63,9 @@ class HfFilesystemDestinationClientConfiguration(FilesystemDestinationClientConf
     credentials: HfCredentials = None
     hf_dataset_card: bool = True
     """Create and update dataset card (README.md) with subset metadata for the Hugging Face dataset viewer."""
+    hf_show_progress: bool = False
+    """Show `huggingface_hub` upload and commit progress bars in the terminal. Disabled by default so
+    that `dlt` controls progress reporting via `dlt.pipeline(progress=...)`."""
 
     @property
     def hf_namespace(self) -> str:

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -1464,9 +1464,21 @@ class HfFilesystemClient(FilesystemClient):
         capabilities: DestinationCapabilitiesContext,
     ) -> None:
         from huggingface_hub import HfApi
+        from huggingface_hub.constants import HF_HUB_DISABLE_PROGRESS_BARS
+        from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 
         super().__init__(schema, config, capabilities)
         self.config: HfFilesystemDestinationClientConfiguration = config
+        # by default dlt reports progress via `dlt.pipeline(progress=...)`, so silence the
+        # `huggingface_hub` upload and commit tqdm progress bars unless the user opts in. the
+        # `HF_HUB_DISABLE_PROGRESS_BARS` env var (None when unset) takes priority in
+        # `huggingface_hub`, so we only set the global state when the user has not pinned it via
+        # the env var -- otherwise `huggingface_hub` warns and ignores us on every construction
+        if HF_HUB_DISABLE_PROGRESS_BARS is None:
+            if config.hf_show_progress:
+                enable_progress_bars()
+            else:
+                disable_progress_bars()
         self.hf_api = HfApi(**config.credentials.to_hf_api_credentials())
 
     @property

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -1464,21 +1464,31 @@ class HfFilesystemClient(FilesystemClient):
         capabilities: DestinationCapabilitiesContext,
     ) -> None:
         from huggingface_hub import HfApi
-        from huggingface_hub.constants import HF_HUB_DISABLE_PROGRESS_BARS
-        from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
+        from huggingface_hub.utils import (
+            are_progress_bars_disabled,
+            disable_progress_bars,
+            enable_progress_bars,
+        )
 
         super().__init__(schema, config, capabilities)
         self.config: HfFilesystemDestinationClientConfiguration = config
         # by default dlt reports progress via `dlt.pipeline(progress=...)`, so silence the
-        # `huggingface_hub` upload and commit tqdm progress bars unless the user opts in. the
-        # `HF_HUB_DISABLE_PROGRESS_BARS` env var (None when unset) takes priority in
-        # `huggingface_hub`, so we only set the global state when the user has not pinned it via
-        # the env var -- otherwise `huggingface_hub` warns and ignores us on every construction
-        if HF_HUB_DISABLE_PROGRESS_BARS is None:
-            if config.hf_show_progress:
-                enable_progress_bars()
-            else:
-                disable_progress_bars()
+        # `huggingface_hub` upload and commit tqdm progress bars unless the user opts in.
+        # `huggingface_hub` exposes no scoped/per-client switch for these bars, so this is a
+        # process-global toggle (the same one `disable_progress_bars()`/`enable_progress_bars()`
+        # flip); with concurrent pipelines using different settings the last constructed client
+        # wins. we minimize that churn by only flipping the state when it actually differs.
+        # the `HF_HUB_DISABLE_PROGRESS_BARS` env var takes priority in `huggingface_hub`, so when
+        # the user pinned it we leave the global state alone -- detecting presence (rather than the
+        # parsed constant) keeps this robust across `huggingface_hub` versions and avoids
+        # `huggingface_hub` warning and ignoring us on every construction
+        if "HF_HUB_DISABLE_PROGRESS_BARS" not in os.environ:
+            want_disabled = not config.hf_show_progress
+            if are_progress_bars_disabled() is not want_disabled:
+                if config.hf_show_progress:
+                    enable_progress_bars()
+                else:
+                    disable_progress_bars()
         self.hf_api = HfApi(**config.credentials.to_hf_api_credentials())
 
     @property

--- a/docs/website/docs/dlt-ecosystem/destinations/huggingface.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/huggingface.md
@@ -147,6 +147,16 @@ hf_dataset_card = false
 
 When disabled, the dataset viewer will not display table subsets, but data loading is unaffected.
 
+### Upload progress bars
+By default, `dlt` reports progress via `dlt.pipeline(progress=...)`, so the `huggingface_hub` upload and commit progress bars are not printed to the terminal. To show them, set `hf_show_progress` to `true`:
+
+```toml
+[destination.filesystem]
+hf_show_progress = true
+```
+
+This toggles the `huggingface_hub` progress bars process-wide (the same global switch as `disable_progress_bars()`/`enable_progress_bars()`). If you set the `HF_HUB_DISABLE_PROGRESS_BARS` environment variable, it takes priority and `hf_show_progress` is ignored.
+
 ### Atomic commits
 
 All data files for a table and its child tables are committed to the Hub in a single git commit via the `HfApi` client. This minimizes the number of commits, avoids hitting Hugging Face [rate limits](https://huggingface.co/docs/hub/rate-limits#rate-limit-tiers), and prevents commit conflicts.

--- a/tests/load/filesystem/test_filesystem_factory.py
+++ b/tests/load/filesystem/test_filesystem_factory.py
@@ -87,6 +87,70 @@ def test_resolve_bucket_url_ignores_foreign_credentials():
         assert not fs.is_hf
 
 
+@pytest.mark.parametrize("hf_show_progress", [True, False])
+def test_hf_show_progress_flag(hf_show_progress: bool) -> None:
+    """huggingface_hub progress bars are disabled by default and enabled only when opted in."""
+    from huggingface_hub.utils import (
+        are_progress_bars_disabled,
+        enable_progress_bars,
+    )
+
+    config = MagicMock(spec=HfFilesystemDestinationClientConfiguration)
+    config.hf_show_progress = hf_show_progress
+    config.credentials = MagicMock()
+    config.credentials.to_hf_api_credentials.return_value = {}
+
+    client = MagicMock(spec=HfFilesystemClient)
+    client.config = config
+
+    # start from a known state where progress bars are enabled
+    enable_progress_bars()
+    try:
+        # env var unset -> the config flag controls the global state
+        with patch("huggingface_hub.constants.HF_HUB_DISABLE_PROGRESS_BARS", None):
+            with patch("huggingface_hub.HfApi"):
+                with patch.object(FilesystemClient, "__init__", return_value=None):
+                    HfFilesystemClient.__init__(client, MagicMock(), config, MagicMock())
+        assert are_progress_bars_disabled() is (not hf_show_progress)
+    finally:
+        enable_progress_bars()
+
+
+@pytest.mark.parametrize("env_disabled", [True, False])
+def test_hf_show_progress_respects_env_var(env_disabled: bool) -> None:
+    """`HF_HUB_DISABLE_PROGRESS_BARS` takes priority: dlt leaves the global state untouched
+    and does not emit huggingface_hub's "env var has priority" warning."""
+    import warnings
+
+    from huggingface_hub.utils import enable_progress_bars
+
+    config = MagicMock(spec=HfFilesystemDestinationClientConfiguration)
+    config.hf_show_progress = False
+    config.credentials = MagicMock()
+    config.credentials.to_hf_api_credentials.return_value = {}
+
+    client = MagicMock(spec=HfFilesystemClient)
+    client.config = config
+
+    enable_progress_bars()
+    try:
+        # env var pinned (True or False) -> dlt must not touch the global state
+        with (
+            patch("huggingface_hub.constants.HF_HUB_DISABLE_PROGRESS_BARS", env_disabled),
+            patch("huggingface_hub.utils.disable_progress_bars") as disable_mock,
+            patch("huggingface_hub.utils.enable_progress_bars") as enable_mock,
+        ):
+            with patch("huggingface_hub.HfApi"):
+                with patch.object(FilesystemClient, "__init__", return_value=None):
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("error")
+                        HfFilesystemClient.__init__(client, MagicMock(), config, MagicMock())
+            disable_mock.assert_not_called()
+            enable_mock.assert_not_called()
+    finally:
+        enable_progress_bars()
+
+
 @pytest.mark.parametrize("hf_dataset_card", [True, False])
 def test_hf_dataset_card_flag(hf_dataset_card: bool) -> None:
     """Card operations are called only when hf_dataset_card is True."""

--- a/tests/load/filesystem/test_filesystem_factory.py
+++ b/tests/load/filesystem/test_filesystem_factory.py
@@ -88,7 +88,7 @@ def test_resolve_bucket_url_ignores_foreign_credentials():
 
 
 @pytest.mark.parametrize("hf_show_progress", [True, False])
-def test_hf_show_progress_flag(hf_show_progress: bool) -> None:
+def test_hf_show_progress_flag(hf_show_progress: bool, monkeypatch: pytest.MonkeyPatch) -> None:
     """huggingface_hub progress bars are disabled by default and enabled only when opted in."""
     from huggingface_hub.utils import (
         are_progress_bars_disabled,
@@ -103,27 +103,33 @@ def test_hf_show_progress_flag(hf_show_progress: bool) -> None:
     client = MagicMock(spec=HfFilesystemClient)
     client.config = config
 
+    # env var absent -> the config flag controls the global state. patch the environment (the
+    # same signal users set) rather than huggingface_hub's parsed constant
+    monkeypatch.delenv("HF_HUB_DISABLE_PROGRESS_BARS", raising=False)
+
     # start from a known state where progress bars are enabled
     enable_progress_bars()
     try:
-        # env var unset -> the config flag controls the global state
-        with patch("huggingface_hub.constants.HF_HUB_DISABLE_PROGRESS_BARS", None):
-            with patch("huggingface_hub.HfApi"):
-                with patch.object(FilesystemClient, "__init__", return_value=None):
-                    HfFilesystemClient.__init__(client, MagicMock(), config, MagicMock())
+        with patch("huggingface_hub.HfApi"):
+            with patch.object(FilesystemClient, "__init__", return_value=None):
+                HfFilesystemClient.__init__(client, MagicMock(), config, MagicMock())
         assert are_progress_bars_disabled() is (not hf_show_progress)
     finally:
         enable_progress_bars()
 
 
-@pytest.mark.parametrize("env_disabled", [True, False])
-def test_hf_show_progress_respects_env_var(env_disabled: bool) -> None:
-    """`HF_HUB_DISABLE_PROGRESS_BARS` takes priority: dlt leaves the global state untouched
-    and does not emit huggingface_hub's "env var has priority" warning."""
+@pytest.mark.parametrize("env_value", ["1", "0"], ids=["env_disabled", "env_enabled"])
+def test_hf_show_progress_respects_env_var(env_value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`HF_HUB_DISABLE_PROGRESS_BARS` takes priority: when the user pinned the env var dlt leaves
+    the global state untouched and does not emit huggingface_hub's "env var has priority" warning.
+    """
     import warnings
 
     from huggingface_hub.utils import enable_progress_bars
 
+    # default config (hf_show_progress=False) while the global state starts enabled -- absent the
+    # env-var guard dlt would call `disable_progress_bars()`, so the asserts below prove the env
+    # var (not the no-op churn check) is what keeps the state untouched
     config = MagicMock(spec=HfFilesystemDestinationClientConfiguration)
     config.hf_show_progress = False
     config.credentials = MagicMock()
@@ -132,11 +138,12 @@ def test_hf_show_progress_respects_env_var(env_disabled: bool) -> None:
     client = MagicMock(spec=HfFilesystemClient)
     client.config = config
 
+    # env var present (set to any value) -> dlt must not touch the global state
+    monkeypatch.setenv("HF_HUB_DISABLE_PROGRESS_BARS", env_value)
+
     enable_progress_bars()
     try:
-        # env var pinned (True or False) -> dlt must not touch the global state
         with (
-            patch("huggingface_hub.constants.HF_HUB_DISABLE_PROGRESS_BARS", env_disabled),
             patch("huggingface_hub.utils.disable_progress_bars") as disable_mock,
             patch("huggingface_hub.utils.enable_progress_bars") as enable_mock,
         ):


### PR DESCRIPTION
## Summary

Loading to the filesystem destination over `hf://` printed `huggingface_hub`'s own tqdm progress bars on every `pipeline.run()`. dlt already manages progress via `dlt.pipeline(progress=...)`, so these are unrequested noise.

This disables them by default and adds an opt-in `hf_show_progress` config to re-enable. The toggle is guarded on `HF_HUB_DISABLE_PROGRESS_BARS` being unset, so dlt defers to that env var and doesn't emit huggingface_hub's "env var has priority" warning.

## Changes

- Add `hf_show_progress: bool = False` to the filesystem destination configuration
- Toggle huggingface_hub progress bars in `HfFilesystemClient.__init__`, guarded on the env var being unset
- Document the option (process-global; `HF_HUB_DISABLE_PROGRESS_BARS` takes priority)
- Tests for default/opt-in and the env-var path

## Testing

- `uv run pytest tests/load/filesystem/test_filesystem_factory.py` → 8 passed
- `ruff check`, `black --check`, `mypy` on touched files → clean

Closes #3690