### PR TITLE
Update dlthub platform docs with playground destination.

### DIFF
--- a/docs/website/docs/hub/getting-started/installation.md
+++ b/docs/website/docs/hub/getting-started/installation.md
@@ -24,6 +24,10 @@ Every workspace contains:
 
 For the wider feature surface that a workspace unlocks — [profiles](../pipeline-operations/profiles.md), [data quality](../data-quality/index.md), [transformations](../transformations/index.md), the [managed platform](../pipeline-operations/overview.md), the [dashboard](../ingestion/dashboard.md) — see the [introduction](introduction.md).
 
+### Playground destination
+
+When you deploy and run pipelines on the dltHub platform, you can use `destination="playground"` without configuring credentials or storage. The platform provisions isolated storage for each workspace and loads your pipeline data as [Delta tables](../ingestion/delta.md). Use it for testing and for a faster introduction to the platform — set `destination="playground"` in your pipeline and run.
+
 ## Quickstart
 
 If you already have `uv` installed:

--- a/docs/website/docs/hub/getting-started/introduction.md
+++ b/docs/website/docs/hub/getting-started/introduction.md
@@ -22,6 +22,8 @@ uvx dlthub-start@latest
 
 Scaffolds a local workspace with the dltHub AI Workbench, example pipelines, and `dlt[hub]` installed. See [installation](installation.md) for prerequisites and alternative install paths.
 
+On the [dltHub platform](../pipeline-operations/overview.md), set `destination="playground"` for a zero-config destination that is ideal for testing and a quick first run.
+
 ## What is dltHub?
 
 dltHub is an agent-native data engineering platform for building, running, and operating production-grade data pipelines. The toolchain is designed to be driven from coding agents — Claude Code, Codex, and Cursor — through [scaffolding commands](../ingestion/init.md) and [per-source context files](../ingestion/rest-api-source.md). A developer or analyst comfortable with Python and a coding agent can build and operate ingestion, [transformations](../transformations/index.md), [quality checks](../data-quality/index.md), and data apps end-to-end without managing infrastructure.


### PR DESCRIPTION
This PR adds simple documentation about the managed playground destination in the dlthub docs.