### PR TITLE
fix: emit Oracle SCD2 timestamp expressions

### DIFF
--- a/dlt/destinations/impl/sqlalchemy/dialect.py
+++ b/dlt/destinations/impl/sqlalchemy/dialect.py
@@ -216,6 +216,13 @@ class MssqlDialectCapabilities(DialectCapabilities):
 class OracleDialectCapabilities(DialectCapabilities):
     """Capabilities for Oracle."""
 
+    def adjust_capabilities(
+        self,
+        caps: DestinationCapabilitiesContext,
+        dialect: sa.engine.interfaces.Dialect,
+    ) -> None:
+        caps.format_datetime_literal = _format_oracle_datetime_literal
+
     def is_undefined_relation(self, e: Exception) -> Optional[bool]:
         msg = str(e).lower()
         # ORA-00942: table or view does not exist
@@ -228,6 +235,18 @@ def _format_mysql_datetime_literal(v: Any, precision: int = 6, no_tz: bool = Fal
     from dlt.common.data_writers.escape import format_datetime_literal
 
     return format_datetime_literal(v, precision, no_tz=True)
+
+
+def _format_oracle_datetime_literal(v: Any, precision: int = 6, no_tz: bool = False) -> str:
+    from dlt.common.data_writers.escape import format_datetime_literal
+
+    datetime = format_datetime_literal(v, precision, no_tz=no_tz).strip("'")
+    oracle_format = "YYYY-MM-DD HH24:MI:SS"
+    if precision >= 3:
+        oracle_format += f".FF{precision}"
+    if no_tz:
+        return f"TO_TIMESTAMP('{datetime}', '{oracle_format}')"
+    return f"TO_TIMESTAMP_TZ('{datetime}', '{oracle_format} TZH:TZM')"
 
 
 register_dialect_capabilities("mysql", MysqlDialectCapabilities)

--- a/dlt/destinations/impl/sqlalchemy/merge_job.py
+++ b/dlt/destinations/impl/sqlalchemy/merge_job.py
@@ -422,13 +422,13 @@ class SqlalchemyMergeFollowupJob(SqlMergeFollowupJob):
         select_cols = []
         for col in root_table_obj.columns:
             if col.name == from_:
-                select_cols.append(sa.literal(boundary_literal.strip("'")).label(from_))
+                select_cols.append(sa.literal_column(boundary_literal).label(from_))
             elif col.name == to:
                 select_cols.append(
-                    sa.literal(
-                        active_record_literal.strip("'")
+                    (
+                        sa.literal_column(active_record_literal)
                         if active_record_literal is not None
-                        else None
+                        else sa.null()
                     ).label(to)
                 )
             else:

--- a/tests/load/sqlalchemy/test_sqlalchemy_dialect.py
+++ b/tests/load/sqlalchemy/test_sqlalchemy_dialect.py
@@ -26,6 +26,7 @@ from dlt.destinations.impl.sqlalchemy.dialect import (
     MssqlDialectCapabilities,
     TrinoDialectCapabilities,
     OracleDialectCapabilities,
+    _format_oracle_datetime_literal,
     register_dialect_capabilities,
     get_dialect_capabilities,
     DIALECT_CAPS_REGISTRY,
@@ -37,6 +38,7 @@ from dlt.destinations.impl.sqlalchemy.type_mapper import (
     TrinoVariantTypeMapper,
 )
 from dlt.destinations.impl.sqlalchemy.db_api_client import SqlalchemyClient
+from dlt.destinations.impl.sqlalchemy.merge_job import SqlalchemyMergeFollowupJob
 from dlt.destinations.exceptions import DatabaseUndefinedRelation, DatabaseTerminalException
 
 from tests.load.utils import (
@@ -193,6 +195,7 @@ def test_factory_caps_oracle() -> None:
     assert caps.sqlglot_dialect == "oracle"
     assert caps.max_identifier_length == 128
     assert caps.max_column_identifier_length == 128
+    assert caps.format_datetime_literal is _format_oracle_datetime_literal
     assert isinstance(caps.dialect_capabilities, OracleDialectCapabilities)
     assert issubclass(caps.type_mapper, SqlalchemyTypeMapper)
 
@@ -209,6 +212,78 @@ def test_oracle_dialect_caps() -> None:
     assert dc.is_undefined_relation(Exception("relation does not exist")) is True
     # unrelated error returns None
     assert dc.is_undefined_relation(Exception("syntax error")) is None
+
+
+def test_oracle_scd2_sql_uses_timestamp_expression() -> None:
+    engine = sa.create_mock_engine("oracle://", executor=None)
+    metadata = sa.MetaData()
+    reports_table = sa.Table(
+        "reports",
+        metadata,
+        sa.Column("_dlt_valid_from", sa.TIMESTAMP(timezone=True)),
+        sa.Column("_dlt_valid_to", sa.TIMESTAMP(timezone=True)),
+        sa.Column("id", sa.BigInteger()),
+        sa.Column("_dlt_id", sa.String()),
+        schema="aqua_biomass",
+    )
+
+    class FakeSqlClient:
+        staging_dataset_name = "dlt_user"
+
+        def __init__(self) -> None:
+            self.engine = engine
+            self.metadata = metadata
+            self.capabilities = DestinationCapabilitiesContext.generic_capabilities()
+            OracleDialectCapabilities("oracle").adjust_capabilities(
+                self.capabilities,
+                self.engine.dialect,
+            )
+            self.capabilities.timestamp_precision = 6
+
+        def get_existing_table(self, name: str) -> sa.Table:
+            assert name == "reports"
+            return reports_table
+
+        def fully_qualified_dataset_name(self, staging: bool = False) -> str:
+            return "dlt_user" if staging else "aqua_biomass"
+
+    table_chain: list[PreparedTableSchema] = [
+        {
+            "name": "reports",
+            "columns": {
+                "_dlt_valid_from": {
+                    "name": "_dlt_valid_from",
+                    "data_type": "timestamp",
+                    "x-valid-from": True,
+                },
+                "_dlt_valid_to": {
+                    "name": "_dlt_valid_to",
+                    "data_type": "timestamp",
+                    "x-valid-to": True,
+                    "x-active-record-timestamp": None,
+                    "nullable": True,
+                },
+                "id": {
+                    "name": "id",
+                    "data_type": "bigint",
+                    "primary_key": True,
+                },
+                "_dlt_id": {
+                    "name": "_dlt_id",
+                    "data_type": "text",
+                    "x-row-version": True,
+                },
+            },
+            "x-boundary-timestamp": "2026-04-09T12:49:16.835364+00:00",
+        }
+    ]
+
+    statements = SqlalchemyMergeFollowupJob.gen_scd2_sql(table_chain, FakeSqlClient())
+    sql = "\n".join(statements)
+
+    assert "TO_TIMESTAMP_TZ(" in sql
+    assert "'TO_TIMESTAMP_TZ(" not in sql
+    assert "YYYY-MM-DD HH24:MI:SS.FF6 TZH:TZM" in sql
 
 
 def test_sqlglot_dialect_explicit_mappings() -> None:
@@ -602,7 +677,8 @@ def test_type_mapper_param_overrides_dialect_caps(
             return CustomJsonStr(length=256)
 
     dest_ = dlt.destinations.sqlalchemy(
-        credentials=destination_config.credentials, type_mapper=DirectMapper  # type: ignore[arg-type]
+        credentials=destination_config.credentials,
+        type_mapper=DirectMapper,  # type: ignore[arg-type]
     )
     pipeline = destination_config.setup_pipeline(
         "test_type_mapper_override", destination=dest_, dev_mode=True


### PR DESCRIPTION
Fixes #3846

## What changed
- Add an Oracle-specific datetime literal formatter for the SQLAlchemy destination so timestamp literals are emitted as `TO_TIMESTAMP_TZ(...)` / `TO_TIMESTAMP(...)` expressions.
- Preserve formatted timestamp expressions in the SCD2 `INSERT ... SELECT` path with `sa.literal_column(...)` instead of turning them back into quoted string literals.
- Add a regression test covering Oracle SCD2 SQL generation with a boundary timestamp.

## Root cause
The SQLAlchemy SCD2 merge path used the generic quoted datetime literal for Oracle, producing SQL such as `'2026-04-09 12:49:16.835364+00:00'`. In the insert-select half of the SCD2 flow, the generated boundary value was also wrapped with `sa.literal(...)`, which would quote any backend-specific expression.

## Validation
- `uv run --with sqlalchemy pytest tests/load/sqlalchemy/test_sqlalchemy_dialect.py::test_oracle_scd2_sql_uses_timestamp_expression tests/load/sqlalchemy/test_sqlalchemy_dialect.py::test_oracle_dialect_caps -q` -> `2 passed`
- `uv run --with ruff ruff check dlt/destinations/impl/sqlalchemy/dialect.py dlt/destinations/impl/sqlalchemy/merge_job.py tests/load/sqlalchemy/test_sqlalchemy_dialect.py` -> passed
- `uv run --with ruff ruff format --check dlt/destinations/impl/sqlalchemy/dialect.py dlt/destinations/impl/sqlalchemy/merge_job.py tests/load/sqlalchemy/test_sqlalchemy_dialect.py` -> passed
- `git diff --check` -> passed

I also tried the full `tests/load/sqlalchemy/test_sqlalchemy_dialect.py` file with `sqlalchemy`, `pymysql`, `psycopg`, and `pyodbc` installed. It reached `25 passed, 1 skipped`, then failed on local environment dependencies/services: missing unixODBC dylib for pyodbc, missing `psycopg2` for the default PostgreSQL URL, and no local MySQL server on `127.0.0.1:3306`.

AI assistance was used to prepare this patch.