### PR TITLE
Update incremental troubleshooting docs page

### DIFF
--- a/docs/website/docs/general-usage/incremental/troubleshooting.md
+++ b/docs/website/docs/general-usage/incremental/troubleshooting.md
@@ -6,7 +6,7 @@ keywords: [incremental loading, troubleshooting]
 
 If you see that the incremental loading is not working as expected and the incremental values are not modified between pipeline runs, check the following:
 
-1. Make sure the `destination`, `pipeline_name`, and `dataset_name` are the same between pipeline runs.
+1. Make sure the `destination`, `pipeline_name`, `dataset_name`, and source name are the same between pipeline runs. The source name is derived from the `@dlt.source` function name — if the function is renamed, the incremental state will not be found and the cursor will reset. To make the source name explicit and stable, set it directly: `@dlt.source(name="my_source")`.
 
 2. Check if `dev_mode` is `False` in the pipeline configuration. Check if `refresh` for associated sources and resources is not enabled.
 
@@ -89,3 +89,24 @@ To avoid similar issues:
 - Always ensure the `initial_value` type matches the data type in the source field.
 - If the field requires transformation, apply `add_map` to convert the type before incremental tracking.
 - Use a separate column if needed to retain the original format for downstream processing or reference.
+
+
+### Source key mismatch
+
+If the bind log shows `start_value: None` but `dlt pipeline -v <pipeline_name> info` shows a valid `last_value`, the state exists but is stored under a different key than the one the current code is using.
+
+DLT stores incremental state under a source key derived from the `@dlt.source` function name. If this key changes — for example because the source function was renamed — the existing state will not be found and the cursor will reset to `initial_value`.
+
+Check the `sources` block in `pipeline info` and verify that the key there matches the name of your `@dlt.source` function. To make the source key explicit and stable, set the `name` parameter directly on the decorator:
+
+```py
+@dlt.source(name="my_source")  # state key is always "my_source", regardless of function name
+def my_source():
+    ...
+```
+
+If the key has already drifted, drop the stale state and do a full reload. For `append` resources, skipping the reload will produce duplicate rows.
+
+```sh
+dlt pipeline <pipeline_name> drop --state-only
+```


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Add a note to troubleshooting checklist item 1 explaining that the `@dlt.source` function name is used as the source key for incremental state, and that renaming it will cause the cursor to reset. Recommends pinning the name explicitly with `@dlt.source(name="...")`.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

N/A

<!--
Provide any additional context about the PR here.
-->
### Additional Context

I discovered this when having issues with incremental loading and talking to the slack bot: [https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1782076681882769](https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1782076681882769). The existing checklist already covered pipeline_name and dataset_name but not the source name, which has the same effect on incremental state continuity.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->