### PR TITLE
Additional copy options

### DIFF
--- a/dlt/destinations/impl/redshift/configuration.py
+++ b/dlt/destinations/impl/redshift/configuration.py
@@ -27,6 +27,7 @@ class RedshiftClientConfiguration(PostgresClientConfiguration):
 
     staging_iam_role: Optional[str] = None
     has_case_sensitive_identifiers: bool = False
+    additional_copy_options: Optional[list[str]] = None
 
     def fingerprint(self) -> str:
         """Returns a fingerprint of host part of a connection string"""

--- a/dlt/destinations/impl/redshift/factory.py
+++ b/dlt/destinations/impl/redshift/factory.py
@@ -179,6 +179,7 @@ class redshift(Destination[RedshiftClientConfiguration, "RedshiftClient"]):
         credentials: Union[RedshiftCredentials, Dict[str, Any], str] = None,
         staging_iam_role: Optional[str] = None,
         has_case_sensitive_identifiers: bool = False,
+        additional_copy_options: Optional[list[str]] = None,
         destination_name: str = None,
         environment: str = None,
         **kwargs: Any,
@@ -192,6 +193,7 @@ class redshift(Destination[RedshiftClientConfiguration, "RedshiftClient"]):
                 a connection string in the format `redshift://user:password@host:port/database`. Defaults to None.
             staging_iam_role (Optional[str], optional): IAM role to use for staging data in S3. Defaults to None.
             has_case_sensitive_identifiers (bool, optional): Whether case sensitive identifiers are enabled for the database. Defaults to False.
+            additional_copy_options (list[str], optional): Additional Redshift COPY options.
             destination_name (str, optional): Name of the destination. Defaults to None.
             environment (str, optional): Environment name. Defaults to None.
             **kwargs (Any): Additional arguments passed to the destination config.
@@ -200,6 +202,7 @@ class redshift(Destination[RedshiftClientConfiguration, "RedshiftClient"]):
             credentials=credentials,
             staging_iam_role=staging_iam_role,
             has_case_sensitive_identifiers=has_case_sensitive_identifiers,
+            additional_copy_options=additional_copy_options,
             destination_name=destination_name,
             environment=environment,
             **kwargs,

--- a/dlt/destinations/impl/redshift/factory.py
+++ b/dlt/destinations/impl/redshift/factory.py
@@ -193,7 +193,7 @@ class redshift(Destination[RedshiftClientConfiguration, "RedshiftClient"]):
                 a connection string in the format `redshift://user:password@host:port/database`. Defaults to None.
             staging_iam_role (Optional[str], optional): IAM role to use for staging data in S3. Defaults to None.
             has_case_sensitive_identifiers (bool, optional): Whether case sensitive identifiers are enabled for the database. Defaults to False.
-            additional_copy_options (list[str], optional): Additional Redshift COPY options.
+            additional_copy_options (Optional[list[str]], optional): Additional Redshift COPY options.
             destination_name (str, optional): Name of the destination. Defaults to None.
             environment (str, optional): Environment name. Defaults to None.
             **kwargs (Any): Additional arguments passed to the destination config.

--- a/dlt/destinations/impl/redshift/redshift.py
+++ b/dlt/destinations/impl/redshift/redshift.py
@@ -83,9 +83,11 @@ class RedshiftCopyFileLoadJob(CopyRemoteFileLoadJob):
         file_path: str,
         staging_credentials: Optional[CredentialsConfiguration] = None,
         staging_iam_role: str = None,
+        additional_copy_options: Optional[list[str]] = None,
     ) -> None:
         super().__init__(file_path, staging_credentials)
         self._staging_iam_role = staging_iam_role
+        self.additional_copy_options = additional_copy_options or []
         self._job_client: "RedshiftClient" = None
 
     def run(self) -> None:
@@ -116,6 +118,7 @@ class RedshiftCopyFileLoadJob(CopyRemoteFileLoadJob):
         file_type = ""
         dateformat = ""
         compression = ""
