### PR TITLE
docs(hub): recommend dlthub-init vs dlthub-start consistently in onboarding docs

### DIFF
--- a/docs/website/docs/hub/getting-started/installation.md
+++ b/docs/website/docs/hub/getting-started/installation.md
@@ -42,7 +42,7 @@ If you don't have `uv` yet, either [install it first](#setting-up-your-environme
 pipx run dlthub-start
 ```
 
-Either way, it prompts you to pick a coding agent (Claude / Cursor / Codex; defaults to Claude), then runs a guided first experience — it scaffolds the workspace, installs `dlt[hub]` and dependencies with `uv sync`, logs you in to the dltHub platform, runs a sample pipeline in a playground, and launches your agent ready to build your own source.
+Either way, it prompts you to pick a coding agent (Claude / Cursor / Codex), then runs a guided first experience — it scaffolds the workspace, installs `dlt[hub]` and dependencies with `uv sync`, logs you in to the dltHub platform, runs a sample pipeline in a playground, and launches your agent ready to build your own source.
 
 :::tip
 Run `dlthub-start` yourself with no arguments — it's interactive and guides you through each step. It scaffolds into your current folder, so the AI skills land right where your coding agent is open.
@@ -90,9 +90,9 @@ To add dltHub to an existing project, run:
 ```sh
 uvx dlthub-init@latest
 ```
-This scaffolds a workspace, installs `dlt[hub]`, and sets up the AI skills your coding agent uses:
-* `dlthub`—enables the **dlthub** command and features like AI toolkits and transformations
-* `dlthub-client`—enables access to the [managed dltHub Platform](../pipeline-operations/overview.md) (login, deploy, run, serve, etc.)
+This scaffolds a workspace, installs `dlt[hub]`, and sets up the AI skills your coding agent uses. The `dlt[hub]` extra pulls in two plugin packages:
+* `dlthub`—enables the `dlthub` command and features like AI toolkits and transformations
+* `dlthub-client`—enables access to the [managed dltHub platform](../pipeline-operations/overview.md) (login, deploy, run, serve, etc.)
 
 Workspace-level dependencies (destinations like `duckdb`, plus tools like `marimo` or `fastmcp` used by notebooks and MCP jobs) are managed in the generated `pyproject.toml`, not via `dlt` extras—extend it with `uv add <package>`.
 

--- a/docs/website/docs/hub/getting-started/installation.md
+++ b/docs/website/docs/hub/getting-started/installation.md
@@ -1,7 +1,7 @@
 ---
 title: Installation
 description: Install dlt[hub], create a workspace, and license paid features
-keywords: [installation, dlthub, dlthub init, workspace mode, license]
+keywords: [installation, dlthub, dlthub-init, dlthub-start, workspace mode, license]
 ---
 
 :::info Supported Python versions
@@ -42,13 +42,11 @@ If you don't have `uv` yet, either [install it first](#setting-up-your-environme
 pipx run dlthub-start
 ```
 
-Either way, it prompts for a workspace name, scaffold, and which AI agents to wire up (Claude / Cursor / Codex), scaffolds a workspace with `.dlt/.workspace` already set, vendors the AI toolkits (`rest-api-pipeline`, `transformations`, `dlthub-platform`, `data-exploration`), and runs `uv sync` so `dlt[hub]` and all workspace dependencies are installed.
+Either way, it prompts you to pick a coding agent (Claude / Cursor / Codex; defaults to Claude), then runs a guided first experience — it scaffolds the workspace, installs `dlt[hub]` and dependencies with `uv sync`, logs you in to the dltHub platform, runs a sample pipeline in a playground, and launches your agent ready to build your own source.
 
-For the recommended defaults non-interactively, pass a name explicitly:
-
-```sh
-uvx dlthub-start@latest my-workspace --yes
-```
+:::tip
+Run `dlthub-start` yourself with no arguments — it's interactive and guides you through each step. It scaffolds into your current folder, so the AI skills land right where your coding agent is open.
+:::
 
 ## Setting up your environment
 
