### PR TITLE
fix(dashboard): keep the pipeline selector when no pipeline is selected

### DIFF
--- a/dlt/_workspace/cli/_pipeline_command.py
+++ b/dlt/_workspace/cli/_pipeline_command.py
@@ -35,7 +35,7 @@ def list_pipelines(pipelines_dir: str = None, verbosity: int = 1) -> None:
                    - 0: Only show count summary
                    - 1+: Show full list with last run times
     """
-    pipelines_dir, pipelines = utils.list_local_pipelines(pipelines_dir)
+    pipelines_dir, pipelines, _ = utils.list_local_pipelines(pipelines_dir)
 
     if len(pipelines) > 0:
         if verbosity == 0:

--- a/dlt/_workspace/cli/utils.py
+++ b/dlt/_workspace/cli/utils.py
@@ -10,11 +10,8 @@ from typing import (
     Dict,
     FrozenSet,
     List,
-    Literal,
     Optional,
     Tuple,
-    Union,
-    overload,
 )
 
 import dlt
@@ -97,37 +94,12 @@ def _get_pipeline_initial_cwd(pipelines_dir: str, pipeline_name: str) -> Optiona
         return None
 
 
-@overload
 def list_local_pipelines(
     pipelines_dir: str = None,
     sort_by_trace: bool = True,
     additional_pipelines: List[str] = None,
     run_dir: Optional[str] = None,
-    include_local_pipeline_names: Literal[False] = False,
-) -> Tuple[str, List[TPipelineListItem]]:
-    ...
-
-
-@overload
-def list_local_pipelines(
-    pipelines_dir: str = None,
-    sort_by_trace: bool = True,
-    additional_pipelines: List[str] = None,
-    run_dir: Optional[str] = None,
-    include_local_pipeline_names: Literal[True] = True,
 ) -> Tuple[str, List[TPipelineListItem], List[str]]:
-    ...
-
-
-def list_local_pipelines(
-    pipelines_dir: str = None,
-    sort_by_trace: bool = True,
-    additional_pipelines: List[str] = None,
-    run_dir: Optional[str] = None,
-    include_local_pipeline_names: bool = False,
-) -> Union[
-    Tuple[str, List[TPipelineListItem]], Tuple[str, List[TPipelineListItem], List[str]]
-]:
     """Get the local pipelines directory and the list of pipeline names in it.
 
     Args:
