### PR TITLE
Bump jsonpath-ng and improve test coverage

### DIFF
--- a/dlt/common/jsonpath.py
+++ b/dlt/common/jsonpath.py
@@ -3,7 +3,7 @@ from itertools import chain
 
 from dlt.common.typing import DictStrAny
 
-from jsonpath_ng import JSONPath, Fields as JSONPathFields
+from jsonpath_ng import JSONPath, Fields as JSONPathFields, DatumInContext, Root, This
 from jsonpath_ng.ext import parse as _parse
 
 TJsonPath = Union[str, JSONPath]  # Jsonpath compiled or str
@@ -36,6 +36,24 @@ def find_values(path: TJsonPath, data: DictStrAny) -> List[Any]:
     return [m.value for m in path.find(data)]
 
 
+def _stringify_path(match: DatumInContext) -> str:
+    """Render `DatumInContext` to parseable string representation"""
+    parts: list[str] = []
+    current: Optional[DatumInContext] = match
+
+    while current is not None:
+        if not isinstance(current.path, (Root, This)):
+            parts.append(str(current.path))
+        current = current.context
+
+    if parts:
+        parts.reverse()
+        return ".".join(parts)
+
+    # fallback to native __str__ for whole-object matches (e.g. $ or @)
+    return str(match.path)
+
+
 def resolve_paths(paths: TAnyJsonPath, data: DictStrAny) -> List[str]:
     """Return a list of paths resolved against `data`. The return value is a list of strings.
 
@@ -44,7 +62,7 @@ def resolve_paths(paths: TAnyJsonPath, data: DictStrAny) -> List[str]:
     >>> # ['a.items.[0].b', 'a.items.[1].b']
     """
     paths = compile_paths(paths)
