### PR TITLE
feat(claude): add git commit-message rule, hook, and /commit skill

### DIFF
--- a/.agents/rules/git-github.md
+++ b/.agents/rules/git-github.md
@@ -5,7 +5,7 @@ description: Rules for using git and the GitHub CLI in dlt. Read when committing
 
 # dlt — Git & GitHub
 
-Rules for git and GitHub CLI usage in this repo. They override the harness defaults where they differ. See `CONTRIBUTING.md` for the human-facing version.
+Rules for git and GitHub CLI usage in this repo, for any coding agent. They override the agent's defaults where they differ. See `CONTRIBUTING.md` for the human-facing version.
 
 ## When to use
 
@@ -28,10 +28,10 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
 - **Subject line only for the vast majority of commits.**
 - **Max 3 lines total** including any body. If you can't say it in 3 lines, the commit is probably too big — split it.
 - **Code-comment rules apply to commit bodies too.** Don't explain *what* the diff does (the diff shows that). Add a body line only when the *why* is non-obvious and not already in the PR description.
-- **No footers.** No `Co-Authored-By: Claude ...`, no "Generated with Claude Code". Treat the model as a dev tool, not a co-author. This overrides the harness default.
+- **No footers.** No `Co-Authored-By` lines, no "Generated with ..." trailers. Treat the agent as a dev tool, not a co-author. This overrides the agent's default.
 - **No references to the task/ticket/caller** in the message unless the user asks ("as discussed", "per review feedback", etc.).
 
