### PR TITLE
Added config that allows overriding the text date type to be used on the destination config.

### DIFF
--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -183,6 +183,7 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
     supports_create_table_if_not_exists: bool = True
     supports_truncate_command: bool = True
     schema_supports_numeric_precision: bool = True
+    text_data_type: str = None
     timestamp_precision: int = DEFAULT_TIMESTAMP_PRECISION
     """Default precision of the timestamp type"""
     max_timestamp_precision: int = DEFAULT_TIMESTAMP_PRECISION

--- a/dlt/destinations/impl/mssql/configuration.py
+++ b/dlt/destinations/impl/mssql/configuration.py
@@ -134,6 +134,7 @@ class MsSqlClientConfiguration(DestinationClientDwhWithStagingConfiguration):
 
     create_indexes: bool = False
     has_case_sensitive_identifiers: bool = False
+    text_data_type: str = "nvarchar"
 
     def fingerprint(self) -> str:
         """Returns a fingerprint of the configured host."""

--- a/dlt/destinations/impl/mssql/factory.py
+++ b/dlt/destinations/impl/mssql/factory.py
@@ -42,6 +42,7 @@ class MsSqlTypeMapper(TypeMapperImpl):
 
     dbt_to_sct = {
         "nvarchar": "text",
+        "varchar": "text",
         "float": "double",
         "bit": "bool",
         "datetimeoffset": "timestamp",
@@ -56,6 +57,16 @@ class MsSqlTypeMapper(TypeMapperImpl):
         "int": "bigint",
         "json": "json",
     }
