### PR TITLE
fix: isolate extra provider config resolution

### DIFF
--- a/dlt/common/configuration/specs/config_providers_context.py
+++ b/dlt/common/configuration/specs/config_providers_context.py
@@ -89,9 +89,11 @@ class ConfigProvidersContainer:
 
 def _extra_providers() -> List[ConfigProvider]:
     """Providers that require initial providers to be instantiated as the are enabled via config"""
-    from dlt.common.configuration.resolve import resolve_configuration
+    from dlt.common.configuration.resolve import inject_section, resolve_configuration
+    from dlt.common.configuration.specs.config_section_context import ConfigSectionContext
 
-    providers_config = resolve_configuration(ConfigProvidersConfiguration())
+    with inject_section(ConfigSectionContext(), merge_existing=False):
+        providers_config = resolve_configuration(ConfigProvidersConfiguration())
     extra_providers = []
     if providers_config.enable_airflow_secrets:
         extra_providers.extend(_airflow_providers(providers_config.airflow_secrets))

--- a/tests/common/configuration/test_config_providers_context.py
+++ b/tests/common/configuration/test_config_providers_context.py
@@ -1,0 +1,29 @@
+from dlt.common.configuration import inject_section
+from dlt.common.configuration.providers import ConfigProvider
+from dlt.common.configuration.specs import ConfigSectionContext
+from dlt.common.configuration.specs import config_providers_context
+from tests.common.configuration.utils import MockProvider, environment  # noqa: F401
+
+
+def test_extra_providers_ignore_injected_source_section(environment, monkeypatch) -> None:
+    environment["PROVIDERS__ENABLE_AIRFLOW_SECRETS"] = "false"
+    environment["PROVIDERS__ENABLE_GOOGLE_SECRETS"] = "true"
+    environment["PROVIDERS__GOOGLE_SECRETS__ONLY_TOML_FRAGMENTS"] = "false"
+
+    captured_settings = []
+
+    def fake_google_provider(settings) -> ConfigProvider:
+        captured_settings.append(dict(settings))
+        return MockProvider()
+
+    monkeypatch.setattr(config_providers_context, "_google_secrets_provider", fake_google_provider)
+
+    with inject_section(
+        ConfigSectionContext(sections=("sources", "sample_source")), merge_existing=False
+    ):
+        providers = config_providers_context._extra_providers()
+
+    assert len(providers) == 1
+    assert captured_settings == [
+        {"only_secrets": True, "only_toml_fragments": False, "list_secrets": False}
+    ]


### PR DESCRIPTION
## Summary
- Fixes #3969 by resolving `ConfigProvidersConfiguration` outside the currently injected source/resource section.
- Adds a regression test showing `providers.google_secrets.only_toml_fragments=false` is honored even while a source section is active.

## Root cause
`_extra_providers()` resolves provider bootstrap configuration while whatever `ConfigSectionContext` is currently active remains in the container. When provider setup happens during source resolution, the active source section is prepended to the lookup path, so provider-level settings can fall back to defaults instead of the intended `providers.*` values.

## Validation
- `uv run pytest tests/common/configuration/test_config_providers_context.py tests/common/configuration/test_vault_provider.py -q`
- `uv run ruff check dlt/common/configuration/specs/config_providers_context.py tests/common/configuration/test_config_providers_context.py`
- `uv run ruff format --check dlt/common/configuration/specs/config_providers_context.py tests/common/configuration/test_config_providers_context.py`
- `git diff --check`