### PR TITLE
fix: detect duckdb_engine schemas in SQLAlchemy destination

### DIFF
--- a/.github/workflows/test_destinations_local.yml
+++ b/.github/workflows/test_destinations_local.yml
@@ -72,7 +72,7 @@ jobs:
             filesystem_drivers: "[\"memory\", \"file\"]"
             extras: "--extra sqlalchemy --extra filesystem --extra parquet --extra postgres --extra oracle --group adbc"
             needs_mysql: true
-            post_install_commands: "uv run pip install pymysql && uv run pip install sqlalchemy==1.4 && uv run dbc install mysql && uv run dbc install sqlite"
+            post_install_commands: "uv run pip install pymysql duckdb-engine && uv run pip install sqlalchemy==1.4 && uv run dbc install mysql && uv run dbc install sqlite"
 
           # SQLAlchemy 2.0 (same as above but with sqlalchemy 2.0)
           - display_name: sqlalchemy-2.0
@@ -80,7 +80,7 @@ jobs:
             filesystem_drivers: "[\"memory\", \"file\"]"
             extras: "--extra sqlalchemy --extra filesystem --extra parquet --extra postgres --extra oracle --group adbc"
             needs_mysql: true
-            post_install_commands: "uv run pip install pymysql && uv run pip install sqlalchemy==2.0 && uv run dbc install mysql && uv run dbc install sqlite"
+            post_install_commands: "uv run pip install pymysql duckdb-engine && uv run pip install sqlalchemy==2.0 && uv run dbc install mysql && uv run dbc install sqlite"
 
     env:
       ACTIVE_DESTINATIONS: ${{ matrix.destinations }}

--- a/dlt/destinations/impl/sqlalchemy/configuration.py
+++ b/dlt/destinations/impl/sqlalchemy/configuration.py
@@ -214,6 +214,7 @@ class SqlalchemyCredentials(ConnectionStringCredentials):
 
 
 SQLITE_DB_NAME_PAT = "%s.db"
+DUCKDB_DB_NAME_PAT = "%s.duckdb"
 
 
 @configspec
