### PR TITLE
fix(mssql): map varchar to text type

### DIFF
--- a/dlt/destinations/impl/mssql/factory.py
+++ b/dlt/destinations/impl/mssql/factory.py
@@ -42,6 +42,7 @@ class MsSqlTypeMapper(TypeMapperImpl):
 
     dbt_to_sct = {
         "nvarchar": "text",
+        "varchar": "text",
         "float": "double",
         "bit": "bool",
         "datetimeoffset": "timestamp",

--- a/tests/load/mssql/test_type_mapper.py
+++ b/tests/load/mssql/test_type_mapper.py
@@ -1,0 +1,9 @@
+from dlt.destinations import mssql
+
+
+def test_from_destination_type_mssql_text_types() -> None:
+    caps = mssql().capabilities()
+    mapper = caps.get_type_mapper()
+
+    assert mapper.from_destination_type("nvarchar", None, None) == {"data_type": "text"}
+    assert mapper.from_destination_type("varchar", None, None) == {"data_type": "text"}


### PR DESCRIPTION
### Description

This PR adds MSSQL `varchar` to the destination-to-schema type mapping so that `varchar` columns are recognized as dlt `text` columns, matching the existing `nvarchar` behavior.

Changes:
- Added `varchar -> text` to `MsSqlTypeMapper.dbt_to_sct`.
- Added a focused regression test for MSSQL text type mapping from destination types.

### Related Issues

- Closes #4100

### Additional Context

Validated with:

```bash
pytest tests/load/mssql/test_type_mapper.py