### PR TITLE
fix: keep dashboard pipeline selector after deselect

### DIFF
--- a/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
+++ b/dlt/_workspace/helpers/dashboard/dlt_dashboard.py
@@ -37,6 +37,7 @@ with app.setup:
 
 @app.cell(hide_code=True)
 def home(
+    dlt_all_pipelines: List[TPipelineListItem],
     dlt_profile_select: mo.ui.dropdown,
     dlt_pipeline_select: mo.ui.multiselect,
     dlt_local_pipeline_names: List[str],

--- a/dlt/_workspace/helpers/dashboard/strings.py
+++ b/dlt/_workspace/helpers/dashboard/strings.py
@@ -51,10 +51,9 @@ home_no_pipelines = f"""
 No pipelines found yet. A pipeline shows up here once it has run, or after you restore one \
 from its destination (see the [sync docs]({_sync_help_url})).
 """
-
-home_no_pipeline_selected = (
-    "No pipeline selected. Choose a pipeline from the dropdown above to inspect it."
-)
+home_no_pipeline_selected = """
+Select a pipeline to inspect from the dropdown above.
+"""
 
 home_workspace_label = " Workspace: {}"
 home_open_working_dir_button = "Open pipeline working directory"

--- a/tests/workspace/helpers/dashboard/test_all_cells.py
+++ b/tests/workspace/helpers/dashboard/test_all_cells.py
@@ -108,7 +108,7 @@ def test_home_no_pipeline_selected(success_pipeline_duckdb: dlt.Pipeline):
         dlt_all_pipelines=[{"name": success_pipeline_duckdb.pipeline_name}],
         dlt_pipelines_dir=success_pipeline_duckdb.pipelines_dir,
     )
-    assert strings.home_no_pipeline_selected in html
+    assert strings.home_no_pipeline_selected.strip() in html
     assert NO_PIPELINES_TEXT not in html
 
 
@@ -116,7 +116,7 @@ def test_home_no_pipelines_at_all():
     """Empty workspace: the cell picks the no-pipelines landing."""
     html = _run_home(dlt_pipeline_name=None, dlt_all_pipelines=[])
     assert NO_PIPELINES_TEXT in html
-    assert strings.home_no_pipeline_selected not in html
+    assert strings.home_no_pipeline_selected.strip() not in html
 
 
 def test_home_phantom_pipeline_shows_empty_landing():
@@ -127,7 +127,7 @@ def test_home_phantom_pipeline_shows_empty_landing():
         dlt_local_pipeline_names=[],
     )
     assert NO_PIPELINES_TEXT in html
-    assert strings.home_no_pipeline_selected not in html
+    assert strings.home_no_pipeline_selected.strip() not in html
 
 
 def test_home_pipeline_selected(success_pipeline_duckdb: dlt.Pipeline):
@@ -138,7 +138,7 @@ def test_home_pipeline_selected(success_pipeline_duckdb: dlt.Pipeline):
         dlt_pipelines_dir=success_pipeline_duckdb.pipelines_dir,
     )
     assert NO_PIPELINES_TEXT not in html
-    assert strings.home_no_pipeline_selected not in html
+    assert strings.home_no_pipeline_selected.strip() not in html
     assert strings.app_refresh_button in html
 
 
@@ -192,4 +192,4 @@ def test_home_selected_pipeline_never_ran_stays_on_selected_path(
     )
     assert NO_TRACE_TEXT in html
     assert NO_PIPELINES_TEXT not in html
-    assert strings.home_no_pipeline_selected not in html
+    assert strings.home_no_pipeline_selected.strip() not in html


### PR DESCRIPTION
### Description
Fixes #4093.

When the dashboard pipeline multiselect is cleared, `dlt_pipeline_name` becomes `None`. Previously the home cell treated that the same as an empty workspace, so it rendered the no-pipelines landing and removed the only control that could re-select a pipeline.

This change keeps those states separate:
- no local pipelines exist: keep the existing no-pipelines landing
- pipelines exist but none is selected: keep the profile/pipeline controls visible and show a neutral selection hint

### Validation
```text
uv run --with duckdb --with pyarrow --with marimo pytest tests/workspace/helpers/dashboard/test_all_cells.py -q
# 3 passed in 1.27s

uv run --with ruff ruff check dlt/_workspace/helpers/dashboard/dlt_dashboard.py dlt/_workspace/helpers/dashboard/utils/home.py dlt/_workspace/helpers/dashboard/strings.py tests/workspace/helpers/dashboard/test_all_cells.py
# All checks passed!

uv run --with ruff ruff format --check dlt/_workspace/helpers/dashboard/dlt_dashboard.py dlt/_workspace/helpers/dashboard/utils/home.py dlt/_workspace/helpers/dashboard/strings.py tests/workspace/helpers/dashboard/test_all_cells.py
# 4 files already formatted

git diff --check
# clean
```