### PR TITLE
fix: suppress pyarrow nullability warning for primary keys

### DIFF
--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -541,6 +541,14 @@ class ArrowExtractor(Extractor):
                         for hint_name, hint in column.items():
                             if (src_hint := src_column.get(hint_name)) is not None:
                                 if src_hint != hint:
+                                    if (
+                                        hint_name == "nullable"
+                                        and src_column.get("primary_key") is True
+                                        and src_hint is False
+                                        and hint is True
+                                    ):
+                                        # PyArrow has no primary-key metadata, so dlt PK fields may look nullable.
+                                        continue
                                     override_warn = True
                                     logger.info(
                                         f"In resource: {resource.name}, when merging arrow schema"

--- a/tests/load/sources/sql_database/test_sql_database_source.py
+++ b/tests/load/sources/sql_database/test_sql_database_source.py
@@ -708,6 +708,35 @@ def test_remove_nullability(postgres_db: PostgresSourceDB) -> None:
     assert len(data) == postgres_db.table_infos["chat_message"]["row_count"]
 
 
+def test_remove_nullability_pyarrow_primary_key_does_not_warn(
+    postgres_db: PostgresSourceDB, caplog: Any
+) -> None:
+    read_table = sql_table(
+        table="chat_message",
+        credentials=postgres_db.credentials,
+        schema=postgres_db.schema,
+        backend="pyarrow",
+        reflection_level="full_with_precision",
+        table_adapter_callback=remove_nullability_adapter,
+    )
+
+    table_schema = read_table.compute_table_schema()
+    id_column = table_schema["columns"]["id"]
+    assert id_column["primary_key"] is True
+    assert id_column["nullable"] is False
+
+    pipeline = make_pipeline("duckdb")
+    with capture_dlt_logger(caplog) as caplog:
+        pipeline.run(read_table)
+
+    warning_messages = [
+        record.message
+        for record in caplog.records
+        if "when merging arrow schema" in record.message
+    ]
+    assert warning_messages == []
+
+
 @pytest.mark.parametrize("backend", ["sqlalchemy", "pandas", "pyarrow", "connectorx"])
 @pytest.mark.parametrize("row_order", ["asc", "desc", None])
 @pytest.mark.parametrize("last_value_func", [min, max, lambda x: max(x)])


### PR DESCRIPTION
## Description

Fixes #3581.

When `remove_nullability_adapter` is used with the PyArrow backend, dlt correctly keeps reflected primary-key columns as `nullable=False`. PyArrow does not retain primary-key metadata and reports those fields as nullable, which causes a misleading Arrow-schema conflict warning.

This PR suppresses only that expected mismatch when:

* the computed dlt column is a primary key
* dlt has `nullable=False`
* Arrow has `nullable=True`

Schema merging remains unchanged, and primary-key columns remain non-nullable.

## Related Issues

* Fixes #3581

## Additional Context

Added a SQL + PyArrow regression test using `remove_nullability_adapter` that verifies the reflected `id` column remains a non-nullable primary key and that no Arrow-schema merge message is emitted.

Local checks completed:

* Focused SQL + PyArrow regression test passed
* Existing `test_remove_nullability` passed
* `flake8` for changed files passed
* `git diff --check` passed

Targeted `mypy` did not complete locally within five minutes and produced no diagnostics, so CI should verify that check.