@@ -257,23 +258,29 @@ class SqlalchemyClientConfiguration(WithLocalFiles, DestinationClientDwhConfigur
         if self.engine_kwargs and not self.credentials.engine_kwargs:
             self.credentials.engine_kwargs = self.engine_kwargs
 
-        # resolve local file path for sqlite backends
-        if self.credentials.drivername == "sqlite":
-            if not SqlalchemyCredentials.is_memory_database(
-                self.credentials.database, self.credentials.query
-            ):
-                db = self.credentials.database
+        # resolve local file path for file-based backends
+        if self.credentials.drivername in ("sqlite", "duckdb"):
+            db = self.credentials.database
+            # skip in-memory databases and special locations like motherduck (md:)
+            if not SqlalchemyCredentials.is_memory_database(db, self.credentials.query) and not (
+                db or ""
+            ).startswith("md:"):
                 if not db or not os.path.isabs(db):
+                    name_pat = (
+                        SQLITE_DB_NAME_PAT
+                        if self.credentials.drivername == "sqlite"
+                        else DUCKDB_DB_NAME_PAT
+                    )
                     self.credentials.database = os.path.normpath(
-                        self.make_location(db or None, SQLITE_DB_NAME_PAT)
+                        self.make_location(db or None, name_pat)
                     )
 
     def physical_location(self) -> str:
-        """Returns sqlite database path for sqlite, otherwise host:port."""
+        """Returns database file path for file-based backends, otherwise host:port."""
         if not self.credentials:
             return ""
 
-        if self.get_backend_name() == "sqlite":
+        if self.get_backend_name() in ("sqlite", "duckdb"):
             # each in-memory database is a separate database
             if SqlalchemyCredentials.is_memory_database(
                 self.credentials.database, self.credentials.query

--- a/dlt/destinations/impl/sqlalchemy/db_api_client.py
+++ b/dlt/destinations/impl/sqlalchemy/db_api_client.py
@@ -206,7 +206,12 @@ class SqlalchemyClient(SqlClientBase[Connection]):
     def has_dataset(self) -> bool:
         with self._ensure_transaction():
             schema_names = self.engine.dialect.get_schema_names(self._current_connection)  # type: ignore[attr-defined]
-        return self.dataset_name in schema_names
+        if self.dataset_name in schema_names:
+            return True
+        if self.dialect_name == "duckdb" and self.database_name:
+            duckdb_database_name = Path(self.database_name).stem
+            return f"{duckdb_database_name}.{self.dataset_name}" in schema_names
+        return False
 
     def _sqlite_dataset_filename(self, dataset_name: str) -> str:
         current_file_path = Path(self.database_name)

--- a/dlt/destinations/impl/sqlalchemy/db_api_client.py
+++ b/dlt/destinations/impl/sqlalchemy/db_api_client.py
@@ -205,13 +205,12 @@ class SqlalchemyClient(SqlClientBase[Connection]):
 
     def has_dataset(self) -> bool:
         with self._ensure_transaction():
+            if self.dialect_name == "duckdb":
+                # duckdb_engine returns catalog-qualified names from get_schema_names(),
+                # has_schema resolves the dataset within the current catalog
+                return self.dialect.has_schema(self._current_connection, self.dataset_name)  # type: ignore[attr-defined,no-any-return]
             schema_names = self.engine.dialect.get_schema_names(self._current_connection)  # type: ignore[attr-defined]
-        if self.dataset_name in schema_names:
-            return True
-        if self.dialect_name == "duckdb" and self.database_name:
-            duckdb_database_name = Path(self.database_name).stem
-            return f"{duckdb_database_name}.{self.dataset_name}" in schema_names
-        return False
+        return self.dataset_name in schema_names
 
     def _sqlite_dataset_filename(self, dataset_name: str) -> str:
         current_file_path = Path(self.database_name)

--- a/dlt/destinations/impl/sqlalchemy/dialect.py
+++ b/dlt/destinations/impl/sqlalchemy/dialect.py
@@ -224,6 +224,17 @@ class OracleDialectCapabilities(DialectCapabilities):
         return super().is_undefined_relation(e)
 
 
+class DuckdbDialectCapabilities(DialectCapabilities):
+    """Capabilities for DuckDB via duckdb_engine."""
+
+    def is_undefined_relation(self, e: Exception) -> Optional[bool]:
+        msg = str(e).lower()
+        # binder errors (ie. unknown column) also contain "not found" but are terminal
+        if "binder error" in msg:
+            return False
+        return super().is_undefined_relation(e)
+
+
 def _format_mysql_datetime_literal(v: Any, precision: int = 6, no_tz: bool = False) -> str:
     from dlt.common.data_writers.escape import format_datetime_literal
 
@@ -235,3 +246,4 @@ register_dialect_capabilities("mariadb", MysqlDialectCapabilities)
 register_dialect_capabilities("trino", TrinoDialectCapabilities)
 register_dialect_capabilities("mssql", MssqlDialectCapabilities)
 register_dialect_capabilities("oracle", OracleDialectCapabilities)
+register_dialect_capabilities("duckdb", DuckdbDialectCapabilities)

--- a/dlt/destinations/impl/sqlalchemy/sqlalchemy_job_client.py
+++ b/dlt/destinations/impl/sqlalchemy/sqlalchemy_job_client.py
@@ -108,6 +108,9 @@ class SqlalchemyJobClient(SqlJobClientWithStagingDataset):
             schema_column["name"],
             self.type_mapper.to_destination_type(schema_column, table),
             nullable=schema_column.get("nullable", True),
+            # dlt always provides explicit values, never use db-side identity columns
+            # ie. duckdb_engine compiles autoincrement primary keys to unsupported BIGSERIAL
+            autoincrement=False,
         )
         if self.config.create_unique_indexes:
             col_.unique = schema_column.get("unique", False)
@@ -145,11 +148,12 @@ class SqlalchemyJobClient(SqlJobClientWithStagingDataset):
         elif parsed_file.file_format == "parquet":
             table_obj = self._to_table_object(table)
             dialect_name = self.config.credentials.engine.dialect.name
-            # Skip ADBC for SQLite: Python's sqlite3 and adbc_driver_sqlite bundle different
-            # SQLite versions. In WAL mode, both libraries mmap the same -shm index file but
-            # have separate internal state, causing page-level corruption when writing.
+            # ADBC copy job implements mysql and sqlite dialects only. SQLite is skipped:
+            # Python's sqlite3 and adbc_driver_sqlite bundle different SQLite versions.
+            # In WAL mode, both libraries mmap the same -shm index file but have separate
+            # internal state, causing page-level corruption when writing.
             # See: https://github.com/tensorflow/tensorboard/issues/1467
-            if dialect_name != "sqlite" and adbc_has_driver(dialect_name)[0]:
+            if dialect_name == "mysql" and adbc_has_driver(dialect_name)[0]:
                 return SqlalchemyParquetADBCJob(file_path, table_obj)
             else:
                 return SqlalchemyParquetInsertJob(file_path, table_obj)

--- a/docs/website/docs/dlt-ecosystem/destinations/sqlalchemy.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/sqlalchemy.md
@@ -8,7 +8,7 @@ keywords: [sql, sqlalchemy, database, destination]
 
 The SQLAlchemy destination allows you to use any database that has an [SQLAlchemy dialect](https://docs.sqlalchemy.org/en/20/dialects/) implemented as a destination.
 
-Currently, MySQL and SQLite are considered to have full support and are tested as part of the `dlt` CI suite. Other dialects are not tested but should generally work.
+Currently, MySQL, SQLite, and DuckDB are considered to have full support and are tested as part of the `dlt` CI suite. Other dialects are not tested but should generally work.
 
 ## Install dlt with SQLAlchemy
 
@@ -258,8 +258,56 @@ To work around this issue, use one of the following approaches:
    workers=1
    ```
 
+## Notes on DuckDB
+Install the [duckdb_engine](https://github.com/Mause/duckdb_engine) dialect to use DuckDB with the SQLAlchemy destination:
+
+```sh
+pip install duckdb-engine
+```
+
+```py
+import dlt
+
+pipeline = dlt.pipeline(
+    pipeline_name="my_pipeline",
+    destination=dlt.destinations.sqlalchemy(credentials="duckdb:///my_data.duckdb"),
+    dataset_name="my_dataset",
+)
+```
+
+Relative database paths are placed in the pipeline's local directory, same as for SQLite and the native DuckDB destination.
+
+**Note**: Prefer the native [DuckDB destination](duckdb.md). Use SQLAlchemy when you need full control over the engine, e.g., to `ATTACH` encrypted database files with connection setup SQL.
+
+### In-memory databases
+An in-memory DuckDB database is private to each connection. Pass an `Engine` that shares a single connection and load sequentially:
+
+```py
+import dlt
+import sqlalchemy as sa
+
+engine = sa.create_engine("duckdb:///:memory:", poolclass=sa.pool.StaticPool)
+
+pipeline = dlt.pipeline(
+    pipeline_name="my_pipeline",
+    destination=dlt.destinations.sqlalchemy(engine),
+    dataset_name="my_dataset",
+)
+```
+
+```toml
+[load]
+workers=1
+```
+
+### DuckDB dialect limitations
+* `duckdb_engine` does not reflect primary key and unique constraints nor indexes: they are created when `create_primary_keys` / `create_unique_indexes` are enabled but cannot be read back with SQLAlchemy tooling.
+* JSON columns are reflected as VARCHAR.
+* VARCHAR precision is accepted in DDL but not stored by DuckDB.
+* Parquet files are loaded with batch INSERT statements: ADBC ingestion is not implemented for this dialect.
+
 ## Notes on other dialects
-We tested this destination on **mysql**, **sqlite**, **oracledb** and **mssql** dialects. Below are a few notes that may help enabling other dialects:
+We tested this destination on **mysql**, **sqlite**, **duckdb**, **oracledb** and **mssql** dialects. Below are a few notes that may help enabling other dialects:
 1. `dlt` must be able to recognize if a database exception relates to non existing entity (like table or schema). We put
 some work to recognize those for most of the popular dialects (look for `db_api_client.py`)
 2. Primary keys and unique constraints are not created by default to avoid problems with particular dialects.

--- a/tests/load/pipeline/test_adbc_loading.py
+++ b/tests/load/pipeline/test_adbc_loading.py
@@ -39,6 +39,8 @@ def test_adbc_detection(destination_config: DestinationTestConfiguration) -> Non
         driver = "sqlite"
     elif driver == "sqlalchemy_mysql":
         driver = "mysql"
+    elif driver == "sqlalchemy_duckdb":
+        pytest.skip("ADBC ingestion not implemented for duckdb via sqlalchemy")
 
     assert has_adbc_driver(driver)[0] is True
 

--- a/tests/load/pipeline/test_sqlalchemy_pipeline.py
+++ b/tests/load/pipeline/test_sqlalchemy_pipeline.py
@@ -48,6 +48,10 @@ def test_sqlalchemy_create_indexes(
 
     from sqlalchemy import inspect
 
+    if destination_config.destination_name == "sqlalchemy_duckdb":
+        # duckdb_engine does not reflect primary key constraints nor indexes
+        return
+
     with pipeline.sql_client() as client:
         with_pk: Table = client.reflect_table("with_pk", metadata=MetaData())
         assert (with_pk.c.id.primary_key or False) is create_primary_keys
@@ -155,4 +159,8 @@ def test_custom_type_mapper(destination_config: DestinationTestConfiguration) ->
 
         # Check that the json field was mapped to String with length 345
         assert isinstance(json_column.type, sa.String)
-        assert json_column.type.length == 345
+        if destination_config.destination_name == "sqlalchemy_duckdb":
+            # duckdb accepts varchar length in DDL but does not store it
+            assert json_column.type.length is None
+        else:
+            assert json_column.type.length == 345

--- a/tests/load/sqlalchemy/test_duckdb_engine_destination.py
+++ b/tests/load/sqlalchemy/test_duckdb_engine_destination.py
@@ -1,5 +1,9 @@
-import dlt
+import os
+
 import pytest
+
+import dlt
+from dlt.common.utils import uniq_id
 
 from tests.pipeline.utils import assert_load_info
 
@@ -7,15 +11,29 @@ sa = pytest.importorskip("sqlalchemy")
 pytest.importorskip("duckdb_engine")
 
 
-def test_duckdb_engine_detects_existing_dataset(tmp_path) -> None:
-    db_path = tmp_path / "mydata.db"
-    engine = sa.create_engine(f"duckdb:///{db_path}")
+@pytest.mark.parametrize(
+    "db_file",
+    ["mydata.db", "my.data.duckdb", "weird name.db", "123abc.db", ":memory:"],
+    ids=["simple", "dotted", "space", "leading-digit", "memory"],
+)
+def test_duckdb_engine_detects_existing_dataset(tmp_path, db_file: str) -> None:
+    """Second run against the same duckdb database must detect the existing dataset:
+    duckdb_engine returns catalog-qualified schema names so a bare name lookup fails
+    and dlt attempts CREATE SCHEMA again.
+    """
+    if db_file == ":memory:":
+        # in-memory duckdb is private per connection: share a single one and load serially
+        engine = sa.create_engine("duckdb:///:memory:", poolclass=sa.pool.StaticPool)
+        os.environ["LOAD__WORKERS"] = "1"
+    else:
+        engine = sa.create_engine(f"duckdb:///{tmp_path / db_file}")
+    pipeline_name = "duckdb_engine_dataset_" + uniq_id()
 
     try:
         for item_id in (1, 2):
             pipeline = dlt.pipeline(
                 destination=dlt.destinations.sqlalchemy(engine),
-                pipeline_name="mydata",
+                pipeline_name=pipeline_name,
                 dataset_name="myschema",
                 pipelines_dir=str(tmp_path),
             )

--- a/tests/load/sqlalchemy/test_duckdb_engine_destination.py
+++ b/tests/load/sqlalchemy/test_duckdb_engine_destination.py
@@ -1,0 +1,27 @@
+import dlt
+import pytest
+
+from tests.pipeline.utils import assert_load_info
+
+sa = pytest.importorskip("sqlalchemy")
+pytest.importorskip("duckdb_engine")
+
+
+def test_duckdb_engine_detects_existing_dataset(tmp_path) -> None:
+    db_path = tmp_path / "mydata.db"
+    engine = sa.create_engine(f"duckdb:///{db_path}")
+
+    try:
+        for item_id in (1, 2):
+            pipeline = dlt.pipeline(
+                destination=dlt.destinations.sqlalchemy(engine),
+                pipeline_name="mydata",
+                dataset_name="myschema",
+                pipelines_dir=str(tmp_path),
+            )
+
+            info = pipeline.run([{"id": item_id}], table_name="numbers")
+
+            assert_load_info(info)
+    finally:
+        engine.dispose()

--- a/tests/load/sqlalchemy/test_sqlalchemy_configuration.py
+++ b/tests/load/sqlalchemy/test_sqlalchemy_configuration.py
@@ -134,7 +134,10 @@ def test_sqlalchemy_credentials_from_engine() -> None:
     assert creds.database == ":memory:"
 
 
-def test_sqlalchemy_sqlite_follows_local_dir() -> None:
+@pytest.mark.parametrize(
+    "driver,ext", [("sqlite", ".db"), ("duckdb", ".duckdb")], ids=["sqlite", "duckdb"]
+)
+def test_sqlalchemy_file_db_follows_local_dir(driver: str, ext: str) -> None:
     local_dir = os.path.join(get_test_storage_root(), uniq_id())
     os.makedirs(local_dir)
     os.environ[DLT_LOCAL_DIR] = local_dir
@@ -142,58 +145,67 @@ def test_sqlalchemy_sqlite_follows_local_dir() -> None:
     # default case: no explicit database, uses destination_type as default name
     c = resolve_configuration(
         SqlalchemyClientConfiguration(
-            credentials=SqlalchemyCredentials("sqlite:///")
+            credentials=SqlalchemyCredentials(f"{driver}:///")
         )._bind_dataset_name(dataset_name="test_dataset")
     )
-    db_path = os.path.join(local_dir, "sqlalchemy.db")
+    db_path = os.path.join(local_dir, f"sqlalchemy{ext}")
     assert c.credentials.database == os.path.abspath(db_path)
 
     # named destination: uses destination_name for the filename
     c = resolve_configuration(
         SqlalchemyClientConfiguration(
-            credentials=SqlalchemyCredentials("sqlite:///"),
+            credentials=SqlalchemyCredentials(f"{driver}:///"),
             destination_name="named",
         )._bind_dataset_name(dataset_name="test_dataset")
     )
-    db_path = os.path.join(local_dir, "named.db")
+    db_path = os.path.join(local_dir, f"named{ext}")
     assert c.credentials.database == os.path.abspath(db_path)
 
     # explicit relative location: relocated to local_dir
     c = resolve_configuration(
         SqlalchemyClientConfiguration(
-            credentials=SqlalchemyCredentials("sqlite:///./local.db"),
+            credentials=SqlalchemyCredentials(f"{driver}:///./local{ext}"),
         )._bind_dataset_name(dataset_name="test_dataset")
     )
-    db_path = os.path.join(local_dir, "local.db")
+    db_path = os.path.join(local_dir, f"local{ext}")
     assert c.credentials.database.endswith(db_path)
 
-    # pipeline context: uses <pipeline_name>.db for the filename
-    pipeline = dlt.pipeline("test_sqlalchemy_sqlite_follows_local_dir")
+    # pipeline context: uses <pipeline_name>.<ext> for the filename
+    pipeline = dlt.pipeline(f"test_sqlalchemy_follows_local_dir_{driver}")
     c = resolve_configuration(
         pipeline._bind_local_files(
             SqlalchemyClientConfiguration(
-                credentials=SqlalchemyCredentials("sqlite:///"),
+                credentials=SqlalchemyCredentials(f"{driver}:///"),
             )._bind_dataset_name(dataset_name="test_dataset")
         )
     )
-    db_path = os.path.join(local_dir, "test_sqlalchemy_sqlite_follows_local_dir.db")
+    db_path = os.path.join(local_dir, f"test_sqlalchemy_follows_local_dir_{driver}{ext}")
     assert c.credentials.database.endswith(db_path)
 
     # absolute path: preserved as-is
     c = resolve_configuration(
         SqlalchemyClientConfiguration(
-            credentials=SqlalchemyCredentials("sqlite:////absolute/path/test.db"),
+            credentials=SqlalchemyCredentials(f"{driver}:////absolute/path/test{ext}"),
         )._bind_dataset_name(dataset_name="test_dataset")
     )
-    assert c.credentials.database == "/absolute/path/test.db"
+    assert c.credentials.database == f"/absolute/path/test{ext}"
 
     # memory database: preserved as-is
     c = resolve_configuration(
         SqlalchemyClientConfiguration(
-            credentials=SqlalchemyCredentials("sqlite:///:memory:"),
+            credentials=SqlalchemyCredentials(f"{driver}:///:memory:"),
         )._bind_dataset_name(dataset_name="test_dataset")
     )
     assert c.credentials.database == ":memory:"
+
+    if driver == "duckdb":
+        # motherduck database: preserved as-is
+        c = resolve_configuration(
+            SqlalchemyClientConfiguration(
+                credentials=SqlalchemyCredentials("duckdb:///md:my_db"),
+            )._bind_dataset_name(dataset_name="test_dataset")
+        )
+        assert c.credentials.database == "md:my_db"
 
 
 def test_engine_kwargs_forwarded_to_credentials() -> None:

--- a/tests/load/test_job_client.py
+++ b/tests/load/test_job_client.py
@@ -542,6 +542,9 @@ def test_get_storage_table_with_all_types(
                 continue
         if client.config.destination_type == "dremio" and c["data_type"] == "json":
             continue
+        # duckdb_engine reflects JSON columns as VARCHAR
+        if client.config.destination_name == "sqlalchemy_duckdb" and c["data_type"] == "json":
+            continue
         if not client.capabilities.supports_native_boolean and c["data_type"] == "bool":
             # The reflected data type is probably either int or boolean depending on how the client is implemented
             assert expected_c["data_type"] in ("bigint", "bool")

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -554,6 +554,13 @@ def destinations_configs(
                 destination_name="sqlalchemy_sqlite",
                 credentials="sqlite:///db.sqlite",
             ),
+            DestinationTestConfiguration(
+                destination_type="sqlalchemy",
+                supports_merge=True,
+                supports_dbt=False,
+                destination_name="sqlalchemy_duckdb",
+                credentials="duckdb:///db.duckdb",
+            ),
             # TODO: enable in sql alchemy destination test, 99% of tests work
             # DestinationTestConfiguration(
             #     destination_type="sqlalchemy",


### PR DESCRIPTION
## Summary
- detect duckdb_engine's database-qualified schema names in the SQLAlchemy destination
- add a regression test that runs the same DuckDB-backed SQLAlchemy pipeline twice against one database file

## Root Cause
`duckdb_engine` returns schema names as `database.schema` from `get_schema_names()`. `SqlalchemyClient.has_dataset()` only checked for the bare dlt dataset name, so a second run against the same DuckDB file believed the dataset was missing and tried `CREATE SCHEMA` again, triggering `Catalog Error: Schema with name "myschema" already exists!`.

## Validation
- `uv run --with pytest --with sqlalchemy --with duckdb-engine --with duckdb --with pandas --with pyarrow pytest tests/load/sqlalchemy/test_duckdb_engine_destination.py -q`
- `uv run --with pytest --with sqlalchemy pytest tests/load/sqlalchemy/test_sqlite_destination.py::test_file_based_database_with_engine_kwargs tests/load/sqlalchemy/test_sqlite_destination.py::test_merge_with_main_dataset -q`

Closes #3907