### PR TITLE
fix(cli): send dlt handoff note to stderr

### DIFF
--- a/dlt/_workspace/cli/_dlt.py
+++ b/dlt/_workspace/cli/_dlt.py
@@ -375,12 +375,14 @@ def _main() -> None:
     # when workspace is active, dlt commands mirrors dlthub
     if is_workspace_active():
         host = "dlthub"
-        fmt.note(
-            "Please use %s as top level command. Check `%s` for former dlt commands. "
+        fmt.secho(
+            "NOTE: Please use %s as top level command. Check `%s` for former dlt commands. "
             "Falling back to dlthub command set."
-            % (fmt.bold("dlthub"), fmt.bold("dlthub local --help"))
+            % (fmt.bold("dlthub"), fmt.bold("dlthub local --help")),
+            fg="green",
+            err=True,
         )
-        fmt.echo()
+        fmt.echo(err=True)
     else:
         host = "dlt"
     exit(main(host))

--- a/tests/workspace/cli/common/test_cli_invoke.py
+++ b/tests/workspace/cli/common/test_cli_invoke.py
@@ -406,7 +406,7 @@ def test_main_in_workspace_prints_dlthub_handoff_note(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """`_main()` inside a workspace tells the user to use the `dlthub` command."""
+    """`_main()` inside a workspace sends the handoff note to stderr."""
     # short-circuit the inner dispatch so we only exercise the handoff branch
     monkeypatch.setattr("dlt._workspace.cli._dlt.main", lambda host: 0)
     monkeypatch.setattr("sys.argv", ["dlt", "--version"])
@@ -414,10 +414,10 @@ def test_main_in_workspace_prints_dlthub_handoff_note(
         _main()
     assert ei.value.code == 0
     captured = capsys.readouterr()
-    combined = captured.out + captured.err
-    assert "Please use" in combined
-    assert "dlthub" in combined
-    assert "dlthub local --help" in combined
+    assert "Please use" not in captured.out
+    assert "Please use" in captured.err
+    assert "dlthub" in captured.err
+    assert "dlthub local --help" in captured.err
 
 
 def test_main_outside_workspace_no_handoff_note(


### PR DESCRIPTION
### Description

Fixes the legacy `dlt` command handoff note so it is emitted on stderr instead of stdout when a workspace is active.

The `dlt local schema --format json ... > my_schema.json` flow should keep stdout reserved for machine-readable command output. Before this change, the compatibility note was printed to stdout before the JSON payload, producing invalid redirected JSON. The note remains visible to interactive users, but no longer contaminates stdout.

### Related Issues

- Fixes #4035

### Additional Context

Validation run locally:

```text
uv run --with pytest pytest tests/workspace/cli/common/test_cli_invoke.py::test_main_in_workspace_prints_dlthub_handoff_note tests/workspace/cli/common/test_cli_invoke.py::test_main_outside_workspace_no_handoff_note -q
# 2 passed in 0.09s

uv run --with ruff ruff check dlt/_workspace/cli/_dlt.py tests/workspace/cli/common/test_cli_invoke.py
# All checks passed!

uv run --with ruff ruff format --check dlt/_workspace/cli/_dlt.py tests/workspace/cli/common/test_cli_invoke.py
# 2 files already formatted

python3 -m py_compile dlt/_workspace/cli/_dlt.py tests/workspace/cli/common/test_cli_invoke.py
# passed

git diff --check
# passed
```