-    return list(chain.from_iterable((str(r.full_path) for r in p.find(data)) for p in paths))
+    return list(chain.from_iterable((_stringify_path(r) for r in p.find(data)) for p in paths))
 
 
 def is_simple_field_path(path: JSONPath) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,7 @@ dependencies = [
     "orjson>=3.10.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
     "orjson>=3.11.0 ; python_version > '3.13'",
     "tenacity>=8.0.2",
-    # 1.8.0 wraps Child/Descendants str() in parens, breaking resolve_paths round-trip in drop.py
-    "jsonpath-ng>=1.5.3,<1.8",
+    "jsonpath-ng>=1.8.0",
     "fsspec>=2022.4.0",
     "packaging>=21.1",
     "pluggy>=1.3.0",

--- a/tests/common/test_jsonpath.py
+++ b/tests/common/test_jsonpath.py
@@ -73,4 +73,49 @@ def test_set_value_at_path():
     assert test_obj == {"key": "new_value"}
 
 
-# TODO: Test all jsonpath utils
+@pytest.mark.parametrize(
+    "data,selector,matched_paths,matched_data",
+    [
+        pytest.param(
+            {"data_from_d": {"foo1": {"bar": 1}, "foo2": {"bar": 2}}},
+            "data_from_d.*.bar",
+            ["data_from_d.foo1.bar", "data_from_d.foo2.bar"],
+            [[1], [2]],
+            id="star-selector-mid-path",
+        ),
+        pytest.param(
+            {"data_from_d": {"foo1": {"bar": 1}, "foo2": {"bar": 2}}},
+            "@.data_from_d",
+            ["data_from_d"],
+            [[{"foo1": {"bar": 1}, "foo2": {"bar": 2}}]],
+            id="current-datum-selector",
+        ),
+        pytest.param(
+            {"a": {"items": [{"b": 2}, {"b": 3}]}},
+            "$.a.items[*].b",
+            ["a.items.[0].b", "a.items.[1].b"],
+            [[2], [3]],
+            id="array-wildcard-selector",
+        ),
+        pytest.param(
+            {"a.b": {"c": 1}},
+            "$['a.b'].c",
+            ["'a.b'.c"],
+            [[1]],
+            id="quoted-field-preserves-dot",
+        ),
+        pytest.param(
+            {"@odata.nextLink": "https://example.com/next"},
+            "$['@odata.nextLink']",
+            ["'@odata.nextLink'"],
+            [["https://example.com/next"]],
+            id="quoted-odata-field",
+        ),
+    ],
+)
+def test_resolve_paths_roundtrips_to_matching_paths(
+    data: dict[str, Any], selector: str, matched_paths: list[str], matched_data: list[Any]
+) -> None:
+    resolved_paths = jp.resolve_paths(selector, data)
+    assert resolved_paths == matched_paths
+    assert [jp.find_values(path, data) for path in resolved_paths] == matched_data

--- a/tests/common/test_jsonpath.py
+++ b/tests/common/test_jsonpath.py
@@ -146,7 +146,9 @@ def test_resolve_paths_roundtrips_to_matching_paths(
 
     roundtripped_data = [jp.find_values(path, data) for path in resolved_paths]
     assert all(len(values) == 1 for values in roundtripped_data)
-    assert [value for values in roundtripped_data for value in values] == jp.find_values(selector, data)
+    assert [value for values in roundtripped_data for value in values] == jp.find_values(
+        selector, data
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/common/test_jsonpath.py
+++ b/tests/common/test_jsonpath.py
@@ -74,48 +74,111 @@ def test_set_value_at_path():
 
 
 @pytest.mark.parametrize(
-    "data,selector,matched_paths,matched_data",
+    "data,selector,matched_paths",
     [
         pytest.param(
             {"data_from_d": {"foo1": {"bar": 1}, "foo2": {"bar": 2}}},
             "data_from_d.*.bar",
             ["data_from_d.foo1.bar", "data_from_d.foo2.bar"],
-            [[1], [2]],
             id="star-selector-mid-path",
         ),
         pytest.param(
             {"data_from_d": {"foo1": {"bar": 1}, "foo2": {"bar": 2}}},
             "@.data_from_d",
             ["data_from_d"],
-            [[{"foo1": {"bar": 1}, "foo2": {"bar": 2}}]],
             id="current-datum-selector",
         ),
         pytest.param(
             {"a": {"items": [{"b": 2}, {"b": 3}]}},
             "$.a.items[*].b",
             ["a.items.[0].b", "a.items.[1].b"],
-            [[2], [3]],
             id="array-wildcard-selector",
         ),
         pytest.param(
             {"a.b": {"c": 1}},
             "$['a.b'].c",
             ["'a.b'.c"],
-            [[1]],
             id="quoted-field-preserves-dot",
         ),
         pytest.param(
             {"@odata.nextLink": "https://example.com/next"},
             "$['@odata.nextLink']",
             ["'@odata.nextLink'"],
-            [["https://example.com/next"]],
             id="quoted-odata-field",
+        ),
+        pytest.param(
+            {"x": {"bar": 1}, "y": {"z": {"bar": 2}}},
+            "$..bar",
+            ["x.bar", "y.z.bar"],
+            id="recursive-descent-selector",
+        ),
+        pytest.param(
+            {"items": [{"v": 0}, {"v": 1}, {"v": 2}, {"v": 3}]},
+            "$.items[1:3]",
+            ["items.[1]", "items.[2]"],
+            id="array-slice-selector",
+        ),
+        pytest.param(
+            {"a": 1},
+            "$",
+            ["$"],
+            id="whole-root-selector",
+        ),
+        pytest.param(
+            {
+                "items": [
+                    {"id": 1, "active": True},
+                    {"id": 2, "active": False},
+                    {"id": 3, "active": True},
+                ]
+            },
+            "$.items[?(@.active==true)].id",
+            ["items.[0].id", "items.[2].id"],
+            id="filter-selector-resolves-to-concrete-indices",
         ),
     ],
 )
 def test_resolve_paths_roundtrips_to_matching_paths(
-    data: dict[str, Any], selector: str, matched_paths: list[str], matched_data: list[Any]
+    data: dict[str, Any], selector: str, matched_paths: list[str]
 ) -> None:
     resolved_paths = jp.resolve_paths(selector, data)
     assert resolved_paths == matched_paths
+
+    roundtripped_data = [jp.find_values(path, data) for path in resolved_paths]
+    assert all(len(values) == 1 for values in roundtripped_data)
+    assert [value for values in roundtripped_data for value in values] == jp.find_values(selector, data)
+
+
+@pytest.mark.parametrize(
+    "paths,data,matched_paths,matched_data",
+    [
+        pytest.param(
+            ["$.a", "$.b"],
+            {"a": 1, "b": 2},
+            ["a", "b"],
+            [[1], [2]],
+            id="list-of-selectors",
+        ),
+        pytest.param(
+            jp.compile_path("$.a.items[*].b"),
+            {"a": {"items": [{"b": 2}, {"b": 3}]}},
+            ["a.items.[0].b", "a.items.[1].b"],
+            [[2], [3]],
+            id="compiled-jsonpath-input",
+        ),
+    ],
+)
+def test_resolve_paths_accepts_multiple_and_compiled_inputs(
+    paths: Any, data: dict[str, Any], matched_paths: list[str], matched_data: list[Any]
+) -> None:
+    resolved_paths = jp.resolve_paths(paths, data)
+    assert resolved_paths == matched_paths
     assert [jp.find_values(path, data) for path in resolved_paths] == matched_data
+
+
+def test_resolve_paths_returns_empty_list_when_selector_matches_nothing() -> None:
+    data = {"a": {"b": 1}}
+    selector = "$.missing"
+
+    assert jp.resolve_paths(selector, data) == []
+    assert jp.find_values(selector, data) == []

--- a/tests/sources/helpers/rest_client/test_detector.py
+++ b/tests/sources/helpers/rest_client/test_detector.py
@@ -386,19 +386,27 @@ def test_find_next_page_key(test_case):
 
 @pytest.mark.parametrize("test_case", TEST_RESPONSES)
 def test_find_paginator(test_case) -> None:
+    response = test_case["response"]
     factory = PaginatorFactory()
-    mock_response = PaginatorResponse(test_case["response"], test_case.get("links"))
+    mock_response = PaginatorResponse(response, test_case.get("links"))
     paginator, _ = factory.create_paginator(mock_response)  # type: ignore[arg-type]
     expected_paginator = test_case["expected"]["type"]
     if expected_paginator is OffsetPaginator:
         expected_paginator = SinglePagePaginator
     assert type(paginator) is expected_paginator
     if isinstance(paginator, PageNumberPaginator):
-        assert str(paginator.total_path) == ".".join(test_case["expected"]["total_path"])
+        assert paginator.total_path is not None
+        assert jsonpath.resolve_paths(paginator.total_path, response) == [
+            ".".join(test_case["expected"]["total_path"])
+        ]
     if isinstance(paginator, JSONLinkPaginator):
-        assert str(paginator.next_url_path) == ".".join(test_case["expected"]["next_path"])
+        assert jsonpath.resolve_paths(paginator.next_url_path, response) == [
+            ".".join(test_case["expected"]["next_path"])
+        ]
     if isinstance(paginator, JSONResponseCursorPaginator):
-        assert str(paginator.cursor_path) == ".".join(test_case["expected"]["next_path"])
+        assert jsonpath.resolve_paths(paginator.cursor_path, response) == [
+            ".".join(test_case["expected"]["next_path"])
+        ]
 
 
 @pytest.mark.parametrize(

--- a/tests/sources/rest_api/configurations/test_custom_paginator_config.py
+++ b/tests/sources/rest_api/configurations/test_custom_paginator_config.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import pytest
 
+from dlt.common import jsonpath
 from dlt.common.exceptions import ValueErrorWithKnownValues
 from dlt.sources import rest_api
 from dlt.sources.helpers.rest_client.paginators import JSONLinkPaginator
@@ -60,8 +61,15 @@ class TestCustomPaginator:
         rest_api.config_setup.register_paginator("custom_paginator", CustomPaginator)
         paginator = rest_api.config_setup.create_paginator(custom_paginator_config)
         paginator = cast(CustomPaginator, paginator)
+        response = {"response": {"next_page_link": "https://example.com/page/2"}}
+
         assert paginator.has_next_page is True
-        assert str(paginator.next_url_path) == "response.next_page_link"
+        assert jsonpath.resolve_paths(paginator.next_url_path, response) == [
+            "response.next_page_link"
+        ]
+        assert jsonpath.find_values(paginator.next_url_path, response) == [
+            "https://example.com/page/2"
+        ]
 
     def test_registering_not_base_paginator_throws_error(self) -> None:
         class NotAPaginator:

--- a/uv.lock
+++ b/uv.lock
@@ -2864,7 +2864,7 @@ requires-dist = [
     { name = "humanize", specifier = ">=4.4.0" },
     { name = "ibis-framework", marker = "extra == 'lance'", specifier = ">=12.0.0" },
     { name = "ibis-framework", marker = "extra == 'lancedb'", specifier = ">=12.0.0" },
-    { name = "jsonpath-ng", specifier = ">=1.5.3,<1.8" },
+    { name = "jsonpath-ng", specifier = ">=1.8.0" },
     { name = "lancedb", marker = "extra == 'lance'", specifier = ">=0.33.0" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.22.0" },
     { name = "oracledb", marker = "extra == 'oracle'", specifier = ">=3.4.1" },
@@ -4921,14 +4921,11 @@ wheels = [
 
 [[package]]
 name = "jsonpath-ng"
-version = "1.7.0"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ply" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513, upload-time = "2026-02-24T14:42:06.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/03/99/33c7d78a3fb70d545fd5411ac67a651c81602cc09c9cf0df383733f068c5/jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138", size = 67844, upload-time = "2026-02-28T00:53:19.637Z" },
 ]
 
 [[package]]
@@ -7531,15 +7528,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "ply"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `jsonpath-ng` to `1.8.0`. This removes a transitive dependency on `ply` which was archived and contained an active CVE (not exploitable through `dlt` but still showing up on security scanners). Due to changes in how the string conversion works from `1.8.0` onwards we have to vendor in our own logic to convert a `JSONPath` to a `str` value that can be re-parsed again.

Closes #3869 