### PR TITLE
(fix) install latest airflow dependencies with airflow constraints file declared

### DIFF
--- a/.github/workflows/test_tools_airflow.yml
+++ b/.github/workflows/test_tools_airflow.yml
@@ -14,12 +14,12 @@ jobs:
         include:
           - airflow-version: "2"
             python-version: "3.12"
-            airflow-pin: ""
+            airflow-pin: "apache-airflow>=2.8.0,<3"
             run-unit-tests: true
             run-smoke-test: false
           - airflow-version: "3"
             python-version: "3.12"
-            airflow-pin: "apache-airflow>=3.1"
+            airflow-pin: ""
             run-unit-tests: false
             run-smoke-test: true
 
@@ -41,11 +41,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --group airflow --group pipeline --extra duckdb --extra parquet
-          if [ -n "${{ matrix.airflow-pin }}" ]; then
+          uv sync --group pipeline --extra duckdb --extra parquet
+          if [ "${{ matrix.airflow-version }}" = "3" ]; then
+            uv run python tools/install_airflow_ci.py
+          else
             uv pip install '${{ matrix.airflow-pin }}'
-            # overrife fastapi (airflow has special contstaints)
-            uv pip install 'fastapi<0.137'
           fi
 
       - name: Run unit tests

--- a/.github/workflows/test_tools_airflow.yml
+++ b/.github/workflows/test_tools_airflow.yml
@@ -14,12 +14,12 @@ jobs:
         include:
           - airflow-version: "2"
             python-version: "3.12"
-            airflow-pin: "apache-airflow>=2.8.0,<3"
+            airflow-specifier: ">=2.8.0,<3"
             run-unit-tests: true
             run-smoke-test: false
           - airflow-version: "3"
             python-version: "3.12"
-            airflow-pin: ""
+            airflow-specifier: ">=3.1,<4"
             run-unit-tests: false
             run-smoke-test: true
 
@@ -42,11 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --group pipeline --extra duckdb --extra parquet
-          if [ "${{ matrix.airflow-version }}" = "3" ]; then
-            uv run python tools/install_airflow_ci.py
-          else
-            uv pip install '${{ matrix.airflow-pin }}'
-          fi
+          uv run python tools/install_airflow_ci.py '${{ matrix.airflow-specifier }}'
 
       - name: Run unit tests
         if: matrix.run-unit-tests

--- a/tools/install_airflow_ci.py
+++ b/tools/install_airflow_ci.py
@@ -2,11 +2,12 @@
 # ruff: noqa: T201
 # flake8: noqa: T201
 
+import argparse
 import subprocess
 import sys
-from typing import Any, Dict, List, Tuple
 
 import requests
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 
@@ -15,24 +16,18 @@ AIRFLOW_CONSTRAINTS_URL_TEMPLATE = (
     "https://raw.githubusercontent.com/apache/airflow/"
     "constraints-{airflow_version}/constraints-{python_version}.txt"
 )
-MIN_AIRFLOW_VERSION = Version("3.1")
-MAX_AIRFLOW_VERSION = Version("4")
 REQUEST_TIMEOUT_SECONDS = 30
 
 
-def is_supported_airflow_version(version: Version) -> bool:
-    return (
-        MIN_AIRFLOW_VERSION <= version < MAX_AIRFLOW_VERSION
-        and not version.is_prerelease
-        and not version.is_devrelease
-    )
+def is_supported_airflow_version(version: Version, specifier: SpecifierSet) -> bool:
+    return version in specifier and not version.is_prerelease and not version.is_devrelease
 
 
-def is_yanked_release(files: List[Dict[str, Any]]) -> bool:
+def is_yanked_release(files: list[dict[str, object]]) -> bool:
     return bool(files) and all(bool(file.get("yanked")) for file in files)
 
 
-def get_airflow_versions() -> List[Version]:
+def get_airflow_versions(specifier: SpecifierSet) -> list[Version]:
     response = requests.get(PYPI_AIRFLOW_URL, timeout=REQUEST_TIMEOUT_SECONDS)
     response.raise_for_status()
 
@@ -40,7 +35,8 @@ def get_airflow_versions() -> List[Version]:
     versions = [
         Version(version)
         for version, files in releases.items()
-        if is_supported_airflow_version(Version(version)) and not is_yanked_release(files)
+        if is_supported_airflow_version(Version(version), specifier)
+        and not is_yanked_release(files)
     ]
     versions.sort(reverse=True)
     return versions
@@ -62,13 +58,16 @@ def constraints_exist(url: str) -> bool:
     return True
 
 
