### PR TITLE
docs(hub): add Orchestrate with dltHub Cookbook entry

### DIFF
--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/deploy-with-dlthub.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/deploy-with-dlthub.md
@@ -21,3 +21,5 @@ Instead of deploying a `dlt` pipeline to your own runner (Airflow, GitHub Action
 ## Get started
 
 For installation, tutorials, and the full reference, see the [dltHub documentation](../../hub/getting-started/introduction.md).
+
+For a quick walkthrough, see [Deploy a pipeline with dltHub](orchestrate-with-dlthub.md).

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
@@ -1,44 +1,35 @@
 ---
-title: Orchestrate with dltHub
-description: Schedule dlt pipelines, chain follow-up jobs, and gate on freshness using dltHub's built-in orchestrator
-keywords: [orchestrator, scheduling, cron, follow-up, freshness, refresh, dlthub, platform]
+title: Deploy a pipeline with dltHub
+description: Run, deploy, and schedule dlt pipelines with dltHub's managed orchestrator
+keywords: [orchestrator, scheduling, cron, dlthub, platform, deploy]
 ---
 
-# Orchestrate with dltHub
+# Deploy a pipeline with dltHub
 
-dltHub's managed platform includes a job orchestrator built around the `@dlt.hub.run` decorators. Unlike external orchestrators (Airflow, Prefect, GitHub Actions), the schedule and the data dependencies live in your Python code, with no separate DAG (directed acyclic graph) file or YAML to maintain.
+dltHub ships a managed orchestrator built around the `@dlt.hub.run` decorators. The schedule and the data dependencies live in your Python code, not in a separate DAG (directed acyclic graph) file or YAML.
 
-This page walks through three core orchestration primitives: **cron and interval triggers**, **follow-up chains**, and **freshness gates with refresh cascades**.
+This page walks through three stages: running a pipeline ad-hoc, deploying it via `__deployment__.py`, and scheduling it with a trigger. For the full feature surface (follow-up chains, freshness gates, refresh cascade, tags, timezones) see [Triggers and scheduling](../../hub/pipeline-operations/triggers.md).
 
-For the deployment lifecycle (manifest, sync, reconciliation) see [Deployments](../../hub/pipeline-operations/deployments.md).
+## 1. Run a pipeline ad-hoc
 
-## Example dependency graph
+Any regular dlt pipeline can be run on the platform without a deployment file. Given a `pipeline.py` with a top-level `pipeline.run(...)` call:
 
-The example below is a three-job graph: ingest data on a cron, transform it whenever the ingest succeeds, then run data-quality checks once the transform is fresh.
-
-```mermaid
-flowchart LR
-    A[ingest_breweries<br/>cron: every hour] --> B[transform_breweries<br/>trigger: ingest.success]
-    B --> C[brewery_dq<br/>cron + freshness gate]
+```sh
+uv run dlthub run pipeline.py
 ```
 
-Each job is a decorated Python function. Wiring them into a graph is just passing the upstream job's `.success` or `.is_fresh` to the downstream decorator.
+This deploys the file ad-hoc, executes it on the platform, and streams logs back to your terminal. Use this for one-off runs and smoke tests. See [Quick deploy](../../hub/pipeline-operations/deployments.md#quick-deploy-ad-hoc-launch).
 
-## Cron and interval triggers
+## 2. Add `__deployment__.py`
 
-`@run.pipeline` and `@run.job` accept a `trigger=` argument. The factories live under `dlt.hub.run.trigger`:
+To run the same pipeline as a managed job, decorate the entrypoint and declare it in a workspace `__deployment__.py`:
 
 ```py
 import dlt
 from dlt.hub import run
-from dlt.hub.run import trigger
 
 
-@run.pipeline(
-    "ingest_breweries",
-    trigger=trigger.schedule("0 * * * *"),    # every hour, on the hour
-    expose={"tags": ["ingest"], "display_name": "Ingest breweries"},
-)
+@run.pipeline("ingest_breweries")
 def ingest_breweries():
     pipeline = dlt.pipeline(
         pipeline_name="ingest_breweries",
@@ -48,182 +39,54 @@ def ingest_breweries():
     pipeline.run(brewery_source())
 ```
 
-| Trigger factory | When it fires |
-|---|---|
-| `trigger.schedule("0 * * * *")` | A cron expression. UTC by default; pass `require={"timezone": "..."}` to interpret in another zone. |
-| `trigger.every("5m")` | A fixed interval relative to "now". Useful when "every five minutes" matters more than absolute tick times. |
-| `trigger.once("2026-12-31T00:00:00Z")` | Single run at a wall-clock time. |
-| `trigger.manual()` | Job only runs when invoked by hand via `dlthub run`, `dlthub job trigger`, or the dashboard. |
+```py
+# __deployment__.py
+from ingest_breweries import ingest_breweries
 
-:::tip Adjust the schedule from the platform
-For deployed jobs, you can also change the cron schedule from the dltHub platform: open the job's detail page and click **Manage Schedule**. Pick a quick preset or type a new cron expression. This is useful for ad-hoc pauses or quick tweaks without redeploying. To make a change permanent, update the decorator and run `dlthub deploy`.
-:::
+__all__ = ["ingest_breweries"]
+```
 
-A job can have multiple triggers. Pass a list:
+Deploy with:
+
+```sh
+uv run dlthub deploy
+```
+
+See [Deployments](../../hub/pipeline-operations/deployments.md) for the manifest layout, reconciliation rules, and the full lifecycle.
+
+## 3. Schedule it
+
+Pass a `trigger=` to the decorator to make the job cron-driven:
 
 ```py
+from dlt.hub.run import trigger
+
+
 @run.pipeline(
     "ingest_breweries",
-    trigger=[trigger.schedule("0 * * * *"), trigger.manual()],
+    trigger=trigger.schedule("0 * * * *"),    # every hour, on the hour
 )
 def ingest_breweries():
     ...
 ```
 
-## Follow-up chains
+After the next `dlthub deploy`, the scheduler runs the job on its cron. Trigger factories also include `trigger.every("5m")` (fixed interval), `trigger.once(...)` (single run), and `trigger.manual()` (run on demand only). See [Basic triggers](../../hub/pipeline-operations/triggers.md#basic-triggers).
 
-Every decorated job exposes `.success`, `.fail`, and `.completed` attributes. Pass them as triggers on a downstream job and dltHub fires that job the moment the upstream finishes, with no polling and no scheduler delay:
+:::tip Adjust the schedule from the platform
+You can also change the cron from the dltHub platform's **Manage Schedule** dialog, useful for ad-hoc pauses or tweaks without redeploying. To make a change permanent, update the decorator and run `dlthub deploy`.
+:::
 
-```py
-from ingest_breweries import ingest_breweries
+## Advanced features
 
-
-@run.pipeline(
-    "transform_breweries",
-    trigger=ingest_breweries.success,           # fires when ingest succeeds
-    expose={"tags": ["transform"], "display_name": "Transform breweries"},
-)
-def transform_breweries():
-    pipeline = dlt.pipeline(
-        pipeline_name="transform_breweries",
-        destination="warehouse",
-        dataset_name="brewery_data",
-    )
-    # ... run transformations against the dataset ...
-```
-
-`.fail` fires only on failure; `.completed` fires on either outcome, useful for cleanup jobs that should run regardless. You can combine cron and follow-up triggers on the same job:
-
-```py
-@run.pipeline(
-    "transform_breweries",
-    trigger=[
-        trigger.schedule("30 * * * *"),         # back-stop hourly even if no upstream
-        ingest_breweries.success,                # also run as soon as ingest finishes
-    ],
-)
-def transform_breweries():
-    ...
-```
-
-To find out which trigger fired a particular run, declare a `run_context` parameter:
-
-```py
-from dlt.hub.run import TJobRunContext
-
-
-@run.pipeline("transform_breweries", trigger=[trigger.schedule("30 * * * *"), ingest_breweries.success])
-def transform_breweries(run_context: TJobRunContext):
-    trigger_type = run_context["trigger"].split(":", 1)[0]
-    if trigger_type == "schedule":
-        print("Hourly back-stop run")
-    elif trigger_type == "job.success":
-        print("Upstream finished; running follow-up")
-```
-
-`run_context["trigger"]` is a `"type:expression"` string (e.g. `"schedule:30 * * * *"`, `"job.success:jobs.ingest.ingest_breweries"`).
-
-## Freshness gates and refresh cascade
-
-Follow-up triggers run downstream **whenever** upstream finishes. **Freshness gates** are the opposite: they let a downstream job run on its own schedule, but skip if upstream hasn't produced a fresh result yet. See [Freshness checks](../../hub/pipeline-operations/triggers.md#freshness-checks) for the full set of freshness operators and how staleness is computed.
-
-```py
-from ingest_breweries import ingest_breweries
-from transform_breweries import transform_breweries
-
-
-@run.job(
-    trigger=trigger.schedule("15 * * * *"),     # try every hour at :15
-    freshness=[transform_breweries.is_fresh],   # ...but skip if transform isn't fresh
-    expose={"tags": ["dq"], "display_name": "Brewery DQ"},
-)
-def brewery_dq():
-    """Run data-quality checks against the latest transformed data."""
-    import dlthub.data_quality as dq
-    pipeline = dlt.attach("transform_breweries")
-    dq.run_metrics(pipeline)
-    dq.run_checks(pipeline, checks={
-        "breweries": [
-            dq.checks.is_not_null("id"),
-            dq.checks.is_not_null("name"),
-        ],
-    })
-```
-
-Use freshness when partial data would silently break a metric (e.g. an aggregate that compares this hour to last).
-
-### Refresh cascade
-
-A job marked `refresh="always"` originates a *refresh signal* that propagates downstream through the dependency graph. Each downstream job receives `run_context["refresh"] = True` and can react, for example by passing `refresh="drop_data"` to `pipeline.run`. See [Refresh cascade](../../hub/pipeline-operations/triggers.md#refresh-cascade) for propagation rules across the graph.
-
-```py
-@run.job(
-    trigger=trigger.manual(),
-    refresh="always",
-    expose={"tags": ["backfill"], "display_name": "Backfill cascade"},
-)
-def backfill():
-    """Cascade a refresh through the graph; does not load data itself."""
-
-
-@run.pipeline("ingest_breweries", trigger=[trigger.schedule("0 * * * *"), backfill.success])
-def ingest_breweries(run_context: TJobRunContext):
-    pipeline = dlt.pipeline(
-        pipeline_name="ingest_breweries",
-        destination="warehouse",
-        dataset_name="brewery_data",
-    )
-    pipeline.run(
-        brewery_source(),
-        refresh="drop_data" if run_context["refresh"] else None,
-    )
-```
-
-Three refresh policies on any decorated job:
-
-| Policy | Behavior |
-|---|---|
-| `"always"` | Originate a refresh signal on every run of this job. |
-| `"auto"` (default) | Forward any refresh signal received from upstream. |
-| `"block"` | Stop refresh propagation here. Downstream jobs after this one see `refresh = False`. |
-
-## Wire jobs into the workspace and deploy
-
-Declare every job in `__deployment__.py` so the manifest picks them up:
-
-```py
-"""Brewery workspace."""
-
-from ingest_breweries import ingest_breweries
-from transform_breweries import transform_breweries
-from brewery_dq import brewery_dq
-from backfill import backfill
-
-__all__ = ["ingest_breweries", "transform_breweries", "brewery_dq", "backfill"]
-```
-
-Deploy and let the scheduler take over:
-
-```sh
-uv run dlthub deploy                         # syncs code + manifest to dltHub
-uv run dlthub deploy --dry-run               # preview reconciliation
-uv run dlthub deploy --show-manifest         # dump the YAML manifest
-```
-
-After the first deploy, scheduled jobs start running on their cron. You can:
-
-```sh
-dlthub job list                              # see every deployed job + status
-dlthub job trigger "tag:ingest"              # bulk-trigger by tag selector
-dlthub job logs ingest_breweries --follow    # stream the latest run's logs
-dlthub job cancel ingest_breweries           # cancel an in-flight run
-```
-
-See [Monitoring and debugging](../../hub/pipeline-operations/monitoring.md) for the full observability surface.
+- [Follow-up triggers](../../hub/pipeline-operations/triggers.md#follow-up-triggers): chain jobs by passing `.success` / `.fail` / `.completed` from one job as the trigger of another.
+- [Freshness checks](../../hub/pipeline-operations/triggers.md#freshness-checks): let a job skip its scheduled run if upstream data isn't fresh.
+- [Refresh cascade](../../hub/pipeline-operations/triggers.md#refresh-cascade): propagate a refresh signal downstream through the graph.
+- [Tags and bulk triggering](../../hub/pipeline-operations/triggers.md#tags-and-bulk-triggering): group jobs and trigger them by selector.
+- [Monitoring and debugging](../../hub/pipeline-operations/monitoring.md): runs, logs, and lineage from CLI or web UI.
 
 ## See also
 
-- [Introduction to dltHub](../../hub/getting-started/introduction.md): overview of the platform.
-- [Triggers and scheduling](../../hub/pipeline-operations/triggers.md): full reference for triggers, intervals, freshness, and refresh.
-- [Deployments](../../hub/pipeline-operations/deployments.md): `__deployment__.py`, manifest layout, reconciliation rules.
-- [dltHub platform tutorial](../../hub/getting-started/platform-tutorial.md): guided end-to-end walkthrough from scaffold to deploy.
+- [Introduction to dltHub](../../hub/getting-started/introduction.md)
+- [dltHub platform tutorial](../../hub/getting-started/platform-tutorial.md)
+- [Triggers and scheduling](../../hub/pipeline-operations/triggers.md)
+- [Deployments](../../hub/pipeline-operations/deployments.md)

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
@@ -15,16 +15,10 @@ This page walks through four stages: scaffolding a workspace, running a pipeline
 If you don't have `uv` yet, follow the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/). Then scaffold a workspace:
 
 ```sh
-uvx dlthub-init my-workspace
-cd my-workspace
-uv sync
+uvx dlthub-init
 ```
 
-This creates the `.dlt/.workspace` marker that activates workspace mode, along with `pyproject.toml` and `.dlt/` config and secrets files. Then create a `pipeline.py` before continuing.
-
-:::tip Already have a Python project?
-See [Add dltHub to an existing project](../../hub/getting-started/installation.md#add-dlthub-to-an-existing-project) to enable workspace mode without scaffolding from scratch.
-:::
+This creates the `.dlt/.workspace` marker that activates workspace mode, along with `pyproject.toml` and `.dlt/` config and secrets files. For other install options and setup paths, see [Installation](../../hub/getting-started/installation.md).
 
 ## 2. Run a pipeline ad-hoc
 

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
@@ -6,7 +6,7 @@ keywords: [orchestrator, scheduling, cron, follow-up, freshness, refresh, dlthub
 
 # Orchestrate with dltHub
 
-dltHub's managed platform includes a job orchestrator built around the `@dlt.hub.run` decorators. Unlike external orchestrators (Airflow, Prefect, GitHub Actions), the schedule and the data dependencies live in your Python code — no separate DAG (directed acyclic graph) file or YAML to maintain.
+dltHub's managed platform includes a job orchestrator built around the `@dlt.hub.run` decorators. Unlike external orchestrators (Airflow, Prefect, GitHub Actions), the schedule and the data dependencies live in your Python code, with no separate DAG (directed acyclic graph) file or YAML to maintain.
 
 This page walks through three core orchestration primitives: **cron and interval triggers**, **follow-up chains**, and **freshness gates with refresh cascades**.
 
@@ -56,10 +56,10 @@ def ingest_breweries():
 | `trigger.manual()` | Job only runs when invoked by hand via `dlthub run`, `dlthub job trigger`, or the dashboard. |
 
 :::tip Adjust the schedule from the platform
-For deployed jobs, you can also change the cron schedule from the dltHub platform — open the job's detail page and click **Manage Schedule**. Pick a quick preset or type a new cron expression. This is useful for ad-hoc pauses or quick tweaks without redeploying. To make a change permanent, update the decorator and run `dlthub deploy`.
+For deployed jobs, you can also change the cron schedule from the dltHub platform: open the job's detail page and click **Manage Schedule**. Pick a quick preset or type a new cron expression. This is useful for ad-hoc pauses or quick tweaks without redeploying. To make a change permanent, update the decorator and run `dlthub deploy`.
 :::
 
-A job can have multiple triggers — pass a list:
+A job can have multiple triggers. Pass a list:
 
 ```py
 @run.pipeline(
@@ -72,7 +72,7 @@ def ingest_breweries():
 
 ## Follow-up chains
 
-Every decorated job exposes `.success`, `.fail`, and `.completed` attributes. Pass them as triggers on a downstream job and dltHub fires that job the moment the upstream finishes — no polling, no scheduler delay:
+Every decorated job exposes `.success`, `.fail`, and `.completed` attributes. Pass them as triggers on a downstream job and dltHub fires that job the moment the upstream finishes, with no polling and no scheduler delay:
 
 ```py
 from ingest_breweries import ingest_breweries
@@ -92,7 +92,7 @@ def transform_breweries():
     # ... run transformations against the dataset ...
 ```
 
-`.fail` fires only on failure; `.completed` fires on either outcome — useful for cleanup jobs that should run regardless. You can combine cron and follow-up triggers on the same job:
+`.fail` fires only on failure; `.completed` fires on either outcome, useful for cleanup jobs that should run regardless. You can combine cron and follow-up triggers on the same job:
 
 ```py
 @run.pipeline(
@@ -125,7 +125,7 @@ def transform_breweries(run_context: TJobRunContext):
 
 ## Freshness gates and refresh cascade
 
-Follow-up triggers run downstream **whenever** upstream finishes. **Freshness gates** are the opposite: they let a downstream job run on its own schedule, but skip if upstream hasn't produced a fresh result yet.
+Follow-up triggers run downstream **whenever** upstream finishes. **Freshness gates** are the opposite: they let a downstream job run on its own schedule, but skip if upstream hasn't produced a fresh result yet. See [Freshness checks](../../hub/pipeline-operations/triggers.md#freshness-checks) for the full set of freshness operators and how staleness is computed.
 
 ```py
 from ingest_breweries import ingest_breweries
@@ -154,7 +154,7 @@ Use freshness when partial data would silently break a metric (e.g. an aggregate
 
 ### Refresh cascade
 
-A job marked `refresh="always"` originates a *refresh signal* that propagates downstream through the dependency graph. Each downstream job receives `run_context["refresh"] = True` and can react — for example by passing `refresh="drop_data"` to `pipeline.run`.
+A job marked `refresh="always"` originates a *refresh signal* that propagates downstream through the dependency graph. Each downstream job receives `run_context["refresh"] = True` and can react, for example by passing `refresh="drop_data"` to `pipeline.run`. See [Refresh cascade](../../hub/pipeline-operations/triggers.md#refresh-cascade) for propagation rules across the graph.
 
 ```py
 @run.job(
@@ -223,7 +223,7 @@ See [Monitoring and debugging](../../hub/pipeline-operations/monitoring.md) for 
 
 ## See also
 
-- [Introduction to dltHub](../../hub/getting-started/introduction.md) — overview of the platform.
-- [Triggers and scheduling](../../hub/pipeline-operations/triggers.md) — full reference for triggers, intervals, freshness, and refresh.
-- [Deployments](../../hub/pipeline-operations/deployments.md) — `__deployment__.py`, manifest layout, reconciliation rules.
-- [dltHub platform tutorial](../../hub/getting-started/platform-tutorial.md) — guided end-to-end walkthrough from scaffold to deploy.
+- [Introduction to dltHub](../../hub/getting-started/introduction.md): overview of the platform.
+- [Triggers and scheduling](../../hub/pipeline-operations/triggers.md): full reference for triggers, intervals, freshness, and refresh.
+- [Deployments](../../hub/pipeline-operations/deployments.md): `__deployment__.py`, manifest layout, reconciliation rules.
+- [dltHub platform tutorial](../../hub/getting-started/platform-tutorial.md): guided end-to-end walkthrough from scaffold to deploy.

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
@@ -15,7 +15,7 @@ This page walks through four stages: scaffolding a workspace, running a pipeline
 If you don't have `uv` yet, follow the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/). Then scaffold a workspace:
 
 ```sh
-uvx dlthub-init
+uvx dlthub-init@latest
 ```
 
 This creates the `.dlt/.workspace` marker that activates workspace mode, along with `pyproject.toml` and `.dlt/` config and secrets files. For other install options and setup paths, see [Installation](../../hub/getting-started/installation.md).

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
@@ -52,6 +52,12 @@ Deploy with:
 uv run dlthub deploy
 ```
 
+To trigger a run, invoke the job by name:
+
+```sh
+uv run dlthub run ingest_breweries
+```
+
 See [Deployments](../../hub/pipeline-operations/deployments.md) for the manifest layout, reconciliation rules, and the full lifecycle.
 
 ## 3. Schedule it
@@ -70,7 +76,7 @@ def ingest_breweries():
     ...
 ```
 
-After the next `dlthub deploy`, the scheduler runs the job on its cron. Trigger factories also include `trigger.every("5m")` (fixed interval), `trigger.once(...)` (single run), and `trigger.manual()` (run on demand only). See [Basic triggers](../../hub/pipeline-operations/triggers.md#basic-triggers).
+Run `dlthub deploy` again to push the trigger to the platform. The scheduler then runs the job on its cron. Trigger factories also include `trigger.every("5m")` (fixed interval) and `trigger.once(...)` (single run). See [Basic triggers](../../hub/pipeline-operations/triggers.md#basic-triggers).
 
 :::tip Adjust the schedule from the platform
 You can also change the cron from the dltHub platform's **Manage Schedule** dialog, useful for ad-hoc pauses or tweaks without redeploying. To make a change permanent, update the decorator and run `dlthub deploy`.

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
@@ -8,9 +8,25 @@ keywords: [orchestrator, scheduling, cron, dlthub, platform, deploy]
 
 dltHub ships a managed orchestrator built around the `@dlt.hub.run` decorators. The schedule and the data dependencies live in your Python code, not in a separate DAG (directed acyclic graph) file or YAML.
 
-This page walks through three stages: running a pipeline ad-hoc, deploying it via `__deployment__.py`, and scheduling it with a trigger. For the full feature surface (follow-up chains, freshness gates, refresh cascade, tags, timezones) see [Triggers and scheduling](../../hub/pipeline-operations/triggers.md).
+This page walks through four stages: scaffolding a workspace, running a pipeline ad-hoc, deploying it via `__deployment__.py`, and scheduling it with a trigger. For the full feature surface (follow-up chains, freshness gates, refresh cascade, tags, timezones) see [Triggers and scheduling](../../hub/pipeline-operations/triggers.md).
 
-## 1. Run a pipeline ad-hoc
+## 1. Install and scaffold a workspace
+
+If you don't have `uv` yet, follow the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/). Then scaffold a workspace:
+
+```sh
+uvx dlthub-init my-workspace
+cd my-workspace
+uv sync
+```
+
+This creates the `.dlt/.workspace` marker that activates workspace mode, along with `pyproject.toml` and `.dlt/` config and secrets files. Then create a `pipeline.py` before continuing.
+
+:::tip Already have a Python project?
+See [Add dltHub to an existing project](../../hub/getting-started/installation.md#add-dlthub-to-an-existing-project) to enable workspace mode without scaffolding from scratch.
+:::
+
+## 2. Run a pipeline ad-hoc
 
 Any regular dlt pipeline can be run on the platform without a deployment file. Given a `pipeline.py` with a top-level `pipeline.run(...)` call:
 
@@ -20,7 +36,7 @@ uv run dlthub run pipeline.py
 
 This deploys the file ad-hoc, executes it on the platform, and streams logs back to your terminal. Use this for one-off runs and smoke tests. See [Quick deploy](../../hub/pipeline-operations/deployments.md#quick-deploy-ad-hoc-launch).
 
-## 2. Add `__deployment__.py`
+## 3. Add `__deployment__.py`
 
 To run the same pipeline as a managed job, decorate the entrypoint and declare it in a workspace `__deployment__.py`:
 
@@ -60,7 +76,7 @@ uv run dlthub run ingest_breweries
 
 See [Deployments](../../hub/pipeline-operations/deployments.md) for the manifest layout, reconciliation rules, and the full lifecycle.
 
-## 3. Schedule it
+## 4. Schedule it
 
 Pass a `trigger=` to the decorator to make the job cron-driven:
 
@@ -88,7 +104,7 @@ You can also change the cron from the dltHub platform's **Manage Schedule** dial
 - [Freshness checks](../../hub/pipeline-operations/triggers.md#freshness-checks): let a job skip its scheduled run if upstream data isn't fresh.
 - [Refresh cascade](../../hub/pipeline-operations/triggers.md#refresh-cascade): propagate a refresh signal downstream through the graph.
 - [Tags and bulk triggering](../../hub/pipeline-operations/triggers.md#tags-and-bulk-triggering): group jobs and trigger them by selector.
-- [Monitoring and debugging](../../hub/pipeline-operations/monitoring.md): runs, logs, and lineage from CLI or web UI.
+- [Monitoring and debugging](../../hub/pipeline-operations/monitoring.md): runs, logs, and lineage from the command line or web UI.
 
 ## See also
 

--- a/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
+++ b/docs/website/docs/walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub.md
@@ -1,0 +1,229 @@
+---
+title: Orchestrate with dltHub
+description: Schedule dlt pipelines, chain follow-up jobs, and gate on freshness using dltHub's built-in orchestrator
+keywords: [orchestrator, scheduling, cron, follow-up, freshness, refresh, dlthub, platform]
+---
+
+# Orchestrate with dltHub
+
+dltHub's managed platform includes a job orchestrator built around the `@dlt.hub.run` decorators. Unlike external orchestrators (Airflow, Prefect, GitHub Actions), the schedule and the data dependencies live in your Python code — no separate DAG (directed acyclic graph) file or YAML to maintain.
+
+This page walks through three core orchestration primitives: **cron and interval triggers**, **follow-up chains**, and **freshness gates with refresh cascades**.
+
+For the deployment lifecycle (manifest, sync, reconciliation) see [Deployments](../../hub/pipeline-operations/deployments.md).
+
+## Example dependency graph
+
+The example below is a three-job graph: ingest data on a cron, transform it whenever the ingest succeeds, then run data-quality checks once the transform is fresh.
+
+```mermaid
+flowchart LR
+    A[ingest_breweries<br/>cron: every hour] --> B[transform_breweries<br/>trigger: ingest.success]
+    B --> C[brewery_dq<br/>cron + freshness gate]
+```
+
+Each job is a decorated Python function. Wiring them into a graph is just passing the upstream job's `.success` or `.is_fresh` to the downstream decorator.
+
+## Cron and interval triggers
+
+`@run.pipeline` and `@run.job` accept a `trigger=` argument. The factories live under `dlt.hub.run.trigger`:
+
+```py
+import dlt
+from dlt.hub import run
+from dlt.hub.run import trigger
+
+
+@run.pipeline(
+    "ingest_breweries",
+    trigger=trigger.schedule("0 * * * *"),    # every hour, on the hour
+    expose={"tags": ["ingest"], "display_name": "Ingest breweries"},
+)
+def ingest_breweries():
+    pipeline = dlt.pipeline(
+        pipeline_name="ingest_breweries",
+        destination="warehouse",
+        dataset_name="brewery_data",
+    )
+    pipeline.run(brewery_source())
+```
+
+| Trigger factory | When it fires |
+|---|---|
+| `trigger.schedule("0 * * * *")` | A cron expression. UTC by default; pass `require={"timezone": "..."}` to interpret in another zone. |
+| `trigger.every("5m")` | A fixed interval relative to "now". Useful when "every five minutes" matters more than absolute tick times. |
+| `trigger.once("2026-12-31T00:00:00Z")` | Single run at a wall-clock time. |
+| `trigger.manual()` | Job only runs when invoked by hand via `dlthub run`, `dlthub job trigger`, or the dashboard. |
+
+:::tip Adjust the schedule from the platform
+For deployed jobs, you can also change the cron schedule from the dltHub platform — open the job's detail page and click **Manage Schedule**. Pick a quick preset or type a new cron expression. This is useful for ad-hoc pauses or quick tweaks without redeploying. To make a change permanent, update the decorator and run `dlthub deploy`.
+:::
+
+A job can have multiple triggers — pass a list:
+
+```py
+@run.pipeline(
+    "ingest_breweries",
+    trigger=[trigger.schedule("0 * * * *"), trigger.manual()],
+)
+def ingest_breweries():
+    ...
+```
+
+## Follow-up chains
+
+Every decorated job exposes `.success`, `.fail`, and `.completed` attributes. Pass them as triggers on a downstream job and dltHub fires that job the moment the upstream finishes — no polling, no scheduler delay:
+
+```py
+from ingest_breweries import ingest_breweries
+
+
+@run.pipeline(
+    "transform_breweries",
+    trigger=ingest_breweries.success,           # fires when ingest succeeds
+    expose={"tags": ["transform"], "display_name": "Transform breweries"},
+)
+def transform_breweries():
+    pipeline = dlt.pipeline(
+        pipeline_name="transform_breweries",
+        destination="warehouse",
+        dataset_name="brewery_data",
+    )
+    # ... run transformations against the dataset ...
+```
+
+`.fail` fires only on failure; `.completed` fires on either outcome — useful for cleanup jobs that should run regardless. You can combine cron and follow-up triggers on the same job:
+
+```py
+@run.pipeline(
+    "transform_breweries",
+    trigger=[
+        trigger.schedule("30 * * * *"),         # back-stop hourly even if no upstream
+        ingest_breweries.success,                # also run as soon as ingest finishes
+    ],
+)
+def transform_breweries():
+    ...
+```
+
+To find out which trigger fired a particular run, declare a `run_context` parameter:
+
+```py
+from dlt.hub.run import TJobRunContext
+
+
+@run.pipeline("transform_breweries", trigger=[trigger.schedule("30 * * * *"), ingest_breweries.success])
+def transform_breweries(run_context: TJobRunContext):
+    trigger_type = run_context["trigger"].split(":", 1)[0]
+    if trigger_type == "schedule":
+        print("Hourly back-stop run")
+    elif trigger_type == "job.success":
+        print("Upstream finished; running follow-up")
+```
+
+`run_context["trigger"]` is a `"type:expression"` string (e.g. `"schedule:30 * * * *"`, `"job.success:jobs.ingest.ingest_breweries"`).
+
+## Freshness gates and refresh cascade
+
+Follow-up triggers run downstream **whenever** upstream finishes. **Freshness gates** are the opposite: they let a downstream job run on its own schedule, but skip if upstream hasn't produced a fresh result yet.
+
+```py
+from ingest_breweries import ingest_breweries
+from transform_breweries import transform_breweries
+
+
+@run.job(
+    trigger=trigger.schedule("15 * * * *"),     # try every hour at :15
+    freshness=[transform_breweries.is_fresh],   # ...but skip if transform isn't fresh
+    expose={"tags": ["dq"], "display_name": "Brewery DQ"},
+)
+def brewery_dq():
+    """Run data-quality checks against the latest transformed data."""
+    import dlthub.data_quality as dq
+    pipeline = dlt.attach("transform_breweries")
+    dq.run_metrics(pipeline)
+    dq.run_checks(pipeline, checks={
+        "breweries": [
+            dq.checks.is_not_null("id"),
+            dq.checks.is_not_null("name"),
+        ],
+    })
+```
+
+Use freshness when partial data would silently break a metric (e.g. an aggregate that compares this hour to last).
+
+### Refresh cascade
+
+A job marked `refresh="always"` originates a *refresh signal* that propagates downstream through the dependency graph. Each downstream job receives `run_context["refresh"] = True` and can react — for example by passing `refresh="drop_data"` to `pipeline.run`.
+
+```py
+@run.job(
+    trigger=trigger.manual(),
+    refresh="always",
+    expose={"tags": ["backfill"], "display_name": "Backfill cascade"},
+)
+def backfill():
+    """Cascade a refresh through the graph; does not load data itself."""
+
+
+@run.pipeline("ingest_breweries", trigger=[trigger.schedule("0 * * * *"), backfill.success])
+def ingest_breweries(run_context: TJobRunContext):
+    pipeline = dlt.pipeline(
+        pipeline_name="ingest_breweries",
+        destination="warehouse",
+        dataset_name="brewery_data",
+    )
+    pipeline.run(
+        brewery_source(),
+        refresh="drop_data" if run_context["refresh"] else None,
+    )
+```
+
+Three refresh policies on any decorated job:
+
+| Policy | Behavior |
+|---|---|
+| `"always"` | Originate a refresh signal on every run of this job. |
+| `"auto"` (default) | Forward any refresh signal received from upstream. |
+| `"block"` | Stop refresh propagation here. Downstream jobs after this one see `refresh = False`. |
+
+## Wire jobs into the workspace and deploy
+
+Declare every job in `__deployment__.py` so the manifest picks them up:
+
+```py
+"""Brewery workspace."""
+
+from ingest_breweries import ingest_breweries
+from transform_breweries import transform_breweries
+from brewery_dq import brewery_dq
+from backfill import backfill
+
+__all__ = ["ingest_breweries", "transform_breweries", "brewery_dq", "backfill"]
+```
+
+Deploy and let the scheduler take over:
+
+```sh
+uv run dlthub deploy                         # syncs code + manifest to dltHub
+uv run dlthub deploy --dry-run               # preview reconciliation
+uv run dlthub deploy --show-manifest         # dump the YAML manifest
+```
+
+After the first deploy, scheduled jobs start running on their cron. You can:
+
+```sh
+dlthub job list                              # see every deployed job + status
+dlthub job trigger "tag:ingest"              # bulk-trigger by tag selector
+dlthub job logs ingest_breweries --follow    # stream the latest run's logs
+dlthub job cancel ingest_breweries           # cancel an in-flight run
+```
+
+See [Monitoring and debugging](../../hub/pipeline-operations/monitoring.md) for the full observability surface.
+
+## See also
+
+- [Introduction to dltHub](../../hub/getting-started/introduction.md) — overview of the platform.
+- [Triggers and scheduling](../../hub/pipeline-operations/triggers.md) — full reference for triggers, intervals, freshness, and refresh.
+- [Deployments](../../hub/pipeline-operations/deployments.md) — `__deployment__.py`, manifest layout, reconciliation rules.
+- [dltHub platform tutorial](../../hub/getting-started/platform-tutorial.md) — guided end-to-end walkthrough from scaffold to deploy.

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -423,6 +423,11 @@ const sidebars = {
           label: "Orchestrators",
           items: [
             {
+              type: "doc",
+              id: "walkthroughs/deploy-a-pipeline/orchestrate-with-dlthub",
+              label: "dltHub",
+            },
+            {
               id: "walkthroughs/deploy-a-pipeline/deploy-with-github-actions",
               type: "doc",
               label: "GitHub Actions",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
New walkthrough under Orchestrators showing the three core orchestration primitives: cron and interval triggers, follow-up chains via .success/.fail/ .completed, and freshness gates with refresh cascade. Mid-length walkthrough (~180 lines) modelled on the brewery example so snippets stay verifiable against dlthub-walkthrough.

Adds a :::tip explaining that schedules can also be adjusted ad-hoc from the dltHub platform's Manage Schedule dialog, with decorators remaining the source of truth.

Sidebar: adds "dltHub" as the first entry under Orchestrators in docs/website/sidebars.js.