### PR TITLE
docs(databricks): correct default staging_volume_name in docstrings

### DIFF
--- a/dlt/destinations/impl/databricks/configuration.py
+++ b/dlt/destinations/impl/databricks/configuration.py
@@ -244,7 +244,10 @@ class DatabricksClientConfiguration(DestinationClientDwhWithStagingConfiguration
     is_staging_external_location: bool = False
     """If true, the temporary credentials are not propagated to the COPY command"""
     staging_volume_name: Optional[str] = None
-    """Name of the Databricks managed volume for temporary storage, e.g., <catalog_name>.<database_name>.<volume_name>. Defaults to '_dlt_staging_load_volume' if not set."""
+    """Fully qualified name of the Databricks managed volume for temporary storage, e.g.,
+    `catalog.database.volume`. When omitted, dlt creates or reuses `_dlt_staging_load_volume`
+    in the destination catalog and dataset.
+    """
     keep_staged_files: Optional[bool] = True
     """Tells if to keep the files in internal (volume) stage"""
     create_indexes: bool = False

--- a/dlt/destinations/impl/databricks/configuration.py
+++ b/dlt/destinations/impl/databricks/configuration.py
@@ -244,7 +244,7 @@ class DatabricksClientConfiguration(DestinationClientDwhWithStagingConfiguration
     is_staging_external_location: bool = False
     """If true, the temporary credentials are not propagated to the COPY command"""
     staging_volume_name: Optional[str] = None
-    """Name of the Databricks managed volume for temporary storage, e.g., <catalog_name>.<database_name>.<volume_name>. Defaults to '_dlt_temp_load_volume' if not set."""
+    """Name of the Databricks managed volume for temporary storage, e.g., <catalog_name>.<database_name>.<volume_name>. Defaults to '_dlt_staging_load_volume' if not set."""
     keep_staged_files: Optional[bool] = True
     """Tells if to keep the files in internal (volume) stage"""
     create_indexes: bool = False

--- a/dlt/destinations/impl/databricks/factory.py
+++ b/dlt/destinations/impl/databricks/factory.py
@@ -216,7 +216,8 @@ class databricks(Destination[DatabricksClientConfiguration, "DatabricksClient"])
             staging_credentials_name (str, optional): If set, credentials with given name will be used in copy command
             destination_name (str, optional): Name of the destination, can be used in config section to differentiate between multiple of the same type
             environment (str, optional): Environment of the destination
-            staging_volume_name (str, optional): Fully qualified name of the Databricks managed volume for temporary storage, e.g., `catalog.database.volume`. Defaults to `_dlt_staging_load_volume` if not set.
+            staging_volume_name (str, optional): Fully qualified name of the Databricks managed volume for temporary storage, e.g., `catalog.database.volume`.
+                When omitted, dlt creates or reuses `_dlt_staging_load_volume` in the destination catalog and dataset.
             create_indexes (bool, optional): Whether PRIMARY KEY or FOREIGN KEY constrains should be created
             insert_api (TDatabricksInsertApi, optional): Ingestion backend for `append` write
                 disposition. Can be overridden per resource via `databricks_adapter`.

--- a/dlt/destinations/impl/databricks/factory.py
+++ b/dlt/destinations/impl/databricks/factory.py
@@ -216,7 +216,7 @@ class databricks(Destination[DatabricksClientConfiguration, "DatabricksClient"])
             staging_credentials_name (str, optional): If set, credentials with given name will be used in copy command
             destination_name (str, optional): Name of the destination, can be used in config section to differentiate between multiple of the same type
             environment (str, optional): Environment of the destination
-            staging_volume_name (str, optional): Name of the staging volume to use
+            staging_volume_name (str, optional): Fully qualified name of the Databricks managed volume for temporary storage, e.g., `catalog.database.volume`. Defaults to `_dlt_staging_load_volume` if not set.
             create_indexes (bool, optional): Whether PRIMARY KEY or FOREIGN KEY constrains should be created
             insert_api (TDatabricksInsertApi, optional): Ingestion backend for `append` write
                 disposition. Can be overridden per resource via `databricks_adapter`.


### PR DESCRIPTION
## Description

The Databricks `staging_volume_name` docstring referenced the stale name `_dlt_temp_load_volume`, while the load job actually uses `_dlt_staging_load_volume`.

This PR corrects that mismatch and clarifies the runtime behavior in both the configuration field and destination factory docstrings:

- A user-supplied value must be fully qualified, for example `catalog.database.volume`.
- When omitted, dlt creates or reuses `_dlt_staging_load_volume` in the destination catalog and dataset.

Docs-only change; no behavior change.

## Tests

- `make lint-docstrings`
- `uv run ruff check dlt/destinations/impl/databricks/configuration.py dlt/destinations/impl/databricks/factory.py`
- `uv run pytest tests/load/databricks/test_databricks_configuration.py::test_databricks_configuration -q`