+        additional_copy_options = "\n                ".join(self.additional_copy_options)
         if file_format == "jsonl":
             file_type = "FORMAT AS JSON 'auto'"
             dateformat = "dateformat 'auto' timeformat 'auto'"
@@ -147,7 +150,9 @@ class RedshiftCopyFileLoadJob(CopyRemoteFileLoadJob):
                 {dateformat}
                 {compression}
                 {credentials}
-                {region} MAXERROR 0;""")
+                {region}
+                {additional_copy_options}
+                MAXERROR 0;""")
 
 
 class RedshiftMergeJob(SqlMergeFollowupJob):
@@ -216,6 +221,7 @@ class RedshiftClient(InsertValuesJobClient, SupportsStagingDestination):
                 file_path,
                 staging_credentials=self.config.staging_config.credentials,
                 staging_iam_role=self.config.staging_iam_role,
+                additional_copy_options=self.config.additional_copy_options,
             )
         return job
 

--- a/docs/website/docs/dlt-ecosystem/destinations/redshift.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/redshift.md
@@ -122,6 +122,13 @@ If the S3 bucket is in a different region than your Redshift cluster:
 - For Parquet files, cross-region COPY operations are not supported by Redshift, so the region setting will be ignored
 :::
 
+### Additional COPY Options
+You can append additional Redshift [COPY options/Data conversion Parameters](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-conversion.html) to staged loads with `additional_copy_options`. For example:
+```toml
+[destination.redshift]
+additional_copy_options = ["FILLRECORD", "NULL AS 'null_string'"]
+```
+
 ## Identifier names and case sensitivity
 * Up to 127 characters
 * Case insensitive

--- a/tests/load/redshift/test_redshift_client.py
+++ b/tests/load/redshift/test_redshift_client.py
@@ -61,24 +61,32 @@ def test_redshift_factory() -> None:
     assert client.config.has_case_sensitive_identifiers is False
     assert client.capabilities.has_case_sensitive_identifiers is False
     assert client.capabilities.casefold_identifier is str.lower
+    assert client.config.additional_copy_options is None
 
     # set args explicitly
-    dest = redshift(has_case_sensitive_identifiers=True, staging_iam_role="LOADER")
+    dest = redshift(
+        has_case_sensitive_identifiers=True,
+        staging_iam_role="LOADER",
+        additional_copy_options=["FILLRECORD"],
+    )
     client = dest.client(schema, RedshiftClientConfiguration()._bind_dataset_name("dataset"))
     assert client.config.staging_iam_role == "LOADER"
     assert client.config.has_case_sensitive_identifiers is True
     assert client.capabilities.has_case_sensitive_identifiers is True
     assert client.capabilities.casefold_identifier is str
+    assert client.config.additional_copy_options == ["FILLRECORD"]
 
     # set args via config
     os.environ["DESTINATION__STAGING_IAM_ROLE"] = "LOADER"
     os.environ["DESTINATION__HAS_CASE_SENSITIVE_IDENTIFIERS"] = "True"
+    os.environ["DESTINATION__REDSHIFT__ADDITIONAL_COPY_OPTIONS"] = '["FILLRECORD"]'
     dest = redshift()
     client = dest.client(schema, RedshiftClientConfiguration()._bind_dataset_name("dataset"))
     assert client.config.staging_iam_role == "LOADER"
     assert client.config.has_case_sensitive_identifiers is True
     assert client.capabilities.has_case_sensitive_identifiers is True
     assert client.capabilities.casefold_identifier is str
+    assert client.config.additional_copy_options == ["FILLRECORD"]
 
 
 @skipifpypy


### PR DESCRIPTION
### Description
Add Redshift destination configuration option, that appends extra options to the generated Redshift COPY command for staged loads. This allows users to configure Reshift-specific COPY behavior.
For more information see: https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-conversion.html

### Result
Provides more flexibility and especially enables options like FILLRECORD.
Tested for S3 -> Redshift Serverless