### PR TITLE
docs(hub): document inviting members and org/workspace roles

### DIFF
--- a/docs/website/docs/hub/platform-capabilities/users-and-roles.md
+++ b/docs/website/docs/hub/platform-capabilities/users-and-roles.md
@@ -19,6 +19,10 @@ Users authenticate against the dltHub platform in the following ways:
 
 ## Inviting people to your organization and workspaces
 
+:::info Public preview
+This feature is available as a preliminary public preview to all dltHub customers.
+:::
+
 You can invite teammates by email into a whole organization or into a specific workspace, and control what each person can do with [roles](#roles).
 
 ### Inviting someone

--- a/docs/website/docs/hub/platform-capabilities/users-and-roles.md
+++ b/docs/website/docs/hub/platform-capabilities/users-and-roles.md
@@ -1,7 +1,7 @@
 ---
 title: Users and roles
-description: How users, organizations, and workspaces relate on the dltHub platform, and what each role can do.
-keywords: [users, roles, permissions, organization, workspace, access control, RBAC, dltHub platform]
+description: How users, organizations, and workspaces relate on the dltHub platform, how to invite people, and what each role can do.
+keywords: [users, roles, permissions, organization, workspace, access control, RBAC, invite, members, dltHub platform]
 ---
 
 # Users and roles
@@ -17,29 +17,62 @@ Users authenticate against the dltHub platform in the following ways:
 - **Email signup.** Register for the Web UI ([app.dlthub.com](https://app.dlthub.com)) with an email address and password when you don't want to use a third-party identity provider.
 - **API keys.** Personal, long-lived tokens (prefixed `dlt_`) for non-interactive clients such as CI jobs or scripts. A key inherits the organization and workspace permissions of the user who created it. See [API keys](settings.md#api-keys) for creating, scoping, and revoking keys.
 
-## Organization roles
+## Inviting people to your organization and workspaces
+
+You can invite teammates by email into a whole organization or into a specific workspace, and control what each person can do with [roles](#roles).
+
+### Inviting someone
+
+1. Open the **Settings** page for the organization or workspace you want to add someone to.
+2. In the **Members** area, find the pending-invites section and enter the person's **email address**.
+3. Pick the **role** they should have (see [Roles](#roles) below).
+4. Send the invite. It appears in the pending-invites list until it's accepted.
+
+You can invite people who don't have an account yet — they'll be added automatically when they sign up and sign in with that email.
+
+### Accepting an invite
+
+There's nothing for the invited person to click. The next time they **sign in** with the email the invite was sent to, they're automatically added to the organization or workspace with the role you chose. Brand-new users skip the "create your own organization" step and land directly in the team that invited them.
+
+### Revoking an invite
+
+If you invited the wrong person or no longer want them to join, open the pending-invites list and **revoke** the invite. A revoked invite won't be accepted on sign-in. You can always send a new invite later.
+
+## Roles
+
+Roles decide what a member can see and do. Organizations and workspaces have separate roles.
+
+### Organization roles
 
 Organization membership is a prerequisite for any workspace access — a user must be added to the organization before they can be granted a role in any workspace.
 
-| Role     | Permissions                                                                                                                |
-| -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Owner    | Manage organization settings, manage members, create and delete workspaces, and access every workspace in the organization. |
-| Member   | Create new workspaces in the organization, and access the workspaces they have been assigned to (with the role granted there). |
+| Role     | Can do |
+| -------- | ------ |
+| `owner`  | Full control: manage members and invites, change roles, manage workspaces and billing. |
+| `member` | Work within the organization and the workspaces they belong to. |
+| `guest`  | Limited access — typically someone invited to a single workspace rather than the whole org. |
 
-## Workspace roles
+### Workspace roles
 
 A workspace role is assigned per workspace and controls what a user can do inside that workspace. A user can hold different workspace roles in different workspaces.
 
-| Role     | Permissions                                                                                                                                                   |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Owner    | Full access: manage members, edit workspace settings, start and cancel runs, manage schedules, manage public links, archive jobs, and publish interactive apps. |
-| Viewer   | Read-only access to jobs, runs, logs, pipelines, deployments, and notebooks. Viewers can also launch jobs on the [`access` profile](../pipeline-operations/profiles.md) — for example, running interactive notebooks. |
+| Role        | Can do |
+| ----------- | ------ |
+| `owner`     | Full control of the workspace: manage members, invites, settings, and content. |
+| `developer` | Create and edit work in the workspace (such as configurations, deployments, and run jobs). |
+| `viewer`    | Read-only access to jobs, runs, logs, pipelines, deployments, and notebooks. Viewers can also launch jobs on the [`access` profile](../pipeline-operations/profiles.md) — for example, running interactive notebooks. |
+
+### How invites and roles combine
+
+- Inviting someone to a **workspace** also adds them to the parent **organization** as a `guest`, so they can reach that workspace. If they're later removed from their last workspace in that organization, they're removed from the organization too.
+- If someone has more than one pending invite for the same organization or workspace, they get the **most permissive** role. Accepting an invite never lowers a role they already have.
 
 ## Permission scope
 
 Role-based restrictions apply to both the dashboard and the API, so a viewer cannot bypass restrictions by using the CLI.
 
 - **Workspace owners** can launch, cancel, and schedule any job, change workspace configuration, manage members, and publish interactive applications.
+- **Workspace developers** can create and edit work in the workspace — configurations, deployments, and run jobs — and launch and cancel jobs (including on the `prod` profile). They cannot manage members or change workspace settings.
 - **Workspace viewers** have read access to all workspace data and can launch jobs that run under the `access` profile (notebooks and other interactive read-only workloads). They cannot launch or cancel `prod` jobs, edit schedules, change workspace settings, or manage members.
 - **All roles** can view jobs, runs, logs, pipelines, deployments, and notebooks in the workspaces they have access to.
 
@@ -47,11 +80,19 @@ For details on which profiles are used for which workloads, see [Profiles in dlt
 
 ## Managing members
 
-Members are managed from the workspace **Settings** page. The same flow is used to invite new users, change roles, and remove access.
+On the **Members** table of an organization or workspace Settings page you can:
 
-- **Invite a user.** Add the user to the workspace from Settings and choose their workspace role at invitation time. The user must already belong to the organization, or be invited to it as part of the same flow.
-- **Change a role.** Update the role from Settings; the new permissions take effect immediately.
-- **Remove a user.** Removing a user from a workspace revokes their access to that workspace immediately. They remain in the organization and can be re-added to the same or other workspaces later without a new invitation.
+- **Change a member's role** with the inline role dropdown. The new permissions take effect immediately.
+- **Remove a member.** Removing a user from a workspace revokes their access to that workspace immediately.
+
+A few rules keep things safe:
+
+- You can't change **your own** role from the members table.
+- An organization or workspace can have **multiple owners**, but the **last owner can't be removed or demoted** — promote someone else to owner first.
+
+## Multiple members per role
+
+Every role can be held by any number of people — there are no single-holder roles. In particular, organizations and workspaces can have more than one **owner**, so responsibility isn't tied to a single person. Any owner can invite people, manage members, and change roles. The only limit is that the **last owner can't be removed or demoted** — promote someone else to owner first.
 
 ## See also
 

--- a/docs/website/docs/hub/platform-capabilities/users-and-roles.md
+++ b/docs/website/docs/hub/platform-capabilities/users-and-roles.md
@@ -30,13 +30,13 @@ You can invite teammates by email into a whole organization or into a specific w
 1. Open the **Settings** page for the organization or workspace you want to add someone to.
 2. In the members section, find the pending-invites area and enter the person's **email address**.
 3. Pick the **role** they should have (see [Roles](#roles) below).
-4. Send the invite. It appears in the pending-invites list until it's accepted.
+4. Send the invite. The invitee receives an email with a link to the platform, and the invite appears in the pending-invites list until it's accepted. Invites expire after 14 days.
 
 You can invite people who don't have an account yet. They'll be added automatically when they sign up and sign in with that email.
 
 ### Accepting an invite
 
-There's nothing for the invited person to click. The next time they **sign in** with the email the invite was sent to, they're automatically added to the organization or workspace with the role you chose. Brand-new users skip the "create your own organization" step and land directly in the team that invited them.
+The invitee receives an email announcing the invite with a link to the platform. When they follow the link and **sign in** with the email the invite was sent to, they're automatically added to the organization or workspace with the role you chose. Brand-new users skip the "create your own organization" step and land directly in the team that invited them. Invites expire 14 days after they're sent.
 
 ### Revoking an invite
 

--- a/docs/website/docs/hub/platform-capabilities/users-and-roles.md
+++ b/docs/website/docs/hub/platform-capabilities/users-and-roles.md
@@ -12,8 +12,8 @@ The dltHub platform uses a two-level access model. Every user belongs to an **or
 
 Users authenticate against the dltHub platform in the following ways:
 
-- **GitHub OAuth.** Interactive sign-in for both the Web UI ([app.dlthub.com](https://app.dlthub.com)) and the CLI (`dlthub login`). The same identity is used everywhere—your CLI session inherits the workspaces and roles granted to your GitHub account.
-- **Google OAuth.** Interactive sign-in to the Web UI ([app.dlthub.com](https://app.dlthub.com)) with a Google account. As with GitHub OAuth, the same identity is used across the Web UI and CLI.
+- **GitHub OAuth.** Interactive sign-in for both the Web UI ([app.dlthub.com](https://app.dlthub.com)) and the CLI (`dlthub login`). The same identity is used everywhere. Your CLI session inherits the workspaces and roles granted to your GitHub account.
+- **Google OAuth.** Interactive sign-in to the Web UI ([app.dlthub.com](https://app.dlthub.com)) with a Google Account. As with GitHub OAuth, the same identity is used across the Web UI and CLI.
 - **Email signup.** Register for the Web UI ([app.dlthub.com](https://app.dlthub.com)) with an email address and password when you don't want to use a third-party identity provider.
 - **API keys.** Personal, long-lived tokens (prefixed `dlt_`) for non-interactive clients such as CI jobs or scripts. A key inherits the organization and workspace permissions of the user who created it. See [API keys](settings.md#api-keys) for creating, scoping, and revoking keys.
 
@@ -28,15 +28,15 @@ You can invite teammates by email into a whole organization or into a specific w
 ### Inviting someone
 
 1. Open the **Settings** page for the organization or workspace you want to add someone to.
-2. In the **Members** area, find the pending-invites section and enter the person's **email address**.
+2. In the members section, find the pending-invites area and enter the person's **email address**.
 3. Pick the **role** they should have (see [Roles](#roles) below).
 4. Send the invite. It appears in the pending-invites list until it's accepted.
 
-You can invite people who don't have an account yet — they'll be added automatically when they sign up and sign in with that email.
+You can invite people who don't have an account yet. They'll be added automatically when they sign up and sign in with that email.
 
 ### Accepting an invite
 
-There's nothing for the invited person to click. The next time they **sign in** with the email the invite was sent to, they're automatically added to the organization or workspace with the role you chose. Brand-new users skip the "create your own organization" step and land directly in the team that invited them.
+There's nothing for the invited person to click. The next time they **sign in** with the email the invite was sent to, they are automatically added to the organization or workspace with the role you chose. Brand-new users skip the "create your own organization" step and land directly in the team that invited them.
 
 ### Revoking an invite
 
@@ -48,13 +48,13 @@ Roles decide what a member can see and do. Organizations and workspaces have sep
 
 ### Organization roles
 
-Organization membership is a prerequisite for any workspace access — a user must be added to the organization before they can be granted a role in any workspace.
+Organization membership is a prerequisite for any workspace access: a user must be added to the organization before they can be granted a role in any workspace.
 
 | Role     | Can do |
 | -------- | ------ |
 | `owner`  | Full control: manage members and invites, change roles, manage workspaces and billing. |
-| `member` | Work within the organization and the workspaces they belong to. |
-| `guest`  | Limited access — typically someone invited to a single workspace rather than the whole org. |
+| `member` | Standard access: work within the organization and the workspaces they belong to. |
+| `collaborator`  | Limited access: typically someone invited to a single workspace rather than the whole org. |
 
 ### Workspace roles
 
@@ -62,29 +62,29 @@ A workspace role is assigned per workspace and controls what a user can do insid
 
 | Role        | Can do |
 | ----------- | ------ |
-| `owner`     | Full control of the workspace: manage members, invites, settings, and content. |
-| `developer` | Create and edit work in the workspace (such as configurations, deployments, and run jobs). |
-| `viewer`    | Read-only access to jobs, runs, logs, pipelines, deployments, and notebooks. Viewers can also launch jobs on the [`access` profile](../pipeline-operations/profiles.md) — for example, running interactive notebooks. |
+| `owner`     | Full control: manage members, invites, settings, and content in the workspace. |
+| `developer` | Edit access: create and edit work in the workspace (such as configurations, deployments, and run jobs). |
+| `viewer`    | Read-only access: jobs, runs, logs, pipelines, deployments, and notebooks. Viewers can also launch jobs on the [access profile](../pipeline-operations/profiles.md), such as interactive notebooks. |
 
 ### How invites and roles combine
 
-- Inviting someone to a **workspace** also adds them to the parent **organization** as a `guest`, so they can reach that workspace. If they're later removed from their last workspace in that organization, they're removed from the organization too.
+- Inviting someone to a **workspace** also adds them to the parent **organization** as a `collaborator`, so they can reach that workspace. If they are later removed from their last workspace in that organization, they are removed from the organization too.
 - If someone has more than one pending invite for the same organization or workspace, they get the **most permissive** role. Accepting an invite never lowers a role they already have.
 
 ## Permission scope
 
-Role-based restrictions apply to both the dashboard and the API, so a viewer cannot bypass restrictions by using the CLI.
+Role-based restrictions apply to both the dashboard and the API, so a viewer can't bypass restrictions by using the CLI.
 
 - **Workspace owners** can launch, cancel, and schedule any job, change workspace configuration, manage members, and publish interactive applications.
-- **Workspace developers** can create and edit work in the workspace — configurations, deployments, and run jobs — and launch and cancel jobs (including on the `prod` profile). They cannot manage members or change workspace settings.
-- **Workspace viewers** have read access to all workspace data and can launch jobs that run under the `access` profile (notebooks and other interactive read-only workloads). They cannot launch or cancel `prod` jobs, edit schedules, change workspace settings, or manage members.
+- **Workspace developers** can create and edit work in the workspace (configurations, deployments, and run jobs) and launch and cancel jobs, including on the `prod` profile. They can't manage members or change workspace settings.
+- **Workspace viewers** have read access to all workspace data and can launch jobs that run under the `access` profile (notebooks and other interactive read-only workloads). They can't launch or cancel `prod` jobs, edit schedules, change workspace settings, or manage members.
 - **All roles** can view jobs, runs, logs, pipelines, deployments, and notebooks in the workspaces they have access to.
 
 For details on which profiles are used for which workloads, see [Profiles in dltHub](../pipeline-operations/profiles.md).
 
 ## Managing members
 
-On the **Members** table of an organization or workspace Settings page you can:
+In the members section of an organization's or workspace's settings, you can:
 
 - **Change a member's role** with the inline role dropdown. The new permissions take effect immediately.
 - **Remove a member.** Removing a user from a workspace revokes their access to that workspace immediately.
@@ -92,11 +92,11 @@ On the **Members** table of an organization or workspace Settings page you can:
 A few rules keep things safe:
 
 - You can't change **your own** role from the members table.
-- An organization or workspace can have **multiple owners**, but the **last owner can't be removed or demoted** — promote someone else to owner first.
+- An organization or workspace can have **multiple owners**, but the **last owner can't be removed or demoted**. Promote someone else to owner first.
 
 ## Multiple members per role
 
-Every role can be held by any number of people — there are no single-holder roles. In particular, organizations and workspaces can have more than one **owner**, so responsibility isn't tied to a single person. Any owner can invite people, manage members, and change roles. The only limit is that the **last owner can't be removed or demoted** — promote someone else to owner first.
+Every role can be held by any number of people; there are no single-holder roles. In particular, organizations and workspaces can have more than one **owner**, so responsibility isn't tied to a single person. Any owner can invite people, manage members, and change roles. The only limit is that the **last owner can't be removed or demoted**. Promote someone else to owner first.
 
 ## See also
 

--- a/docs/website/docs/hub/platform-capabilities/users-and-roles.md
+++ b/docs/website/docs/hub/platform-capabilities/users-and-roles.md
@@ -36,7 +36,7 @@ You can invite people who don't have an account yet. They'll be added automatica
 
 ### Accepting an invite
 
-There's nothing for the invited person to click. The next time they **sign in** with the email the invite was sent to, they are automatically added to the organization or workspace with the role you chose. Brand-new users skip the "create your own organization" step and land directly in the team that invited them.
+There's nothing for the invited person to click. The next time they **sign in** with the email the invite was sent to, they're automatically added to the organization or workspace with the role you chose. Brand-new users skip the "create your own organization" step and land directly in the team that invited them.
 
 ### Revoking an invite
 
@@ -52,7 +52,7 @@ Organization membership is a prerequisite for any workspace access: a user must 
 
 | Role     | Can do |
 | -------- | ------ |
-| `owner`  | Full control: manage members and invites, change roles, manage workspaces and billing. |
+| `owner`  | Full control: manage members and invites, change roles, and manage workspaces. |
 | `member` | Standard access: work within the organization and the workspaces they belong to. |
 | `collaborator`  | Limited access: typically someone invited to a single workspace rather than the whole org. |
 
@@ -63,22 +63,30 @@ A workspace role is assigned per workspace and controls what a user can do insid
 | Role        | Can do |
 | ----------- | ------ |
 | `owner`     | Full control: manage members, invites, settings, and content in the workspace. |
-| `developer` | Edit access: create and edit work in the workspace (such as configurations, deployments, and run jobs). |
+| `developer` | Write access: create and edit scripts, deployments, and configurations, deploy the workspace, and launch or cancel jobs on any profile. Can't manage members or change workspace settings. |
 | `viewer`    | Read-only access: jobs, runs, logs, pipelines, deployments, and notebooks. Viewers can also launch jobs on the [access profile](../pipeline-operations/profiles.md), such as interactive notebooks. |
 
 ### How invites and roles combine
 
-- Inviting someone to a **workspace** also adds them to the parent **organization** as a `collaborator`, so they can reach that workspace. If they are later removed from their last workspace in that organization, they are removed from the organization too.
+- Inviting someone to a **workspace** also adds them to the parent **organization** as a `collaborator`, so they can reach that workspace. If they are later removed from their last workspace in that organization, they're removed from the organization too.
 - If someone has more than one pending invite for the same organization or workspace, they get the **most permissive** role. Accepting an invite never lowers a role they already have.
 
 ## Permission scope
 
-Role-based restrictions apply to both the dashboard and the API, so a viewer can't bypass restrictions by using the CLI.
+Role-based restrictions apply to both the dashboard and the API, so a viewer can't bypass restrictions by using the CLI. The table below summarizes what each workspace role can do.
 
-- **Workspace owners** can launch, cancel, and schedule any job, change workspace configuration, manage members, and publish interactive applications.
-- **Workspace developers** can create and edit work in the workspace (configurations, deployments, and run jobs) and launch and cancel jobs, including on the `prod` profile. They can't manage members or change workspace settings.
-- **Workspace viewers** have read access to all workspace data and can launch jobs that run under the `access` profile (notebooks and other interactive read-only workloads). They can't launch or cancel `prod` jobs, edit schedules, change workspace settings, or manage members.
-- **All roles** can view jobs, runs, logs, pipelines, deployments, and notebooks in the workspaces they have access to.
+| Action | Owner | Developer | Viewer |
+| --- | :---: | :---: | :---: |
+| View jobs, runs, logs, pipelines, deployments, and notebooks | Yes | Yes | Yes |
+| Launch jobs on the `access` profile (notebooks and read-only interactive workloads) | Yes | Yes | Yes |
+| Launch jobs on the `prod` profile | Yes | Yes | No |
+| Create or edit scripts, configurations, and deployments | Yes | Yes | No |
+| Deploy the workspace (`dlthub deploy`) | Yes | Yes | No |
+| Cancel runs | Yes | Yes | No |
+| Publish or revoke public links for interactive applications | Yes | Yes | No |
+| Change workspace settings | Yes | No | No |
+| Manage members and invites | Yes | No | No |
+| Manage workspace API keys | Yes | No | No |
 
 For details on which profiles are used for which workloads, see [Profiles in dltHub](../pipeline-operations/profiles.md).
 
@@ -96,7 +104,7 @@ A few rules keep things safe:
 
 ## Multiple members per role
 
-Every role can be held by any number of people; there are no single-holder roles. In particular, organizations and workspaces can have more than one **owner**, so responsibility isn't tied to a single person. Any owner can invite people, manage members, and change roles. The only limit is that the **last owner can't be removed or demoted**. Promote someone else to owner first.
+Every role can be held by any number of people. There are no single-holder roles. In particular, organizations and workspaces can have more than one **owner**, so responsibility isn't tied to a single person. Any owner can invite people, manage members, and change roles. The only limit is that the **last owner can't be removed or demoted**. Promote someone else to owner first.
 
 ## See also
 


### PR DESCRIPTION
## Description

Expands the **Users and roles** hub doc (`docs/website/docs/hub/platform-capabilities/users-and-roles.md`) to cover inviting teammates and the full role model.

Changes:
- **Inviting people** — new section covering invite-by-email, accept-on-sign-in (no link to click), and revoking pending invites.
- **Roles** — expanded the role tables with the organization `guest` role and the workspace `developer` role, plus a "how invites and roles combine" note (workspace invite adds the user to the org as `guest`; most-permissive role wins).
- **Permission scope** — added a workspace `developer` bullet so all three workspace roles are described.
- **Managing members** — documented the safety rules: can't change your own role, and the last owner can't be removed or demoted.


🤖 Generated with [Claude Code](https://claude.com/claude-code)