@@ -88,15 +86,15 @@ source .venv/bin/activate
 
 ## Add dltHub to an existing project
 
-To install `dlt[hub]` into an existing project, activate its virtual environment and run:
+To add dltHub to an existing project, run:
 ```sh
-uv pip install "dlt[hub]"
+uvx dlthub-init@latest
 ```
-This installs `dlt` plus two plugin packages pulled in by the `hub` extra:
+This scaffolds a workspace, installs `dlt` plus two plugin packages pulled in by the `hub` extra, and sets up the AI skills your coding agent uses:
 * `dlthub`—enables the **dlthub** command and features like AI toolkits and transformations
 * `dlthub-client`—enables access to the [managed dltHub Platform](../pipeline-operations/overview.md) (login, deploy, run, serve, etc.)
 
-Workspace-level dependencies (destinations like `duckdb`, plus tools like `marimo` or `fastmcp` used by notebooks and MCP jobs) are managed in your workspace's `pyproject.toml`, not via `dlt` extras. Run `dlthub init` (see [below](#enable-workspace-mode))—it scaffolds a `pyproject.toml` you can extend with `uv add <package>`.
+Workspace-level dependencies (destinations like `duckdb`, plus tools like `marimo` or `fastmcp` used by notebooks and MCP jobs) are managed in the generated `pyproject.toml`, not via `dlt` extras—extend it with `uv add <package>`.
 
 ## Upgrade existing installation
 
@@ -122,10 +120,10 @@ how to install a compatible plugin version).
 The full dltHub feature surface—profiles, the `dlthub` CLI host, and [managed-platform commands](../pipeline-operations/overview.md)—is gated behind **Workspace mode**, signaled by a `.dlt/.workspace` marker file. The simplest way to turn it on is:
 
 ```sh
-dlthub init
+uvx dlthub-init@latest
 ```
 
