### PR TITLE
feat(databricks): create tables with IF NOT EXISTS and reconcile columns for concurrent loads

### DIFF
--- a/dlt/destinations/impl/databricks/databricks.py
+++ b/dlt/destinations/impl/databricks/databricks.py
@@ -52,7 +52,7 @@ from dlt.common.destination.exceptions import (
 from dlt.common.exceptions import TerminalValueError
 from dlt.common.typing import TDataRecordBatch
 from dlt.common.schema import Schema, TColumnSchema, TTableSchema
-from dlt.common.schema.typing import TColumnType
+from dlt.common.schema.typing import TColumnType, TSchemaTables
 from dlt.common.schema.utils import get_columns_names_with_prop
 from dlt.common.storages import FilesystemConfiguration, fsspec_from_config
 from dlt.common.storages.configuration import ensure_canonical_az_url
@@ -68,7 +68,11 @@ from dlt.common.storages.load_package import (
     group_jobs_by_table_name,
 )
 from dlt.common.utils import uniq_id
-from dlt.destinations.exceptions import LoadJobTerminalException, LoadJobTransientException
+from dlt.destinations.exceptions import (
+    DatabaseTerminalException,
+    LoadJobTerminalException,
+    LoadJobTransientException,
+)
 from dlt.destinations.file_batching import (
     JsonlFileBatchIterator,
     ParquetFileBatchIterator,
@@ -671,6 +675,36 @@ class DatabricksClient(SqlJobClientWithStagingDataset, SupportsStagingDestinatio
             return constraints_sql
 
         return ""
+
+    def _make_create_table(self, qualified_name: str, table: PreparedTableSchema) -> str:
+        # IF NOT EXISTS for all tables (not just dlt system tables) so concurrent loads
+        # racing to create the same new table do not fail; columns missed by a no-op
+        # create are reconciled in _execute_schema_update_sql
+        if self.capabilities.supports_create_table_if_not_exists:
+            return f"CREATE TABLE IF NOT EXISTS {qualified_name}"
+        return f"CREATE TABLE {qualified_name}"
+
+    def _execute_schema_update_sql(
+        self, only_tables: Iterable[str], store_schema: bool = True
+    ) -> TSchemaTables:
+        applied_update = super()._execute_schema_update_sql(only_tables, store_schema)
+        self._reconcile_columns_after_create(only_tables)
+        return applied_update
+
+    def _reconcile_columns_after_create(self, only_tables: Iterable[str]) -> None:
+        # a CREATE TABLE IF NOT EXISTS becomes a no-op when a concurrent load wins the
+        # race to create a new table, leaving this run's columns unapplied. Databricks
+        # has no ADD COLUMN IF NOT EXISTS, so re-read the destination and add whatever
+        # is still missing, tolerating a column another load added in the meantime
+        storage_tables = self.get_storage_tables(only_tables or self.schema.tables.keys())
+        sql_scripts, _ = self._build_schema_update_sql(list(storage_tables))
+        for sql in sql_scripts:
+            try:
+                self.sql_client.execute_sql(sql)
+            except DatabaseTerminalException as e:
+                if "FIELDS_ALREADY_EXISTS" not in str(e):
+                    raise
+                logger.info(f"Column added by a concurrent load, skipping: {sql}")
 
     def _get_table_update_sql(
         self, table_name: str, new_columns: Sequence[TColumnSchema], generate_alter: bool

--- a/tests/load/databricks/test_databricks_table_builder.py
+++ b/tests/load/databricks/test_databricks_table_builder.py
@@ -3,6 +3,7 @@ from tests.utils import skip_if_not_active
 skip_if_not_active("databricks")
 
 from typing import List
+from unittest import mock
 
 import pytest
 
@@ -11,6 +12,7 @@ from dlt.common.schema.typing import TColumnSchema
 from dlt.common.schema.utils import new_table
 from dlt.common.utils import uniq_id
 from dlt.destinations import databricks
+from dlt.destinations.exceptions import DatabaseTerminalException
 from dlt.destinations.impl.databricks.databricks import DatabricksClient
 from dlt.destinations.impl.databricks.configuration import (
     DatabricksClientConfiguration,
@@ -83,3 +85,64 @@ def test_primary_key_constraint_conditional_on_create_indexes(
         assert "PRIMARY KEY (`id`)" in sql
     else:
         assert "PRIMARY KEY" not in sql
+
+
+@pytest.mark.parametrize("with_cluster", [False, True], ids=["plain", "clustered"])
+def test_create_table_uses_if_not_exists(empty_schema: Schema, with_cluster: bool) -> None:
+    columns: List[TColumnSchema] = [
+        {"name": "col_a", "data_type": "text", "cluster": with_cluster},
+        {"name": "col_b", "data_type": "bigint"},
+    ]
+    client = create_client(empty_schema, create_indexes=False)
+
+    # generate_alter=False takes both the base and the custom-clause CREATE paths
+    sql = client._get_table_update_sql("event_test_table", columns, generate_alter=False)[0]
+
+    assert sql.startswith("CREATE TABLE IF NOT EXISTS")
+
+
+def test_reconcile_adds_columns_missed_by_concurrent_create(empty_schema: Schema) -> None:
+    table_name = "event_test_table"
+    columns: List[TColumnSchema] = [
+        {"name": "col_a", "data_type": "text"},
+        {"name": "col_b", "data_type": "bigint"},
+        {"name": "col_c", "data_type": "bool"},
+    ]
+    client = create_client(empty_schema, create_indexes=False)
+    client.schema.update_table(new_table(table_name, columns=columns))
+
+    # a concurrent load won the create race with only col_a and col_b
+    storage_columns = {c["name"]: c for c in columns[:2]}
+    client.get_storage_tables = mock.MagicMock(return_value=[(table_name, storage_columns)])  # type: ignore[method-assign]
+    executed: List[str] = []
+    client.sql_client.execute_sql = mock.MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda sql, *args: executed.append(sql)
+    )
+
+    client._reconcile_columns_after_create([table_name])
+
+    assert any("ADD COLUMN" in sql and "`col_c`" in sql for sql in executed)
+    assert not any("`col_a`" in sql for sql in executed)
+
+
+def test_reconcile_tolerates_column_added_by_concurrent_load(empty_schema: Schema) -> None:
+    table_name = "event_test_table"
+    columns: List[TColumnSchema] = [
+        {"name": "col_a", "data_type": "text"},
+        {"name": "col_b", "data_type": "bigint"},
+    ]
+    client = create_client(empty_schema, create_indexes=False)
+    client.schema.update_table(new_table(table_name, columns=columns))
+    client.get_storage_tables = mock.MagicMock(  # type: ignore[method-assign]
+        return_value=[(table_name, {"col_a": columns[0]})]
+    )
+
+    fields_exist = DatabaseTerminalException(Exception("[FIELDS_ALREADY_EXISTS] col_b"))
+    client.sql_client.execute_sql = mock.MagicMock(side_effect=fields_exist)  # type: ignore[method-assign]
+    # the concurrent column is swallowed
+    client._reconcile_columns_after_create([table_name])
+
+    other_error = DatabaseTerminalException(Exception("PARSE_SYNTAX_ERROR"))
+    client.sql_client.execute_sql = mock.MagicMock(side_effect=other_error)  # type: ignore[method-assign]
+    with pytest.raises(DatabaseTerminalException):
+        client._reconcile_columns_after_create([table_name])


### PR DESCRIPTION
Closes #4135

## Problem

When several dlt runs load into the same Databricks table concurrently and the table doesn't exist yet, every run reads storage, sees the table missing (`generate_alter = False`), and emits a plain `CREATE TABLE`. The first commit wins; the rest fail with *"table already exists"*. Hiding behind that crash is a second bug: a run carrying an extra column would see its create become a no-op and then fail when its load writes a column that was never added.

## Change (Databricks only)

- **`CREATE TABLE IF NOT EXISTS` for all tables.** `_make_create_table` is overridden to drop the "dlt system tables only" restriction (still gated by the existing `supports_create_table_if_not_exists` capability). Covers both the base CREATE path and the custom cluster/partition/tblproperties path.
- **Column reconciliation after the create.** Databricks has **no** `ADD COLUMN IF NOT EXISTS`, so `_execute_schema_update_sql` re-reads the destination after the (possibly no-op) create and issues `ALTER TABLE … ADD COLUMN` for any columns still missing, tolerating the `FIELDS_ALREADY_EXISTS` error raised when a concurrent run adds the same column first.

Net effect: identical-schema parallel loads stop racing, and divergent-schema loads converge.

## Notes

- The reconciliation read runs only inside `update_stored_schema` (i.e. when the schema hash actually changes), not on every load.
- Reconciled columns may not appear in the per-load-package `applied_update` diff; this is informational only — the data write maps columns by name against the full stored schema, so the load is unaffected.

## Tests

Added to `tests/load/databricks/test_databricks_table_builder.py` (no live connection needed):
- `CREATE TABLE IF NOT EXISTS` emitted on both create paths.
- Reconciliation adds a column a concurrent create missed.
- `FIELDS_ALREADY_EXISTS` is tolerated; other errors re-raise.