### PR TITLE
fix: send dlt handoff note to stderr

### DIFF
--- a/dlt/_workspace/cli/_dlt.py
+++ b/dlt/_workspace/cli/_dlt.py
@@ -375,12 +375,14 @@ def _main() -> None:
     # when workspace is active, dlt commands mirrors dlthub
     if is_workspace_active():
         host = "dlthub"
-        fmt.note(
-            "Please use %s as top level command. Check `%s` for former dlt commands. "
+        fmt.secho(
+            "NOTE: Please use %s as top level command. Check `%s` for former dlt commands. "
             "Falling back to dlthub command set."
-            % (fmt.bold("dlthub"), fmt.bold("dlthub local --help"))
+            % (fmt.bold("dlthub"), fmt.bold("dlthub local --help")),
+            fg="green",
+            err=True,
         )
-        fmt.echo()
+        fmt.echo(err=True)
     else:
         host = "dlt"
     exit(main(host))

--- a/tests/workspace/cli/common/test_cli_invoke.py
+++ b/tests/workspace/cli/common/test_cli_invoke.py
@@ -406,7 +406,7 @@ def test_main_in_workspace_prints_dlthub_handoff_note(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """`_main()` inside a workspace tells the user to use the `dlthub` command."""
+    """`_main()` inside a workspace sends the handoff note to stderr."""
     # short-circuit the inner dispatch so we only exercise the handoff branch
     monkeypatch.setattr("dlt._workspace.cli._dlt.main", lambda host: 0)
     monkeypatch.setattr("sys.argv", ["dlt", "--version"])
@@ -414,10 +414,10 @@ def test_main_in_workspace_prints_dlthub_handoff_note(
         _main()
     assert ei.value.code == 0
     captured = capsys.readouterr()
-    combined = captured.out + captured.err
-    assert "Please use" in combined
-    assert "dlthub" in combined
-    assert "dlthub local --help" in combined
+    assert "Please use" not in captured.out
+    assert "Please use" in captured.err
+    assert "dlthub" in captured.err
+    assert "dlthub local --help" in captured.err
 
 
 def test_main_outside_workspace_no_handoff_note(


### PR DESCRIPTION
Fixes #4035.

## Summary
- send the workspace-active `dlt` -> `dlthub` handoff NOTE to stderr
- keep stdout clean for commands whose output may be piped or parsed
- tighten the CLI regression test to assert stdout stays clean

## Validation
- `uv run --extra hub pytest tests/workspace/cli/common/test_cli_invoke.py::test_main_in_workspace_prints_dlthub_handoff_note tests/workspace/cli/common/test_cli_invoke.py::test_main_outside_workspace_no_handoff_note tests/workspace/cli/common/test_cli_invoke.py::test_dlthub_help_outside_workspace_prints_hint tests/workspace/cli/common/test_cli_invoke.py::test_dlthub_help_inside_workspace_no_hint -q` -> 8 passed
- `uv run ruff format --check dlt/_workspace/cli/_dlt.py tests/workspace/cli/common/test_cli_invoke.py`
- `uv run ruff check dlt/_workspace/cli/_dlt.py tests/workspace/cli/common/test_cli_invoke.py`

I also ran `uv run --extra hub pytest tests/workspace/cli/common/test_cli_invoke.py -q`; it reached 45 passed / 9 failed, with the failures caused by missing optional dependencies for unrelated duckdb/dashboard paths (`dlt[duckdb]`, `marimo`, `pyarrow`, `ibis-framework`).