-Format (HEREDOC, as in the harness default):
+Format (HEREDOC):
 
 ```
 git commit -m "$(cat <<'EOF'
@@ -52,7 +52,7 @@ into the merge.
 ## When to commit
 
 - **Only when the user explicitly asks.** Finishing a task is not a trigger; "looks good" is not a trigger. Wait for an explicit "commit this" / "make a commit".
-- `git add -A` is fine — but never stage anything secret-looking (`.env`, `*secrets.toml`, credentials).
+- `git add -A` is fine — but NEVER stage anything secret-looking (`.env`, `*secrets.toml`, credentials).
 
 ## Branches
 
@@ -75,7 +75,7 @@ feat/4922-add-avro-support
 - **Creating a PR requires the branch to be pushed already.** If `gh pr create` would need a push, stop and ask the user to push.
 - Confirm the title and body with the user before running `gh pr create`.
 
-## Hard rules for Claude (never without an explicit ask)
+## Hard rules for the coding agent (never without an explicit ask)
 
 - **Don't push.** No `git push`/`git push -u`. The user pushes.
 - **Don't merge PRs.** No `gh pr merge`, no auto-merge.

--- a/.claude/rules/git-github.md
+++ b/.claude/rules/git-github.md
@@ -70,7 +70,7 @@ feat/4922-add-avro-support
 
 ## Pull requests
 
-- PRs **target `devel`** (out-of-schedule hotfixes target `master` — ask first).
+- PRs **target `devel`**. Agents may **NEVER** merge to `master`.
 - **Link the PR to its ticket**, or describe the change clearly enough for someone without prior context.
 - **Creating a PR requires the branch to be pushed already.** If `gh pr create` would need a push, stop and ask the user to push.
 - Confirm the title and body with the user before running `gh pr create`.

--- a/.claude/rules/git-github.md
+++ b/.claude/rules/git-github.md
@@ -1,0 +1,97 @@
+---
+name: git-github
+description: Rules for using git and the GitHub CLI in dlt. Read when committing, creating PRs, or running any git/gh command.
+---
+
+# dlt — Git & GitHub
+
+Rules for git and GitHub CLI usage in this repo. They override the harness defaults where they differ. See `CONTRIBUTING.md` for the human-facing version.
+
+## When to use
+
+Apply whenever running `git` or `gh`, drafting commit messages, or creating/updating PRs.
+
+## Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+{type}: short imperative subject
+# or, when one area is in focus
+{type}({scope}): short imperative subject
+```
+
+- **Types** (lowercase, matching branch categories): `feat`, `fix`, `docs`, `test`, plus `refactor`/`chore` for non-functional changes.
+- **Scope** is optional — an area like `dashboard`, `cli`, `destinations`, `extract`, `normalize`. Comma-separate multiple.
+- **Subject is lowercase, imperative, no trailing period.**
+- **No emojis** anywhere in the message — not in the subject, not in the body.
+- **Subject line only for the vast majority of commits.**
+- **Max 3 lines total** including any body. If you can't say it in 3 lines, the commit is probably too big — split it.
+- **Code-comment rules apply to commit bodies too.** Don't explain *what* the diff does (the diff shows that). Add a body line only when the *why* is non-obvious and not already in the PR description.
+- **No footers.** No `Co-Authored-By: Claude ...`, no "Generated with Claude Code". Treat the model as a dev tool, not a co-author. This overrides the harness default.
+- **No references to the task/ticket/caller** in the message unless the user asks ("as discussed", "per review feedback", etc.).
+
+Format (HEREDOC, as in the harness default):
+
+```
+git commit -m "$(cat <<'EOF'
+fix(dashboard): keep the selector when no pipeline is selected
+EOF
+)"
+```
+
+## Cleaning up before a squash-merge
+
+GitHub hides everything after the first line in the commit list, so multi-line
+bodies and footers are easy to overlook — and squashing several such commits
+floods the merge commit. **When squash-merging, clean the squash message down to
+a single Conventional-Commit subject line** (plus a short *why* body only if it
+genuinely helps). Never let `Co-Authored-By` / "Generated with" lines survive
+into the merge.
+
+## When to commit
+
+- **Only when the user explicitly asks.** Finishing a task is not a trigger; "looks good" is not a trigger. Wait for an explicit "commit this" / "make a commit".
+- `git add -A` is fine — but never stage anything secret-looking (`.env`, `*secrets.toml`, credentials).
+
+## Branches
+
+From `CONTRIBUTING.md` — all lowercase, dashes, no underscores:
+
+```
+{category}/{ticket-id}-description-of-the-branch
+# example:
+feat/4922-add-avro-support
+```
+
+- **Categories**: `feat` (ticket required), `fix` (ticket required), `exp`, `test`, `docs`, `keep`.
+- **Branch from `devel`.** Feature branches and most fixes go to `devel`.
+- Don't create branches unless asked. Don't switch the branch a worktree is on without asking.
+
+## Pull requests
+
+- PRs **target `devel`** (out-of-schedule hotfixes target `master` — ask first).
+- **Link the PR to its ticket**, or describe the change clearly enough for someone without prior context.
+- **Creating a PR requires the branch to be pushed already.** If `gh pr create` would need a push, stop and ask the user to push.
+- Confirm the title and body with the user before running `gh pr create`.
+
+## Hard rules for Claude (never without an explicit ask)
+
+- **Don't push.** No `git push`/`git push -u`. The user pushes.
+- **Don't merge PRs.** No `gh pr merge`, no auto-merge.
+- **Don't force-push, ever.** If history needs rewriting, describe it and let the user do it.
+- **Don't `--amend` pushed commits**, and never use `--no-verify` or skip hooks/signing.
+- **Don't touch `master`** — it's the release branch (`devel → master` on release day).
+
+## Safe read-only commands (no confirmation needed)
+
+- `git status`, `git diff`, `git log`, `git show`, `git branch`, `git remote -v`
+- `gh pr view`, `gh pr list`, `gh pr checks`, `gh pr diff`, `gh issue view`, `gh api` for GET requests
+
+## Quick checklist before any git/gh action
+
+1. Push, merge, force-push, or amend of a pushed commit? → **Stop**, the user does this.
+2. New commit? → Did the user explicitly ask? If no, **stop**.
+3. Is the subject `type:` / `type(scope):`, lowercase, 1–3 lines total, free of "what" narration? If no, rewrite.
+4. Is the commit free of footers (no `Co-Authored-By`, no "Generated with") and emojis? If no, trim.
+5. Squash-merging? → Clean the squash message to a single subject line.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,5 +15,33 @@
       "Bash(less *secrets.toml*)",
       "Bash(more *secrets.toml*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git *)",
