### PR TITLE
feat(bigquery): implement atomic replace via GCS-staged WRITE_TRUNCATE_DATA

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/get_docs_changes.yml
+++ b/.github/workflows/get_docs_changes.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
 
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test_common.yml
+++ b/.github/workflows/test_common.yml
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test_destinations_local.yml
+++ b/.github/workflows/test_destinations_local.yml
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       #
       # Start required services

--- a/.github/workflows/test_destinations_remote.yml
+++ b/.github/workflows/test_destinations_remote.yml
@@ -223,9 +223,12 @@ jobs:
     steps:
 
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+          # fork code runs by design, gated by per-run `fork-ci` environment approval
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -237,7 +240,8 @@ jobs:
         with:
           python-version: "3.11"
           activate-environment: true
-          enable-cache: true
+          # fork runs (pull_request_target) must not write the default-branch cache scope
+          enable-cache: ${{ github.event_name != 'pull_request_target' }}
 
       - name: Run pre install commands
         run: ${{ matrix.pre_install_commands }}
@@ -281,9 +285,12 @@ jobs:
     steps:
 
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+          # fork code runs by design, gated by per-run `fork-ci` environment approval
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -295,7 +302,8 @@ jobs:
         with:
           python-version: "3.11"
           activate-environment: true
-          enable-cache: true
+          # fork runs (pull_request_target) must not write the default-branch cache scope
+          enable-cache: ${{ github.event_name != 'pull_request_target' }}
 
       - name: Install dependencies
         # google-api-python-client for google secrets, botocore (s3 extra) for aws secrets manager

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
 
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/.github/workflows/test_hub.yml
+++ b/.github/workflows/test_hub.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test_sources_local.yml
+++ b/.github/workflows/test_sources_local.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Start postgres
         run: docker compose -f "tests/load/sources/sql_database/docker-compose.yml" up -d --wait postgres

--- a/.github/workflows/test_tools_airflow.yml
+++ b/.github/workflows/test_tools_airflow.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test_tools_build_images.yml
+++ b/.github/workflows/test_tools_build_images.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test_tools_dashboard.yml
+++ b/.github/workflows/test_tools_dashboard.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test_tools_dbt_cloud.yml
+++ b/.github/workflows/test_tools_dbt_cloud.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 

--- a/.github/workflows/test_tools_dbt_runner.yml
+++ b/.github/workflows/test_tools_dbt_runner.yml
@@ -29,9 +29,12 @@ jobs:
     steps:
 
       - name: Check out
-        uses: actions/checkout@master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+          # fork code runs by design, gated by per-run `fork-ci` environment approval
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -43,7 +46,8 @@ jobs:
         with:
           python-version: "3.11"
           activate-environment: true
-          enable-cache: true
+          # fork runs (pull_request_target) must not write the default-branch cache scope
+          enable-cache: ${{ github.event_name != 'pull_request_target' }}
 
       - name: Install dependencies
         # install dlt with postgres support

--- a/dlt/destinations/impl/bigquery/bigquery.py
+++ b/dlt/destinations/impl/bigquery/bigquery.py
@@ -1,6 +1,8 @@
 import os
+import warnings
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, cast
+from urllib.parse import urlparse
 
 import google.cloud.bigquery as bigquery  # noqa: I250
 from google.api_core import exceptions as api_core_exceptions
@@ -22,7 +24,7 @@ from dlt.common.runtime.signals import sleep
 from dlt.common.schema import TColumnSchema, Schema, TTableSchemaColumns
 from dlt.common.schema.typing import TColumnType
 from dlt.common.schema.utils import get_inherited_table_hint, get_columns_names_with_prop
-from dlt.common.storages.load_package import destination_state
+from dlt.common.storages.load_package import destination_state, LoadJobInfo
 from dlt.common.storages.load_storage import ParsedLoadJobFileName
 from dlt.common.typing import DictStrAny
 from dlt.common.data_writers.escape import escape_bigquery_literal
@@ -50,13 +52,25 @@ from dlt.destinations.impl.bigquery.configuration import BigQueryClientConfigura
 from dlt.destinations.impl.bigquery.warnings import per_column_cluster_hint_deprecated
 from dlt.destinations.impl.bigquery.sql_client import BigQuerySqlClient, BQ_TERMINAL_REASONS
 from dlt.destinations.job_client_impl import SqlJobClientWithStagingDataset
-from dlt.destinations.job_impl import DestinationJsonlLoadJob, DestinationParquetLoadJob
-from dlt.destinations.job_impl import ReferenceFollowupJobRequest
+from dlt.destinations.job_impl import (
+    DestinationJsonlLoadJob,
+    DestinationParquetLoadJob,
+    FinalizedLoadJobWithFollowupJobs,
+    ReferenceFollowupJobRequest,
+)
 from dlt.destinations.sql_jobs import SqlMergeFollowupJob
 from dlt.destinations.sql_client import SqlClientBase
 
 