-This scaffolds a fresh dltHub workspace—it creates the `.dlt/.workspace` marker plus `config.toml`, `secrets.toml`, `.gitignore`, and a `pyproject.toml` (or `requirements.txt` if `uv` isn't on `PATH`). See [Initialize a pipeline](../ingestion/init.md) for the next steps.
+This scaffolds a fresh, ready-to-run dltHub workspace—the `.dlt/.workspace` marker, local config and secrets, dependencies, and the dltHub AI skills your coding agent uses—and installs everything with `uv sync`. See [Initialize a pipeline](../ingestion/init.md) for the next steps.
 
 If you'd rather flip the toggle by hand in an existing project, create the empty marker file yourself:
 

--- a/docs/website/docs/hub/getting-started/introduction.md
+++ b/docs/website/docs/hub/getting-started/introduction.md
@@ -20,7 +20,7 @@ Use of the dltHub platform and toolkits is subject to a commercial [dltHub Licen
 uvx dlthub-start@latest
 ```
 
-Scaffolds a local workspace with the dltHub AI Workbench, example pipelines, and `dlt[hub]` installed. See [installation](installation.md) for prerequisites and alternative install paths.
+Runs a guided first experience: it scaffolds a local workspace (dltHub AI Workbench + `dlt[hub]`), installs dependencies, logs you in to the dltHub platform, runs a sample pipeline in a playground, and launches your coding agent ready to build your own source. See [installation](installation.md) for prerequisites and alternative install paths.
 
 On the [dltHub platform](../pipeline-operations/overview.md), set `destination="playground"` for a zero-config destination that is ideal for testing and a quick first run.
 

--- a/docs/website/docs/hub/getting-started/oss-and-dlthub.md
+++ b/docs/website/docs/hub/getting-started/oss-and-dlthub.md
@@ -44,12 +44,11 @@ dltHub is a managed cloud platform for running your dlt pipelines, transformatio
 - **Web UI** at [app.dlthub.com](https://app.dlthub.com) — sign up to deploy, schedule, monitor pipelines, manage profiles, browse datasets.
 - **Locally, from the CLI or Python** — bootstrap a new workspace in one command:
   ```sh
-  uvx dlthub-start@latest my-workspace
+  uvx dlthub-start@latest
   ```
   This creates a runnable workspace with the AI Workbench, example pipelines, and the [`dlt[hub]`](installation.md) extra installed. To add dltHub to an existing project instead, run:
   ```sh
-  pip install "dlt[hub]"
-  dlthub init
+  uvx dlthub-init@latest
   ```
   Either way, you get the dltHub workspace and dashboard, the AI development tooling (`dlthub ai`, MCP server, AI Workbench), per-source contexts, and the `dlthub` library that adds data quality, transformations, and premium sources/destinations.
 

--- a/docs/website/docs/hub/ingestion/delta.md
+++ b/docs/website/docs/hub/ingestion/delta.md
@@ -19,7 +19,7 @@ Make sure you have installed the necessary dependencies:
 pip install deltalake
 ```
 
-If you don't have a dltHub workspace yet, scaffold one with `uvx dlthub-start@latest` (see the [installation guide](../getting-started/installation.md)). Then, from inside the workspace, add a Delta pipeline:
+If you don't have a dltHub workspace yet, scaffold one with `uvx dlthub-init@latest` (see the [installation guide](../getting-started/installation.md)). Then, from inside the workspace, add a Delta pipeline:
 
 ```sh
 dlthub pipeline init sql_database delta

--- a/docs/website/docs/hub/ingestion/iceberg.md
+++ b/docs/website/docs/hub/ingestion/iceberg.md
@@ -28,7 +28,7 @@ The Iceberg destination in dlt allows you to load data into Iceberg tables using
 If you don't have a dltHub workspace yet, scaffold one with:
 
 ```sh
-uvx dlthub-start@latest
+uvx dlthub-init@latest
 ```
 
 This installs `dlt[hub]` and sets up the workspace. Alternatively, install the required extras into an existing project:

--- a/docs/website/docs/hub/ingestion/init.md
+++ b/docs/website/docs/hub/ingestion/init.md
@@ -27,7 +27,7 @@ Outside of a workspace (plain OSS `dlt`), the same scaffold is reachable as `dlt
 Before you start, make sure you followed the [installation instructions](../getting-started/installation.md) and have a dltHub workspace initialized. The fastest way is:
 
 ```sh
-uvx dlthub-start@latest
+uvx dlthub-init@latest
 ```
 
 This scaffolds a workspace with `.dlt/.workspace` already set, the AI toolkits vendored, and `dlt[hub]` synced. See the [installation guide](../getting-started/installation.md) for the alternative paths (adding to an existing project, or enabling workspace mode by hand).

--- a/docs/website/docs/hub/ingestion/ms-sql.md
+++ b/docs/website/docs/hub/ingestion/ms-sql.md
@@ -45,7 +45,7 @@ WITH (TRACK_COLUMNS_UPDATED = ON);
 
 ### Set up dlthub and drivers
 
-* If you don't have a dltHub workspace yet, scaffold one with `uvx dlthub-start@latest` (see the [installation guide](../getting-started/installation.md) for prerequisites and alternative install paths).
+* If you don't have a dltHub workspace yet, scaffold one with `uvx dlthub-init@latest` (see the [installation guide](../getting-started/installation.md) for prerequisites and alternative install paths).
 
 * Install the Microsoft ODBC Driver for SQL Server according to the official [instructions](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16). If you prefer, there is also a [Python library alternative](https://www.pymssql.org/).
 

--- a/docs/website/docs/hub/ingestion/rest-api-source.md
+++ b/docs/website/docs/hub/ingestion/rest-api-source.md
@@ -20,35 +20,17 @@ The dltHub AI workbench works with **Claude Code**, **Cursor**, and **Codex**.
 
 ## Setup
 
-### Python environment
+### Create the workspace
 
-Install `uv` ([instructions](https://docs.astral.sh/uv/getting-started/installation/)) and create a virtual environment:
-
-```sh
-uv venv && source .venv/bin/activate
-```
-
-We recommend using uv. If you use uv, prefix all following commands with `uv run`. 
-
-### Install dlt
-
-Install the dlt workspace:
+Install `uv` ([instructions](https://docs.astral.sh/uv/getting-started/installation/)), then scaffold a dltHub workspace — this installs `dlt[hub]` and all dependencies and sets up the AI skills your coding assistant uses (see the [installation guide](../getting-started/installation.md)):
 
 ```sh
-pip install "dlt[hub]"
-```
-or upgrade to the latest version:
-
-```sh
-pip install --upgrade "dlt[hub]"
+uvx dlthub-init@latest
 ```
 
 ### Initialize the AI assistant
 
-First create the dlthub workspace and install dependencies (see the [installation guide](../getting-started/installation.md)):
-```sh
-uvx dlthub-start@latest
-```
+Wire up your specific coding assistant:
 
 <Tabs values={[{"label": "Claude Code", "value": "claude"}, {"label": "Cursor", "value": "cursor"}, {"label": "Codex", "value": "codex"}]} groupId="ai-agent" defaultValue="claude">
 <TabItem value="claude">

--- a/docs/website/docs/hub/ingestion/snowflake-plus.md
+++ b/docs/website/docs/hub/ingestion/snowflake-plus.md
@@ -54,7 +54,7 @@ Once the `snowflake` extra is installed, you can configure a pipeline to use `sn
 GRANT USAGE ON EXTERNAL VOLUME <external_volume_name> TO ROLE <role_name>;
 ```
 
-5. If you don't have a dltHub workspace yet, scaffold one with `uvx dlthub-start@latest` (see the [installation guide](../getting-started/installation.md)). Then, from inside the workspace, add a Snowflake pipeline:
+5. If you don't have a dltHub workspace yet, scaffold one with `uvx dlthub-init@latest` (see the [installation guide](../getting-started/installation.md)). Then, from inside the workspace, add a Snowflake pipeline:
 
 ```sh
 dlthub pipeline init sql_database snowflake

--- a/docs/website/docs/hub/pipeline-operations/overview.md
+++ b/docs/website/docs/hub/pipeline-operations/overview.md
@@ -152,5 +152,5 @@ For detailed CLI documentation, see [CLI](../command-line-interface.md).
 - **UI operations**: new jobs must currently be created via the CLI; once a job exists, subsequent runs can be triggered from the Web UI (and schedules can be changed there too)
 - **Pagination**: list views are paginated; the page size can be adjusted in the Web UI
 - **Log latency**: logs typically lag a few seconds during execution and are guaranteed complete after the run finishes (completed or failed state)
-- **One workspace per repo**: a single GitHub repository can only be connected to one remote workspace at a time; reconnecting deactivates jobs deployed under the previous binding — see [Workspace setup](workspace-setup.md#3-log-in-to-the-dlthub-platform)
+- **One workspace per repo**: a single GitHub repository can only be connected to one remote workspace at a time; reconnecting deactivates jobs deployed under the previous binding — see [Workspace setup](workspace-setup.md#2-log-in-to-the-dlthub-platform)
 - **No drift detection**: the CLI does not yet detect whether local code differs from remote. Run `dlthub workspace deployment sync` (or any `run` / `serve` / `deploy`) to ensure your latest code is deployed

--- a/docs/website/docs/hub/pipeline-operations/profiles.md
+++ b/docs/website/docs/hub/pipeline-operations/profiles.md
@@ -25,7 +25,7 @@ Before you start, make sure you have followed the [installation instructions](..
 
 [More about dlt Workspace →](../getting-started/installation.md#what-is-a-dlthub-workspace)
 
-[Scaffold](../ingestion/init.md) a workspace with `uvx dlthub-start@latest`, then add a pipeline to it from inside the workspace:
+[Scaffold](../ingestion/init.md) a workspace with `uvx dlthub-init@latest`, then add a pipeline to it from inside the workspace:
 
 ```sh
 dlthub pipeline init pokemon_api duckdb

--- a/docs/website/docs/hub/pipeline-operations/workspace-setup.md
+++ b/docs/website/docs/hub/pipeline-operations/workspace-setup.md
@@ -8,38 +8,19 @@ keywords: [dlthub platform, workspace, setup, login, profiles, credentials, conf
 
 A workspace ready for the dltHub platform is a regular Python project with a few additions. You can easily convert any existing dlt project into a dltHub workspace.
 
-## 1. Initialize a Python project
+## 1. Enable dltHub platform features
 
-If your project doesn't have a `pyproject.toml` yet, create one:
-
-```sh
-uv init
-```
-
-The dltHub platform uses `pyproject.toml` to install dependencies remotely.
-
-## 2. Enable dltHub platform features
-
-Install `dlt[hub]` and initialize the workspace:
+Initialize the workspace:
 
 ```sh
-uv add "dlt[hub]"
-uv run dlthub init
+uvx dlthub-init@latest
 ```
 
-`dlthub init` scaffolds:
+`uvx dlthub-init@latest` scaffolds a ready-to-run workspace—the `.dlt/.workspace` marker that turns on workspace mode, local config and secrets, a managed `pyproject.toml`, and the dltHub AI skills your coding agent uses—then installs dependencies with `uv sync`.
 
-```text
-.dlt/
-├── .workspace          # marker that enables the extended `dlthub` command surface
-├── config.toml         # workspace-wide config
-└── secrets.toml        # workspace-wide secrets (gitignored)
-.gitignore
-```
+The `.dlt/.workspace` marker activates [profile support](./profiles.md) and enables the `dlthub` CLI command (including `dlthub profile` and `dlthub local`). Run `uvx dlthub-init@latest --help` for options like `--no-sync`. If you'd rather flip the toggle by hand, see [Enable workspace mode](../getting-started/installation.md#enable-workspace-mode).
 
-The `.dlt/.workspace` marker activates [profile support](./profiles.md) and enables the `dlthub` CLI command (including `dlthub profile` and `dlthub local`). Pass `--name <workspace>` to override the default (the current directory's basename), or `--dry-run` to preview the file plan without writing. If you'd rather flip the toggle by hand, see [Enable workspace mode](../getting-started/installation.md#enable-workspace-mode).
-
-## 3. Log in to the dltHub platform
+## 2. Log in to the dltHub platform
 
 ```sh
 dlthub login
@@ -65,7 +46,7 @@ A single GitHub repository can be connected to only one remote workspace at a ti
 Connecting multiple local repositories to the same remote workspace is not yet supported.
 :::
 
-## 4. Add pipelines
+## 3. Add pipelines
 
 ```sh
 dlthub pipeline init <source> <destination>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Aligns the dltHub onboarding docs with our two distinct entry-point commands:

- **`uvx dlthub-start@latest`** — the guided first-run experience. Kept only on genuine first-time onboarding pages, recommended bare (no args) and user-run. Corrected its description to match what it actually does (scaffold → install → login → playground → sample pipeline → launch agent).
- **`uvx dlthub-init@latest`** — the standalone workspace scaffold that ships AI skills. Now used on task pages (delta, iceberg, ms-sql, rest-api, etc.) and existing-project setup, replacing plain `dlthub init` and the redundant `pip install`/`uv add` prereqs.

Why: using `dlthub-start` on task pages derailed already-onboarded users into the full onboarding journey; `dlthub-init` is the right standalone command and bundles the AI skills. Also removed drift-prone details (file trees, toolkit lists, stale flags) in favor of outcome-focused descriptions.