### PR TITLE
fix(cli): route dlthub handoff NOTE to stderr so piping isn't broken

### DIFF
--- a/dlt/_workspace/cli/_dlt.py
+++ b/dlt/_workspace/cli/_dlt.py
@@ -375,12 +375,15 @@ def _main() -> None:
     # when workspace is active, dlt commands mirrors dlthub
     if is_workspace_active():
         host = "dlthub"
+        # emit the handoff banner on stderr so it never corrupts piped stdout (e.g. `dlt local
+        # schema --format json ... > file.json`)
         fmt.note(
             "Please use %s as top level command. Check `%s` for former dlt commands. "
             "Falling back to dlthub command set."
-            % (fmt.bold("dlthub"), fmt.bold("dlthub local --help"))
+            % (fmt.bold("dlthub"), fmt.bold("dlthub local --help")),
+            err=True,
         )
-        fmt.echo()
+        fmt.echo(err=True)
     else:
         host = "dlt"
     exit(main(host))

--- a/dlt/_workspace/cli/echo.py
+++ b/dlt/_workspace/cli/echo.py
@@ -131,8 +131,8 @@ def warning(msg: str) -> None:
     click.secho("WARNING: " + msg, fg="yellow")
 
 
-def note(msg: str) -> None:
-    click.secho("NOTE: " + msg, fg="green")
+def note(msg: str, err: bool = False) -> None:
+    click.secho("NOTE: " + msg, fg="green", err=err)
 
 
 def _raise_no_default(text: str) -> None:

--- a/tests/workspace/cli/common/test_cli_invoke.py
+++ b/tests/workspace/cli/common/test_cli_invoke.py
@@ -406,7 +406,11 @@ def test_main_in_workspace_prints_dlthub_handoff_note(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """`_main()` inside a workspace tells the user to use the `dlthub` command."""
+    """`_main()` inside a workspace tells the user to use the `dlthub` command.
+
+    The handoff banner must go to stderr so it never corrupts piped stdout data
+    (e.g. `dlt local schema --format json ... > file.json`). See issue #4035.
+    """
     # short-circuit the inner dispatch so we only exercise the handoff branch
     monkeypatch.setattr("dlt._workspace.cli._dlt.main", lambda host: 0)
     monkeypatch.setattr("sys.argv", ["dlt", "--version"])
@@ -414,10 +418,12 @@ def test_main_in_workspace_prints_dlthub_handoff_note(
         _main()
     assert ei.value.code == 0
     captured = capsys.readouterr()
-    combined = captured.out + captured.err
-    assert "Please use" in combined
-    assert "dlthub" in combined
-    assert "dlthub local --help" in combined
+    # banner is on stderr, never on stdout (which carries the command's data output)
+    assert "Please use" in captured.err
+    assert "dlthub" in captured.err
+    assert "dlthub local --help" in captured.err
+    assert "Please use" not in captured.out
+    assert "NOTE:" not in captured.out
 
 
 def test_main_outside_workspace_no_handoff_note(


### PR DESCRIPTION
Closes #4035.

## Summary

When a dlt workspace is active, every `dlt ...` command printed a green `NOTE: Please use dlthub ...` banner to **stdout** before delegating to the dlthub command set — corrupting piped output (e.g. `dlt local schema --format json SCHEMA > out.json` wrote the NOTE into the JSON, breaking it).

This routes the banner to **stderr**: `fmt.note()` gains an opt-in `err: bool = False` (default preserves every existing caller, including the deploy-NOTE test that asserts on stdout), and the single handoff call site in `_main()` passes `err=True`.

## Tests

- Regression test red-green proven: fails without the fix (NOTE on stdout, stderr empty), passes with it
- `black --check`, `ruff check`, `flake8`, `mypy` green on the 3 touched files