### PR TITLE
fix(cli): remove generic "refer to our docs" note from cli errors

### DIFF
--- a/dlt/_workspace/cli/_dlt.py
+++ b/dlt/_workspace/cli/_dlt.py
@@ -18,7 +18,6 @@ from dlt._workspace.cli._telemetry_command import (
 from dlt._workspace.cli.echo import maybe_no_stdin
 
 ACTION_EXECUTED = False
-DEFAULT_DOCS_URL = "https://dlthub.com/docs/intro"
 
 
 class _LazyMarkdown:
@@ -317,7 +316,6 @@ def main(host: str = "dlt") -> int:
         parser, pre_parser, installed_commands = _create_parser(host)
     except ValueError as ex:
         fmt.secho(str(ex), err=True, fg="red")
-        fmt.note("Please refer to our docs at '%s' for further assistance." % DEFAULT_DOCS_URL)
         return -1
     # pre-pass extracts global flags at any argv position; main parse uses namespace=ns to keep them
     ns, remaining = pre_parser.parse_known_args(sys.argv[1:])
@@ -346,7 +344,7 @@ def main(host: str = "dlt") -> int:
                         sys.path.insert(0, "")
                 cmd.execute(args)
         except Exception as ex:
-            docs_url = getattr(cmd, "docs_url", None) or DEFAULT_DOCS_URL
+            docs_url = getattr(cmd, "docs_url", None)
             error_code = -1
             raiseable_exception = ex
 
@@ -358,7 +356,10 @@ def main(host: str = "dlt") -> int:
             if raiseable_exception:
                 fmt.secho(str(raiseable_exception) or str(ex), err=True, fg="red")
 
-            fmt.note("Please refer to our docs at '%s' for further assistance." % docs_url)
+            # only point to docs when the command or exception provides a specific
+            # link; the generic intro-page footer was removed (#4126)
+            if docs_url:
+                fmt.note("Please refer to our docs at '%s' for further assistance." % docs_url)
             if _debug.is_debug_enabled() and raiseable_exception:
                 raise raiseable_exception
 

--- a/tests/workspace/cli/common/test_cli_invoke.py
+++ b/tests/workspace/cli/common/test_cli_invoke.py
@@ -336,6 +336,48 @@ def test_dlt_ai_moved_to_dlthub_stub(
     assert rc != 0
 
 
+def test_command_error_omits_generic_docs_note(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failing command with no specific docs link shows the real error but no docs footer (#4126)."""
+    # the moved `ai` stub has `docs_url = None` and raises a docs-url-less CliCommandException,
+    # so the command-error path has no command/exception-specific link to fall back to
+    monkeypatch.setattr("sys.argv", ["dlt", "ai", "init"])
+    rc = main("dlt")
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    # the actual error context is still reported
+    assert "`ai` command moved to dlthub" in combined
+    assert rc != 0
+    # but the generic "go to the intro page" footer is gone
+    assert "Please refer to our docs" not in combined
+    assert "docs/intro" not in combined
+
+
+def test_command_error_keeps_specific_docs_note(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A command/exception that defines its own docs_url still surfaces that contextual link (#4126)."""
+    from dlt._workspace.cli import commands
+    from dlt._workspace.cli._urls import DLT_TELEMETRY_DOCS_URL
+
+    # `telemetry` carries a command-specific docs_url; force it to fail to hit the error path
+    def _raise(self: Any, args: Any) -> None:
+        raise CliCommandException()
+
+    monkeypatch.setattr(commands.TelemetryCommand, "execute", _raise)
+    monkeypatch.setattr("sys.argv", ["dlt", "telemetry"])
+    rc = main("dlt")
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert rc != 0
+    # the command's own contextual docs link is still shown, but not the generic intro page
+    assert DLT_TELEMETRY_DOCS_URL in combined
+    assert "docs/intro" not in combined
+
+
 @pytest.mark.parametrize(
     "argv,case_id",
     [


### PR DESCRIPTION
### Description

The CLI's two generic error handlers always appended:

```
NOTE: Please refer to our docs at 'https://dlthub.com/docs/intro' for further assistance.
```

regardless of the actual error, so every failure (e.g. "workspace already exists", invalid args) pointed at the same intro page. As #4126 notes, that is not specific to what the user is facing and clutters the output.

This removes the generic intro-page footer but keeps a docs link when the command or exception provides a *specific* one:

- `main()` parser-`ValueError` path: footer removed (no command context there); the error line is unchanged.
- `main()` catch-all command-error path: drop the `DEFAULT_DOCS_URL` intro fallback and only emit the note when a command/exception supplies its own `docs_url` (e.g. `dlt telemetry` -> the telemetry docs). The real error line (red) is always kept.
- Removed the now-unused `DEFAULT_DOCS_URL` constant (no other references).

Out of scope: the deploy command's note (`_deploy_command.py:483`) is left intact - it points at deploy-specific docs after concrete `git init` remediation, so it is contextual and useful rather than the generic intro link. Happy to drop it too if you read "all CLI commands" literally.

### Related Issues

- Fixes #4126

### Additional Context

Tested with `tests/workspace/cli/common/test_cli_invoke.py`: added `test_command_error_omits_generic_docs_note` (failing command with no docs link -> error shown, no footer) and `test_command_error_keeps_specific_docs_note` (command with its own `docs_url` -> contextual link still shown). Ran `tests/workspace/cli` + `tests/plugins` (507 passed) and `make lint` (ruff / flake8 / black / mypy) clean.