-def select_airflow_release() -> Tuple[Version, str]:
-    for airflow_version in get_airflow_versions():
+def select_airflow_release(specifier: SpecifierSet) -> tuple[Version, str]:
+    for airflow_version in get_airflow_versions(specifier):
         constraints_url = get_constraints_url(airflow_version)
         if constraints_exist(constraints_url):
             return airflow_version, constraints_url
 
-    raise RuntimeError("No apache-airflow >=3.1,<4 release has matching constraints")
+    raise RuntimeError(
+        f"No apache-airflow release matching {specifier} has constraints for "
+        f"Python {sys.version_info.major}.{sys.version_info.minor}"
+    )
 
 
 def install_airflow(airflow_version: Version, constraints_url: str) -> None:
@@ -84,8 +83,19 @@ def install_airflow(airflow_version: Version, constraints_url: str) -> None:
     )
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "specifier",
+        help="Airflow version specifier, for example '>=2.8.0,<3' or '>=3.1,<4'",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
-    airflow_version, constraints_url = select_airflow_release()
+    args = parse_args()
+    specifier = SpecifierSet(args.specifier)
+    airflow_version, constraints_url = select_airflow_release(specifier)
 
     print(f"Installing apache-airflow=={airflow_version}")
     print(f"Using constraints {constraints_url}")

--- a/tools/install_airflow_ci.py
+++ b/tools/install_airflow_ci.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# ruff: noqa: T201
+# flake8: noqa: T201
+
+import subprocess
+import sys
+from typing import Any, Dict, List, Tuple
+
+import requests
+from packaging.version import Version
+
+
+PYPI_AIRFLOW_URL = "https://pypi.org/pypi/apache-airflow/json"
+AIRFLOW_CONSTRAINTS_URL_TEMPLATE = (
+    "https://raw.githubusercontent.com/apache/airflow/"
+    "constraints-{airflow_version}/constraints-{python_version}.txt"
+)
+MIN_AIRFLOW_VERSION = Version("3.1")
+MAX_AIRFLOW_VERSION = Version("4")
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+def is_supported_airflow_version(version: Version) -> bool:
+    return (
+        MIN_AIRFLOW_VERSION <= version < MAX_AIRFLOW_VERSION
+        and not version.is_prerelease
+        and not version.is_devrelease
+    )
+
+
+def is_yanked_release(files: List[Dict[str, Any]]) -> bool:
+    return bool(files) and all(bool(file.get("yanked")) for file in files)
+
+
+def get_airflow_versions() -> List[Version]:
+    response = requests.get(PYPI_AIRFLOW_URL, timeout=REQUEST_TIMEOUT_SECONDS)
+    response.raise_for_status()
+
+    releases = response.json()["releases"]
+    versions = [
+        Version(version)
+        for version, files in releases.items()
+        if is_supported_airflow_version(Version(version)) and not is_yanked_release(files)
+    ]
+    versions.sort(reverse=True)
+    return versions
+
+
+def get_constraints_url(airflow_version: Version) -> str:
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    return AIRFLOW_CONSTRAINTS_URL_TEMPLATE.format(
+        airflow_version=airflow_version,
+        python_version=python_version,
+    )
+
+
+def constraints_exist(url: str) -> bool:
+    response = requests.head(url, allow_redirects=True, timeout=REQUEST_TIMEOUT_SECONDS)
+    if response.status_code == 404:
+        return False
+    response.raise_for_status()
+    return True
+
+
+def select_airflow_release() -> Tuple[Version, str]:
+    for airflow_version in get_airflow_versions():
+        constraints_url = get_constraints_url(airflow_version)
+        if constraints_exist(constraints_url):
+            return airflow_version, constraints_url
+
+    raise RuntimeError("No apache-airflow >=3.1,<4 release has matching constraints")
+
+
+def install_airflow(airflow_version: Version, constraints_url: str) -> None:
+    subprocess.check_call(
+        [
+            "uv",
+            "pip",
+            "install",
+            f"apache-airflow=={airflow_version}",
+            "--constraint",
+            constraints_url,
+        ]
+    )
+
+
+def main() -> None:
+    airflow_version, constraints_url = select_airflow_release()
+
+    print(f"Installing apache-airflow=={airflow_version}")
+    print(f"Using constraints {constraints_url}")
+
+    install_airflow(airflow_version, constraints_url)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a small script that fetches the latest airflow version and builds the correct constraint file for it. Airflow suggests using the constrained install when running it as an application (e.g. to run DAGs) which we do in the smoke tests