### PR TITLE
fix: warn when type adapter drops reflected type

### DIFF
--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -94,7 +94,8 @@ def sql_database(
         include_views (bool): Reflect views as well as tables. Note view names included in `table_names` are always included regardless of this setting.
 
         type_adapter_callback (Optional[TTypeAdapter]): Callable to override type inference when reflecting columns.
-            Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type, or `None` (type will be inferred from data)
+            Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type.
+            Return the input type to leave a column unchanged. Returning `None` drops the reflected source type and forces dlt to infer the type from data.
 
         query_adapter_callback (Optional[TQueryAdapter]): Callable to override the SELECT query used to fetch data from the table.
             The callback receives the sqlalchemy `Select` and corresponding `Table`, 'Incremental` and `Engine` objects and should return the modified `Select` or `Text`.
@@ -248,7 +249,8 @@ def sql_table(
         backend_kwargs (Dict[str, Any], optional): kwargs passed to table backend ie. "conn" is used to pass specialized connection string to connectorx.
 
         type_adapter_callback (Optional[TTypeAdapter]): Callable to override type inference when reflecting columns.
-            Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type, or `None` (type will be inferred from data)
+            Argument is a single sqlalchemy data type (`TypeEngine` instance) and it should return another sqlalchemy data type.
+            Return the input type to leave a column unchanged. Returning `None` drops the reflected source type and forces dlt to infer the type from data.
 
         included_columns (Optional[List[str]]): List of column names to select from the table. If not provided, all columns are loaded.
 

--- a/dlt/sources/sql_database/schema_types.py
+++ b/dlt/sources/sql_database/schema_types.py
@@ -117,9 +117,19 @@ def sqla_col_to_column_schema(
     sql_t = sql_col.type
 
     if type_adapter_callback:
+        original_sql_t = sql_t
         sql_t = type_adapter_callback(sql_t)
+        if sql_t is None:
+            logger.warning(
+                "`type_adapter_callback` returned None for column %s with reflected type %s."
+                " This drops reflected type information and forces dlt to infer the type from"
+                " data. If you want to keep the reflected type unchanged, return the original"
+                " SQLAlchemy type from the callback.",
+                sql_col.name,
+                original_sql_t,
+            )
         # Check if sqla type class rather than instance is returned
-        if sql_t is not None and isinstance(sql_t, type):
+        elif isinstance(sql_t, type):
             sql_t = sql_t()
 
     if sql_t is None:

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/advanced.md
@@ -184,7 +184,7 @@ most of the coercion problems.
 
 ### Adapt reflected types to your needs
 
-You can also override the SQL type by passing a `type_adapter_callback` function. This function takes a `SQLAlchemy` data type as input and returns a new type (or `None` to force the column to be inferred from the data) as output.
+You can also override the SQL type by passing a `type_adapter_callback` function. This function takes a `SQLAlchemy` data type as input and returns a new type as output. Return the input type to leave a column unchanged. Returning `None` drops the reflected type information and forces the column to be inferred from the data.
 
 This is useful, for example, when:
 - You're loading a data type that is not supported by the destination (e.g., you need JSON type columns to be coerced to string).

--- a/tests/sources/sql_database/test_schema_types.py
+++ b/tests/sources/sql_database/test_schema_types.py
@@ -105,6 +105,27 @@ def test_datetime_timezone_mapping(sql_type: sa.types.TypeEngine, expected_tz: b
     assert col_schema["timezone"] is expected_tz
 
 
+def test_type_adapter_none_warns_and_keeps_inference(monkeypatch: pytest.MonkeyPatch) -> None:
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("amount", sa.Numeric(7, 2)))
+    warnings = []
+
+    def capture_warning(message: str, *args: object) -> None:
+        warnings.append(message % args)
+
+    monkeypatch.setattr("dlt.sources.sql_database.schema_types.logger.warning", capture_warning)
+
+    col_schema = sqla_col_to_column_schema(
+        table.c.amount, "full_with_precision", lambda sql_t: None
+    )
+
+    assert col_schema == {"name": "amount", "nullable": True}
+    assert len(warnings) == 1
+    assert "`type_adapter_callback` returned None for column amount" in warnings[0]
+    assert "forces dlt to infer the type from data" in warnings[0]
+    assert "return the original SQLAlchemy type" in warnings[0]
+
+
 def test_get_table_references() -> None:
     # Test converting foreign keys to reference hints
     metadata = sa.MetaData()


### PR DESCRIPTION
Closes #4032.

## Summary
- warn when `type_adapter_callback` returns `None` for a reflected SQLAlchemy column type
- clarify in the `sql_database` / `sql_table` docstrings that `None` drops reflected type info and forces data inference
- update the SQL database docs to say that the no-op callback path should return the input type
- add a regression test covering the warning while preserving the existing inference behavior

## Root cause
`type_adapter_callback` currently receives the reflected SQLAlchemy type, but if it returns `None`, `sqla_col_to_column_schema()` exits before adding `data_type`, precision, or scale. That behavior can be intentional, but it is easy to mistake `None` for "no override". With pyarrow/parquet, this can silently defer decimal inference to data batches and later fail when batches infer incompatible decimal precision.

This PR keeps the existing `None` behavior for compatibility, but makes the type drop explicit at runtime and in the docs.

## Validation
- Base reproduction on `origin/devel`: a callback returning `None` for `Numeric(7, 2)` produced `{'name': 'amount', 'nullable': True}` and emitted `0` warnings
- `uv run --with sqlalchemy pytest tests/sources/sql_database/test_schema_types.py::test_type_adapter_none_warns_and_keeps_inference -q` -> `1 passed`
- `uv run --with sqlalchemy pytest tests/sources/sql_database/test_schema_types.py -q` -> `15 passed, 3 skipped`
- `uv run ruff check dlt/sources/sql_database/schema_types.py dlt/sources/sql_database/__init__.py tests/sources/sql_database/test_schema_types.py` -> `All checks passed`
- `git diff --check` -> clean
