### PR TITLE
fix: guard source resource lookup before init

### DIFF
--- a/dlt/extract/source.py
+++ b/dlt/extract/source.py
@@ -611,7 +611,9 @@ class DltSource(Iterable[TDataItem]):
             Container().injectable_context(source_context),
             Container().injectable_context(schema_context),
         ):
-            pipe_iterator: ManagedPipeIterator = ManagedPipeIterator.from_pipes(self._resources.selected_pipes)  # type: ignore
+            pipe_iterator: ManagedPipeIterator = ManagedPipeIterator.from_pipes(
+                self._resources.selected_pipes
+            )  # type: ignore
         pipe_iterator.set_context([section_context, state_context, schema_context, source_context])
         _iter = map(lambda item: item.item, pipe_iterator)
         return flatten_list_or_items(_iter)
@@ -629,10 +631,13 @@ class DltSource(Iterable[TDataItem]):
         # do not intercept dunder attributes (needed for copy/pickle/deepcopy)
         if resource_name.startswith("__") and resource_name.endswith("__"):
             raise AttributeError(resource_name)
+        resources = self.__dict__.get("_resources")
+        if resources is None:
+            raise AttributeError(resource_name)
         try:
-            return self._resources[resource_name]
+            return resources[resource_name]
         except KeyError:
-            all_resources = ", ".join(self._resources.keys())
+            all_resources = ", ".join(resources.keys())
             raise AttributeError(
                 f"Resource `{resource_name}` not found in source `{self.name}`. Available"
                 f" resources: {all_resources}"

--- a/tests/extract/test_sources.py
+++ b/tests/extract/test_sources.py
@@ -539,6 +539,16 @@ def test_select_resources() -> None:
     assert list(s.with_resources()) == []
 
 
+def test_source_getattr_without_resources_raises_attribute_error() -> None:
+    source = DltSource.__new__(DltSource)
+
+    with pytest.raises(AttributeError, match="anything"):
+        source.anything
+
+    with pytest.raises(AttributeError, match="_resources"):
+        source._resources
+
+
 def test_clone_source() -> None:
     @dlt.source
     def test_source(no_resources):


### PR DESCRIPTION
Fixes #4107.

## What changed
- Make `DltSource.__getattr__` read `_resources` directly from `__dict__` before attempting resource-name lookup.
- Raise `AttributeError` cleanly when `_resources` is missing, which can happen for partially initialized / restored objects.
- Add a regression test for a `DltSource.__new__(DltSource)` instance accessing both a normal missing attribute and `_resources` itself.

## Why
`__getattr__` previously accessed `self._resources` while handling a missing attribute. If `_resources` was not present yet, that lookup recursively called `__getattr__("_resources")` until Python raised `RecursionError`.

The new guard avoids re-entering the attribute machinery and preserves the existing resource lookup behavior once `_resources` exists.

## Validation
- Reproduced on current `origin/devel` before the fix: `DltSource.__new__(DltSource).anything` raised `RecursionError`.
- `uv run pytest tests/extract/test_sources.py::test_source_getattr_without_resources_raises_attribute_error tests/extract/test_sources.py::test_select_resources tests/extract/test_sources.py::test_clone_source -q` -> `3 passed`
- `uv run ruff check dlt/extract/source.py tests/extract/test_sources.py` -> `All checks passed!`
- `uv run ruff format --check dlt/extract/source.py tests/extract/test_sources.py` -> `2 files already formatted`
- `git diff --check` -> clean