### PR TITLE
Clear key hints when apply_hints receives empty keys

### DIFF
--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -539,8 +539,14 @@ class DltResourceHints:
                     # set to empty columns
                     t["columns"] = ensure_table_schema_columns(columns)
             if primary_key is not None:
+                if not primary_key:
+                    DltResourceHints._clear_key_hint_in_template(
+                        "primary_key", t.get("primary_key"), t
+                    )
                 t["primary_key"] = primary_key
             if merge_key is not None:
+                if not merge_key:
+                    DltResourceHints._clear_key_hint_in_template("merge_key", t.get("merge_key"), t)
                 t["merge_key"] = merge_key
             if schema_contract is not None:
                 if schema_contract:
@@ -677,9 +683,12 @@ class DltResourceHints:
 
     @staticmethod
     def _merge_key(hint: TColumnProp, keys: TColumnNames, partial: TPartialTableSchema) -> None:
-        remove_compound_props(partial["columns"], {hint})
         if not keys:
+            for column in partial["columns"].values():
+                if column.get(hint):
+                    column[hint] = False
             return
+        remove_compound_props(partial["columns"], {hint})
         if isinstance(keys, str):
             keys = [keys]
         for key in keys:
@@ -690,6 +699,27 @@ class DltResourceHints:
             else:
                 partial["columns"][key] = new_column(key, nullable=False)
                 partial["columns"][key][hint] = True
+
+    @staticmethod
+    def _clear_key_hint_in_template(
+        hint: TColumnProp,
+        keys: Optional[TTableHintTemplate[TColumnNames]],
+        template: TResourceHints,
+    ) -> None:
+        if callable(keys) or not keys:
+            return
+        if isinstance(keys, str):
+            keys = [keys]
+        columns_hint = template.get("columns")
+        if callable(columns_hint) or columns_hint is None:
+            columns: TTableSchemaColumns = {}
+            template["columns"] = columns
+        else:
+            columns = cast(TTableSchemaColumns, columns_hint)
+        for key in keys:
+            column = columns.get(key) or new_column(key)
+            column[hint] = False
+            columns[key] = column
 
     @staticmethod
     def _merge_keys(dict_: TResourceHints) -> None:

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -211,6 +211,28 @@ def test_extract_hints_mark(extract_step: Extract) -> None:
     assert "pk" not in table["columns"]
 
 
+def test_empty_key_hints_clear_existing_schema_columns(extract_step: Extract) -> None:
+    os.environ["DATA_WRITER__DISABLE_COMPRESSION"] = "TRUE"
+
+    @dlt.resource
+    def with_table_hints():
+        yield {"id": 1, "merge_id": 1}
+
+    source = DltSource(dlt.Schema("hintable"), "module", [with_table_hints])
+    resource = source.resources["with_table_hints"]
+    resource.apply_hints(primary_key="id", merge_key="merge_id")
+    extract_step.extract(source, 20, 1)
+    table = source.schema.tables["with_table_hints"]
+    assert table["columns"]["id"]["primary_key"] is True
+    assert table["columns"]["merge_id"]["merge_key"] is True
+
+    resource.apply_hints(primary_key="", merge_key=[])
+    extract_step.extract(source, 20, 1)
+    table = source.schema.tables["with_table_hints"]
+    assert table["columns"]["id"].get("primary_key") is not True
+    assert table["columns"]["merge_id"].get("merge_key") is not True
+
+
 def test_extract_hints_table_variant(extract_step: Extract) -> None:
     os.environ["DATA_WRITER__DISABLE_COMPRESSION"] = "TRUE"
 


### PR DESCRIPTION
## Summary
- preserve empty `primary_key` / `merge_key` updates as explicit column-level clears so schema merges remove previous key hints
- keep empty key handling from leaving existing column-level key hints behind
- add a regression test that extracts once with keys, then extracts again after clearing them

Closes #3210.

## Validation
- `uv run pytest tests/extract/test_extract.py::test_extract_hints_mark tests/extract/test_extract.py::test_empty_key_hints_clear_existing_schema_columns tests/extract/test_extract.py::test_extract_hints_table_variant tests/extract/test_extract.py::test_extract_hints_mark_incremental -q`
- `uv run ruff check dlt/extract/hints.py tests/extract/test_extract.py`
- `uv run mypy dlt/extract/hints.py`
- `uv run black --check dlt/extract/hints.py tests/extract/test_extract.py`