### PR TITLE
fix(databricks): validate staging_volume_name format at config time

### DIFF
--- a/dlt/destinations/impl/databricks/configuration.py
+++ b/dlt/destinations/impl/databricks/configuration.py
@@ -262,6 +262,14 @@ class DatabricksClientConfiguration(DestinationClientDwhWithStagingConfiguration
             return ""
 
     def on_resolved(self) -> None:
+        if self.staging_volume_name:
+            parts = self.staging_volume_name.split(".")
+            if len(parts) != 3 or not all(part.strip() for part in parts):
+                raise ConfigurationValueError(
+                    f"Invalid `staging_volume_name` value `{self.staging_volume_name}`. It must be"
+                    " a fully qualified name in the form `catalog.database.volume`."
+                )
+
         if self.zerobus is None:
             return
 

--- a/dlt/destinations/impl/databricks/configuration.py
+++ b/dlt/destinations/impl/databricks/configuration.py
@@ -264,7 +264,7 @@ class DatabricksClientConfiguration(DestinationClientDwhWithStagingConfiguration
     def on_resolved(self) -> None:
         if self.staging_volume_name:
             parts = self.staging_volume_name.split(".")
-            if len(parts) != 3 or not all(part.strip() for part in parts):
+            if len(parts) != 3 or any(not part or part != part.strip() for part in parts):
                 raise ConfigurationValueError(
                     f"Invalid `staging_volume_name` value `{self.staging_volume_name}`. It must be"
                     " a fully qualified name in the form `catalog.database.volume`."

--- a/tests/load/databricks/test_databricks_configuration.py
+++ b/tests/load/databricks/test_databricks_configuration.py
@@ -86,6 +86,9 @@ def test_databricks_configuration() -> None:
         pytest.param("catalog.database.volume.extra", id="four-parts"),
         pytest.param("catalog..volume", id="empty-middle-part"),
         pytest.param(".database.volume", id="empty-catalog"),
+        pytest.param("catalog.database.", id="empty-volume"),
+        pytest.param("catalog. database.volume", id="leading-whitespace"),
+        pytest.param("catalog.database.volume ", id="trailing-whitespace"),
     ],
 )
 def test_databricks_invalid_staging_volume_name(staging_volume_name: str) -> None:

--- a/tests/load/databricks/test_databricks_configuration.py
+++ b/tests/load/databricks/test_databricks_configuration.py
@@ -78,6 +78,51 @@ def test_databricks_configuration() -> None:
     assert config.is_staging_external_location is None
 
 
+@pytest.mark.parametrize(
+    "staging_volume_name",
+    [
+        pytest.param("grp_raw", id="single-part"),
+        pytest.param("catalog.volume", id="two-parts"),
+        pytest.param("catalog.database.volume.extra", id="four-parts"),
+        pytest.param("catalog..volume", id="empty-middle-part"),
+        pytest.param(".database.volume", id="empty-catalog"),
+    ],
+)
+def test_databricks_invalid_staging_volume_name(staging_volume_name: str) -> None:
+    # a non fully qualified `staging_volume_name` must fail at config time with a clear error
+    # instead of an unpack ValueError raised later inside the load job
+    with pytest.raises(
+        ConfigurationValueError,
+        match="must be a fully qualified name in the form `catalog.database.volume`",
+    ):
+        resolve_configuration(
+            DatabricksClientConfiguration(
+                credentials=DatabricksCredentials(
+                    catalog="foo",
+                    server_hostname="foo",
+                    http_path="foo",
+                    access_token="foo",
+                ),
+                staging_volume_name=staging_volume_name,
+            )._bind_dataset_name(dataset_name="foo")
+        )
+
+
+def test_databricks_valid_staging_volume_name() -> None:
+    config = resolve_configuration(
+        DatabricksClientConfiguration(
+            credentials=DatabricksCredentials(
+                catalog="foo",
+                server_hostname="foo",
+                http_path="foo",
+                access_token="foo",
+            ),
+            staging_volume_name="catalog.database.volume",
+        )._bind_dataset_name(dataset_name="foo")
+    )
+    assert config.staging_volume_name == "catalog.database.volume"
+
+
 def test_databricks_abfss_converter() -> None:
     with pytest.raises(TerminalValueError):
         DatabricksLoadJob.ensure_databricks_abfss_url("az://dlt-ci-test-bucket")


### PR DESCRIPTION
## Description

A non-fully-qualified `staging_volume_name` (for example, `my_volume` instead of `catalog.database.volume`) was only rejected deep inside the load job when the value was unpacked with `.split(".")`. That produced a cryptic `ValueError` without identifying the invalid configuration option.

This PR validates `staging_volume_name` in `DatabricksClientConfiguration.on_resolved` and raises a clear `ConfigurationValueError` at configuration time:

> Invalid `staging_volume_name` value `my_volume`. It must be a fully qualified name in the form `catalog.database.volume`.

The validation rejects values that:
- do not contain exactly three dot-separated components;
- contain an empty component;
- contain leading or trailing whitespace in a component.

## Tests

- `uv run pytest tests/load/databricks/test_databricks_configuration.py -q -k staging_volume_name` (9 passed)
- `uv run ruff check dlt/destinations/impl/databricks/configuration.py tests/load/databricks/test_databricks_configuration.py`