### PR TITLE
fix: clear stale dashboard pipeline on profile switch

### DIFF
--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -719,7 +719,9 @@ def utils_discover_profiles(mo_query_var_profile: str, mo_cli_arg_profile: str):
             selected_profile = mo_cli_arg_profile
 
         def _on_profile_change(v: str) -> None:
-            mo.query_params().set("profile", v)
+            query_params = mo.query_params()
+            query_params.set("pipeline", None)
+            query_params.set("profile", v)
 
         dlt_profile_select = mo.ui.dropdown(
             options=options,
@@ -867,18 +869,28 @@ def ui_controls(mo_cli_arg_with_test_identifiers: bool):
 
 @app.cell(hide_code=True)
 def watch_changes(
+    dlt_all_pipelines: List[TPipelineListItem],
     dlt_pipeline_select: mo.ui.multiselect,
     dlt_pipelines_dir: str,
 ):
     """
     Watch changes in the trace file and trigger reload in the home cell and all following cells on change
     """
+    import os
+
     from dlt.pipeline.trace import get_trace_file_path
+
+    def _pipeline_exists(name: str) -> bool:
+        return bool(name and os.path.isdir(os.path.join(dlt_pipelines_dir, name)))
 
     # provide pipeline object to the following cells
     dlt_pipeline_name: str = (
         str(dlt_pipeline_select.value[0]) if dlt_pipeline_select.value else None
     )
+    if not _pipeline_exists(dlt_pipeline_name):
+        dlt_pipeline_name = next(
+            (p["name"] for p in dlt_all_pipelines if _pipeline_exists(p["name"])), None
+        )
     dlt_file_watcher = None
     if dlt_pipeline_name:
         dlt_file_watcher = mo.watch.file(get_trace_file_path(dlt_pipelines_dir, dlt_pipeline_name))

--- a/tests/e2e/helpers/dashboard/test_e2e.py
+++ b/tests/e2e/helpers/dashboard/test_e2e.py
@@ -381,6 +381,33 @@ def test_workspace_profile_dev(page: Page):
             expect(page.get_by_role("row", name="fruitshop").first).to_be_visible()
 
 
+def test_workspace_profile_switch_clears_selected_pipeline(page: Page):
+    test_port = 2723
+    with isolated_workspace("pipelines", profile="tests"):
+        switch_profile("tests")
+        alpha = dlt.pipeline(pipeline_name="alpha_pipeline", destination="duckdb")
+        alpha.run(fruitshop_source().with_resources("customers"))
+
+        switch_profile("prod")
+        beta = dlt.pipeline(pipeline_name="beta_pipeline", destination="duckdb")
+        beta.run(fruitshop_source().with_resources("inventory"))
+
+        with start_dashboard(port=test_port):
+            page.goto(f"http://localhost:{test_port}/?profile=tests&pipeline=alpha_pipeline")
+            expect(
+                page.get_by_role("heading", name=re.compile(r"Pipeline\s+alpha_pipeline"))
+            ).to_be_visible(timeout=20000)
+
+            page.get_by_test_id("marimo-plugin-searchable-dropdown").click()
+            page.get_by_text("prod", exact=True).click()
+
+            expect(page).to_have_url(re.compile(rf":{test_port}/\?profile=prod$"))
+            expect(page.get_by_text("Could not attach to pipeline alpha_pipeline")).to_have_count(0)
+            expect(
+                page.get_by_role("heading", name=re.compile(r"Pipeline\s+beta_pipeline"))
+            ).to_be_visible(timeout=20000)
+
+
 def test_broken_trace_pipeline(page: Page, broken_trace_pipeline: Any, pipelines_dir: Path):
     """Dashboard should still render overview even if the last trace file is corrupted."""
     _open_pipeline(page, "broken_trace_pipeline")


### PR DESCRIPTION
## Summary

Fixes #4094.

This prevents the workspace dashboard from carrying a pipeline selected under one profile into another profile after the user switches via the profile dropdown.

Changes:
- clear the `pipeline` query parameter when the profile dropdown changes
- guard the selected pipeline name against the current profile's actual pipelines directory before attaching
- add an e2e regression that switches from `tests`/`alpha_pipeline` to `prod` and verifies the dashboard lands on `beta_pipeline` without the stale attach error

## Validation

- `uv run black --check dlt/_workspace/helpers/dashboard/dlt_dashboard.py tests/e2e/helpers/dashboard/test_e2e.py`
- `uv run python -m py_compile dlt/_workspace/helpers/dashboard/dlt_dashboard.py tests/e2e/helpers/dashboard/test_e2e.py`
- `uv run ruff check dlt/_workspace/helpers/dashboard/dlt_dashboard.py tests/e2e/helpers/dashboard/test_e2e.py`
- `uv run --with marimo --with pyarrow --with ibis-framework --with playwright --with pytest-playwright --with duckdb pytest tests/e2e/helpers/dashboard/test_e2e.py::test_workspace_profile_switch_clears_selected_pipeline -q` -> 1 passed
- `uv run --with marimo --with pyarrow --with ibis-framework --with playwright --with pytest-playwright --with duckdb pytest tests/e2e/helpers/dashboard/test_e2e.py::test_workspace_profile_prod tests/e2e/helpers/dashboard/test_e2e.py::test_workspace_profile_dev -q` -> 2 passed
- `git diff --check`