-class BigQueryLoadJob(RunnableLoadJob, HasFollowupJobs):
+# file_id prefix marking the single aggregated reference job that atomic replace loads with
+# WRITE_TRUNCATE_DATA. The uniq suffix keeps the derived BigQuery job id unique per run.
+ATOMIC_REPLACE_FILE_ID_PREFIX = "atomic_"
+GCS_SCHEMES = ("gs", "gcs")
+
+
+class _BigQueryLoadJobBase(RunnableLoadJob):
+    """BigQuery load job polling logic shared by per-file and aggregated atomic replace jobs."""
+
     def __init__(
         self,
         file_path: str,
@@ -147,6 +161,15 @@ class BigQueryLoadJob(RunnableLoadJob, HasFollowupJobs):
         return Path(file_path).name.replace(".", "_")
 
 
+class BigQueryLoadJob(_BigQueryLoadJobBase, HasFollowupJobs):
+    """Per-file load job. Completing it triggers the table-chain followup hook."""
+
+
+class BigQueryAtomicReplaceLoadJob(_BigQueryLoadJobBase):
+    """Aggregated atomic replace job. Not `HasFollowupJobs` so completing it never re-fires the
+    table-chain hook."""
+
+
 class BigQueryMergeJob(SqlMergeFollowupJob):
     @classmethod
     def _gen_table_setup_clauses(
@@ -207,6 +230,84 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
     ) -> List[FollowupJobRequest]:
         return [BigQueryMergeJob.from_table_chain(table_chain, self.sql_client)]
 
+    def _use_atomic_replace(self, table: PreparedTableSchema) -> bool:
+        """Whether `table` is replaced with a single atomic WRITE_TRUNCATE_DATA load job.
+
+        The replace-strategy conflict is validated once in `BigQueryClientConfiguration.on_resolved`;
+        the GCS staging precondition is checked here because staging is only injected on the load
+        client, not on every config resolution."""
+        return (
+            self.config.enable_atomic_replace
+            and table["write_disposition"] == "replace"
+            and table.get("x-replace-strategy") == "truncate-and-insert"
+            and self._has_gcs_staging()
+        )
+
+    def _has_gcs_staging(self) -> bool:
+        staging = self.config.staging_config
+        return bool(staging and staging.bucket_url) and (
+            urlparse(staging.bucket_url).scheme in GCS_SCHEMES
+        )
+
+    def should_truncate_table_before_load(self, table_name: str) -> bool:
+        table = self.prepare_load_table(table_name)
+        if (
+            table["write_disposition"] == "replace"
+            and table.get("x-replace-strategy") == "truncate-and-insert"
+        ):
+            if self._use_atomic_replace(table):
+                # atomic replace truncates inside the load job, so skip the upfront truncate
+                return False
+            if self.config.enable_atomic_replace:
+                # flag on for a truncate-and-insert table but atomic did not engage: no GCS staging
+                warnings.warn(
+                    "BigQuery atomic replace (enable_atomic_replace) requires a Google Cloud"
+                    " Storage staging destination; none is configured. Falling back to the standard"
+                    " truncate-and-insert replace.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            return True
+        return False
+
+    def create_table_chain_completed_followup_jobs(
+        self,
+        table_chain: Sequence[PreparedTableSchema],
+        completed_table_chain_jobs: Optional[Sequence[LoadJobInfo]] = None,
+    ) -> List[FollowupJobRequest]:
+        root_table = table_chain[0]
+        if root_table["write_disposition"] == "replace" and self._use_atomic_replace(root_table):
+            return self._create_atomic_replace_followup_jobs(
+                table_chain, completed_table_chain_jobs or []
+            )
+        return super().create_table_chain_completed_followup_jobs(
+            table_chain, completed_table_chain_jobs
+        )
+
+    def _create_atomic_replace_followup_jobs(
+        self,
+        table_chain: Sequence[PreparedTableSchema],
+        completed_table_chain_jobs: Sequence[LoadJobInfo],
+    ) -> List[FollowupJobRequest]:
+        """Emits one WRITE_TRUNCATE_DATA reference job per chain table. A table with staged files
+        is replaced by them; a table that received no data is truncated by a zero-row load."""
+        jobs: List[FollowupJobRequest] = []
+        for table in table_chain:
+            # collect the per-file reference job paths; they are resolved at execution time when
+            # all jobs have moved to completed_jobs (like the filesystem delta/iceberg jobs do).
+            # an empty list still yields a job that truncates the table.
+            reference_paths = [
+                job.file_path
+                for job in completed_table_chain_jobs
+                if job.job_file_info.table_name == table["name"]
+                and job.job_file_info.file_format == "reference"
+            ]
+            file_id = f"{ATOMIC_REPLACE_FILE_ID_PREFIX}{ParsedLoadJobFileName.new_file_id()}"
+            jobs.append(
+                ReferenceFollowupJobRequest(f"{table['name']}.{file_id}.0.jsonl", reference_paths)
+            )
+        return jobs
+
     def initialize_storage(self, truncate_tables: Iterable[str] = None) -> None:
         truncate_tables = truncate_tables or []
 
@@ -226,6 +327,16 @@ class BigQueryClient(SqlJobClientWithStagingDataset, SupportsStagingDestination)
         job = super().create_load_job(table, file_path, load_id)
 
         if not job:
+            if ReferenceFollowupJobRequest.is_reference_job(file_path):
+                parsed = ParsedLoadJobFileName.parse(file_path)
+                if parsed.file_id.startswith(ATOMIC_REPLACE_FILE_ID_PREFIX):
+                    return BigQueryAtomicReplaceLoadJob(
+                        file_path, self.config.http_timeout, self.config.retry_deadline
+                    )
+                if self._use_atomic_replace(table):
+                    # per-file reference is a no-op that drives the chain to its aggregated job
+                    return FinalizedLoadJobWithFollowupJobs.from_file_path(file_path)
+
             insert_api = table.get("x-insert-api", "default")
             if insert_api == "streaming":
                 if table["write_disposition"] != "append":
@@ -488,12 +599,28 @@ SELECT {",".join(self._get_storage_table_query_columns())}
         # append to table for merge loads (append to stage) and regular appends.
         table_name = table["name"]
 
-        # determine whether we load from local or url
-        bucket_path = None
+        # a reference job loads one or more staged urls; a local file is uploaded directly
+        source_uris: Optional[List[str]] = None
+        is_atomic_replace = False
+        # literal string keeps the google-cloud-bigquery floor (enum added in 3.32)
+        write_disposition: str = bigquery.WriteDisposition.WRITE_APPEND
         ext: str = os.path.splitext(file_path)[1][1:]
         if ReferenceFollowupJobRequest.is_reference_job(file_path):
-            bucket_path = ReferenceFollowupJobRequest.resolve_reference(file_path)
-            ext = os.path.splitext(bucket_path)[1][1:]
+            if ParsedLoadJobFileName.parse(file_path).file_id.startswith(
+                ATOMIC_REPLACE_FILE_ID_PREFIX
+            ):
+                is_atomic_replace = True
+                write_disposition = "WRITE_TRUNCATE_DATA"
+                # the aggregated job references the per-file reference jobs; resolve each to its url
+                source_uris = [
+                    ReferenceFollowupJobRequest.resolve_reference(reference_path)
+                    for reference_path in ReferenceFollowupJobRequest.resolve_references(file_path)
+                    if reference_path
+                ]
+            else:
+                source_uris = [ReferenceFollowupJobRequest.resolve_reference(file_path)]
+            if source_uris:
+                ext = os.path.splitext(source_uris[0])[1][1:]
 
         # Select a correct source format
         source_format = bigquery.SourceFormat.NEWLINE_DELIMITED_JSON
@@ -506,7 +633,7 @@ SELECT {",".join(self._get_storage_table_query_columns())}
         job_id = BigQueryLoadJob.get_job_id_from_file_path(file_path)
         job_config = bigquery.LoadJobConfig(
             autodetect=False,
-            write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
+            write_disposition=write_disposition,
             create_disposition=bigquery.CreateDisposition.CREATE_NEVER,
             source_format=source_format,
             decimal_target_types=decimal_target_types,
@@ -517,10 +644,21 @@ SELECT {",".join(self._get_storage_table_query_columns())}
             # Allow BigQuery to infer and evolve the schema, note that dlt is not creating such tables at all.
             job_config = self._set_user_hints_with_schema_autodetection(table, job_config)
 
-        if bucket_path:
+        qualified_table_name = self.sql_client.make_qualified_table_name(table_name, quote=False)
+        if source_uris:
             return self.sql_client.native_connection.load_table_from_uri(
-                bucket_path,
-                self.sql_client.make_qualified_table_name(table_name, quote=False),
+                source_uris,
+                qualified_table_name,
+                job_id=job_id,
+                job_config=job_config,
+                timeout=self.config.file_upload_timeout,
+            )
+
+        if is_atomic_replace:
+            # no staged files: truncate the table with a zero-row load, preserving schema+metadata
+            return self.sql_client.native_connection.load_table_from_json(
+                [],
+                qualified_table_name,
                 job_id=job_id,
                 job_config=job_config,
                 timeout=self.config.file_upload_timeout,
@@ -529,7 +667,7 @@ SELECT {",".join(self._get_storage_table_query_columns())}
         with open(file_path, "rb") as f:
             return self.sql_client.native_connection.load_table_from_file(
                 f,
-                self.sql_client.make_qualified_table_name(table_name, quote=False),
+                qualified_table_name,
                 job_id=job_id,
                 job_config=job_config,
                 timeout=self.config.file_upload_timeout,

--- a/dlt/destinations/impl/bigquery/configuration.py
+++ b/dlt/destinations/impl/bigquery/configuration.py
@@ -32,7 +32,7 @@ class BigQueryClientConfiguration(DestinationClientDwhWithStagingConfiguration):
     """Allow BigQuery to autodetect schemas and create data tables"""
     ignore_unknown_values: bool = False
     """Ignore unknown values in the data"""
-    enable_atomic_replace: bool = True
+    enable_atomic_replace: bool = False
     """Replace `truncate-and-insert` tables with a single metadata-preserving WRITE_TRUNCATE_DATA
     load job. Requires a GCS filesystem staging destination."""
 

--- a/dlt/destinations/impl/bigquery/configuration.py
+++ b/dlt/destinations/impl/bigquery/configuration.py
@@ -1,4 +1,5 @@
 import dataclasses
+import warnings
 from typing import ClassVar, Final, List, Optional, Union
 
 from dlt.common.configuration import configspec
@@ -31,8 +32,26 @@ class BigQueryClientConfiguration(DestinationClientDwhWithStagingConfiguration):
     """Allow BigQuery to autodetect schemas and create data tables"""
     ignore_unknown_values: bool = False
     """Ignore unknown values in the data"""
+    enable_atomic_replace: bool = True
+    """Replace `truncate-and-insert` tables with a single metadata-preserving WRITE_TRUNCATE_DATA
+    load job. Requires a GCS filesystem staging destination."""
 
     __config_gen_annotations__: ClassVar[List[str]] = ["location"]
+
+    def on_resolved(self) -> None:
+        if (
+            self.enable_atomic_replace
+            and self.replace_strategy is not None
+            and self.replace_strategy != "truncate-and-insert"
+        ):
+            warnings.warn(
+                "BigQuery atomic replace (enable_atomic_replace) requires the 'truncate-and-insert'"
+                f" replace strategy but 'replace_strategy' is set to '{self.replace_strategy}'."
+                " Disabling atomic replace.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.enable_atomic_replace = False
 
     def get_location(self) -> str:
         return self.location

--- a/dlt/destinations/impl/bigquery/factory.py
+++ b/dlt/destinations/impl/bigquery/factory.py
@@ -175,6 +175,7 @@ class bigquery(Destination[BigQueryClientConfiguration, "BigQueryClient"]):
         credentials: GcpServiceAccountCredentials = None,
         location: str = None,
         has_case_sensitive_identifiers: bool = None,
+        enable_atomic_replace: bool = None,
         destination_name: str = None,
         environment: str = None,
         **kwargs: Any,
@@ -188,6 +189,7 @@ class bigquery(Destination[BigQueryClientConfiguration, "BigQueryClient"]):
                 a dict or string with service accounts credentials as used in the Google Cloud
             location (str, optional): A location where the datasets will be created, eg. "EU". The default is "US"
             has_case_sensitive_identifiers (bool, optional): Is the dataset case-sensitive, defaults to True
+            enable_atomic_replace (bool, optional): Replace `truncate-and-insert` tables with a single metadata-preserving WRITE_TRUNCATE_DATA load job. Requires a GCS staging destination.
             destination_name (str, optional): Name of the destination, can be used in config section to differentiate between multiple of the same type
             environment (str, optional): Environment of the destination
             **kwargs (Any): Additional arguments passed to the destination config
@@ -196,6 +198,7 @@ class bigquery(Destination[BigQueryClientConfiguration, "BigQueryClient"]):
             credentials=credentials,
             location=location,
             has_case_sensitive_identifiers=has_case_sensitive_identifiers,
+            enable_atomic_replace=enable_atomic_replace,
             destination_name=destination_name,
             environment=environment,
             **kwargs,

--- a/docs/website/docs/dlt-ecosystem/destinations/bigquery.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/bigquery.md
@@ -123,6 +123,35 @@ All write dispositions are supported.
 
 If you set the [`replace` strategy](../../general-usage/full-loading.md) to `staging-optimized`, the destination tables will be dropped and recreated with a [clone command](https://cloud.google.com/bigquery/docs/table-clones-create) from the staging tables.
 
+### Atomic, metadata-preserving replace
+
+`staging-optimized` drops and recreates the table, which loses table-level access controls, column policy tags, primary key constraints, row access policies, and breaks dependent materialized views. If you need a full refresh that keeps all of this, enable `enable_atomic_replace`:
+
+```toml
+[destination.bigquery]
+enable_atomic_replace = true
+```
+
+When enabled, the `truncate-and-insert` replace strategy loads a table's staged files with a single BigQuery load job using `write_disposition=WRITE_TRUNCATE_DATA`. This replaces the data **in place**: the table object is kept, so its schema, descriptions, labels, column policy tags, primary key constraints, and row access policies survive the refresh, dependent materialized views keep working, and there is no empty-table window (the truncate and load are atomic).
+
+Requirements and behavior:
+
+- Requires a [Google Cloud Storage staging destination](#staging-support) (`gs://` bucket). With no staging, or a non-GCS staging bucket, `dlt` logs a warning and falls back to the regular `truncate-and-insert` (which briefly empties the table).
+- Active only when the replace strategy is `truncate-and-insert` (the default). Other strategies are unaffected.
+- Atomicity is **per table**: every table in a nested chain is replaced by its own atomic load job, not the whole chain as a single transaction.
+
+You can also enable it in code:
+
+```py
+import dlt
+
+pipeline = dlt.pipeline(
+    "bq_pipeline",
+    destination=dlt.destinations.bigquery(enable_atomic_replace=True),
+    staging="filesystem",
+)
+```
+
 ## Data loading
 
 `dlt` uses `BigQuery` load jobs that send files from the local filesystem or GCS buckets.

--- a/tests/load/bigquery/test_bigquery_atomic_replace.py
+++ b/tests/load/bigquery/test_bigquery_atomic_replace.py
@@ -1,0 +1,278 @@
+"""Unit tests for BigQuery atomic replace (enable_atomic_replace / WRITE_TRUNCATE_DATA).
+
+These exercise the routing and followup-creation logic without a live BigQuery connection.
+End-to-end replacement and metadata survival are covered in tests/load/pipeline and the live
+BigQuery tests.
+"""
+import os
+import warnings
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from dlt.common import pendulum
+from dlt.common.configuration.specs import GcpServiceAccountCredentials
+from dlt.common.destination.client import (
+    DestinationClientStagingConfiguration,
+    HasFollowupJobs,
+    PreparedTableSchema,
+)
+from dlt.common.schema import Schema
+from dlt.common.storages.load_package import LoadJobInfo
+from dlt.common.storages.load_storage import ParsedLoadJobFileName
+from dlt.common.utils import uniq_id
+
+from dlt.destinations import bigquery
+from dlt.destinations.impl.bigquery.bigquery import (
+    ATOMIC_REPLACE_FILE_ID_PREFIX,
+    BigQueryAtomicReplaceLoadJob,
+    BigQueryClient,
+    BigQueryLoadJob,
+)
+from dlt.destinations.impl.bigquery.configuration import BigQueryClientConfiguration
+from dlt.destinations.job_impl import (
+    FinalizedLoadJobWithFollowupJobs,
+    ReferenceFollowupJobRequest,
+)
+
+pytestmark = pytest.mark.essential
+
+
+def _client(
+    *, enable_atomic_replace: bool = True, staging_bucket: str = "gs://bucket/path"
+) -> BigQueryClient:
+    creds = GcpServiceAccountCredentials()
+    creds.project_id = "test_project_id"
+    config = BigQueryClientConfiguration(credentials=creds)._bind_dataset_name(
+        dataset_name=f"test_{uniq_id()}"
+    )
+    client = bigquery().client(Schema("test"), config)
+    client.config.enable_atomic_replace = enable_atomic_replace
+    if staging_bucket is not None:
+        client.config.staging_config = DestinationClientStagingConfiguration(
+            bucket_url=staging_bucket
+        )
+    return client
+
+
+def _config(
+    *, enable_atomic_replace: bool = True, replace_strategy: str = None, staging_bucket: str = None
+) -> BigQueryClientConfiguration:
+    creds = GcpServiceAccountCredentials()
+    creds.project_id = "test_project_id"
+    config = BigQueryClientConfiguration(
+        credentials=creds, enable_atomic_replace=enable_atomic_replace
+    )
+    config.replace_strategy = replace_strategy  # type: ignore[assignment]
+    if staging_bucket is not None:
+        config.staging_config = DestinationClientStagingConfiguration(bucket_url=staging_bucket)
+    return config
+
+
+def _replace_table(name: str = "items") -> PreparedTableSchema:
+    return cast(
+        PreparedTableSchema,
+        {"name": name, "write_disposition": "replace", "x-replace-strategy": "truncate-and-insert"},
+    )
+
+
+def _job_info(table_name: str, file_id: str, file_path: str) -> LoadJobInfo:
+    return LoadJobInfo(
+        "completed_jobs",
+        file_path,
+        0,
+        pendulum.now(),
+        0.0,
+        ParsedLoadJobFileName(table_name, file_id, 0, "reference"),
+        None,
+    )
+
+
+def test_load_job_class_followup_traits() -> None:
+    # per-file job drives the chain hook, the aggregated job must not re-fire it
+    assert issubclass(BigQueryLoadJob, HasFollowupJobs)
+    assert not issubclass(BigQueryAtomicReplaceLoadJob, HasFollowupJobs)
+
+
+@pytest.mark.parametrize(
+    "enable,disposition,strategy,expected",
+    [
+        (True, "replace", "truncate-and-insert", True),
+        (False, "replace", "truncate-and-insert", False),
+        (True, "append", "truncate-and-insert", False),
+        (True, "replace", "insert-from-staging", False),
+    ],
+    ids=["enabled", "flag-off", "append", "wrong-strategy"],
+)
+def test_use_atomic_replace_per_table_gating(
+    enable: bool, disposition: str, strategy: str, expected: bool
+) -> None:
+    client = _client(enable_atomic_replace=enable)
+    table = cast(
+        PreparedTableSchema,
+        {"name": "items", "write_disposition": disposition, "x-replace-strategy": strategy},
+    )
+    assert client._use_atomic_replace(table) is expected
+
+
+@pytest.mark.parametrize(
+    "staging_bucket,expected",
+    [
+        ("gs://b/p", True),
+        ("gcs://b/p", True),
+        (None, False),
+        ("s3://b/p", False),
+        ("/local/path", False),
+    ],
+    ids=["gs", "gcs", "no-staging", "s3", "local"],
+)
+def test_use_atomic_replace_requires_gcs_staging(staging_bucket: str, expected: bool) -> None:
+    client = _client(enable_atomic_replace=True, staging_bucket=staging_bucket)
+    assert client._use_atomic_replace(_replace_table()) is expected
+
+
+@pytest.mark.parametrize(
+    "replace_strategy,stays_enabled",
+    [
+        (None, True),
+        ("truncate-and-insert", True),
+        ("staging-optimized", False),
+        ("insert-from-staging", False),
+    ],
+    ids=["none", "truncate-and-insert", "staging-optimized", "insert-from-staging"],
+)
+def test_on_resolved_gates_replace_strategy(replace_strategy: str, stays_enabled: bool) -> None:
+    config = _config(enable_atomic_replace=True, replace_strategy=replace_strategy)
+    if stays_enabled:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            config.on_resolved()
+    else:
+        with pytest.warns(UserWarning):
+            config.on_resolved()
+    assert config.enable_atomic_replace is stays_enabled
+
+
+def test_on_resolved_noop_when_flag_off() -> None:
+    # flag off, or a conflicting strategy without the flag: never warns, never mutates
+    config = _config(enable_atomic_replace=False, replace_strategy="staging-optimized")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        config.on_resolved()
+    assert config.enable_atomic_replace is False
+
+
+def test_should_truncate_skips_upfront_for_atomic(mocker: MockerFixture) -> None:
+    client = _client(enable_atomic_replace=True)
+    mocker.patch.object(client, "prepare_load_table", return_value=_replace_table())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert client.should_truncate_table_before_load("items") is False
+
+
+def test_should_truncate_truncates_when_flag_off(mocker: MockerFixture) -> None:
+    client = _client(enable_atomic_replace=False)
+    mocker.patch.object(client, "prepare_load_table", return_value=_replace_table())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert client.should_truncate_table_before_load("items") is True
+
+
+def test_should_truncate_warns_when_flag_on_without_gcs_staging(mocker: MockerFixture) -> None:
+    client = _client(enable_atomic_replace=True, staging_bucket=None)
+    mocker.patch.object(client, "prepare_load_table", return_value=_replace_table())
+    with pytest.warns(UserWarning):
+        assert client.should_truncate_table_before_load("items") is True
+
+
+@pytest.mark.parametrize(
+    "enable,file_id,expected_cls",
+    [
+        (True, f"{ATOMIC_REPLACE_FILE_ID_PREFIX}{uniq_id(5)}", BigQueryAtomicReplaceLoadJob),
+        (True, uniq_id(5), FinalizedLoadJobWithFollowupJobs),
+        (False, uniq_id(5), BigQueryLoadJob),
+    ],
+    ids=["aggregated-atomic", "per-file-noop", "flag-off-regular"],
+)
+def test_create_load_job_routing(enable: bool, file_id: str, expected_cls: type) -> None:
+    client = _client(enable_atomic_replace=enable)
+    file_path = os.path.join("/tmp", f"items.{file_id}.0.reference")
+    job = client.create_load_job(_replace_table(), file_path, "load_1")
+    assert isinstance(job, expected_cls)
+
+
+def test_create_atomic_replace_followup_jobs() -> None:
+    """One aggregated reference job per chain table storing its per-file reference paths; the
+    nested table that received no data gets a job with an empty reference list (it truncates)."""
+    client = _client()
+    table_chain = [_replace_table("items"), _replace_table("items__children")]
+    completed_jobs = [
+        _job_info("items", "aaaaa", "/pkg/completed_jobs/items.aaaaa.0.reference"),
+        _job_info("items", "bbbbb", "/pkg/completed_jobs/items.bbbbb.0.reference"),
+    ]
+
+    jobs = client._create_atomic_replace_followup_jobs(table_chain, completed_jobs)
+    by_table = {ParsedLoadJobFileName.parse(j.new_file_path()).table_name: j for j in jobs}
+
+    assert set(by_table) == {"items", "items__children"}
+    assert all(
+        ParsedLoadJobFileName.parse(j.new_file_path()).file_id.startswith(
+            ATOMIC_REPLACE_FILE_ID_PREFIX
+        )
+        for j in jobs
+    )
+    assert ReferenceFollowupJobRequest.resolve_references(by_table["items"].new_file_path()) == [
+        "/pkg/completed_jobs/items.aaaaa.0.reference",
+        "/pkg/completed_jobs/items.bbbbb.0.reference",
+    ]
+    # the jobless nested table references nothing -> resolves to no urls -> truncates
+    assert ReferenceFollowupJobRequest.resolve_references(
+        by_table["items__children"].new_file_path()
+    ) == [""]
+
+
+def test_create_load_job_resolves_and_uses_write_truncate_data(tmp_path: Any) -> None:
+    client = _client()
+    conn = MagicMock()
+    client.sql_client._client = conn
+    # per-file reference jobs each hold one gs url
+    ref1 = tmp_path / "items.aaaaa.0.reference"
+    ref1.write_text("gs://bucket/items/f1.jsonl")
+    ref2 = tmp_path / "items.bbbbb.0.reference"
+    ref2.write_text("gs://bucket/items/f2.jsonl")
+    # the aggregated job references those per-file reference jobs
+    agg = tmp_path / f"items.{ATOMIC_REPLACE_FILE_ID_PREFIX}{uniq_id(5)}.0.reference"
+    agg.write_text(f"{ref1}\n{ref2}")
+
+    client._create_load_job(_replace_table(), str(agg))
+
+    call = conn.load_table_from_uri.call_args
+    assert call.args[0] == ["gs://bucket/items/f1.jsonl", "gs://bucket/items/f2.jsonl"]
+    job_config = call.kwargs["job_config"]
+    assert job_config.write_disposition == "WRITE_TRUNCATE_DATA"
+    assert job_config.create_disposition == "CREATE_NEVER"
+    assert job_config.autodetect is False
+
+
+def test_restored_atomic_job_resumes_by_stable_id(tmp_path: Any) -> None:
+    """When the load step restarts, resume_started_jobs re-creates the started aggregated job with
+    restore=True. It must come back as the atomic job, and creating vs. retrieving its BigQuery job
+    must use the same deterministic id, so a job already submitted before the crash is resumed via
+    the 409 path rather than loaded twice."""
+    client = _client()
+    conn = MagicMock()
+    client.sql_client._client = conn
+    ref = tmp_path / "items.aaaaa.0.reference"
+    ref.write_text("gs://bucket/items/f1.jsonl")
+    agg = tmp_path / f"items.{ATOMIC_REPLACE_FILE_ID_PREFIX}xxxxx.0.reference"
+    agg.write_text(str(ref))
+
+    job = client.create_load_job(_replace_table(), str(agg), "load_1", restore=True)
+    assert isinstance(job, BigQueryAtomicReplaceLoadJob)
+
+    client._create_load_job(_replace_table(), str(agg))
+    created_id = conn.load_table_from_uri.call_args.kwargs["job_id"]
+    client._retrieve_load_job(str(agg))
+    assert conn.get_job.call_args.args[0] == created_id

--- a/tests/load/pipeline/test_bigquery.py
+++ b/tests/load/pipeline/test_bigquery.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, Iterator, List
 import pytest
 import io
 
+from pytest_mock import MockerFixture
+
 import dlt
 from dlt.common import Decimal, json, pendulum
 from dlt.common.typing import TLoaderFileFormat
@@ -9,8 +11,13 @@ from dlt.common.typing import TLoaderFileFormat
 from dlt.common.utils import uniq_id
 from dlt.destinations.adapters import bigquery_adapter
 from dlt.extract.resource import DltResource
-from tests.pipeline.utils import assert_load_info
-from tests.load.utils import destinations_configs, DestinationTestConfiguration
+from tests.pipeline.utils import (
+    assert_load_info,
+    assert_empty_tables,
+    load_table_counts,
+    load_tables_to_dicts,
+)
+from tests.load.utils import destinations_configs, DestinationTestConfiguration, GCS_BUCKET
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
@@ -396,3 +403,101 @@ def test_adapter_autodetect_schema_with_merge(
 
     assert len(pipeline.dataset().items.df()) == 7
     assert len(pipeline.dataset().items__nested.df()) == 7
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(
+        default_staging_configs=True,
+        subset=["bigquery"],
+        bucket_subset=(GCS_BUCKET,),
+    ),
+    ids=lambda x: x.name,
+)
+def test_atomic_replace(
+    destination_config: DestinationTestConfiguration,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """enable_atomic_replace over GCS staging: a deep nested chain is replaced atomically via
+    WRITE_TRUNCATE_DATA, jobless members (a child and a subchild) are truncated by zero-row loads,
+    a fully empty resource clears everything, and the table's description and out-of-band label
+    survive every replace."""
+    from dlt.destinations.impl.bigquery.bigquery import BigQueryClient
+    from dlt.common.storages.load_storage import ParsedLoadJobFileName
+
+    monkeypatch.setenv("DESTINATION__REPLACE_STRATEGY", "truncate-and-insert")
+    monkeypatch.setenv("DESTINATION__BIGQUERY__ENABLE_ATOMIC_REPLACE", "true")
+    followup_spy = mocker.spy(BigQueryClient, "_create_atomic_replace_followup_jobs")
+
+    pipeline = destination_config.setup_pipeline("bq_atomic_replace", dev_mode=True)
+
+    @dlt.resource(name="items", write_disposition="replace", primary_key="id")
+    def load_items(offset: int, child_b: bool, sub: bool, empty: bool = False):
+        if empty:
+            return
+        for i in range(offset, offset + 3):
+            child_a: Dict[str, Any] = {"cid": i}
+            if sub:
+                child_a["sub"] = [{"sid": i * 10}]
+            row: Dict[str, Any] = {"id": i, "child_a": [child_a]}
+            if child_b:
+                row["child_b"] = [{"bid": i}]
+            yield row
+
+    res = bigquery_adapter(load_items, table_description="preserve me across replace")
+    all_tables = ["items", "items__child_a", "items__child_a__sub", "items__child_b"]
+
+    # first load populates the whole chain
+    info = pipeline.run(res(0, child_b=True, sub=True), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert followup_spy.call_count >= 1
+    assert load_table_counts(pipeline, *all_tables) == {
+        "items": 3,
+        "items__child_a": 3,
+        "items__child_a__sub": 3,
+        "items__child_b": 3,
+    }
+
+    # a label is never managed by dlt: only an object-preserving replace keeps it
+    with pipeline.sql_client() as c:
+        fqtn = c.make_qualified_table_name("items", quote=False)
+        table = c.native_connection.get_table(fqtn)
+        table.labels = {"env": "test"}
+        c.native_connection.update_table(table, ["labels"])
+
+    # replace load: root and child_a get data; child_b and child_a__sub (subchild) get none
+    followup_spy.reset_mock()
+    info = pipeline.run(res(100, child_b=False, sub=False), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    # jobless members carry no source files, so their aggregated job truncates via a zero-row load
+    truncated = {
+        ParsedLoadJobFileName.parse(job.new_file_path()).table_name
+        for job in followup_spy.spy_return
+        if not job._remote_paths
+    }
+    assert truncated == {"items__child_a__sub", "items__child_b"}
+    assert load_table_counts(pipeline, "items", "items__child_a") == {
+        "items": 3,
+        "items__child_a": 3,
+    }
+    assert {int(r["id"]) for r in load_tables_to_dicts(pipeline, "items")["items"]} == {
+        100,
+        101,
+        102,
+    }
+    assert_empty_tables(pipeline, "items__child_a__sub", "items__child_b")
+
+    # a fully empty resource clears every table (root via an empty-file WRITE_TRUNCATE_DATA)
+    info = pipeline.run(
+        res(0, child_b=False, sub=False, empty=True), **destination_config.run_kwargs
+    )
+    assert_load_info(info)
+    assert_empty_tables(pipeline, *all_tables)
+
+    # description and label survived all replaces
+    with pipeline.sql_client() as c:
+        table = c.native_connection.get_table(c.make_qualified_table_name("items", quote=False))
+        assert table.description == "preserve me across replace"
+        assert table.labels.get("env") == "test"


### PR DESCRIPTION
### Description

Adds an opt-in BigQuery config flag, `enable_atomic_replace`, that makes the `truncate-and-insert` replace strategy perform an **atomic, metadata-preserving** full replace using a single BigQuery Load Job with `write_disposition="WRITE_TRUNCATE_DATA"`, when a filesystem (GCS) staging destination is used.

This follows the design agreed with @rudolfix in the linked issue: a config flag on `BigQueryClientConfiguration` that piggybacks on `truncate-and-insert` (active when the strategy is `truncate-and-insert`, the flag is on, and a staging destination is configured), rather than a new `replace_strategy`. Defaulting it on for `truncate-and-insert` is intentionally left for review.

**Why `WRITE_TRUNCATE_DATA`.** I verified the four candidate mechanisms on BigQuery (US), against a table carrying a description, labels, column descriptions, a NOT ENFORCED primary key, a column policy tag, a row access policy, and a dependent materialized view:

| operation | table object | table desc / labels | column desc / policy tag / PK | row access policy | materialized view |
|---|---|---|---|---|---|
| `CREATE OR REPLACE` | replaced | lost | lost | lost | **broken** ("references a table that was deleted and recreated") |
| `WRITE_TRUNCATE` (load) | kept | preserved | lost (schema overwritten) | lost | survives* |
| `WRITE_TRUNCATE_DATA` (load) | kept | preserved | **preserved** | **preserved** | survives |
| Copy job `WRITE_TRUNCATE` | kept | preserved | lost | lost | survives* |

`WRITE_TRUNCATE_DATA` is the only operation that preserves column-level metadata (descriptions, policy tags, PK constraints) and row access policies while keeping the table object and dependent materialized views intact. It is also atomic (no empty-table window), does not scan a staging table, and stays a Load Job (load reservations, not query slots). Copy Jobs reject it (`WRITE_TRUNCATE_DATA is not yet supported for table copy jobs`), so a Load Job is the path. Only *materialized* views are ever affected (and only by `CREATE OR REPLACE`); logical views resolve by name and survive all four operations.

(* MV survival under schema-overwriting ops is for schema-compatible reloads; `WRITE_TRUNCATE_DATA` preserves the schema, so it is unconditional.)

**How it works.** With GCS staging, per-file `.reference` jobs become no-op `FinalizedLoadJobWithFollowupJobs` so they still trigger the table-chain hook. The hook (`create_table_chain_completed_followup_jobs`) emits one aggregated reference job per table, which runs as a dedicated `BigQueryAtomicReplaceLoadJob` that loads all of the table's staged GCS URIs into the destination in a single `WRITE_TRUNCATE_DATA` Load Job (`create_disposition=CREATE_NEVER`, `autodetect=False`). The change is scoped entirely to the BigQuery destination — no changes to filesystem staging, the load orchestration, capabilities, or other destinations.

The diff is larger than the core feature because correctness in the load pipeline required a few specific guards (each covered by tests):

- **No infinite loop:** the aggregated job is a `RunnableLoadJob` *without* `HasFollowupJobs`, so completing it does not re-trigger the table-chain hook (the same pattern `SqlMergeFollowupJob` relies on).
- **No silent data loss:** per-file jobs use `FinalizedLoadJobWithFollowupJobs` (not `FinalizedLoadJob`) so the table-chain hook actually fires; failure of the aggregated job propagates and fails the load.
- **Retry-safe job ids:** the BQ job id includes `load_id` and retry count, so a retried run is not deduplicated to a previous failed job's cached result.
- **URI collection timing:** URIs are scanned from `completed_jobs` at execution time rather than read from `LoadJobInfo` paths at followup-creation time, because the just-completed per-file job is still in `started_jobs` when the hook fires (its `job_to_job_info` path points at `completed_jobs` and would `FileNotFoundError`).
- **Skip the explicit TRUNCATE** for atomic tables (`initialize_storage` / `should_truncate_table_before_load`), since `WRITE_TRUNCATE_DATA` truncates atomically.
- **Local-file fallback:** when the flag is on but files are local (cannot be aggregated into one atomic Load Job), it falls back to regular `truncate-and-insert` with a warning. Non-GCS staging URIs raise a terminal error.

**Notes for review:**

- The client-version requirement is handled by passing the literal string `"WRITE_TRUNCATE_DATA"`. `WriteDisposition` is a plain class of string constants and `write_disposition` is sent to the REST API without client-side validation, so this works without raising the `google-cloud-bigquery` floor (`>=2.26.0`); the backend enforces support.

**Out of scope (possible follow-ups):**

- Making atomic replace the default for `truncate-and-insert`.
- Local-file atomic support (BigQuery cannot aggregate local files into one atomic Load Job).

### Related Issues

- Closes #4012

### Additional Context

The new behavior is **opt-in** (`enable_atomic_replace` defaults to `False`), so existing pipelines are unaffected.

Tests are in `tests/load/bigquery/test_bigquery_atomic_replace.py` and cover the guarantees above (loop prevention, failure propagation, data-loss prevention, load_id scope, retry idempotency, empty-load skip, multi-file aggregation, staging-config gating) without requiring live BigQuery. The metadata-preservation matrix above was verified against live BigQuery separately.