+
+    def to_db_text_type(self, column: TColumnSchema, table: PreparedTableSchema = None) -> str:
+        if self.capabilities.text_data_type == 'varchar':
+            # MsSQL has a limit of 8000 for varchar and 4000 for nvarchar
+            if column.get("precision") is not None and column["precision"] <= 8000:
+                return f"varchar({column['precision']})"
+            return "varchar(max)"
+        if column.get("precision") is not None and column["precision"] <= 4000:
+            return self.sct_to_dbt["text"] % column["precision"]
+        return self.sct_to_unbound_dbt["text"]
 
     def to_db_datetime_type(
         self,
@@ -211,6 +222,8 @@ class mssql(Destination[MsSqlClientConfiguration, "MsSqlJobClient"]):
         if config.has_case_sensitive_identifiers:
             caps.has_case_sensitive_identifiers = True
             caps.casefold_identifier = str
+        if config.text_data_type == 'varchar':
+            caps.text_data_type = 'varchar'
         return super().adjust_capabilities(caps, config, naming)
 
 

--- a/dlt/destinations/type_mapping.py
+++ b/dlt/destinations/type_mapping.py
@@ -69,6 +69,10 @@ class TypeMapperImpl(DataTypeMapper):
             return self.sct_to_unbound_dbt["decimal"]
         return self.sct_to_dbt["decimal"] % (precision_tup[0], precision_tup[1])
 
+    def to_db_text_type(self, column: TColumnSchema, table: PreparedTableSchema = None) -> str:
+        # Override in subclass if db supports other string types (e.g. varchar, char, text, etc.)
+        return None
+
     # TODO: refactor lancedb and weaviate to make table object required
     def to_destination_type(self, column: TColumnSchema, table: PreparedTableSchema) -> str:
         sc_t = column["data_type"]
@@ -80,6 +84,8 @@ class TypeMapperImpl(DataTypeMapper):
             db_t = self.to_db_time_type(column, table)
         elif sc_t == "decimal":
             db_t = self.to_db_decimal_type(column)
+        elif sc_t == "text":
+            db_t = self.to_db_text_type(column, table)
         else:
             db_t = None
         if db_t:

--- a/tests/load/mssql/test_mssql_configuration.py
+++ b/tests/load/mssql/test_mssql_configuration.py
@@ -26,24 +26,28 @@ def test_mssql_factory() -> None:
     # MSSQL uses ADBC for parquet loading which doesn't support dictionary-encoded arrays
     assert client.capabilities.parquet_format is not None
     assert client.capabilities.parquet_format.supports_dictionary_encoding is False
+    assert client.capabilities.text_data_type is None
 
     # set args explicitly
-    dest = mssql(has_case_sensitive_identifiers=True, create_indexes=True)
+    dest = mssql(has_case_sensitive_identifiers=True, create_indexes=True, text_data_type="varchar")
     client = dest.client(schema, MsSqlClientConfiguration()._bind_dataset_name("dataset"))
     assert client.config.create_indexes is True
     assert client.config.has_case_sensitive_identifiers is True
     assert client.capabilities.has_case_sensitive_identifiers is True
     assert client.capabilities.casefold_identifier is str
+    assert client.capabilities.text_data_type == "varchar"
 
     # set args via config
     os.environ["DESTINATION__CREATE_INDEXES"] = "True"
     os.environ["DESTINATION__HAS_CASE_SENSITIVE_IDENTIFIERS"] = "True"
+    os.environ["DESTINATION__TEXT_DATA_TYPE"] = "varchar"
     dest = mssql()
     client = dest.client(schema, MsSqlClientConfiguration()._bind_dataset_name("dataset"))
     assert client.config.create_indexes is True
     assert client.config.has_case_sensitive_identifiers is True
     assert client.capabilities.has_case_sensitive_identifiers is True
     assert client.capabilities.casefold_identifier is str
+    assert client.capabilities.text_data_type == "varchar"
 
 
 def test_mssql_credentials_defaults() -> None:

--- a/tests/load/mssql/test_mssql_table_builder.py
+++ b/tests/load/mssql/test_mssql_table_builder.py
@@ -83,3 +83,72 @@ def test_create_dlt_table(client: MsSqlJobClient) -> None:
     sqlfluff.parse(sql, dialect="tsql")
     qualified_name = client.sql_client.make_qualified_table_name("_dlt_version")
     assert f"CREATE TABLE {qualified_name}" in sql
+
+
+@pytest.fixture
+def client_varchar(empty_schema: Schema) -> MsSqlJobClient:
+    # return client without opening connection
+    return mssql().client(
+        empty_schema,
+        MsSqlClientConfiguration(credentials=MsSqlCredentials(), text_data_type="varchar")._bind_dataset_name(
+            dataset_name="test_" + uniq_id()
+        ),
+    )
+
+
+def test_create_table_varchar(client_varchar: MsSqlJobClient) -> None:
+    # non existing table
+    sql = client_varchar._get_table_update_sql("event_test_table", TABLE_UPDATE, False)[0]
+    sqlfluff.parse(sql, dialect="tsql")
+    assert "event_test_table" in sql
+    assert '"col1" bigint  NOT NULL' in sql
+    assert '"col2" float  NOT NULL' in sql
+    assert '"col3" bit  NOT NULL' in sql
+    assert '"col4" datetimeoffset  NOT NULL' in sql
+    assert '"col5" varchar' in sql
+    assert '"col6" decimal(38,9)  NOT NULL' in sql
+    assert '"col7" varbinary' in sql
+    assert '"col8" decimal(38,0)' in sql
+    assert '"col9" json  NOT NULL' in sql
+    assert '"col10" date  NOT NULL' in sql
+    assert '"col11" time  NOT NULL' in sql
+    assert '"col1_precision" smallint  NOT NULL' in sql
+    assert '"col4_precision" datetimeoffset(3)  NOT NULL' in sql
+    assert '"col5_precision" varchar(25)' in sql
+    assert '"col6_precision" decimal(6,2)  NOT NULL' in sql
+    assert '"col7_precision" varbinary(19)' in sql
+    assert '"col11_precision" time(3)  NOT NULL' in sql
+
+
+def test_alter_table_varchar(client_varchar: MsSqlJobClient) -> None:
+    # existing table has no columns
+    sql = client_varchar._get_table_update_sql("event_test_table", TABLE_UPDATE, True)[0]
+    sqlfluff.parse(sql, dialect="tsql")
+    qualified_name = client_varchar.sql_client.make_qualified_table_name("event_test_table")
+    assert sql.count(f"ALTER TABLE {qualified_name}\nADD") == 1
+    assert "event_test_table" in sql
+    assert '"col1" bigint  NOT NULL' in sql
+    assert '"col2" float  NOT NULL' in sql
+    assert '"col3" bit  NOT NULL' in sql
+    assert '"col4" datetimeoffset  NOT NULL' in sql
+    assert '"col5" varchar' in sql
+    assert '"col6" decimal(38,9)  NOT NULL' in sql
+    assert '"col7" varbinary' in sql
+    assert '"col8" decimal(38,0)' in sql
+    assert '"col9" json  NOT NULL' in sql
+    assert '"col10" date  NOT NULL' in sql
+    assert '"col11" time  NOT NULL' in sql
+    assert '"col1_precision" smallint  NOT NULL' in sql
+    assert '"col4_precision" datetimeoffset(3)  NOT NULL' in sql
+    assert '"col5_precision" varchar(25)' in sql
+    assert '"col6_precision" decimal(6,2)  NOT NULL' in sql
+    assert '"col7_precision" varbinary(19)' in sql
+    assert '"col11_precision" time(3)  NOT NULL' in sql
+
+
+def test_create_dlt_table_varchar(client_varchar: MsSqlJobClient) -> None:
+    # non existing table
+    sql = client_varchar._get_table_update_sql("_dlt_version", TABLE_UPDATE, False)[0]
+    sqlfluff.parse(sql, dialect="tsql")
+    qualified_name = client_varchar.sql_client.make_qualified_table_name("_dlt_version")
+    assert f"CREATE TABLE {qualified_name}" in sql


### PR DESCRIPTION
### Description
Added new destination configuration that allows setting a specific data type for text. This will override the base value. Added new function to allow custom logic for selecting a string data type similar to other data types.


### Related Issues

- Resolves #4100


### Additional Context
This change is to support using `VARCHAR` data type instead of `NVARCHAR` data type as an optional override when syncing into the MsSQL destination.