### PR TITLE
fix: make Snowflake schema creation idempotent

### DIFF
--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -180,6 +180,7 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
     # use naming convention in the schema
     naming_convention: TNamingConventionReferenceArg = None
     alter_add_multi_column: bool = True
+    supports_create_schema_if_not_exists: bool = False
     supports_create_table_if_not_exists: bool = True
     supports_truncate_command: bool = True
     schema_supports_numeric_precision: bool = True

--- a/dlt/destinations/impl/snowflake/factory.py
+++ b/dlt/destinations/impl/snowflake/factory.py
@@ -145,6 +145,7 @@ class snowflake(Destination[SnowflakeClientConfiguration, "SnowflakeClient"]):
         caps.is_max_text_data_type_length_in_bytes = True
         caps.supports_ddl_transactions = True
         caps.alter_add_multi_column = True
+        caps.supports_create_schema_if_not_exists = True
         caps.supports_clone_table = True
         caps.supported_merge_strategies = ["delete-insert", "upsert", "scd2", "insert-only"]
         caps.supported_replace_strategies = [

--- a/dlt/destinations/impl/snowflake/sql_client.py
+++ b/dlt/destinations/impl/snowflake/sql_client.py
@@ -117,6 +117,9 @@ class SnowflakeSqlClient(SqlClientBase[snowflake_lib.SnowflakeConnection], DBTra
     def native_connection(self) -> "snowflake_lib.SnowflakeConnection":
         return self._conn
 
+    def create_dataset(self) -> None:
+        self.execute_sql("CREATE SCHEMA IF NOT EXISTS %s" % self.fully_qualified_dataset_name())
+
     def drop_tables(self, *tables: str) -> None:
         # Tables are drop with `IF EXISTS`, but snowflake raises when the schema doesn't exist.
         # Multi statement exec is safe and the error can be ignored since all tables are in the same schema.

--- a/dlt/destinations/impl/snowflake/sql_client.py
+++ b/dlt/destinations/impl/snowflake/sql_client.py
@@ -117,9 +117,6 @@ class SnowflakeSqlClient(SqlClientBase[snowflake_lib.SnowflakeConnection], DBTra
     def native_connection(self) -> "snowflake_lib.SnowflakeConnection":
         return self._conn
 
-    def create_dataset(self) -> None:
-        self.execute_sql("CREATE SCHEMA IF NOT EXISTS %s" % self.fully_qualified_dataset_name())
-
     def drop_tables(self, *tables: str) -> None:
         # Tables are drop with `IF EXISTS`, but snowflake raises when the schema doesn't exist.
         # Multi statement exec is safe and the error can be ignored since all tables are in the same schema.

--- a/dlt/destinations/sql_client.py
+++ b/dlt/destinations/sql_client.py
@@ -133,7 +133,12 @@ SELECT 1
         return len(rows) > 0
 
     def create_dataset(self) -> None:
-        self.execute_sql("CREATE SCHEMA %s" % self.fully_qualified_dataset_name())
+        not_exists_clause = (
+            " IF NOT EXISTS" if self.capabilities.supports_create_schema_if_not_exists else ""
+        )
+        self.execute_sql(
+            "CREATE SCHEMA%s %s" % (not_exists_clause, self.fully_qualified_dataset_name())
+        )
 
     def drop_dataset(self) -> None:
         # assert self.fully_qualified_dataset_name() != "None"

--- a/tests/load/snowflake/test_snowflake_table_builder.py
+++ b/tests/load/snowflake/test_snowflake_table_builder.py
@@ -21,6 +21,7 @@ from dlt.destinations.impl.snowflake.configuration import (
     SnowflakeClientConfiguration,
     SnowflakeCredentials,
 )
+from dlt.destinations.impl.snowflake.sql_client import SnowflakeSqlClient
 
 from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.schema.typing import TColumnSchema
@@ -55,6 +56,31 @@ def create_client(schema: Schema, use_decfloat: bool = False) -> SnowflakeClient
             credentials=creds, use_decfloat=use_decfloat
         )._bind_dataset_name(dataset_name="test_" + uniq_id()),
     )
+
+
+def test_create_dataset_uses_idempotent_schema_sql(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    credentials = SnowflakeCredentials()
+    credentials.database = "test_db"
+    sql_client = SnowflakeSqlClient(
+        "test_dataset",
+        "test_dataset_staging",
+        credentials,
+        snowflake().capabilities(),
+    )
+    executed_sql: list[str] = []
+
+    def capture_sql(sql: str, *args: object, **kwargs: object) -> None:
+        executed_sql.append(sql)
+
+    monkeypatch.setattr(sql_client, "execute_sql", capture_sql)
+
+    sql_client.create_dataset()
+
+    assert executed_sql == [
+        "CREATE SCHEMA IF NOT EXISTS %s" % sql_client.fully_qualified_dataset_name()
+    ]
 
 
 def test_create_table(snowflake_client: SnowflakeClient) -> None:

--- a/tests/load/test_sql_client.py
+++ b/tests/load/test_sql_client.py
@@ -1,11 +1,13 @@
 import os
 import pytest
 import datetime  # noqa: I251
-from typing import Iterator, Any, Tuple, Type, Union
+from contextlib import contextmanager
+from typing import ContextManager, Iterator, Any, Optional, Sequence, Tuple, Type, Union
 from threading import Thread, Event
 from time import sleep
 
 from dlt.common import pendulum, Decimal
+from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.destination.exceptions import IdentifierTooLongException
 from dlt.common.schema.typing import LOADS_TABLE_NAME
 from dlt.common.storages import FileStorage
@@ -40,9 +42,59 @@ TEST_NAMING_CONVENTIONS = (
 )
 
 
+class RecordingSqlClient(SqlClientBase[Any]):
+    def __init__(self, capabilities: DestinationCapabilitiesContext) -> None:
+        super().__init__(None, "dataset", "dataset_staging", capabilities)
+        self.statements: list[str] = []
+
+    def open_connection(self) -> None:
+        return None
+
+    def close_connection(self) -> None:
+        return None
+
+    @contextmanager
+    def begin_transaction(self) -> Iterator[None]:
+        yield None
+
+    @property
+    def native_connection(self) -> None:
+        return None
+
+    def execute_sql(self, sql: str, *args: Any, **kwargs: Any) -> Optional[Sequence[Sequence[Any]]]:
+        self.statements.append(sql)
+        return None
+
+    def execute_query(self, query: str, *args: Any, **kwargs: Any) -> ContextManager[DBApiCursor]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _make_database_exception(ex: Exception) -> Exception:
+        return ex
+
+
 @pytest.fixture
 def file_storage() -> FileStorage:
     return FileStorage(get_test_storage_root(), file_type="b", makedirs=True)
+
+
+@pytest.mark.parametrize(
+    ("supports_create_schema_if_not_exists", "expected_sql"),
+    [
+        (False, "CREATE SCHEMA dataset"),
+        (True, "CREATE SCHEMA IF NOT EXISTS dataset"),
+    ],
+)
+def test_create_dataset_uses_schema_idempotency_capability(
+    supports_create_schema_if_not_exists: bool, expected_sql: str
+) -> None:
+    capabilities = DestinationCapabilitiesContext.generic_capabilities()
+    capabilities.supports_create_schema_if_not_exists = supports_create_schema_if_not_exists
+    sql_client = RecordingSqlClient(capabilities)
+
+    sql_client.create_dataset()
+
+    assert sql_client.statements == [expected_sql]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Snowflake dataset creation now uses `CREATE SCHEMA IF NOT EXISTS` instead of plain `CREATE SCHEMA`. This removes the race where two concurrent workers both pass the existence check and one fails because the other created the schema first.

The change is scoped to `SnowflakeSqlClient`; the generic SQL client behavior remains unchanged for other destinations.

### Related Issues

- Fixes #3891

### Additional Context

Validation run locally:

```text
env ACTIVE_DESTINATIONS='["snowflake"]' uv run --extra snowflake pytest tests/load/snowflake/test_snowflake_table_builder.py::test_create_dataset_uses_idempotent_schema_sql -q
# 1 passed in 0.16s

uv run ruff check dlt/destinations/impl/snowflake/sql_client.py tests/load/snowflake/test_snowflake_table_builder.py
# All checks passed!

uv run ruff format --check dlt/destinations/impl/snowflake/sql_client.py tests/load/snowflake/test_snowflake_table_builder.py
# 2 files already formatted

python3 -m py_compile dlt/destinations/impl/snowflake/sql_client.py tests/load/snowflake/test_snowflake_table_builder.py
```