+            "command": "f=\"$CLAUDE_PROJECT_DIR/.claude/rules/git-github.md\"; [ -r \"$f\" ] && jq -n --rawfile c \"$f\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",additionalContext:$c}}' || true"
+          },
+          {
+            "type": "command",
+            "if": "Bash(gh *)",
+            "command": "f=\"$CLAUDE_PROJECT_DIR/.claude/rules/git-github.md\"; [ -r \"$f\" ] && jq -n --rawfile c \"$f\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",additionalContext:$c}}' || true"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -n '{hookSpecificOutput:{hookEventName:\"PreToolUse\",additionalContext:\"COMMENT RULE (always applies, even if surrounding code is more heavily commented): default to NO comment. At most one short line, and only for a non-obvious WHY (a constraint, gotcha, or subtle invariant). Inline comments start lowercase. No what-narration, no train-of-thought, no banner/section comments separating code blocks. When editing code that already has noisy comments, trim them to a load-bearing one-liner (or remove) as part of the change.\"}}'"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,12 +24,12 @@
           {
             "type": "command",
             "if": "Bash(git *)",
-            "command": "f=\"$CLAUDE_PROJECT_DIR/.claude/rules/git-github.md\"; [ -r \"$f\" ] && jq -n --rawfile c \"$f\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",additionalContext:$c}}' || true"
+            "command": "f=\"$CLAUDE_PROJECT_DIR/.agents/rules/git-github.md\"; [ -r \"$f\" ] && jq -n --rawfile c \"$f\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",additionalContext:$c}}' || true"
           },
           {
             "type": "command",
             "if": "Bash(gh *)",
-            "command": "f=\"$CLAUDE_PROJECT_DIR/.claude/rules/git-github.md\"; [ -r \"$f\" ] && jq -n --rawfile c \"$f\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",additionalContext:$c}}' || true"
+            "command": "f=\"$CLAUDE_PROJECT_DIR/.agents/rules/git-github.md\"; [ -r \"$f\" ] && jq -n --rawfile c \"$f\" '{hookSpecificOutput:{hookEventName:\"PreToolUse\",additionalContext:$c}}' || true"
           }
         ]
       },

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: commit
+description: Stage changes and write a clean Conventional-Commit message that follows the repo's git rules
+argument-hint: [-- <optional subject hint or scope>]
+---
+
+# Commit
+
+Create a commit that follows `.claude/rules/git-github.md`. Invoke as `/commit`, or
+use these steps whenever you are about to commit.
+
+Parse `$ARGUMENTS`: anything after `--` is an optional hint (a subject, a scope, or
+"only the dashboard files") — guidance, not the literal message.
+
+## Steps
+
+### 1. Inspect
+
+```
+git status
+git diff --staged
+git diff
+```
+
+Decide what belongs in the commit. If nothing is staged, stage the relevant changes
+with `git add <paths>` (or `git add -A` when everything belongs together). **Never
+stage secret-looking files** (`.env`, `*secrets.toml`, credentials) — they are also
+denied in `settings.json`.
+
+### 2. Compose the message
+
+Apply `.claude/rules/git-github.md`:
+
+- One line: `{type}: subject` or `{type}({scope}): subject` — lowercase, imperative,
+  no trailing period. Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`.
+- **Subject line only** for the vast majority of commits. Add a body line *only* for a
+  non-obvious *why*, max 3 lines total. Never narrate *what* the diff does.
+- **No footers** — no `Co-Authored-By`, no "Generated with Claude Code".
+- **No emojis** anywhere in the message.
+
+### 3. Commit
+
+```
+git commit -m "$(cat <<'EOF'
+fix(dashboard): keep the selector when no pipeline is selected
+EOF
+)"
+```
+
+### 4. Confirm
+
+```
+git log -1 --format=%B
+```
+
+Verify it is a single Conventional-Commit subject (plus an optional why) with no
+footers. **Do not push and do not amend pushed commits** unless the user explicitly
+asks.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: [-- <optional subject hint or scope>]
 
 # Commit
 
-Create a commit that follows `.claude/rules/git-github.md`. Invoke as `/commit`, or
+Create a commit that follows `.agents/rules/git-github.md`. Invoke as `/commit`, or
 use these steps whenever you are about to commit.
 
 Parse `$ARGUMENTS`: anything after `--` is an optional hint (a subject, a scope, or
@@ -23,19 +23,19 @@ git diff
 ```
 
 Decide what belongs in the commit. If nothing is staged, stage the relevant changes
