### PR TITLE
perf: cache validation type hints

### DIFF
--- a/dlt/common/validation.py
+++ b/dlt/common/validation.py
@@ -26,6 +26,12 @@ TFilterFunc = Callable[[str], bool]
 TCustomValidator = Callable[[str, str, Any, Any], bool]
 
 
+@functools.lru_cache(maxsize=256)
+def _get_cached_type_hints(spec: Type[_TypedDict]) -> dict[str, Any]:
+    module = sys.modules.get(spec.__module__)
+    return get_type_hints(spec, globalns=module.__dict__ if module else None)
+
+
 def validate_dict(
     spec: Type[_TypedDict],
     doc: StrAny,
@@ -59,13 +65,7 @@ def validate_dict(
     # can't validate anything
     validator_f = validator_f or (lambda p, pk, pv, t: False)
 
-    # TODO: get_type_hints is very slow and we possibly should cache the result
-    # even better option is to rewrite "verify_prop" so we can cache annotations mapper to validators
-    # so we do not check the types of typeddict keys all the time
-    allowed_props = get_type_hints(
-        spec,
-        globalns=sys.modules[spec.__module__].__dict__ if spec.__module__ in sys.modules else None,
-    )
+    allowed_props = _get_cached_type_hints(spec)
     # exclude NotRequired[T] via __required_keys__ and Optional[T] via is_optional_type.
     # Optional[T] treated as not-required for backward compat (existing schemas use it to mean "key may be absent").
     required_keys = getattr(spec, "__required_keys__", None)

--- a/tests/common/test_validation.py
+++ b/tests/common/test_validation.py
@@ -15,6 +15,7 @@ from typing import (
     Union,
 )
 
+import dlt.common.validation as validation_module
 from dlt.common import Decimal, jsonpath
 from dlt.common.exceptions import DictValidationException
 from dlt.common.schema.typing import (
@@ -32,7 +33,6 @@ from dlt.common.typing import (
     TColumnNames,
     TypedDict,
 )
-
 from dlt.common.validation import validate_dict, validate_dict_ignoring_xkeys
 
 
@@ -154,6 +154,22 @@ def test_validate_schema_cases() -> None:
 
 def test_validate_doc() -> None:
     validate_dict(TTestRecord, TEST_DOC, ".")
+
+
+def test_validate_dict_caches_type_hints() -> None:
+    class TCacheRecord(TypedDict):
+        name: str
+
+    validation_module._get_cached_type_hints.cache_clear()
+    try:
+        validate_dict(TCacheRecord, {"name": "first"}, ".")
+        validate_dict(TCacheRecord, {"name": "second"}, ".")
+
+        cache_info = validation_module._get_cached_type_hints.cache_info()
+        assert cache_info.hits == 1
+        assert cache_info.misses == 1
+    finally:
+        validation_module._get_cached_type_hints.cache_clear()
 
 
 def test_missing_values(test_doc: TTestRecord) -> None:


### PR DESCRIPTION
### Description

Caches resolved `TypedDict` type hints used by `validate_dict`.

`validate_dict` is called from schema, REST API config, and deployment manifest validation. It currently resolves the same `TypedDict` annotations with `get_type_hints` on every validation call. PR #2373 noted that `get_type_hints` is slow, but skipped validation in one internal-storage path instead of addressing repeated validation generally.

This keeps validation behavior unchanged and only avoids resolving hints again for the same spec class. The implementation uses stdlib `functools.lru_cache`; there are no public API, dependency, docs, or lockfile changes.

No linked issue. I searched for existing issues/PRs around `validate_dict`, `get_type_hints`, and validation caching; the closest items were #2373 and #2753, but neither implements this cache.

### Benchmark

Repeated validation of `tests/common/cases/schemas/eth/ethereum_schema_v11.yml` as `TStoredSchema`, 200 iterations:

- uncached: 0.7888s
- cached: 0.1341s
- speedup: 5.88x

### Validation

Passed:

- `.venv/bin/ruff check dlt/common/validation.py tests/common/test_validation.py`
- `.venv/bin/python -m mypy dlt/common/validation.py tests/common/test_validation.py`
- `.venv/bin/python -m pytest tests/common/test_validation.py tests/common/schema/test_schema.py tests/sources/rest_api/configurations -q`
- `make lint`

Attempted:

- `make test-common`

`make test-common` first hit the sandboxed `uv` cache permission issue, then was rerun with cache access after `make dev` installed the declared dev dependencies. The rerun completed but failed in unrelated local-environment areas:

- 6,953 passed, 35 failed, 60 skipped, 208 deselected
- temp venv tests abort because created venvs cannot load `libpython3.13.dylib`
- filesystem tests compare an unescaped local path against `file:///Volumes/Mac%20SSD/...`
- workspace deployment detector/manifest tests need `streamlit`, which is not installed by `make dev`

I verified instead of assuming. The same representative failures reproduce on clean `devel`, before the PR changes:

- `tests/common/destination/test_reference.py::test_factory_config_injection`
- `tests/common/runners/test_venv.py::test_create_venv`
- `tests/pipeline/test_dlt_versions.py::test_seen_null_first_columns_cleaned_on_upgrade`
- `tests/sources/rest_api/test_rest_api_pipeline_template.py::test_all_examples[load_github]`
- `tests/workspace/deployment/test_manifest_generator.py::test_manifest_from_module_full_deployment[inprocess]`
- `tests/workspace/deployment/test_detectors.py::test_detect_streamlit[as-st]`

Those six tests fail on `devel` too. I also reran the old-version upgrade test on `devel` with `uv` cache access, and it still fails because the temp venv Python cannot load `libpython3.13.dylib`.

I am marking this ready for review because the changed validation surface passes targeted tests and `make lint`; the broader `make test-common` failures are documented here for reviewer context.
