### PR TITLE
feat(fabric): support staging-optimized replace via DDL transactions

### DIFF
--- a/dlt/destinations/impl/fabric/fabric.py
+++ b/dlt/destinations/impl/fabric/fabric.py
@@ -1,6 +1,7 @@
 """Fabric Warehouse job client implementation - based on Synapse with COPY INTO support"""
 
 import os
+import threading
 from typing import ClassVar, Sequence, List, Dict
 from copy import deepcopy
 from textwrap import dedent
@@ -19,12 +20,43 @@ from dlt.destinations.impl.synapse.synapse import (
 from dlt.destinations.impl.fabric.configuration import FabricClientConfiguration
 from dlt.destinations.impl.fabric.sql_client import FabricSqlClient
 from dlt.destinations.impl.mssql.mssql import MsSqlStagingReplaceJob
-from dlt.destinations.job_client_impl import SqlJobClientBase
+from dlt.destinations.job_client_impl import SqlJobClientBase, SqlLoadJob
 from dlt.common.configuration.exceptions import ConfigurationException
 from dlt.common.configuration.specs import (
     AzureCredentialsWithoutDefaults,
     AzureServicePrincipalCredentialsWithoutDefaults,
 )
+
+
+class FabricStagingReplaceLoadJob(SqlLoadJob):
+    """Runs the `staging-optimized` replace swap (`ALTER SCHEMA ... TRANSFER`) under a
+    per-dataset lock.
+
+    Each replace job swaps one table chain into the destination schema inside its own
+    transaction, so it is internally atomic. But Fabric Warehouse's distributed catalog
+    does not safely isolate *concurrent* `ALTER SCHEMA ... TRANSFER` transactions that
+    target the same destination schema: two replace jobs for different table chains,
+    swapped in at the same time, can silently lose one of the changes even though each
+    swap is individually atomic. SQL Server's usual primitive for this, `sp_getapplock`,
+    is not supported by Fabric Warehouse, so we serialize in Python instead. The loader's
+    worker pool is always thread-based for sql jobs (`LoaderConfiguration.on_resolved`
+    forces `pool_type = "thread"` unless there is a single worker), so an in-process lock
+    keyed by destination dataset is sufficient - it does not need to be cross-process.
+    """
+
+    _dataset_locks: ClassVar[dict[str, threading.Lock]] = {}
+    _registry_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def run(self) -> None:
+        with self._get_dataset_lock():
+            super().run()
+
+    def _get_dataset_lock(self) -> threading.Lock:
+        key = self._job_client.sql_client.fully_qualified_dataset_name()
+        with self._registry_lock:
+            if key not in self._dataset_locks:
+                self._dataset_locks[key] = threading.Lock()
+            return self._dataset_locks[key]
 
 
 class FabricCopyFileLoadJob(SynapseCopyFileLoadJob):
@@ -251,6 +283,14 @@ class FabricClient(SynapseClient):
         # For non-reference jobs, only handle insert-values and sql files
         parsed_file = ParsedLoadJobFileName.parse(file_path)
         if parsed_file.file_format in ("insert_values", "sql", "model"):
+            # The staging-optimized replace swap must be serialized per dataset - see
+            # FabricStagingReplaceLoadJob for why.
+            if (
+                parsed_file.file_format == "sql"
+                and table.get("write_disposition") == "replace"
+                and table.get("x-replace-strategy") == "staging-optimized"
+            ):
+                return FabricStagingReplaceLoadJob(file_path)
             # Use parent's insert job handling
             return super(SynapseClient, self).create_load_job(table, file_path, load_id, restore)
 

--- a/dlt/destinations/impl/fabric/fabric.py
+++ b/dlt/destinations/impl/fabric/fabric.py
@@ -10,7 +10,7 @@ from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.schema.typing import TColumnSchema
 from dlt.common.schema import Schema
 from dlt.common.destination import DestinationCapabilitiesContext
-from dlt.common.destination.client import LoadJob
+from dlt.common.destination.client import LoadJob, FollowupJobRequest
 from dlt.destinations.impl.synapse.synapse import (
     SynapseClient,
     HINT_TO_SYNAPSE_ATTR,
@@ -18,6 +18,7 @@ from dlt.destinations.impl.synapse.synapse import (
 )
 from dlt.destinations.impl.fabric.configuration import FabricClientConfiguration
 from dlt.destinations.impl.fabric.sql_client import FabricSqlClient
+from dlt.destinations.impl.mssql.mssql import MsSqlStagingReplaceJob
 from dlt.destinations.job_client_impl import SqlJobClientBase
 from dlt.common.configuration.exceptions import ConfigurationException
 from dlt.common.configuration.specs import (
@@ -211,6 +212,22 @@ class FabricClient(SynapseClient):
 
     def should_truncate_table_before_load_on_staging_destination(self, table_name: str) -> bool:
         return self.config.truncate_tables_on_staging_destination_before_load
+
+    def _create_replace_followup_jobs(
+        self, table_chain: Sequence[PreparedTableSchema]
+    ) -> list[FollowupJobRequest]:
+        """Override to restore the `staging-optimized` replace job that `SynapseClient` bypasses.
+
+        `SynapseClient` always falls back to the generic `SqlJobClientBase` replace job
+        because Synapse dedicated SQL pools don't support DDL transactions. Fabric does
+        support DDL transactions and `ALTER SCHEMA ... TRANSFER`, so for the
+        `staging-optimized` strategy we use the same job as `mssql`, which transfers the
+        staging table into the destination schema instead of copying rows.
+        """
+        root_table = table_chain[0]
+        if root_table["x-replace-strategy"] == "staging-optimized":  # type: ignore[typeddict-item]
+            return [MsSqlStagingReplaceJob.from_table_chain(table_chain, self.sql_client)]
+        return SqlJobClientBase._create_replace_followup_jobs(self, table_chain)
 
     def create_load_job(
         self, table: PreparedTableSchema, file_path: str, load_id: str, restore: bool = False

--- a/dlt/destinations/impl/fabric/factory.py
+++ b/dlt/destinations/impl/fabric/factory.py
@@ -129,6 +129,16 @@ class fabric(synapse):
         caps.type_mapper = FabricTypeMapper
         # Fabric only supports precision 0-6 for datetime2/time (not 7 like SQL Server)
         caps.max_timestamp_precision = 6
+        # Unlike Synapse dedicated SQL pools, Fabric Warehouse supports DDL transactions
+        # and `ALTER SCHEMA ... TRANSFER`, so the `staging-optimized` replace strategy
+        # (drop the target table, then transfer the freshly loaded staging table into
+        # its place) can be enabled here on top of what's inherited from synapse.
+        caps.supports_ddl_transactions = True
+        caps.supported_replace_strategies = [
+            "truncate-and-insert",
+            "insert-from-staging",
+            "staging-optimized",
+        ]
         return caps
 
     @classmethod

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -88,8 +88,6 @@ import sqlglot
 
 # this should suffice for now
 DDL_COMMANDS = ["ALTER", "CREATE", "DROP"]
-# TODO: move to respective sql clients
-UNLOGGED_COMMANDS = ["ALTER SCHEMA"]
 
 
 class SqlLoadJob(RunnableLoadJob):
@@ -131,9 +129,6 @@ class SqlLoadJob(RunnableLoadJob):
         return False
 
     def _has_out_of_transaction_commands(self, sql: str) -> bool:
-        for cmd in UNLOGGED_COMMANDS:
-            if re.search(cmd, sql, re.IGNORECASE):
-                return True
         # disable transaction on synapse when doing sql jobs, to enable:
         # TODO: 1. disable transaction if temp table is created via select into
         # 2. swap TRUNCATE for delete in replace jobs

--- a/tests/load/fabric/test_fabric_table_builder.py
+++ b/tests/load/fabric/test_fabric_table_builder.py
@@ -1,7 +1,11 @@
 """Tests for Fabric Warehouse table builder and SQL generation"""
+from pathlib import Path
+from typing import cast
+
 import pytest
 import sqlfluff
 
+from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.utils import uniq_id
 from dlt.common.schema import Schema
 
@@ -153,6 +157,52 @@ def test_fabric_capabilities() -> None:
     from dlt.destinations.impl.fabric.factory import FabricTypeMapper
 
     assert isinstance(caps.type_mapper, type) and issubclass(caps.type_mapper, FabricTypeMapper)
+
+    # Unlike Synapse, Fabric Warehouse supports DDL transactions and
+    # `ALTER SCHEMA ... TRANSFER`, so the `staging-optimized` replace strategy is available
+    assert caps.supports_ddl_transactions is True
+    assert "staging-optimized" in caps.supported_replace_strategies
+
+
+def test_fabric_staging_optimized_replace_uses_alter_schema_transfer(client: FabricClient) -> None:
+    """Test that the 'staging-optimized' replace strategy generates an ALTER SCHEMA ...
+    TRANSFER job (like mssql), not the generic truncate-and-insert job that Synapse falls
+    back to for every replace strategy.
+    """
+    table_chain = cast(
+        list[PreparedTableSchema],
+        [{"name": "event_test_table", "x-replace-strategy": "staging-optimized"}],
+    )
+    jobs = client._create_replace_followup_jobs(table_chain)
+    assert len(jobs) == 1
+
+    sql = Path(jobs[0].new_file_path()).read_text(encoding="utf-8")
+    assert "ALTER SCHEMA" in sql
+    assert "TRANSFER" in sql
+    assert "DROP TABLE IF EXISTS" in sql
+
+
+def test_fabric_insert_from_staging_replace_unaffected(client: FabricClient) -> None:
+    """Test that the existing 'insert-from-staging' replace strategy still uses the
+    generic truncate-and-insert job, i.e. enabling 'staging-optimized' didn't change it.
+    """
+    table_chain = cast(
+        list[PreparedTableSchema],
+        [
+            {
+                "name": "event_test_table",
+                "x-replace-strategy": "insert-from-staging",
+                "columns": {c["name"]: c for c in TABLE_UPDATE},
+            }
+        ],
+    )
+    jobs = client._create_replace_followup_jobs(table_chain)
+    assert len(jobs) == 1
+
+    sql = Path(jobs[0].new_file_path()).read_text(encoding="utf-8")
+    assert "ALTER SCHEMA" not in sql
+    assert "TRUNCATE TABLE" in sql
+    assert "INSERT INTO" in sql
 
 
 @pytest.fixture

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -405,7 +405,9 @@ def test_replace_sql_queries(
 
         destination_spy = mocker.spy(PostgresStagingReplaceJob, "generate_sql")
 
-    elif dest_type == "mssql":
+    elif dest_type in ("mssql", "fabric"):
+        # fabric reuses mssql's ALTER SCHEMA ... TRANSFER-based replace job for
+        # staging-optimized (see FabricClient._create_replace_followup_jobs)
         from dlt.destinations.impl.mssql.mssql import MsSqlStagingReplaceJob
 
         destination_spy = mocker.spy(MsSqlStagingReplaceJob, "generate_sql")
@@ -446,7 +448,7 @@ def test_replace_sql_queries(
             )
 
     elif replace_strategy == "staging-optimized":
-        if dest_type in ["postgres", "mssql", "clickhouse"]:
+        if dest_type in ["postgres", "mssql", "clickhouse", "fabric"]:
             assert destination_spy.call_count == 1
         else:
             assert clone_sql_generator_spy.call_count == 1


### PR DESCRIPTION
### Description

Fabric Warehouse, unlike Synapse dedicated SQL pools, supports DDL transactions and `ALTER SCHEMA ... TRANSFER`. This PR enables the `staging-optimized` replace strategy for the `fabric` destination.

Three parts:

1. **Capabilities** (`dlt/destinations/impl/fabric/factory.py`): override the Synapse-inherited capabilities to advertise DDL transactions and the optimized strategy:
   - `supports_ddl_transactions = True`
   - `supported_replace_strategies = ["truncate-and-insert", "insert-from-staging", "staging-optimized"]`

2. **Replace-job routing** (`dlt/destinations/impl/fabric/fabric.py`): `SynapseClient._create_replace_followup_jobs` deliberately bypasses `MsSqlJobClient`'s replace logic and always falls back to the generic truncate-and-insert job, because Synapse dedicated pools do not support DDL transactions. `FabricClient` inherited that bypass, so flipping the capabilities alone would advertise `staging-optimized` without ever emitting `ALTER SCHEMA ... TRANSFER`, silently behaving like `insert-from-staging`. `FabricClient` now overrides `_create_replace_followup_jobs` to route the `staging-optimized` strategy to the same `MsSqlStagingReplaceJob` (ALTER SCHEMA TRANSFER) the mssql destination uses, while keeping the Synapse-style behavior for `truncate-and-insert` and `insert-from-staging`.

3. **Concurrent-load safety** (`dlt/destinations/job_client_impl.py`, `dlt/destinations/impl/fabric/fabric.py`).

   The swap generated by `MsSqlStagingReplaceJob` (`DROP TABLE`, `ALTER SCHEMA ... TRANSFER`, `SELECT ... INTO`) has to run as one atomic transaction, but it was running fully autocommitted, statement by statement. With several table chains replaced concurrently this silently dropped rows: a second chain's swap could interleave with a first still mid-swap, and one chain's data was lost.

   The cause was `SqlLoadJob._has_out_of_transaction_commands`, which forces a job to run outside a transaction. It had two triggers: a blanket `UNLOGGED_COMMANDS = ["ALTER SCHEMA"]` match, and a check for `SynapseClient`. **Why `UNLOGGED_COMMANDS = ["ALTER SCHEMA"]` is removed here:**
   - it already carried a `# TODO: move to respective sql clients` note, i.e. it was flagged as a blanket check living in the wrong place;
   - the `SynapseClient` trigger (kept) already forces every Synapse sql job into autocommit, so the `ALTER SCHEMA` match was redundant for Synapse, which in any case never emits this swap (its `_create_replace_followup_jobs` always falls back to the clone/insert job);
   - the only SQL in the whole codebase that contains `ALTER SCHEMA` is `MsSqlStagingReplaceJob.generate_sql` (`dlt/destinations/impl/mssql/mssql.py`), used by `mssql` and `fabric`. Both advertise `supports_ddl_transactions = True` and are not `SynapseClient`, so this match was the only thing forcing their swap out of a transaction, which is exactly what broke atomicity.

   Removing the constant therefore leaves Synapse unchanged (still autocommit via the `SynapseClient` trigger, and it never reaches the swap) and restores the intended atomic swap for both `fabric` and `mssql` (the mssql case was a latent bug fixed here as well).

   Atomicity alone is not enough on Fabric: it has no `sp_getapplock`, so two atomic swaps for different chains committed at the same time can still race against the same destination schema. A fabric-specific `FabricStagingReplaceLoadJob` serializes the swap with an in-process lock keyed by destination dataset, which is sufficient because the loader always runs sql jobs on a thread pool, never across processes. The lock is fabric-specific: mssql relies on the SQL Server engine's own schema-level locking and is left unchanged.

### Related Issues

- Closes #4144

### Additional Context

Tests in `tests/load/fabric/test_fabric_table_builder.py`:
- `test_fabric_capabilities` asserts DDL transactions and `staging-optimized` are advertised;
- `test_fabric_staging_optimized_replace_uses_alter_schema_transfer` asserts the generated replace-job SQL contains `ALTER SCHEMA`, `TRANSFER` and `DROP TABLE IF EXISTS`;
- `test_fabric_insert_from_staging_replace_unaffected` guards that the non-optimized strategies stay unchanged.

`tests/load/pipeline/test_replace_disposition.py::test_replace_sql_queries` now also covers `fabric`, which reuses mssql's `MsSqlStagingReplaceJob`.

Validated end to end against a live Fabric Warehouse: the multi-table `staging-optimized` replace keeps every child-table row across repeated concurrent runs, and the single-chain and non-optimized strategies are unaffected.