@@ -135,7 +107,10 @@ def list_local_pipelines(
         sort_by_trace: Whether to sort the pipelines by the latest timestamp of trace.
         additional_pipelines: Extra pipeline names to include in the list.
         run_dir: When set, only return pipelines whose initial_cwd matches this path.
-        include_local_pipeline_names: Return the names discovered on disk before adding extras.
+
+    Returns:
+        The pipelines directory, the pipeline list items, and the names discovered on
+        disk before extras are merged in.
     """
     pipelines_dir = pipelines_dir or get_dlt_pipelines_dir()
     storage = FileStorage(pipelines_dir)
@@ -173,10 +148,7 @@ def list_local_pipelines(
     if sort_by_trace:
         pipelines_with_timestamps.sort(key=lambda x: x["timestamp"], reverse=True)
 
-    if include_local_pipeline_names:
-        return pipelines_dir, pipelines_with_timestamps, local_pipeline_names
-
-    return pipelines_dir, pipelines_with_timestamps
+    return pipelines_dir, pipelines_with_timestamps, local_pipeline_names
 
 
 def date_from_timestamp_with_ago(

--- a/dlt/_workspace/cli/utils.py
+++ b/dlt/_workspace/cli/utils.py
@@ -4,7 +4,18 @@ import os
 import platform
 import shutil
 import subprocess
-from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    overload,
+)
 
 import dlt
 from dlt.common.pipeline import get_dlt_pipelines_dir
@@ -86,12 +97,37 @@ def _get_pipeline_initial_cwd(pipelines_dir: str, pipeline_name: str) -> Optiona
         return None
 
 
+@overload
 def list_local_pipelines(
     pipelines_dir: str = None,
     sort_by_trace: bool = True,
     additional_pipelines: List[str] = None,
     run_dir: Optional[str] = None,
+    include_local_pipeline_names: Literal[False] = False,
 ) -> Tuple[str, List[TPipelineListItem]]:
+    ...
+
+
+@overload
+def list_local_pipelines(
+    pipelines_dir: str = None,
+    sort_by_trace: bool = True,
+    additional_pipelines: List[str] = None,
+    run_dir: Optional[str] = None,
+    include_local_pipeline_names: Literal[True] = True,
+) -> Tuple[str, List[TPipelineListItem], List[str]]:
+    ...
+
+
+def list_local_pipelines(
+    pipelines_dir: str = None,
+    sort_by_trace: bool = True,
+    additional_pipelines: List[str] = None,
+    run_dir: Optional[str] = None,
+    include_local_pipeline_names: bool = False,
+) -> Union[
+    Tuple[str, List[TPipelineListItem]], Tuple[str, List[TPipelineListItem], List[str]]
+]:
     """Get the local pipelines directory and the list of pipeline names in it.
 
     Args:
@@ -99,14 +135,17 @@ def list_local_pipelines(
         sort_by_trace: Whether to sort the pipelines by the latest timestamp of trace.
         additional_pipelines: Extra pipeline names to include in the list.
         run_dir: When set, only return pipelines whose initial_cwd matches this path.
+        include_local_pipeline_names: Return the names discovered on disk before adding extras.
     """
     pipelines_dir = pipelines_dir or get_dlt_pipelines_dir()
     storage = FileStorage(pipelines_dir)
 
     try:
-        pipelines = storage.list_folder_dirs(".", to_root=False)
+        local_pipeline_names = storage.list_folder_dirs(".", to_root=False)
     except Exception:
-        pipelines = []
+        local_pipeline_names = []
+
+    pipelines = list(local_pipeline_names)
 
     if additional_pipelines:
         for pipeline in additional_pipelines:
@@ -118,6 +157,11 @@ def list_local_pipelines(
         pipelines = [
             p for p in pipelines if _get_pipeline_initial_cwd(pipelines_dir, p) == abs_project_dir
         ]
+        local_pipeline_names = [
+            p
+            for p in local_pipeline_names
+            if _get_pipeline_initial_cwd(pipelines_dir, p) == abs_project_dir
+        ]
 
     # check last trace timestamp and create dict
     pipelines_with_timestamps: List[TPipelineListItem] = []
@@ -128,6 +172,9 @@ def list_local_pipelines(
 
     if sort_by_trace:
         pipelines_with_timestamps.sort(key=lambda x: x["timestamp"], reverse=True)
+
+    if include_local_pipeline_names:
+        return pipelines_dir, pipelines_with_timestamps, local_pipeline_names
 
     return pipelines_dir, pipelines_with_timestamps
 

--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -89,7 +89,7 @@ def home(
     else:
         try:
             dlt_config = utils.pipeline.resolve_dashboard_config(None)
-            if dlt_all_pipelines:
+            if utils.pipeline.has_local_pipelines(dlt_all_pipelines, dlt_pipelines_dir):
                 _result = utils.home.render_no_pipeline_selected_home(
                     dlt_profile_select,
                     dlt_pipeline_select,

--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -37,9 +37,9 @@ with app.setup:
 
 @app.cell(hide_code=True)
 def home(
-    dlt_all_pipelines: List[TPipelineListItem],
     dlt_profile_select: mo.ui.dropdown,
     dlt_pipeline_select: mo.ui.multiselect,
+    dlt_local_pipeline_names: List[str],
     dlt_pipelines_dir: str,
     dlt_refresh_button: mo.ui.run_button,
     dlt_pipeline_name: str,
@@ -89,7 +89,7 @@ def home(
     else:
         try:
             dlt_config = utils.pipeline.resolve_dashboard_config(None)
-            if utils.pipeline.has_local_pipelines(dlt_all_pipelines, dlt_pipelines_dir):
+            if dlt_local_pipeline_names:
                 _result = utils.home.render_no_pipeline_selected_home(
                     dlt_profile_select,
                     dlt_pipeline_select,
@@ -679,9 +679,11 @@ def utils_discover_pipelines(
     # discover pipelines and build selector
     dlt_pipelines_dir: str = ""
     dlt_all_pipelines: List[TPipelineListItem] = []
-    dlt_pipelines_dir, dlt_all_pipelines = list_local_pipelines(
+    dlt_local_pipeline_names: List[str] = []
+    dlt_pipelines_dir, dlt_all_pipelines, dlt_local_pipeline_names = list_local_pipelines(
         mo_cli_arg_pipelines_dir,
         additional_pipelines=[mo_cli_arg_pipeline, mo_query_var_pipeline_name],
+        include_local_pipeline_names=True,
     )
 
     dlt_pipeline_select: mo.ui.multiselect = mo.ui.multiselect(
@@ -701,7 +703,7 @@ def utils_discover_pipelines(
         on_change=lambda value: mo.query_params().set("pipeline", str(value[0]) if value else None),
     )
 
-    return dlt_all_pipelines, dlt_pipeline_select, dlt_pipelines_dir
+    return dlt_all_pipelines, dlt_local_pipeline_names, dlt_pipeline_select, dlt_pipelines_dir
 
 
 @app.cell(hide_code=True)

--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -37,6 +37,7 @@ with app.setup:
 
 @app.cell(hide_code=True)
 def home(
+    dlt_all_pipelines: List[TPipelineListItem],
     dlt_profile_select: mo.ui.dropdown,
     dlt_pipeline_select: mo.ui.multiselect,
     dlt_pipelines_dir: str,
@@ -88,9 +89,15 @@ def home(
     else:
         try:
             dlt_config = utils.pipeline.resolve_dashboard_config(None)
-            _result = utils.home.render_no_pipelines_home(
-                dlt_profile_select,
-            )
+            if dlt_all_pipelines:
+                _result = utils.home.render_no_pipeline_selected_home(
+                    dlt_profile_select,
+                    dlt_pipeline_select,
+                )
+            else:
+                _result = utils.home.render_no_pipelines_home(
+                    dlt_profile_select,
+                )
         except Exception:
             _result = [
                 utils.ui.error_callout(

--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -62,7 +62,7 @@ def home(
             dlt_config = utils.pipeline.resolve_dashboard_config(dlt_pipeline)
         except Exception:
             _result = utils.home.render_pipeline_header_row(
-                dlt_pipeline_name, dlt_profile_select, dlt_pipeline_select, [dlt_refresh_button]
+                dlt_pipeline_name, dlt_profile_select, dlt_pipeline_select, []
             )
             _result.append(
                 utils.ui.error_callout(

--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -683,7 +683,6 @@ def utils_discover_pipelines(
     dlt_pipelines_dir, dlt_all_pipelines, dlt_local_pipeline_names = list_local_pipelines(
         mo_cli_arg_pipelines_dir,
         additional_pipelines=[mo_cli_arg_pipeline, mo_query_var_pipeline_name],
-        include_local_pipeline_names=True,
     )
 
     dlt_pipeline_select: mo.ui.multiselect = mo.ui.multiselect(

--- a/dlt/_workspace/helpers/dashboard/strings.py
+++ b/dlt/_workspace/helpers/dashboard/strings.py
@@ -52,6 +52,10 @@ No pipelines found yet. A pipeline shows up here once it has run, or after you r
 from its destination (see the [sync docs]({_sync_help_url})).
 """
 
+home_no_pipeline_selected = (
+    "No pipeline selected. Choose a pipeline from the dropdown above to inspect it."
+)
+
 home_workspace_label = " Workspace: {}"
 home_open_working_dir_button = "Open pipeline working directory"
 home_open_local_data_button = "Open local data location"

--- a/dlt/_workspace/helpers/dashboard/utils/home.py
+++ b/dlt/_workspace/helpers/dashboard/utils/home.py
@@ -69,6 +69,22 @@ def home_header_row(
     )
 
 
+def _render_home_callout(
+    dlt_profile_select: mo.ui.dropdown,
+    message: str,
+    right_control: Any = None,
+) -> List[mo.Html]:
+    """Shared landing scaffold: section marker, header row and an info callout."""
+    return [
+        utils.ui.section_marker(strings.app_section_name, has_content=True),
+        home_header_row(dlt_profile_select, right_control),
+        mo.callout(
+            mo.md(message),
+            kind="info",
+        ),
+    ]
+
+
 def render_no_pipelines_home(
     dlt_profile_select: mo.ui.dropdown,
 ) -> List[mo.Html]:
@@ -76,14 +92,22 @@ def render_no_pipelines_home(
 
     The pipeline dropdown is omitted because there is nothing to select.
     """
-    return [
-        utils.ui.section_marker(strings.app_section_name, has_content=True),
-        home_header_row(dlt_profile_select),
-        mo.callout(
-            mo.md(strings.home_no_pipelines),
-            kind="info",
-        ),
-    ]
+    return _render_home_callout(dlt_profile_select, strings.home_no_pipelines)
+
+
+def render_no_pipeline_selected_home(
+    dlt_profile_select: mo.ui.dropdown,
+    dlt_pipeline_select: mo.ui.multiselect,
+) -> List[mo.Html]:
+    """Render the landing shown when pipelines exist but none is selected.
+
+    The pipeline dropdown stays visible so the user can re-select a pipeline.
+    """
+    return _render_home_callout(
+        dlt_profile_select,
+        strings.home_no_pipeline_selected,
+        right_control=dlt_pipeline_select,
+    )
 
 
 def render_pipeline_header_row(

--- a/dlt/_workspace/helpers/dashboard/utils/pipeline.py
+++ b/dlt/_workspace/helpers/dashboard/utils/pipeline.py
@@ -2,9 +2,7 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from dlt.common.storages.file_storage import FileStorage
-
-from dlt._workspace.helpers.dashboard.typing import TNameValueItem, TPipelineListItem
+from dlt._workspace.helpers.dashboard.typing import TNameValueItem
 
 import dlt
 import marimo as mo
@@ -65,20 +63,6 @@ def get_pipeline(pipeline_name: str, pipelines_dir: str) -> dlt.Pipeline:
     p = dlt.attach(pipeline_name, pipelines_dir=pipelines_dir)
     p.config.use_single_dataset = False
     return p
-
-
-def has_local_pipelines(pipelines: List[TPipelineListItem], pipelines_dir: str) -> bool:
-    """Whether any listed pipeline actually exists on disk.
-
-    Names injected from the `?pipeline=` URL param or `--pipeline` argument are
-    listed even when no such pipeline exists, so membership is checked against the
-    real pipeline directories discovered under `pipelines_dir`.
-    """
-    try:
-        local_pipelines = set(FileStorage(pipelines_dir).list_folder_dirs(".", to_root=False))
-    except Exception:
-        return False
-    return any(p["name"] in local_pipelines for p in pipelines)
 
 
 def get_destination_config(pipeline: dlt.Pipeline) -> DestinationClientConfiguration:

--- a/dlt/_workspace/helpers/dashboard/utils/pipeline.py
+++ b/dlt/_workspace/helpers/dashboard/utils/pipeline.py
@@ -2,7 +2,9 @@
 
 from typing import Any, Dict, List, Optional, Tuple
 
-from dlt._workspace.helpers.dashboard.typing import TNameValueItem
+from dlt.common.storages.file_storage import FileStorage
+
+from dlt._workspace.helpers.dashboard.typing import TNameValueItem, TPipelineListItem
 
 import dlt
 import marimo as mo
@@ -63,6 +65,20 @@ def get_pipeline(pipeline_name: str, pipelines_dir: str) -> dlt.Pipeline:
     p = dlt.attach(pipeline_name, pipelines_dir=pipelines_dir)
     p.config.use_single_dataset = False
     return p
+
+
+def has_local_pipelines(pipelines: List[TPipelineListItem], pipelines_dir: str) -> bool:
+    """Whether any listed pipeline actually exists on disk.
+
+    Names injected from the `?pipeline=` URL param or `--pipeline` argument are
+    listed even when no such pipeline exists, so membership is checked against the
+    real pipeline directories discovered under `pipelines_dir`.
+    """
+    try:
+        local_pipelines = set(FileStorage(pipelines_dir).list_folder_dirs(".", to_root=False))
+    except Exception:
+        return False
+    return any(p["name"] in local_pipelines for p in pipelines)
 
 
 def get_destination_config(pipeline: dlt.Pipeline) -> DestinationClientConfiguration:

--- a/dlt/_workspace/mcp/tools/data_tools.py
+++ b/dlt/_workspace/mcp/tools/data_tools.py
@@ -47,7 +47,7 @@ def list_pipelines() -> List[str]:
     ctx = active_run_context()
     # in OSS context (no profiles), filter to pipelines created in this project
     project_dir = None if isinstance(ctx, ProfilesRunContext) else ctx.local_dir
-    _, pipelines = list_local_pipelines(sort_by_trace=False, run_dir=project_dir)
+    _, pipelines, _ = list_local_pipelines(sort_by_trace=False, run_dir=project_dir)
     return [p["name"] for p in pipelines]
 
 

--- a/dlt/helpers/marimo/_pipeline_selector.py
+++ b/dlt/helpers/marimo/_pipeline_selector.py
@@ -10,7 +10,7 @@ with app.setup:
 
 @app.cell
 def pipeline_locations():
-    _pipelines_dir, _pipelines = list_local_pipelines()
+    _pipelines_dir, _pipelines, _ = list_local_pipelines()
     pipelines_locations = {p["name"]: _pipelines_dir + "/" + p["name"] for p in _pipelines}
     return (pipelines_locations,)
 

--- a/tests/e2e/helpers/dashboard/test_e2e.py
+++ b/tests/e2e/helpers/dashboard/test_e2e.py
@@ -563,3 +563,24 @@ def test_empty_workspace_bad_url_deselect_shows_no_pipelines(page: Page):
             expect(page.get_by_text("No pipelines found yet").first).to_be_visible(timeout=15000)
             expect(page.get_by_text("No pipeline selected")).to_have_count(0)
             expect(page.get_by_text(app_strings.app_pipeline_select_label)).to_have_count(0)
+
+
+def test_bad_pipeline_url_keeps_selector(page: Page):
+    """An unknown ?pipeline= shows an attach error but keeps the dropdown so the user recovers."""
+    test_port = 2725
+    with isolated_workspace("pipelines"):
+        beta = dlt.pipeline(pipeline_name="beta", destination="duckdb")
+        beta.run(fruitshop_source().with_resources("inventory"))
+
+        with start_dashboard(port=test_port):
+            page.goto(f"http://localhost:{test_port}/?pipeline=ghost")
+            expect(
+                page.get_by_text(app_strings.home_error_attach_pipeline.format("ghost")).first
+            ).to_be_visible(timeout=20000)
+            expect(page.get_by_text(app_strings.app_pipeline_select_label)).to_have_count(1)
+            expect(page.get_by_role("button", name=app_strings.app_refresh_button)).to_have_count(0)
+
+            _toggle_pipeline(page, "beta")
+            expect(page.get_by_role("heading", name=re.compile(r"Pipeline\s+beta"))).to_be_visible(
+                timeout=15000
+            )

--- a/tests/e2e/helpers/dashboard/test_e2e.py
+++ b/tests/e2e/helpers/dashboard/test_e2e.py
@@ -69,6 +69,22 @@ def _close_sections(page: Page, skip_section: str = None) -> None:
             page.get_by_role("switch", name=s).uncheck()
 
 
+def _pipeline_selector(page: Page) -> Any:
+    """Locator for the pipeline multiselect trigger (a popover button in shadow DOM)."""
+    return page.locator("marimo-multiselect").locator('[aria-haspopup="dialog"]')
+
+
+def _toggle_pipeline(page: Page, pipeline_name: str) -> None:
+    """Open the pipeline multiselect and toggle the given option.
+
+    With `max_selections=1` this selects the pipeline when it is not the current
+    one and deselects it when it is, so it covers both selecting and clearing.
+    """
+    _pipeline_selector(page).click()
+    page.get_by_role("option", name=pipeline_name, exact=True).click()
+    page.keyboard.press("Escape")
+
+
 def test_page_overview(page: Page, fruit_pipeline: Any):
     _open_pipeline(page, "fruit_pipeline")
 
@@ -474,3 +490,59 @@ def test_no_pipelines_home(page: Page):
             expect(page.get_by_text("No pipelines found yet").first).to_be_visible(timeout=20000)
             # the (empty) pipeline dropdown is hidden
             expect(page.get_by_text(app_strings.app_pipeline_select_label)).to_have_count(0)
+
+
+def test_deselect_pipeline_keeps_selector(page: Page):
+    """Clearing the pipeline keeps the dropdown and shows a neutral hint, not the empty landing."""
+    test_port = 2723
+    with isolated_workspace("pipelines"):
+        alpha = dlt.pipeline(pipeline_name="alpha", destination="duckdb")
+        alpha.run(fruitshop_source().with_resources("customers"))
+        time.sleep(1)
+        beta = dlt.pipeline(pipeline_name="beta", destination="duckdb")
+        beta.run(fruitshop_source().with_resources("inventory"))
+
+        with start_dashboard(port=test_port):
+            page.goto(f"http://localhost:{test_port}")
+            expect(page.get_by_role("heading", name=re.compile(r"Pipeline\s+beta"))).to_be_visible(
+                timeout=20000
+            )
+
+            _toggle_pipeline(page, "beta")
+
+            expect(page.get_by_text(app_strings.app_pipeline_select_label)).to_have_count(1)
+            expect(page.get_by_text("No pipeline selected").first).to_be_visible(timeout=15000)
+            expect(page.get_by_text("No pipelines found yet")).to_have_count(0)
+            expect(page.get_by_text(app_strings.browse_data.title)).to_have_count(0)
+
+            _toggle_pipeline(page, "alpha")
+            expect(page.get_by_role("heading", name=re.compile(r"Pipeline\s+alpha"))).to_be_visible(
+                timeout=15000
+            )
+
+
+def test_switch_pipeline_no_error_flash(page: Page):
+    """Switching A->B (a transient empty selection) lands on B with no error or stale hint."""
+    test_port = 2724
+    with isolated_workspace("pipelines"):
+        alpha = dlt.pipeline(pipeline_name="alpha", destination="duckdb")
+        alpha.run(fruitshop_source().with_resources("customers"))
+        time.sleep(1)
+        beta = dlt.pipeline(pipeline_name="beta", destination="duckdb")
+        beta.run(fruitshop_source().with_resources("inventory"))
+
+        with start_dashboard(port=test_port):
+            page.goto(f"http://localhost:{test_port}")
+            expect(page.get_by_role("heading", name=re.compile(r"Pipeline\s+beta"))).to_be_visible(
+                timeout=20000
+            )
+
+            _toggle_pipeline(page, "alpha")
+
+            expect(page.get_by_role("heading", name=re.compile(r"Pipeline\s+alpha"))).to_be_visible(
+                timeout=15000
+            )
+            expect(
+                page.get_by_text(app_strings.home_error_attach_pipeline.format("alpha"))
+            ).to_have_count(0)
+            expect(page.get_by_text("No pipeline selected")).to_have_count(0)

--- a/tests/e2e/helpers/dashboard/test_e2e.py
+++ b/tests/e2e/helpers/dashboard/test_e2e.py
@@ -546,3 +546,20 @@ def test_switch_pipeline_no_error_flash(page: Page):
                 page.get_by_text(app_strings.home_error_attach_pipeline.format("alpha"))
             ).to_have_count(0)
             expect(page.get_by_text("No pipeline selected")).to_have_count(0)
+
+
+def test_empty_workspace_bad_url_deselect_shows_no_pipelines(page: Page):
+    """An empty workspace opened with a bad ?pipeline= must show the no-pipelines landing once cleared."""
+    test_port = 2726
+    with isolated_workspace("pipelines"):
+        with start_dashboard(port=test_port):
+            page.goto(f"http://localhost:{test_port}/?pipeline=ghost")
+            expect(
+                page.get_by_text(app_strings.home_error_attach_pipeline.format("ghost")).first
+            ).to_be_visible(timeout=20000)
+
+            _toggle_pipeline(page, "ghost")
+
+            expect(page.get_by_text("No pipelines found yet").first).to_be_visible(timeout=15000)
+            expect(page.get_by_text("No pipeline selected")).to_have_count(0)
+            expect(page.get_by_text(app_strings.app_pipeline_select_label)).to_have_count(0)

--- a/tests/workspace/helpers/dashboard/conftest.py
+++ b/tests/workspace/helpers/dashboard/conftest.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 import tempfile
 
+from dlt._workspace.helpers.dashboard import strings
+
 from tests.workspace.helpers.dashboard.example_pipelines import (
     create_success_pipeline_duckdb,
     create_success_pipeline_filesystem,
@@ -17,6 +19,22 @@ from tests.workspace.helpers.dashboard.example_pipelines import (
     create_custom_dest_callable_pipeline,
     create_custom_dest_string_ref_pipeline,
 )
+
+
+def _visible_prefix(markdown_text: str) -> str:
+    """First plain-text run of a markdown landing string, before any markup.
+
+    marimo renders the landing strings as markdown (backticks become `<code>`,
+    links become `<a>`), so only this prefix appears verbatim in the rendered
+    output while staying tied to the source-of-truth copy in `strings.py`.
+    """
+    prefix = markdown_text.strip().split("`")[0].split(".")[0].strip()
+    assert prefix, f"no plain-text prefix in landing string: {markdown_text!r}"
+    return prefix
+
+
+NO_PIPELINES_TEXT = _visible_prefix(strings.home_no_pipelines)
+NO_TRACE_TEXT = _visible_prefix(strings.app_pipeline_no_trace)
 
 
 # resolver to resolve strings to pipelines

--- a/tests/workspace/helpers/dashboard/test_all_cells.py
+++ b/tests/workspace/helpers/dashboard/test_all_cells.py
@@ -114,6 +114,13 @@ def test_home_no_pipelines_at_all():
     assert strings.home_no_pipeline_selected not in html
 
 
+def test_home_phantom_pipeline_shows_empty_landing():
+    """A ?pipeline= name with no directory on disk is not treated as an existing pipeline."""
+    html = _run_home(dlt_pipeline_name=None, dlt_all_pipelines=[{"name": "ghost"}])
+    assert NO_PIPELINES_TEXT in html
+    assert strings.home_no_pipeline_selected not in html
+
+
 def test_home_pipeline_selected(success_pipeline_duckdb: dlt.Pipeline):
     """A pipeline is selected: render its home view, neither landing hint present."""
     html = _run_home(

--- a/tests/workspace/helpers/dashboard/test_all_cells.py
+++ b/tests/workspace/helpers/dashboard/test_all_cells.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 import pytest
 
@@ -37,6 +37,7 @@ global_defaults = {
     "dlt_query": "",
     "dlt_loads_table": None,
     "dlt_all_pipelines": [],
+    "dlt_local_pipeline_names": [],
     "mo_cli_arg_with_test_identifiers": True,
 }
 
@@ -75,18 +76,22 @@ def _run_home(
     *,
     dlt_pipeline_name: Any,
     dlt_all_pipelines: List[Dict[str, str]],
+    dlt_local_pipeline_names: Optional[List[str]] = None,
     dlt_pipelines_dir: str = _DEFAULT_PIPELINES_DIR,
 ) -> str:
     """Run the home cell with the given selection state and return its rendered text."""
+    if dlt_local_pipeline_names is None:
+        dlt_local_pipeline_names = [p["name"] for p in dlt_all_pipelines]
+
     output, _ = cast(
         Any,
         dlt_dashboard.home.run(
-            dlt_all_pipelines=dlt_all_pipelines,
             dlt_profile_select=mo.ui.dropdown(["dev"]),
             dlt_pipeline_select=mo.ui.multiselect(
                 [p["name"] for p in dlt_all_pipelines],
                 label=strings.app_pipeline_select_label,
             ),
+            dlt_local_pipeline_names=dlt_local_pipeline_names,
             dlt_pipelines_dir=dlt_pipelines_dir,
             dlt_refresh_button=mo.ui.run_button(label=strings.app_refresh_button),
             dlt_pipeline_name=dlt_pipeline_name,
@@ -116,7 +121,11 @@ def test_home_no_pipelines_at_all():
 
 def test_home_phantom_pipeline_shows_empty_landing():
     """A ?pipeline= name with no directory on disk is not treated as an existing pipeline."""
-    html = _run_home(dlt_pipeline_name=None, dlt_all_pipelines=[{"name": "ghost"}])
+    html = _run_home(
+        dlt_pipeline_name=None,
+        dlt_all_pipelines=[{"name": "ghost"}],
+        dlt_local_pipeline_names=[],
+    )
     assert NO_PIPELINES_TEXT in html
     assert strings.home_no_pipeline_selected not in html
 

--- a/tests/workspace/helpers/dashboard/test_all_cells.py
+++ b/tests/workspace/helpers/dashboard/test_all_cells.py
@@ -133,6 +133,14 @@ def test_home_pipeline_selected(success_pipeline_duckdb: dlt.Pipeline):
     assert strings.app_refresh_button in html
 
 
+def test_home_attach_error_keeps_selector_without_refresh():
+    """A pipeline that cannot be attached shows the error and keeps the selector, no refresh."""
+    html = _run_home(dlt_pipeline_name="ghost", dlt_all_pipelines=[{"name": "ghost"}])
+    assert strings.home_error_attach_pipeline.format("ghost") in html
+    assert strings.app_pipeline_select_label in html
+    assert strings.app_refresh_button not in html
+
+
 _SECTION_SWITCH_DEFAULTS = {
     "dlt_section_info_switch": mo.ui.switch(value=True),
     "dlt_section_schema_switch": mo.ui.switch(value=True),

--- a/tests/workspace/helpers/dashboard/test_all_cells.py
+++ b/tests/workspace/helpers/dashboard/test_all_cells.py
@@ -1,12 +1,16 @@
 import os
-from typing import List
+from typing import Any, Dict, List, cast
 
-from dlt._workspace.helpers.dashboard import dlt_dashboard
+import pytest
+
+import dlt
+from dlt._workspace.helpers.dashboard import dlt_dashboard, strings
 
 from marimo._ast.cell import Cell
 import marimo as mo
 from marimo._runtime.control_flow import MarimoStopError
 from tests.utils import get_test_storage_root
+from tests.workspace.helpers.dashboard.conftest import NO_PIPELINES_TEXT, NO_TRACE_TEXT
 
 global_defaults = {
     "dlt_query_params": {},
@@ -36,6 +40,8 @@ global_defaults = {
     "mo_cli_arg_with_test_identifiers": True,
 }
 
+_DEFAULT_PIPELINES_DIR: str = cast(str, global_defaults["dlt_pipelines_dir"])
+
 
 def test_run_all_cells():
     """
@@ -63,3 +69,103 @@ def test_run_all_cells():
             print(f"Failed running cell {cell.name}: {e}")
             print(f"Missing args: {missing_args}")
             raise e
+
+
+def _run_home(
+    *,
+    dlt_pipeline_name: Any,
+    dlt_all_pipelines: List[Dict[str, str]],
+    dlt_pipelines_dir: str = _DEFAULT_PIPELINES_DIR,
+) -> str:
+    """Run the home cell with the given selection state and return its rendered text."""
+    output, _ = cast(
+        Any,
+        dlt_dashboard.home.run(
+            dlt_all_pipelines=dlt_all_pipelines,
+            dlt_profile_select=mo.ui.dropdown(["dev"]),
+            dlt_pipeline_select=mo.ui.multiselect(
+                [p["name"] for p in dlt_all_pipelines],
+                label=strings.app_pipeline_select_label,
+            ),
+            dlt_pipelines_dir=dlt_pipelines_dir,
+            dlt_refresh_button=mo.ui.run_button(label=strings.app_refresh_button),
+            dlt_pipeline_name=dlt_pipeline_name,
+            dlt_file_watcher=None,
+        ),
+    )
+    return output.text if output is not None else ""
+
+
+def test_home_no_pipeline_selected(success_pipeline_duckdb: dlt.Pipeline):
+    """Pipelines exist but none selected: the cell picks the neutral hint, not the empty landing."""
+    html = _run_home(
+        dlt_pipeline_name=None,
+        dlt_all_pipelines=[{"name": success_pipeline_duckdb.pipeline_name}],
+        dlt_pipelines_dir=success_pipeline_duckdb.pipelines_dir,
+    )
+    assert strings.home_no_pipeline_selected in html
+    assert NO_PIPELINES_TEXT not in html
+
+
+def test_home_no_pipelines_at_all():
+    """Empty workspace: the cell picks the no-pipelines landing."""
+    html = _run_home(dlt_pipeline_name=None, dlt_all_pipelines=[])
+    assert NO_PIPELINES_TEXT in html
+    assert strings.home_no_pipeline_selected not in html
+
+
+def test_home_pipeline_selected(success_pipeline_duckdb: dlt.Pipeline):
+    """A pipeline is selected: render its home view, neither landing hint present."""
+    html = _run_home(
+        dlt_pipeline_name=success_pipeline_duckdb.pipeline_name,
+        dlt_all_pipelines=[{"name": success_pipeline_duckdb.pipeline_name}],
+        dlt_pipelines_dir=success_pipeline_duckdb.pipelines_dir,
+    )
+    assert NO_PIPELINES_TEXT not in html
+    assert strings.home_no_pipeline_selected not in html
+    assert strings.app_refresh_button in html
+
+
+_SECTION_SWITCH_DEFAULTS = {
+    "dlt_section_info_switch": mo.ui.switch(value=True),
+    "dlt_section_schema_switch": mo.ui.switch(value=True),
+    "dlt_section_state_switch": mo.ui.switch(value=True),
+    "dlt_section_trace_switch": mo.ui.switch(value=True),
+    "dlt_section_loads_switch": mo.ui.switch(value=True),
+    "dlt_trace_steps_table": None,
+    "dlt_config": None,
+}
+
+
+@pytest.mark.parametrize(
+    "cell_name",
+    [
+        "section_info",
+        "section_schema",
+        "section_state",
+        "section_trace",
+        "section_loads",
+    ],
+)
+def test_sections_render_no_content_without_pipeline(cell_name: str):
+    """Deselecting a pipeline leaves no stale section content (marker stays empty)."""
+    cell = getattr(dlt_dashboard, cell_name)
+    defaults = {**global_defaults, **_SECTION_SWITCH_DEFAULTS, "dlt_pipeline": None}
+    run_args = {k: v for k, v in defaults.items() if k in cell.refs}
+    output, _ = cast(Any, cell.run(**run_args))
+    text = output.text if output is not None else ""
+    assert "has-content" not in text
+
+
+def test_home_selected_pipeline_never_ran_stays_on_selected_path(
+    never_ran_pipline: dlt.Pipeline,
+):
+    """A selected pipeline with no trace shows its no-trace hint, not a landing hint."""
+    html = _run_home(
+        dlt_pipeline_name=never_ran_pipline.pipeline_name,
+        dlt_all_pipelines=[{"name": never_ran_pipline.pipeline_name}],
+        dlt_pipelines_dir=never_ran_pipline.pipelines_dir,
+    )
+    assert NO_TRACE_TEXT in html
+    assert NO_PIPELINES_TEXT not in html
+    assert strings.home_no_pipeline_selected not in html

--- a/tests/workspace/helpers/dashboard/test_cli_utils.py
+++ b/tests/workspace/helpers/dashboard/test_cli_utils.py
@@ -60,6 +60,23 @@ def test_get_local_pipelines_nonexistent_dir():
     assert pipelines == []
 
 
+def test_get_local_pipelines_returns_local_names_without_additional(temp_pipelines_dir):
+    """Returned local names only include pipeline directories discovered on disk."""
+    pipelines_dir, pipelines, local_pipeline_names = cli_utils.list_local_pipelines(
+        temp_pipelines_dir,
+        additional_pipelines=["ghost", "..", "/etc"],
+        include_local_pipeline_names=True,
+    )
+
+    assert pipelines_dir == temp_pipelines_dir
+    assert "ghost" in {p["name"] for p in pipelines}
+    assert set(local_pipeline_names) == {
+        "success_pipeline_1",
+        "success_pipeline_2",
+        "_dlt_internal",
+    }
+
+
 @pytest.mark.parametrize("pipeline", ALL_PIPELINES, indirect=True)
 def test_get_pipeline_last_run(pipeline: dlt.Pipeline):
     """Test getting the last run of a pipeline"""

--- a/tests/workspace/helpers/dashboard/test_cli_utils.py
+++ b/tests/workspace/helpers/dashboard/test_cli_utils.py
@@ -17,7 +17,7 @@ from tests.workspace.helpers.dashboard.example_pipelines import (
 @pytest.mark.parametrize("pipeline", ALL_PIPELINES, indirect=True)
 def test_get_pipelines(pipeline: dlt.Pipeline):
     """Test getting local pipelines"""
-    pipelines_dir, pipelines = cli_utils.list_local_pipelines(pipeline.pipelines_dir)
+    pipelines_dir, pipelines, _ = cli_utils.list_local_pipelines(pipeline.pipelines_dir)
     assert pipelines_dir == pipeline.pipelines_dir
     assert len(pipelines) == 1
     assert pipelines[0]["name"] == pipeline.pipeline_name
@@ -25,7 +25,7 @@ def test_get_pipelines(pipeline: dlt.Pipeline):
 
 def test_get_local_pipelines_with_temp_dir(temp_pipelines_dir):
     """Test getting local pipelines with temporary directory"""
-    pipelines_dir, pipelines = cli_utils.list_local_pipelines(temp_pipelines_dir)
+    pipelines_dir, pipelines, _ = cli_utils.list_local_pipelines(temp_pipelines_dir)
 
     assert pipelines_dir == temp_pipelines_dir
     assert len(pipelines) == 3  # success_pipeline_1, success_pipeline_2, _dlt_internal
@@ -45,7 +45,7 @@ def test_get_local_pipelines_with_temp_dir(temp_pipelines_dir):
 def test_get_local_pipelines_empty_dir():
     """Test getting local pipelines from empty directory"""
     with tempfile.TemporaryDirectory() as temp_dir:
-        pipelines_dir, pipelines = cli_utils.list_local_pipelines(temp_dir)
+        pipelines_dir, pipelines, _ = cli_utils.list_local_pipelines(temp_dir)
 
         assert pipelines_dir == temp_dir
         assert pipelines == []
@@ -54,7 +54,7 @@ def test_get_local_pipelines_empty_dir():
 def test_get_local_pipelines_nonexistent_dir():
     """Test getting local pipelines from nonexistent directory"""
     nonexistent_dir = "/nonexistent/directory"
-    pipelines_dir, pipelines = cli_utils.list_local_pipelines(nonexistent_dir)
+    pipelines_dir, pipelines, _ = cli_utils.list_local_pipelines(nonexistent_dir)
 
     assert pipelines_dir == nonexistent_dir
     assert pipelines == []
@@ -65,7 +65,6 @@ def test_get_local_pipelines_returns_local_names_without_additional(temp_pipelin
     pipelines_dir, pipelines, local_pipeline_names = cli_utils.list_local_pipelines(
         temp_pipelines_dir,
         additional_pipelines=["ghost", "..", "/etc"],
-        include_local_pipeline_names=True,
     )
 
     assert pipelines_dir == temp_pipelines_dir
@@ -93,7 +92,7 @@ def test_get_pipeline_last_run(pipeline: dlt.Pipeline):
 
 def test_integration_get_local_pipelines_with_sorting(temp_pipelines_dir):
     """Test integration scenario with multiple pipelines sorted by timestamp"""
-    pipelines_dir, pipelines = cli_utils.list_local_pipelines(
+    pipelines_dir, pipelines, _ = cli_utils.list_local_pipelines(
         temp_pipelines_dir, sort_by_trace=True
     )
 

--- a/tests/workspace/helpers/dashboard/test_home.py
+++ b/tests/workspace/helpers/dashboard/test_home.py
@@ -1,0 +1,32 @@
+import marimo as mo
+
+from dlt._workspace.helpers.dashboard import strings
+from dlt._workspace.helpers.dashboard.utils import home
+
+from tests.workspace.helpers.dashboard.conftest import NO_PIPELINES_TEXT
+
+
+def _profile_select() -> mo.ui.dropdown:
+    return mo.ui.dropdown(["dev"])
+
+
+def _pipeline_select() -> mo.ui.multiselect:
+    return mo.ui.multiselect(["my_pipeline"], label=strings.app_pipeline_select_label)
+
+
+def test_render_no_pipeline_selected_home_keeps_dropdown():
+    """The deselected landing keeps the pipeline dropdown and shows the neutral hint."""
+    html = mo.vstack(
+        home.render_no_pipeline_selected_home(_profile_select(), _pipeline_select())
+    ).text
+    assert strings.app_pipeline_select_label in html
+    assert strings.home_no_pipeline_selected in html
+    assert NO_PIPELINES_TEXT not in html
+
+
+def test_render_no_pipelines_home_omits_dropdown():
+    """Regression guard for the scaffold refactor: empty workspace omits the dropdown."""
+    html = mo.vstack(home.render_no_pipelines_home(_profile_select())).text
+    assert strings.app_pipeline_select_label not in html
+    assert NO_PIPELINES_TEXT in html
+    assert strings.home_no_pipeline_selected not in html

--- a/tests/workspace/helpers/dashboard/test_pipeline_operations.py
+++ b/tests/workspace/helpers/dashboard/test_pipeline_operations.py
@@ -1,11 +1,14 @@
+import os
+from typing import Set
+
 import pytest
 import marimo as mo
 import dlt
-from typing import Set
 
 from dlt._workspace.helpers.dashboard.config import DashboardConfiguration
 from dlt._workspace.helpers.dashboard.utils.pipeline import (
     get_pipeline,
+    has_local_pipelines,
     pipeline_details,
     exception_section,
     get_local_data_path,
@@ -67,6 +70,17 @@ def test_get_source_and_resource_state_for_table(pipeline: dlt.Pipeline):
     # check it can be rendered with marimo
     assert mo.json(resource_state).text
     assert mo.json(source_state).text
+
+
+def test_has_local_pipelines(success_pipeline_duckdb: dlt.Pipeline):
+    """Only real pipeline directories count; injected URL/CLI names do not."""
+    p = success_pipeline_duckdb
+    assert has_local_pipelines([{"name": p.pipeline_name, "timestamp": 0}], p.pipelines_dir)
+    assert not has_local_pipelines([{"name": "ghost", "timestamp": 0}], p.pipelines_dir)
+    assert not has_local_pipelines([], p.pipelines_dir)
+    for escaping in ("..", ".", "/etc", "../" + os.path.basename(p.pipelines_dir)):
+        assert not has_local_pipelines([{"name": escaping, "timestamp": 0}], p.pipelines_dir)
+    assert not has_local_pipelines([{"name": "x", "timestamp": 0}], "/no/such/dir")
 
 
 @pytest.mark.parametrize("pipeline", ALL_PIPELINES, indirect=True)

--- a/tests/workspace/helpers/dashboard/test_pipeline_operations.py
+++ b/tests/workspace/helpers/dashboard/test_pipeline_operations.py
@@ -1,4 +1,3 @@
-import os
 from typing import Set
 
 import pytest
@@ -8,7 +7,6 @@ import dlt
 from dlt._workspace.helpers.dashboard.config import DashboardConfiguration
 from dlt._workspace.helpers.dashboard.utils.pipeline import (
     get_pipeline,
-    has_local_pipelines,
     pipeline_details,
     exception_section,
     get_local_data_path,
@@ -70,17 +68,6 @@ def test_get_source_and_resource_state_for_table(pipeline: dlt.Pipeline):
     # check it can be rendered with marimo
     assert mo.json(resource_state).text
     assert mo.json(source_state).text
-
-
-def test_has_local_pipelines(success_pipeline_duckdb: dlt.Pipeline):
-    """Only real pipeline directories count; injected URL/CLI names do not."""
-    p = success_pipeline_duckdb
-    assert has_local_pipelines([{"name": p.pipeline_name, "timestamp": 0}], p.pipelines_dir)
-    assert not has_local_pipelines([{"name": "ghost", "timestamp": 0}], p.pipelines_dir)
-    assert not has_local_pipelines([], p.pipelines_dir)
-    for escaping in ("..", ".", "/etc", "../" + os.path.basename(p.pipelines_dir)):
-        assert not has_local_pipelines([{"name": escaping, "timestamp": 0}], p.pipelines_dir)
-    assert not has_local_pipelines([{"name": "x", "timestamp": 0}], "/no/such/dir")
 
 
 @pytest.mark.parametrize("pipeline", ALL_PIPELINES, indirect=True)

--- a/tests/workspace/mcp/test_mcp_tools.py
+++ b/tests/workspace/mcp/test_mcp_tools.py
@@ -55,11 +55,11 @@ def test_list_pipelines(pokemon_pipeline_context: RunContextBase) -> None:
 
 def test_list_pipelines_project_dir_filter(pokemon_pipeline_context: RunContextBase) -> None:
     local_dir = pokemon_pipeline_context.local_dir
-    _, pipelines = list_local_pipelines(sort_by_trace=False, run_dir=local_dir)
+    _, pipelines, _ = list_local_pipelines(sort_by_trace=False, run_dir=local_dir)
     assert any(p["name"] == "rest_api_pokemon" for p in pipelines)
 
     # a different project_dir should filter it out
-    _, pipelines = list_local_pipelines(sort_by_trace=False, run_dir="/nonexistent/path")
+    _, pipelines, _ = list_local_pipelines(sort_by_trace=False, run_dir="/nonexistent/path")
     assert not any(p["name"] == "rest_api_pokemon" for p in pipelines)
 
 


### PR DESCRIPTION
## What

Improves the dltHub dashboard's "no pipelines" / "no pipeline selected" experience and makes the empty-state copy context-neutral.

fix (issue #4093): when pipelines exist but the user clears the selection in the pipeline dropdown, the dashboard now keeps the pipeline dropdown visible and shows  "No pipeline selected. Choose a pipeline from the dropdown above to inspect it."

## Changes
- **`dlt_dashboard.py`** — the `home` cell now branches on `dlt_all_pipelines`: pipelines exist but none selected → keep the selector (`render_no_pipeline_selected_home`); for a really empty workspace: `render_no_pipelines_home`
- On the **attach-error path** (e.g. a bad `?pipeline=ghost` URL) I removed the dead/unnecesssary Refresh button 

## Tests
- added additional unit tests

Local run: dashboard suite 246 passed; e2e 18 passed. (Pre-existing `test_trace` count assertion fails only with the `hub` extra installed locally; passes in CI, its unrelated, see #4095 context.)