### PR TITLE
fix: include first-response wait in extract progress timing

### DIFF
--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -506,6 +506,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                 ) as pipes:
                     left_gens = total_gens = len(pipes._sources)
                     collector.update("Resources", 0, total_gens)
+                    self._start_resource_counters(source)
                     for pipe_item in pipes:
                         curr_gens = len(pipes._sources)
                         if left_gens > curr_gens:
@@ -527,6 +528,14 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                     if left_gens > 0:
                         # go to 100%
                         collector.update("Resources", left_gens)
+
+    def _start_resource_counters(self, source: DltSource) -> None:
+        for resource in source.selected_resources.values():
+            if resource.is_transformer or resource.has_dynamic_table_name:
+                continue
+            table_name = resource.table_name
+            if isinstance(table_name, str):
+                self.collector.update(table_name, inc=0)
 
     @contextlib.contextmanager
     def manage_writers(self, load_id: str, source: DltSource) -> Iterator[ExtractStorage]:

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -22,6 +22,7 @@ from dlt.extract.extract import ExtractStorage, Extract
 from dlt.extract.hints import TResourceNestedHints, make_hints, make_nested_hints
 from dlt.extract.items_transform import ValidateItem, MetricsItem
 from dlt.extract.items import TableNameMeta, DataItemWithMeta
+from dlt.common.runtime.collector import LogCollector
 
 from tests.utils import MockPipeline, clean_test_storage, get_test_storage_root
 from tests.extract.utils import expect_extracted_file, assert_written_tables_are_computed
@@ -642,6 +643,26 @@ def test_extract_renamed_clone_and_parent(extract_step: Extract):
     assert source.tx_clone._pipe.parent.name == "input_gen_tx_clone"
 
 
+def test_extract_starts_static_resource_counter_before_first_item(extract_step: Extract) -> None:
+    log = []
+    clock = [0.0]
+    collector = LogCollector(log_period=1.0, logger="stdout", dump_system_stats=False)
+    collector._clock = lambda: clock[0]  # type: ignore[assignment]
+    collector._log = lambda _level, message: log.append(message)  # type: ignore[method-assign]
+    extract_step.collector = collector
+
+    @dlt.resource(name="slow_resource")
+    def slow_resource():
+        clock[0] += 30.0
+        yield {"id": 1}
+
+    source = DltSource(dlt.Schema("slow"), "module", [slow_resource()])
+    load_id = extract_step.extract_storage.create_load_package(source.discover_schema())
+    extract_step._extract_single_source(load_id, source, max_parallel_items=5, workers=1)
+
+    assert any("slow_resource: 1  | Time: 30.00s" in message for message in log)
+
+
 def expect_tables(extract_step: Extract, resource: DltResource) -> dlt.Schema:
     source = DltSource(dlt.Schema("selectables"), "module", [resource(10)])
     load_id = extract_step.extract_storage.create_load_package(source.discover_schema())
@@ -702,7 +723,7 @@ def test_materialize_table_schema_with_pipe_items():
     def empty_list(
         some_id: dlt.sources.incremental[int] = dlt.sources.incremental(
             cursor_path="some_id", initial_value=0
-        )
+        ),
     ):
         yield dlt.mark.materialize_table_schema()
 


### PR DESCRIPTION
## Summary

Fixes #3518.

Start static root resource progress counters before the first extracted item is written. This makes log progress timing include the wait before a resource yields its first batch, which is the slow TTFB case reported for non-paginated REST API resources.

## Root cause

`LogCollector` starts a counter's timer when that counter is first updated. During extract, table/resource counters were only updated after the first data item was written. For a single slow request, the generator blocks until the response arrives, so the first table update happens after the long wait and the resource line reports near-zero elapsed time even though the whole extract step took minutes.

The fix pre-registers static non-transformer resource counters with `inc=0` after the extract step starts but before `PipeIterator` begins consuming the resource. Dynamic table-name resources and transformers are skipped so their counters are not started before their actual target table or parent input is known.

## Validation

- `uv run pytest tests/extract/test_extract.py::test_extract_starts_static_resource_counter_before_first_item -q`
- `uv run pytest tests/extract/test_extract.py::test_extract_select_tables_mark tests/extract/test_extract.py::test_extract_empty_metrics tests/common/runtime/test_collector.py -q`
- `uv run pytest tests/extract/test_extract.py -q`
- `uv run pytest tests/common/runtime/test_collector.py -q`
- `uv run ruff format --check dlt/extract/extract.py tests/extract/test_extract.py`
- `uv run ruff check dlt/extract/extract.py tests/extract/test_extract.py`
- `uv run python -m py_compile dlt/extract/extract.py tests/extract/test_extract.py`

## Notes

I checked for an open PR covering `#3518` / RestAPI runtime timing and did not find one. There was an older issue comment from another contributor planning to investigate, but no linked PR appeared to exist.
