### PR TITLE
Update docs to remove memory warning from deltars

### DIFF
--- a/docs/website/docs/dlt-ecosystem/destinations/delta-iceberg.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/delta-iceberg.md
@@ -132,7 +132,3 @@ You don't need to specify credentials here. dlt merges the required credentials 
 
 >❗When using `s3`, you need to specify storage options to [configure](https://delta-io.github.io/delta-rs/usage/writing/writing-to-s3-with-locking-provider/) locking behavior.
 
-## Delta table format memory usage
-:::warning
-Beware that when loading a large amount of data for one table, the underlying rust implementation will consume a lot of memory. This is a known issue and the maintainers are actively working on a solution. You can track the progress [here](https://github.com/delta-io/delta-rs/pull/2289). Until the issue is resolved, you can mitigate the memory consumption by doing multiple smaller incremental pipeline runs.
-:::

--- a/docs/website/docs/hub/ingestion/delta.md
+++ b/docs/website/docs/hub/ingestion/delta.md
@@ -12,10 +12,6 @@ Use of the dltHub platform and toolkits is subject to a commercial dltHub Licens
 
 The Delta destination is based on the [filesystem destination](../../dlt-ecosystem/destinations/filesystem.md) in dlt. All configuration options from the filesystem destination can be configured as well.
 
-:::warning
-Under the hood, dltHub uses the [deltalake library](https://pypi.org/project/deltalake/) to write Delta tables. Beware that when loading a large amount of data for one table, the underlying Rust implementation will consume a lot of memory. This is a known issue, and the maintainers are actively working on a solution. You can track the progress [here](https://github.com/delta-io/delta-rs/pull/2289). Until the issue is resolved, you can mitigate the memory consumption by doing multiple smaller incremental pipeline runs.
-:::
-
 ## Setup
 
 Make sure you have installed the necessary dependencies:


### PR DESCRIPTION
The issue https://github.com/dlt-hub/dlt/issues/3852 got resolved by a related, but not trivial to find, PR in deltars lib https://github.com/delta-io/delta-rs/pull/3229. We can remove the warnings from documentation now.  dlt requires delta >= 0.25.1 and the issue was solved in dleta 0.25.0 https://github.com/delta-io/delta-rs/releases/tag/python-v0.25.0