-with `git add <paths>` (or `git add -A` when everything belongs together). **Never
+with `git add <paths>` (or `git add -A` when everything belongs together). **NEVER
 stage secret-looking files** (`.env`, `*secrets.toml`, credentials) — they are also
 denied in `settings.json`.
 
 ### 2. Compose the message
 
-Apply `.claude/rules/git-github.md`:
+Apply `.agents/rules/git-github.md`:
 
 - One line: `{type}: subject` or `{type}({scope}): subject` — lowercase, imperative,
   no trailing period. Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`.
 - **Subject line only** for the vast majority of commits. Add a body line *only* for a
   non-obvious *why*, max 3 lines total. Never narrate *what* the diff does.
-- **No footers** — no `Co-Authored-By`, no "Generated with Claude Code".
+- **No footers** — no `Co-Authored-By`, no "Generated with ..." trailers.
 - **No emojis** anywhere in the message.
 
 ### 3. Commit

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.codex/hooks/inject-git-rule.sh\"",
+            "statusMessage": "Injecting git/commit rules",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/inject-git-rule.sh
+++ b/.codex/hooks/inject-git-rule.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-rule="$root/.claude/rules/git-github.md"
+rule="$root/.agents/rules/git-github.md"
 
 case "$cmd" in
   git\ *|gh\ *)

--- a/.codex/hooks/inject-git-rule.sh
+++ b/.codex/hooks/inject-git-rule.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Codex PreToolUse hook: inject the repo's git/commit rules as additionalContext
+# before a git/gh shell command runs. Emits nothing for other commands, so the
+# tool call proceeds unchanged.
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
+root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+rule="$root/.claude/rules/git-github.md"
+
+case "$cmd" in
+  git\ *|gh\ *)
+    if [ -n "$root" ] && [ -r "$rule" ]; then
+      jq -n --rawfile c "$rule" \
+        '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$c}}'
+    fi
+    ;;
+esac
+exit 0

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": ".cursor/hooks/git-commit-rule.sh" }
+    ]
+  }
+}

--- a/.cursor/hooks/git-commit-rule.sh
+++ b/.cursor/hooks/git-commit-rule.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Cursor beforeShellExecution hook: inject the repo's git/commit rules as agent
+# context before a git/gh command runs. We deliberately emit no `permission` key
+# so Cursor's normal allow/ask flow is unchanged — this only adds guidance.
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.command // ""')
+root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+rule="$root/.claude/rules/git-github.md"
+
+case "$cmd" in
+  git\ *|gh\ *)
+    if [ -n "$root" ] && [ -r "$rule" ]; then
+      jq -n --rawfile c "$rule" '{agent_message:$c}'
+    else
+      printf '{}\n'
+    fi
+    ;;
+  *)
+    printf '{}\n'
+    ;;
+esac

--- a/.cursor/hooks/git-commit-rule.sh
+++ b/.cursor/hooks/git-commit-rule.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.command // ""')
 root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-rule="$root/.claude/rules/git-github.md"
+rule="$root/.agents/rules/git-github.md"
 
 case "$cmd" in
   git\ *|gh\ *)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,4 @@
 - Subject line only for the vast majority of commits; add a body line only for a non-obvious *why* (max ~3 lines total).
 - No footers — no `Co-Authored-By`, no "Generated with ...". No emojis.
 - When squash-merging, clean the squash message down to a single subject line.
-- Full rules + Claude Code enforcement (git/gh hook + `/commit` skill): @.claude/rules/git-github.md
+- Full rules (enforced per-agent via git/gh hooks under `.claude/`, `.cursor/`, `.codex/`): @.agents/rules/git-github.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,4 +7,10 @@
 # dlt repo
 - we use `uv` and `uv run`. look in @Makefile
 - we branch from `devel` for feature branches
-- git & commit conventions: @.claude/rules/git-github.md (also injected on git/gh commands)
+
+# Commit messages (all agents)
+- [Conventional Commits](https://www.conventionalcommits.org/): `type:` or `type(scope):`, lowercase imperative subject, no trailing period.
+- Subject line only for the vast majority of commits; add a body line only for a non-obvious *why* (max ~3 lines total).
+- No footers — no `Co-Authored-By`, no "Generated with ...". No emojis.
+- When squash-merging, clean the squash message down to a single subject line.
+- Full rules + Claude Code enforcement (git/gh hook + `/commit` skill): @.claude/rules/git-github.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,4 @@
 # dlt repo
 - we use `uv` and `uv run`. look in @Makefile
 - we branch from `devel` for feature branches
+- git & commit conventions: @.claude/rules/git-github.md (also injected on git/gh commands)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,15 @@ We encourage attaching your branches to a ticket. If none exists, create one and
 * For `exp` and `test` branches, tickets are **encouraged**.
 * For `docs` branches, tickets are **optional**.
 
+### Commit Message Rules
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). Keep messages clean — this matters most when squash-merging a PR, since GitHub hides everything after the first line in the commit list:
+
+* `{type}:` or `{type}({scope}):`, lowercase imperative subject, no trailing period (types match the branch categories above).
+* Subject line only for most commits; add a short body only for a non-obvious *why*.
+* No footers (e.g. `Co-Authored-By`, "Generated with …") and no emojis.
+* When squash-merging, clean the squash message down to a single subject line.
+
 ### Submitting a Hotfix
 
 We occasionally fix critical bugs and release `dlt` outside of schedule. Follow the regular procedure but open your PR against the **master** branch. Please ping us on Slack if you do this.


### PR DESCRIPTION
### Description

Adds Claude Code tooling to keep commit messages clean, ported from the working setup in `dlt-hub/runtime`:

- `.claude/rules/git-github.md` — Conventional Commits, subject-line-only by default, body only for a non-obvious *why*, **no `Co-Authored-By` / "Generated with" footers**, **no emojis**, and clean up the message before squash-merging. Also captures dlt branch/PR conventions from `CONTRIBUTING.md`.
- `.claude/settings.json` — a `PreToolUse` hook that injects the rule whenever a `git`/`gh` Bash command runs, plus a comment-rule hook on edits. Existing `permissions.deny` is preserved.
- `.claude/skills/commit/SKILL.md` — a `/commit` skill usable by the user or by Claude that applies the rule to stage and write a clean commit.
- `AGENTS.md` — one-line pointer to the rule as a backstop.

Motivation: Claude-authored commits were carrying multi-line "what" bodies and `Co-Authored-By` footers that GitHub hides behind the first line and that flood squash-merges (e.g. #4068).

### Related Issues

- Closes #4097

### Additional Context

The hook injects the rule per `git`/`gh` tool call, which is far more reliable than a static `CLAUDE.md` line. In-session injection takes effect after a fresh session loads the new `settings.json`.