### PR TITLE
fix: include pandas in filesystem extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ ducklake = [
 filesystem = [
     "s3fs>=2022.4.0",
     "botocore>=1.28",
+    "pandas>=2.3.0,<3",
 ]
 s3 = [
     "s3fs>=2022.4.0",

--- a/tests/workspace/cli/test_init_command.py
+++ b/tests/workspace/cli/test_init_command.py
@@ -4,9 +4,11 @@ from copy import deepcopy
 import hashlib
 import os
 import contextlib
+from pathlib import Path
 from subprocess import CalledProcessError
 from typing import List, Tuple, Optional
 import pytest
+import tomlkit
 from pytest_console_scripts import ScriptRunner
 from unittest import mock
 from pytest import MonkeyPatch
@@ -259,6 +261,13 @@ def test_init_command_core_source_requirements_with_extras(
     )
     canonical_name = source_name.replace("_", "-")
     assert canonical_name in source_requirements.dlt_requirement.extras
+
+
+def test_filesystem_extra_installs_read_csv_dependency() -> None:
+    pyproject = tomlkit.parse(Path(__file__).parents[3].joinpath("pyproject.toml").read_text())
+    filesystem_deps = pyproject["project"]["optional-dependencies"]["filesystem"]
+
+    assert any(Requirement(dep).name == "pandas" for dep in filesystem_deps)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add pandas to the `filesystem` optional extra so `dlt[filesystem]` installs the dependency used by `dlt.sources.filesystem.read_csv`
- add a CLI init regression test that keeps the filesystem extra aligned with the generated filesystem pipeline examples

## Why
`dlt init filesystem postgres` generates requirements that rely on the `filesystem` extra, but the filesystem example calls `read_csv()`, whose implementation imports pandas directly. Without pandas in the extra, users can install the generated requirements and still hit a missing dependency when running the example.

Fixes #3876.

## Validation
- `uv run --extra hub pytest tests/workspace/cli/test_init_command.py::test_filesystem_extra_installs_read_csv_dependency tests/workspace/cli/test_init_command.py::test_init_command_core_source_requirements_with_extras -q` -> 3 passed
- `uv run --extra filesystem python - <<'PY' ...` confirmed editable metadata exposes `pandas<3,>=2.3.0; extra == 'filesystem'`
- `uv run python tools/check_dependency_changes.py origin/devel HEAD` reports the intended optional dependency addition: `[filesystem]: + pandas<3,>=2.3.0`
