### PR TITLE
(fix) use truncate mechanism for "replace" tables without data

### DIFF
--- a/dlt/common/destination/client.py
+++ b/dlt/common/destination/client.py
@@ -605,7 +605,7 @@ class JobClientBase(ABC):
         prepared_tables = [
             self.prepare_load_table(table_name)
             for table_name in set(
-                list(only_tables or []) + self.schema.data_table_names(seen_data_only=True)
+                list(only_tables or self.schema.data_table_names(seen_data_only=True))
             )
         ]
         if exceptions := verify_supported_data_types(

--- a/dlt/common/pipeline.py
+++ b/dlt/common/pipeline.py
@@ -51,15 +51,18 @@ from dlt.common.schema.typing import (
 from dlt.common.storages.load_package import ParsedLoadJobFileName
 from dlt.common.storages.load_storage import LoadPackageInfo
 from dlt.common.time import ensure_pendulum_datetime_utc, precise_time
-from dlt.common.typing import DictStrAny, StrAny, SupportsHumanize, TColumnNames, NotRequired
+from dlt.common.typing import (
+    DictStrAny,
+    StrAny,
+    SupportsHumanize,
+    TColumnNames,
+    TRefreshMode,
+    NotRequired,
+)
 from dlt.common.data_writers.writers import TLoaderFileFormat
 from dlt.common.utils import RowCounts, merge_row_counts
 from dlt.common.versioned_state import TVersionedState
 from dlt.common.runtime.collector_base import Collector
-
-
-# TRefreshMode = Literal["full", "replace"]
-TRefreshMode = Literal["drop_sources", "drop_resources", "drop_data"]
 
 
 class _StepInfo(NamedTuple):
@@ -143,7 +146,11 @@ class StepInfo(SupportsHumanize, Generic[TStepMetricsCo]):
             # complete but failed job will not raise any exceptions
             failed_jobs = load_package.jobs["failed_jobs"]
             jobs_str = "no failed jobs" if not failed_jobs else f"{len(failed_jobs)} FAILED job(s)!"
-            msg += f"\nLoad package {load_package.load_id} is {cstr} and contains {jobs_str}"
+            refresh_str = f" with refresh '{load_package.refresh}'" if load_package.refresh else ""
+            msg += (
+                f"\nLoad package {load_package.load_id}{refresh_str} is {cstr} and contains"
+                f" {jobs_str}"
+            )
             if verbosity > 0:
                 for failed_job in failed_jobs:
                     msg += (
@@ -151,7 +158,7 @@ class StepInfo(SupportsHumanize, Generic[TStepMetricsCo]):
                     )
             if verbosity > 1:
                 msg += "\nPackage details:\n"
-                msg += load_package.asstr() + "\n"
+                msg += load_package.asstr(verbosity) + "\n"
         return msg
 
     @staticmethod

--- a/dlt/common/storages/load_package.py
+++ b/dlt/common/storages/load_package.py
@@ -23,7 +23,14 @@ from typing import (
 )
 import semver
 
-from dlt.common.typing import NotRequired, TypedDict, get_args, DictStrAny, SupportsHumanize
+from dlt.common.typing import (
+    NotRequired,
+    TypedDict,
+    get_args,
+    DictStrAny,
+    SupportsHumanize,
+    TRefreshMode,
+)
 from dlt.common.pendulum import pendulum
 from dlt.common.json import json
 from dlt.common.configuration import configspec
@@ -72,6 +79,8 @@ class TPipelineStateDoc(TypedDict, total=False):
 
 
 class TLoadPackageDropTablesState(TypedDict):
+    refresh: NotRequired[TRefreshMode]
+    """Refresh mode that generated the drop/truncate lists below"""
     dropped_tables: NotRequired[List[TTableSchema]]
     """List of tables that are to be dropped from the schema and destination (i.e. when `refresh` mode is used)"""
     truncated_tables: NotRequired[List[TTableSchema]]
@@ -89,6 +98,10 @@ class TLoadPackageState(TVersionedState, TLoadPackageDropTablesState, total=Fals
     """private space for destinations to store state relevant only to the load package"""
     load_metrics: NotRequired[Dict[str, Any]]
     """Per-job load metrics, persisted so they survive process restarts"""
+    applied_dropped_tables: NotRequired[List[str]]
+    """Names of `dropped_tables` actually dropped at the destination by the load step"""
+    applied_truncated_tables: NotRequired[List[str]]
+    """Names of `truncated_tables` actually truncated at the destination by the load step"""
 
 
 class TLoadPackage(TypedDict, total=False):
@@ -273,6 +286,15 @@ class _LoadPackageInfo(NamedTuple):
     schema_update: TSchemaTables
     completed_at: datetime.datetime
     jobs: Dict[TPackageJobState, List[LoadJobInfo]]
+    refresh: Optional[TRefreshMode] = None
+    """Refresh mode the package was extracted with"""
+    # both lists below show tables requested via the package state; when the package is
+    # loaded they show what the load step actually dropped/truncated. regular truncation
+    # of replace tables during a normal load is not included
+    dropped_tables: Optional[Sequence[str]] = None
+    """Names of tables dropped in the destination"""
+    truncated_tables: Optional[Sequence[str]] = None
+    """Names of tables truncated in the destination"""
 
 
 class LoadPackageInfo(SupportsHumanize, _LoadPackageInfo):
@@ -320,6 +342,13 @@ class LoadPackageInfo(SupportsHumanize, _LoadPackageInfo):
             f" {self.state.upper()} state. It updated schema for {len(self.schema_update)} tables."
             f" {completed_msg}.\n"
         )
+        if self.refresh:
+            msg += f"The package was extracted with refresh '{self.refresh}'.\n"
+        if verbosity > 0:
+            if self.dropped_tables:
+                msg += f"Dropped tables: {', '.join(self.dropped_tables)}.\n"
+            if self.truncated_tables:
+                msg += f"Truncated tables: {', '.join(self.truncated_tables)}.\n"
         msg += "Jobs details:\n"
         msg += "\n".join(job.asstr(verbosity) for job in flatten_list_or_items(iter(self.jobs.values())))  # type: ignore
         return msg
@@ -820,6 +849,16 @@ class PackageStorage:
                 self._read_job_file_info(load_id, state, job, package_created_at) for job in jobs
             ]
 
+        # read refresh mode and drop/truncate info from package state. the load step records
+        # the tables it actually dropped/truncated, until then the requested tables are used
+        load_package_state = self.get_load_package_state(load_id)
+        dropped_tables = load_package_state.get("applied_dropped_tables") or [
+            table["name"] for table in load_package_state.get("dropped_tables", [])
+        ]
+        truncated_tables = load_package_state.get("applied_truncated_tables") or [
+            table["name"] for table in load_package_state.get("truncated_tables", [])
+        ]
+
         return LoadPackageInfo(
             load_id,
             self.storage.make_full_path(package_path),
@@ -828,6 +867,9 @@ class PackageStorage:
             applied_update,
             package_created_at,
             all_job_infos,
+            refresh=load_package_state.get("refresh"),
+            dropped_tables=dropped_tables or None,
+            truncated_tables=truncated_tables or None,
         )
 
     def get_job_failed_message(self, load_id: str, job: ParsedLoadJobFileName) -> str:

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -128,6 +128,7 @@ TVariantRV = Tuple[str, Any]
 VARIANT_FIELD_FORMAT = "v_%s"
 TFileOrPath = Union[str, PathLike, IO[Any]]
 TSortOrder = Literal["asc", "desc"]
+TRefreshMode = Literal["drop_sources", "drop_resources", "drop_data"]
 TLoaderFileFormat = Literal[
     "jsonl", "typed-jsonl", "insert_values", "parquet", "csv", "reference", "model"
 ]

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -2,7 +2,7 @@ import contextlib
 from collections.abc import Sequence as C_Sequence
 from copy import copy
 import itertools
-from typing import Iterator, List, Dict, Any, Optional, cast
+from typing import Iterator, List, Dict, Any, Optional
 import yaml
 
 from dlt.common import logger
@@ -24,7 +24,6 @@ from dlt.common.runtime.collector import Collector, NULL_COLLECTOR
 from dlt.common.schema import Schema, utils
 from dlt.common.schema.typing import (
     TAnySchemaColumns,
-    TPartialTableSchema,
     TSchemaContract,
     TTableFormat,
     TTableSchema,
@@ -307,6 +306,9 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
     _last_extractors: Dict[TDataItemFormat, Extractor] = None
     """Most recently used extractors"""
 
+    _tables_to_truncate: List[TTableSchema]
+    """Tables to truncate via package state"""
+
     def __init__(
         self,
         schema_storage: SchemaStorage,
@@ -419,8 +421,8 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
         json_extractor = extractors["object"]
         tables_with_items = set().union(*[e.tables_with_items for e in extractors.values()])
         computed_tables = set().union(*[e.computed_tables for e in extractors.values()])
-        # find REPLACE resources that did not yield any pipe items and create empty jobs for them
-        # do not include tables that have never seen data
+        # find REPLACE resources that yielded no data and register their tables for truncation;
+        # tables that never saw data are excluded (nothing to truncate)
         data_tables = {t["name"]: t for t in schema.data_tables(seen_data_only=True)}
         tables_by_resources = utils.group_tables_by_resource(data_tables)
         for resource in source.resources.selected.values():
@@ -431,7 +433,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
             if callable(resource_write_disposition_dict):
                 continue
 
-            # disposition shorthand used for comparisons and the replace gate below
+            # disposition shorthand (string) used for the replace check below
             resource_write_disposition = (
                 resource_write_disposition_dict["disposition"]
                 if isinstance(resource_write_disposition_dict, dict)
@@ -443,27 +445,30 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                 if utils.is_nested_table(table) or table_name in tables_with_items:
                     continue
 
-                # apply the fresh disposition as a partial table so hint columns (eg. scd2
-                # validity columns) are normalized and merged like on the data path
-                if table_name not in computed_tables and (
-                    wd_config := get_fresh_write_disposition(schema, resource, table)
-                ):
-                    partial_table: Dict[str, Any] = {
-                        "name": table_name,
-                        "columns": {},
-                        "write_disposition": wd_config,
-                    }
-                    resource._merge_write_disposition_dict(partial_table)
-                    schema.update_table(cast(TPartialTableSchema, partial_table))
-
                 # truncate tables only for resources marked as "replace"
                 if resource_write_disposition != "replace":
                     continue
 
+                # compute the current write disposition in memory
+                if table_name not in computed_tables:
+                    wd_config = get_fresh_write_disposition(schema, resource, table)
+                    disposition = (
+                        wd_config["disposition"]
+                        if isinstance(wd_config, dict)
+                        # fall back to the stored disposition when it can't be re-derived
+                        else (wd_config or table.get("write_disposition"))
+                    )
+                else:
+                    disposition = table.get("write_disposition")
+
                 # table itself must accept replace
-                if table.get("write_disposition") == "replace":
-                    # write empty files so a replace root is truncated even though it received no data
-                    json_extractor.write_empty_items_file(table_name)
+                if disposition == "replace":
+                    # collect tables to truncate via package state
+                    self._tables_to_truncate.extend(
+                        nested_table
+                        for nested_table in utils.get_nested_tables(schema.tables, table_name)
+                        if utils.has_table_seen_data(nested_table)
+                    )
 
         # collect tables that received empty materialized lists and had no items
         tables_with_empty = (
@@ -483,6 +488,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
         workers: int,
     ) -> None:
         schema = source.schema
+        self._tables_to_truncate = []
         collector = self.collector
         extractors: Dict[TDataItemFormat, Extractor] = {
             "object": ObjectExtractor(
@@ -595,6 +601,14 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                     max_parallel_items=max_parallel_items,
                     workers=workers,
                 )
+                # register replace tables that yielded no data for truncation via the load package
+                if self._tables_to_truncate:
+                    truncated = load_package.state.setdefault("truncated_tables", [])
+                    existing_names = {table["name"] for table in truncated}
+                    for table in self._tables_to_truncate:
+                        if table["name"] not in existing_names:
+                            existing_names.add(table["name"])
+                            truncated.append(table)
                 commit_load_package_state()
         return load_id
 

--- a/dlt/extract/items_transform.py
+++ b/dlt/extract/items_transform.py
@@ -8,6 +8,7 @@ from typing import (
     ClassVar,
     Generic,
     Iterator,
+    List,
     Mapping,
     Optional,
     Union,
@@ -74,6 +75,12 @@ class ItemTransform(BaseItemTransform[TCustomMetrics], ABC, Generic[TAny, TCusto
         pass
 
 
+class FilteredEmptyList(List[Any]):
+    """A list variant that was consumed by a filter"""
+
+    pass
+
+
 class FilterItem(ItemTransform[bool, Dict[str, Any]]):
     # mypy needs those to type correctly
     _f_meta: ItemTransformFunctionWithMeta[bool]
@@ -91,7 +98,7 @@ class FilterItem(ItemTransform[bool, Dict[str, Any]]):
                 item = [i for i in item if self._f(i)]
             if not item:
                 # item was fully consumed by the filter
-                return None
+                return FilteredEmptyList()
             return item
         else:
             if self._f_meta:
@@ -217,8 +224,10 @@ class LimitItem(ItemTransform[TDataItem, Dict[str, Any]]):
         if self.count_rows:
             self.count += count_rows_in_items(item)
         else:
-            # NOTE: we count empty batches/pages in this mode
-            self.count += 1
+            # NOTE: we count empty batches/pages in this mode as long as they are not
+            #  marked as filtered
+            if not isinstance(item, FilteredEmptyList):
+                self.count += 1
 
         # detect when the limit is reached, max time or yield count
         if (

--- a/dlt/extract/items_transform.py
+++ b/dlt/extract/items_transform.py
@@ -8,7 +8,6 @@ from typing import (
     ClassVar,
     Generic,
     Iterator,
-    List,
     Mapping,
     Optional,
     Union,
@@ -75,12 +74,6 @@ class ItemTransform(BaseItemTransform[TCustomMetrics], ABC, Generic[TAny, TCusto
         pass
 
 
-class FilteredEmptyList(List[Any]):
-    """A list variant that was consumed by a filter"""
-
-    pass
-
-
 class FilterItem(ItemTransform[bool, Dict[str, Any]]):
     # mypy needs those to type correctly
     _f_meta: ItemTransformFunctionWithMeta[bool]
@@ -98,7 +91,7 @@ class FilterItem(ItemTransform[bool, Dict[str, Any]]):
                 item = [i for i in item if self._f(i)]
             if not item:
                 # item was fully consumed by the filter
-                return FilteredEmptyList()
+                return None
             return item
         else:
             if self._f_meta:
@@ -224,10 +217,8 @@ class LimitItem(ItemTransform[TDataItem, Dict[str, Any]]):
         if self.count_rows:
             self.count += count_rows_in_items(item)
         else:
-            # NOTE: we count empty batches/pages in this mode as long as they are not
-            #  marked as filtered
-            if not isinstance(item, FilteredEmptyList):
-                self.count += 1
+            # NOTE: we count empty batches/pages in this mode
+            self.count += 1
 
         # detect when the limit is reached, max time or yield count
         if (

--- a/dlt/extract/validation.py
+++ b/dlt/extract/validation.py
@@ -63,9 +63,15 @@ class PydanticValidator(ValidateItem, Generic[_TPydanticModel]):
         return_models = cfg.get("return_validated_models", False)
 
         if isinstance(item, list):
+            # preserve incoming empty lists (eg. materialized empties); do not validate them
+            if len(item) == 0:
+                return item
             validated_list = validate_and_filter_items(
                 self.table_name, self.list_model, item, self.column_mode, self.data_mode
             )
+            # a non-empty list fully consumed by validation is treated like a filtered-out item
+            if not validated_list:
+                return None
             if return_models:
                 return validated_list
             return [m.model_dump(by_alias=True) for m in validated_list]

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -650,7 +650,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         with self.get_destination_client(schema) as job_client:
             if (expected_update := self.load_storage.begin_schema_update(load_id)) is not None:
                 # init job client
-                applied_update = init_client(
+                applied_update, applied_dropped, applied_truncated = init_client(
                     job_client,
                     schema,
                     new_jobs,
@@ -688,6 +688,15 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                             truncate_tables=truncated_tables,
                         )
                 self.load_storage.commit_schema_update(load_id, applied_update)
+                # record tables actually dropped and truncated in the destination dataset,
+                # like the applied schema update above this happens exactly once per package
+                if applied_dropped or applied_truncated:
+                    state = current_load_package()["state"]
+                    if applied_dropped:
+                        state["applied_dropped_tables"] = sorted(applied_dropped)
+                    if applied_truncated:
+                        state["applied_truncated_tables"] = sorted(applied_truncated)
+                    commit_load_package_state()
 
             # collect all unfinished jobs
             return self.resume_started_jobs(load_id, schema)

--- a/dlt/load/utils.py
+++ b/dlt/load/utils.py
@@ -72,7 +72,7 @@ def init_client(
     drop_staging_filter: Callable[[TTableSchema], bool],
     drop_tables: Optional[List[TTableSchema]] = None,
     truncate_tables: Optional[List[TTableSchema]] = None,
-) -> TSchemaTables:
+) -> Tuple[TSchemaTables, Set[str], Set[str]]:
     """Initializes destination storage including staging dataset if supported
 
     Will initialize and migrate schema in destination dataset and staging dataset.
@@ -89,7 +89,9 @@ def init_client(
         truncate_tables (Optional[List[TTableSchema]]): List of tables to truncate before initializing storage
 
     Returns:
-        TSchemaTables: Actual migrations done at destination
+        Tuple[TSchemaTables, Set[str], Set[str]]: Actual migrations done at destination and the
+        names of tables actually dropped and truncated in the destination dataset due to the
+        load package state.
     """
     # get dlt/internal tables
     dlt_tables = set(schema.dlt_table_names())
@@ -131,7 +133,7 @@ def init_client(
     job_client.verify_schema(only_tables=tables_with_jobs | dlt_tables, new_jobs=new_jobs)
     # forced migration (re)creates schema-known truncate targets before truncation. targets
     # with old-convention names (after a naming change) are not in the schema
-    applied_update = _init_dataset_and_update_schema(
+    applied_update, applied_dropped, applied_truncated = _init_dataset_and_update_schema(
         job_client,
         expected_update,
         tables_with_jobs | dlt_tables | (initial_truncate_names & set(schema.tables.keys())),
@@ -174,7 +176,7 @@ def init_client(
                     drop_tables=drop_table_names,  # try to drop all the same tables on staging
                 )
 
-    return applied_update
+    return applied_update, applied_dropped, applied_truncated
 
 
 def _init_dataset_and_update_schema(
@@ -186,7 +188,14 @@ def _init_dataset_and_update_schema(
     initial_truncate_tables: Set[str] = None,
     staging_info: bool = False,
     drop_tables: Iterable[str] = None,
-) -> TSchemaTables:
+) -> Tuple[TSchemaTables, Set[str], Set[str]]:
+    """Initializes storage, applies drops/truncates and schema update.
+
+    Returns the applied schema update, the set of table names actually dropped and the subset of
+    `initial_truncate_tables` actually truncated.
+    """
+    applied_dropped: Set[str] = set()
+    applied_truncated: Set[str] = set()
     staging_text = "for staging dataset" if staging_info else ""
     logger.info(
         f"Client for {job_client.config.destination_type} will start initialize storage"
@@ -199,6 +208,7 @@ def _init_dataset_and_update_schema(
                 f" {drop_tables} {staging_text}"
             )
             job_client.drop_tables(*drop_tables, delete_schema=True)
+            applied_dropped = set(drop_tables)
         else:
             logger.warning(
                 f"Client for {job_client.config.destination_type} does not implement drop table."
@@ -224,8 +234,11 @@ def _init_dataset_and_update_schema(
             f"Client for {job_client.config.destination_type} will truncate tables {staging_text}"
         )
         job_client.initialize_storage(truncate_tables=truncate_tables)
+        # report only tables truncated due to the load package state, not the regular
+        # truncation of replace tables that happens on every load
+        applied_truncated = (initial_truncate_tables or set()) & truncate_tables
 
-    return applied_update
+    return applied_update, applied_dropped, applied_truncated
 
 
 def _extend_tables_with_table_chain(

--- a/dlt/load/utils.py
+++ b/dlt/load/utils.py
@@ -94,12 +94,15 @@ def init_client(
     # get dlt/internal tables
     dlt_tables = set(schema.dlt_table_names())
 
-    # tables without data (TODO: normalizer removes such jobs, write tests and remove the line below)
+    # tables that never seen data are not created or verified - the normalizer does not emit jobs
+    # for them, this guards against any stale job still referencing such a table
     tables_no_data = set(
         table["name"] for table in schema.data_tables() if not has_table_seen_data(table)
     )
     # get all tables that actually have load jobs with data
     tables_with_jobs = set(job.table_name for job in new_jobs) - tables_no_data
+    # TODO: remove after full test run
+    assert tables_with_jobs - tables_no_data == tables_with_jobs
 
     # initial tables contain child tables already
     initial_truncate_names = (

--- a/dlt/load/utils.py
+++ b/dlt/load/utils.py
@@ -95,16 +95,8 @@ def init_client(
     """
     # get dlt/internal tables
     dlt_tables = set(schema.dlt_table_names())
-
-    # tables that never seen data are not created or verified - the normalizer does not emit jobs
-    # for them, this guards against any stale job still referencing such a table
-    tables_no_data = set(
-        table["name"] for table in schema.data_tables() if not has_table_seen_data(table)
-    )
-    # get all tables that actually have load jobs with data
-    tables_with_jobs = set(job.table_name for job in new_jobs) - tables_no_data
-    # TODO: remove after full test run
-    assert tables_with_jobs - tables_no_data == tables_with_jobs
+    # get all tables that actually have load jobs
+    tables_with_jobs = set(job.table_name for job in new_jobs)
 
     # initial tables contain child tables already
     initial_truncate_names = (

--- a/dlt/normalize/items_normalizers/jsonl.py
+++ b/dlt/normalize/items_normalizers/jsonl.py
@@ -484,6 +484,7 @@ class JsonLItemsNormalizer(ItemsNormalizer):
             extracted_items_file, "rb"
         ) as f:
             # enumerate jsonl file line by line
+            line_no: Optional[int] = None
             for line_no, line in enumerate(f):
                 self._maybe_cancel()
                 items: List[TDataItem] = json.loadb(line)
@@ -492,29 +493,33 @@ class JsonLItemsNormalizer(ItemsNormalizer):
                 )
                 schema_updates.append(partial_update)
                 logger.debug(f"Processed {line_no+1} lines from file {extracted_items_file}")
-            # generate empty files when (1) input data had no rows (2) rows got filtered out by contract
+            # no active writer means no rows were created for the root table
             if (
                 root_table_name in self.schema.tables
-                and self.item_storage.get_active_writer(  # no active writer if no rows created
+                and self.item_storage.get_active_writer(
                     self.load_id, self.schema.name, root_table_name
                 )[1]
                 is None
             ):
                 root_table = self.schema.tables[root_table_name]
-                if not has_table_seen_data(root_table):
-                    # if this is a new table, add normalizer columns
-                    partial_update = self._normalize_chunk(
-                        root_table_name, [{}], False, skip_write=True
+                table_seen_data = has_table_seen_data(root_table)
+                # empty file (line_no is None) -> explicit materialize, always create the table.
+                # rows filtered out -> only truncate a table that has already seen data
+                if line_no is None or table_seen_data:
+                    if not table_seen_data:
+                        # new materialized table needs normalizer columns
+                        partial_update = self._normalize_chunk(
+                            root_table_name, [{}], False, skip_write=True
+                        )
+                        schema_updates.append(partial_update)
+                    self.item_storage.write_empty_items_file(
+                        self.load_id,
+                        self.schema.name,
+                        root_table_name,
+                        self.schema.get_table_columns(root_table_name),
                     )
-                    schema_updates.append(partial_update)
-                self.item_storage.write_empty_items_file(
-                    self.load_id,
-                    self.schema.name,
-                    root_table_name,
-                    self.schema.get_table_columns(root_table_name),
-                )
-                logger.debug(
-                    f"No rows from file {extracted_items_file}, written empty load job file"
-                )
+                    logger.debug(
+                        f"No rows from file {extracted_items_file}, written empty load job file"
+                    )
 
         return schema_updates

--- a/dlt/pipeline/helpers.py
+++ b/dlt/pipeline/helpers.py
@@ -182,7 +182,7 @@ def prepare_refresh_source(
         state_paths="*" if refresh == "drop_sources" else [],
         state_only=only_truncate,
     )
-    load_package_state: TLoadPackageDropTablesState = {}
+    load_package_state: TLoadPackageDropTablesState = {"refresh": refresh}
     if drop_result.modified_tables:
         if only_truncate:
             load_package_state["truncated_tables"] = drop_result.modified_tables

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "dlt"
-version = "1.27.2"
+version = "1.28.1"
 source = { editable = "../" }
 dependencies = [
     { name = "click" },
@@ -956,8 +956,8 @@ requires-dist = [
     { name = "db-dtypes", marker = "extra == 'bigquery'", specifier = ">=1.2.0" },
     { name = "db-dtypes", marker = "extra == 'gcp'", specifier = ">=1.2.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=0.25.1" },
-    { name = "dlthub", marker = "python_full_version >= '3.10' and extra == 'hub'", specifier = ">=0.27.0,<0.28" },
-    { name = "dlthub-client", marker = "python_full_version >= '3.10' and extra == 'hub'", specifier = ">=0.27.0,<0.28" },
+    { name = "dlthub", marker = "extra == 'hub'", specifier = ">=0.27.0,<0.29" },
+    { name = "dlthub-client", marker = "extra == 'hub'", specifier = ">=0.27.7,<0.29" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
     { name = "duckdb", marker = "extra == 'ducklake'", specifier = ">=1.2.0" },
     { name = "duckdb", marker = "extra == 'lance'", specifier = ">=1.4.3" },
@@ -976,10 +976,10 @@ requires-dist = [
     { name = "grpcio", marker = "extra == 'gcp'", specifier = ">=1.50.0" },
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=1.4.1" },
     { name = "humanize", specifier = ">=4.4.0" },
-    { name = "ibis-framework", marker = "python_full_version >= '3.10' and extra == 'lance'", specifier = ">=12.0.0" },
-    { name = "ibis-framework", marker = "python_full_version >= '3.10' and extra == 'lancedb'", specifier = ">=12.0.0" },
+    { name = "ibis-framework", marker = "extra == 'lance'", specifier = ">=12.0.0" },
+    { name = "ibis-framework", marker = "extra == 'lancedb'", specifier = ">=12.0.0" },
     { name = "jsonpath-ng", specifier = ">=1.5.3,<1.8" },
-    { name = "lancedb", marker = "extra == 'lance'", specifier = ">=0.22.0" },
+    { name = "lancedb", marker = "extra == 'lance'", specifier = ">=0.33.0" },
     { name = "lancedb", marker = "extra == 'lancedb'", specifier = ">=0.22.0" },
     { name = "oracledb", marker = "extra == 'oracle'", specifier = ">=3.4.1" },
     { name = "orjson", marker = "python_full_version >= '3.14'", specifier = ">=3.11.0" },
@@ -1015,14 +1015,15 @@ requires-dist = [
     { name = "pydbml", marker = "extra == 'dbml'" },
     { name = "pyiceberg", marker = "extra == 'pyiceberg'", specifier = ">=0.9.1" },
     { name = "pyiceberg-core", marker = "extra == 'pyiceberg'", specifier = ">=0.6.0" },
-    { name = "pylance", marker = "extra == 'lance'", specifier = ">=4.0.0" },
+    { name = "pylance", marker = "extra == 'lance'", specifier = ">=6.0.1,<8" },
     { name = "pyodbc", marker = "extra == 'fabric'", specifier = ">=4.0.39" },
     { name = "pyodbc", marker = "extra == 'mssql'", specifier = ">=4.0.39" },
     { name = "pyodbc", marker = "extra == 'synapse'", specifier = ">=4.0.39" },
     { name = "pytz", specifier = ">=2022.6" },
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=306" },
     { name = "pyyaml", specifier = ">=5.4.1" },
-    { name = "qdrant-client", extras = ["fastembed"], marker = "extra == 'qdrant'", specifier = ">=1.8" },
+    { name = "qdrant-client", marker = "python_full_version >= '3.14' and extra == 'qdrant'", specifier = ">=1.8" },
+    { name = "qdrant-client", extras = ["fastembed"], marker = "python_full_version < '3.14' and extra == 'qdrant'", specifier = ">=1.8" },
     { name = "requests", specifier = ">=2.26.0" },
     { name = "requirements-parser", specifier = ">=0.5.0" },
     { name = "rich-argparse", specifier = ">=1.6.0" },
@@ -1033,6 +1034,7 @@ requires-dist = [
     { name = "semver", specifier = ">=3.0.0" },
     { name = "setuptools", specifier = ">=65.6.0" },
     { name = "simplejson", specifier = ">=3.17.5" },
+    { name = "snowflake-connector-python", marker = "python_full_version >= '3.14' and extra == 'snowflake'", specifier = ">=4.4.0" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.5.0" },
     { name = "sqlalchemy", marker = "extra == 'pyiceberg'", specifier = ">=1.4" },
     { name = "sqlalchemy", marker = "extra == 'sql-database'", specifier = ">=1.4" },
@@ -1058,12 +1060,12 @@ dashboard-tests = [
     { name = "pytest-playwright", specifier = ">=0.7.1,<1" },
 ]
 dbt = [
-    { name = "dbt-athena-community", specifier = ">=1.7.0" },
+    { name = "dbt-athena-community", marker = "python_full_version < '3.14'", specifier = ">=1.7.0" },
     { name = "dbt-bigquery", specifier = ">=1.7.0" },
     { name = "dbt-core", specifier = ">=1.7.0" },
     { name = "dbt-duckdb", specifier = ">=1.7.0" },
     { name = "dbt-fabric", marker = "python_full_version < '3.13'", specifier = ">=1.7.0" },
-    { name = "dbt-redshift", specifier = ">=1.7.0" },
+    { name = "dbt-redshift", marker = "python_full_version < '3.14'", specifier = ">=1.7.0" },
     { name = "dbt-snowflake", specifier = ">=1.7.0" },
     { name = "dbt-sqlserver", marker = "python_full_version < '3.13'", specifier = ">=1.7.0" },
 ]
@@ -1072,7 +1074,7 @@ dev = [
     { name = "black", extras = ["jupyter"], specifier = ">=23.7.0,<24" },
     { name = "boto3-stubs", extras = ["lakeformation", "s3", "s3tables"], specifier = ">=1.28.28,<2" },
     { name = "flake8", specifier = ">=7.0.0,<8" },
-    { name = "flake8-bugbear", specifier = ">=22.0.0,<23" },
+    { name = "flake8-bugbear", specifier = ">=25.0.0" },
     { name = "flake8-builtins", specifier = ">=1.5.3,<2" },
     { name = "flake8-encodings", git = "https://github.com/dlt-hub/flake8-encodings.git?branch=disable_jedi_support" },
     { name = "flake8-print", specifier = ">=5.0.0,<6" },
@@ -1091,6 +1093,7 @@ dev = [
     { name = "pytest-forked", specifier = ">=1.3.0" },
     { name = "pytest-mock", specifier = ">=3.14.0,<4" },
     { name = "pytest-order", specifier = ">=1.0.0" },
+    { name = "pytest-rerunfailures", specifier = ">=14,<16" },
     { name = "pytest-timeout", specifier = ">=2.3.1,<3" },
     { name = "pytest-xdist", specifier = ">=3.5,<4" },
     { name = "requests-mock", specifier = ">=1.10.0,<2" },
@@ -1115,18 +1118,19 @@ dev = [
 ]
 ibis = [
     { name = "ibis-framework", extras = ["duckdb", "postgres", "bigquery", "snowflake", "clickhouse", "databricks"], marker = "python_full_version >= '3.13'", specifier = ">=12.0.0" },
-    { name = "ibis-framework", extras = ["duckdb", "postgres", "bigquery", "snowflake", "mssql", "clickhouse", "databricks"], marker = "python_full_version >= '3.10' and python_full_version < '3.13'", specifier = ">=12.0.0" },
+    { name = "ibis-framework", extras = ["duckdb", "postgres", "bigquery", "snowflake", "mssql", "clickhouse", "databricks"], marker = "python_full_version < '3.13'", specifier = ">=12.0.0" },
 ]
-ibis-bare = [{ name = "ibis-framework", marker = "python_full_version >= '3.10'", specifier = ">=12.0.0" }]
+ibis-bare = [{ name = "ibis-framework", specifier = ">=12.0.0" }]
 pipeline = [
     { name = "alive-progress", specifier = ">=3.1.1,<4" },
     { name = "cffi", specifier = ">=1.16" },
-    { name = "cryptography", specifier = ">=41.0.7,<42" },
+    { name = "cffi", marker = "python_full_version >= '3.14'", specifier = ">=1.18" },
+    { name = "cryptography", specifier = ">=41.0.7" },
     { name = "datasets", specifier = ">=4.5.0" },
     { name = "enlighten", specifier = ">=1.11.2,<2" },
     { name = "greenlet", specifier = ">=3.1" },
     { name = "mmh3", specifier = ">5.0.0" },
-    { name = "pandas", specifier = ">=2.1.4" },
+    { name = "pandas", specifier = ">=2.3.0,<3" },
     { name = "pyarrow", specifier = ">=16.0.0" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "regex", specifier = ">=2024.10" },
@@ -1137,24 +1141,24 @@ pipeline = [
 providers = [{ name = "google-api-python-client", specifier = ">=2.86.0,<3" }]
 sentry-sdk = [{ name = "sentry-sdk", specifier = ">=2.0.0,<3" }]
 sources = [
-    { name = "connectorx", marker = "python_full_version < '3.10'", specifier = "<0.4.2" },
-    { name = "connectorx", marker = "python_full_version >= '3.10'", specifier = ">=0.4.2" },
+    { name = "connectorx", specifier = ">=0.4.2" },
     { name = "mimesis", specifier = ">=7.0.0,<8" },
     { name = "openpyxl", specifier = ">=3,<4" },
     { name = "pymysql", specifier = ">=1.1.0,<2" },
     { name = "sqlalchemy", specifier = "<2" },
 ]
-streamlit = [{ name = "streamlit", marker = "python_full_version >= '3.10'", specifier = ">1.50" }]
+streamlit = [{ name = "streamlit", specifier = ">1.50" }]
 workspace-deps = [
     { name = "croniter", specifier = ">=6.0.0" },
     { name = "duckdb", specifier = ">=0.9" },
-    { name = "fastmcp", marker = "python_full_version >= '3.10'", specifier = ">=3.0.0" },
-    { name = "ibis-framework", marker = "python_full_version >= '3.10'", specifier = ">=12.0.0" },
+    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "ibis-framework", specifier = ">=12.0.0" },
     { name = "marimo", specifier = ">=0.14.5" },
     { name = "mowidgets", marker = "python_full_version >= '3.11'", specifier = ">=0.2.1" },
     { name = "pathspec", specifier = ">=0.11.2" },
     { name = "pyarrow", specifier = ">=16.0.0" },
     { name = "pydbml", specifier = ">=1.2.0" },
+    { name = "s3fs", specifier = ">=2022.4.0" },
 ]
 
 [[package]]
@@ -1267,7 +1271,7 @@ wheels = [
 
 [[package]]
 name = "dlthub-client"
-version = "0.27.0"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1278,9 +1282,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/4c/1bf717620f937901b5b23d4385440def4b1eeeb41c2bb7ba3e1bcfebf2bf/dlthub_client-0.27.0.tar.gz", hash = "sha256:cd0eb7c36971c357999d79dd5bdfad03cc7492bc32db3bf1ee2719938a4e1e49", size = 130738, upload-time = "2026-05-18T15:59:13.618Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/f9/6f289ce778bdfb6e09c843af97ec50c04158bc4f3ef07375225a6e4265c2/dlthub_client-0.28.0.tar.gz", hash = "sha256:2e2625716ec58912cb449bcb79f89ffaf703eea4d9c99a2a2709c4daaa5288f5", size = 144549, upload-time = "2026-06-29T13:51:18.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/d9/bb355466148889429eb54644a8273b2df061baaa228e2f8aa4cb7f1552b3/dlthub_client-0.27.0-py3-none-any.whl", hash = "sha256:1e6bd0af61c75cffdca6b9104f771cf483c7a5f2697ec81fa828580c6e5c35e4", size = 288837, upload-time = "2026-05-18T15:59:11.334Z" },
+    { url = "https://files.pythonhosted.org/packages/09/4b/7e2ab6b173c041584875cad4c2cc1d59d97648581bee041729cdcfdcb0ed/dlthub_client-0.28.0-py3-none-any.whl", hash = "sha256:56211d610cabb9f5c657b9f08d54d7ac423aa9e27b94bd08e6ac383a43a21da9", size = 333879, upload-time = "2026-06-29T13:51:20.022Z" },
 ]
 
 [[package]]
@@ -3819,14 +3823,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]

--- a/docs/website/docs/running-in-production/running.md
+++ b/docs/website/docs/running-in-production/running.md
@@ -29,6 +29,12 @@ The `load_info` contains plenty of useful information on the recently loaded dat
     print(load_info.load_packages[0])
     # print the information on the first completed job in the first load package
     print(load_info.load_packages[0].jobs["completed_jobs"][0])
+    # see the refresh mode the package was extracted with (None if refresh was not requested)
+    print(load_info.load_packages[0].refresh)
+    # see the tables that were dropped and truncated in the destination, e.g. by refresh,
+    # the drop command, or when a replace resource yields no data
+    print(load_info.load_packages[0].dropped_tables)
+    print(load_info.load_packages[0].truncated_tables)
 ```
 
 `load_info` may also be loaded into the destinations as below:

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, NamedTuple, Optional, Set, Any
 import pytest
 import os
 
@@ -1192,19 +1192,28 @@ def _mark_seen_data(schema: dlt.Schema, *table_names: str) -> None:
         schema.tables[table_name].setdefault("x-normalizer", {})["seen-data"] = True
 
 
+class _ExtractResult(NamedTuple):
+    table_metrics: Dict[str, Any]
+    """writer metrics per table - data writes and materialized (empty-file) tables"""
+    truncated_tables: Set[str]
+    """tables registered for truncation via the load package state (a replace resource with no data)"""
+
+
 def _extract_resource(
     extract_step: Extract, schema: dlt.Schema, resource: DltResource
-) -> Dict[str, Any]:
+) -> _ExtractResult:
     """Extract a single resource into the shared `schema` (mirrors the per-run extraction) and
-    return its per-table writer metrics (table name -> DataWriterMetrics)."""
+    return its per-table writer metrics together with the tables registered for truncation via the
+    load package state."""
     source = DltSource(schema, "module", [resource])
     load_id = extract_step.extract_storage.create_load_package(schema)
     extract_step._extract_single_source(load_id, source, max_parallel_items=5, workers=1)
     table_metrics: Dict[str, Any] = extract_step._step_info_metrics(load_id)[0]["table_metrics"]
+    truncated_tables = {table["name"] for table in extract_step._tables_to_truncate}
     extract_step.extract_storage.commit_new_load_package(load_id, schema)
     for extractor in extract_step._last_extractors.values():
         assert_written_tables_are_computed(extractor)
-    return table_metrics
+    return _ExtractResult(table_metrics, truncated_tables)
 
 
 @pytest.mark.parametrize(
@@ -1212,7 +1221,7 @@ def _extract_resource(
     [("items", "items"), ("MyItems", "my_items")],
     ids=["table_is_resource_name", "table_differs_from_resource_name"],
 )
-def test_handle_empty_tables_refreshes_static_write_disposition(
+def test_handle_empty_tables_does_not_mutate_disposition(
     extract_step: Extract, table_name: str, expected: str
 ) -> None:
     schema = dlt.Schema("empty_tables")
@@ -1245,11 +1254,10 @@ def test_handle_empty_tables_refreshes_static_write_disposition(
     assert object_extractor.tables_with_items == {expected}
     assert object_extractor.tables_with_empty == set()
 
-    # a replace table that yields no data still gets an empty file (so it is truncated): it appears
-    # in the writer metrics with zero items
-    metrics = _extract_resource(extract_step, schema, items_replace([]))
-    assert metrics[expected].items_count == 0
-    # an empty run computes nothing and writes no items; the empty file came from
+    # a replace table that yields no data is truncated by recording it in the load package state
+    result = _extract_resource(extract_step, schema, items_replace([]))
+    assert result.truncated_tables == {expected}
+    # an empty run computes nothing and writes no items; the truncation came from
     # `_handle_empty_tables`, not the extractor
     object_extractor = extract_step._last_extractors["object"]
     assert object_extractor.computed_tables == set()
@@ -1269,31 +1277,28 @@ def test_handle_empty_tables_refreshes_static_write_disposition(
     def items_merge() -> Any:
         yield from []
 
-    # a non-replace table that yields no data must NOT get an empty file - it is absent from metrics
-    metrics = _extract_resource(extract_step, schema, items_merge())
-    assert expected not in metrics
+    # a non-replace table that yields no data must NOT be truncated or written
+    result = _extract_resource(extract_step, schema, items_merge())
+    assert expected not in result.truncated_tables
+    assert expected not in result.table_metrics
 
-    # write disposition refreshed from the resource, with the full scd2 merge config applied
-    assert items_table["write_disposition"] == "merge"
-    assert items_table["x-merge-strategy"] == "scd2"
-    # scd2 validity columns were added by the merge config, normalized like on the data path
-    assert "valid_from" in items_table["columns"]
-    assert "valid_to" in items_table["columns"]
-    assert "ValidFrom" not in items_table["columns"]
-    # existing hints survive the isolated disposition update
+    # an empty run does NOT modify the table: the stored disposition and hints are left untouched,
+    # and the new scd2 merge config (incl. validity columns) is only applied once data arrives
+    assert items_table["write_disposition"] == "replace"
+    assert "x-merge-strategy" not in items_table
+    assert "valid_from" not in items_table["columns"]
+    assert "valid_to" not in items_table["columns"]
+    # existing hints are preserved because the table is not rewritten
     assert items_table["columns"]["id"]["primary_key"] is True
     assert items_table["columns"]["id"]["data_type"] == "bigint"
     assert items_table["columns"]["value"]["cluster"] is True
-    assert items_table["x-custom"] == "keep-me"
+    assert items_table["x-custom"] == "keep-me"  # type: ignore[typeddict-item]
 
 
 def test_handle_empty_tables_variant_pseudo_root_no_cascade(extract_step: Extract) -> None:
-    """Nested hints that break nesting (a primary key) create a pseudo-root table - both for the
-    default table and for a variant. On an empty run every table is refreshed from the current
-    hints: the default root from the resource hints, the variant (declared with a non-normalized
-    name) from its own variant hints keyed by the raw name, and each pseudo-root by re-deriving its
-    write disposition from the parent's nested hints. Re-deriving reads the parent's nested hints
-    only (it never recomputes a pseudo-root as a root), so no spurious cascade tables are created.
+    """Nested hints that break nesting (a primary key) create a pseudo-root table for both the
+    default table and a variant. An empty run does not modify these tables and never recomputes a
+    pseudo-root as a root, so no spurious cascade tables are created.
     """
     schema = dlt.Schema("empty_tables")
 
@@ -1354,11 +1359,10 @@ def test_handle_empty_tables_variant_pseudo_root_no_cascade(extract_step: Extrac
 
     # run 2: replace with no data - every table (roots and pseudo-roots) is replace, so each gets an
     # empty file written (so it is truncated), and no spurious cascade table is created
-    metrics = _extract_resource(
+    result = _extract_resource(
         extract_step, schema, make_resource("replace", "replace", "replace", [])
     )
-    for table in all_tables:
-        assert metrics[table].items_count == 0
+    assert result.truncated_tables == set(all_tables)
     assert "items__sub_items__sub_items" not in schema.tables
     assert "other_items__sub_items__sub_items" not in schema.tables
     # an empty run computes nothing and writes no items - the empty files came from
@@ -1368,32 +1372,25 @@ def test_handle_empty_tables_variant_pseudo_root_no_cascade(extract_step: Extrac
     assert object_extractor.tables_with_items == set()
     assert object_extractor.tables_with_empty == set()
 
-    # run 3: default root -> append, variant -> merge, and the nested hint flips replace -> merge,
-    # all with no data. nothing is replace, so no table is truncated, but every disposition is
-    # refreshed from the current hints - including each pseudo-root, re-derived from the nested hints
-    metrics = _extract_resource(extract_step, schema, make_resource("append", "merge", "merge", []))
+    # run 3: default root -> append, variant -> merge, and the nested hint changes replace -> merge,
+    # all with no data. nothing is replace, so no table is truncated. an empty run does not modify
+    # the schema, so every stored disposition stays at its previous (replace) value - the new hints
+    # would only be applied once data arrives
+    result = _extract_resource(extract_step, schema, make_resource("append", "merge", "merge", []))
     for table in all_tables:
-        assert table not in metrics
-    # the default root from the resource hints, the variant from its own (raw-name-keyed) hints -
-    # a normalized lookup would miss the variant and wrongly fall back to the resource root's append
-    assert schema.tables["items"]["write_disposition"] == "append"
-    assert schema.tables["other_items"]["write_disposition"] == "merge"
-    # each pseudo-root is re-derived from the parent's nested hints: replace -> merge
-    for pseudo in pseudo_roots:
-        assert schema.tables[pseudo]["write_disposition"] == "merge"
-    # re-deriving reads the parent's nested hints only, never recomputing a pseudo-root as a root,
-    # so no spurious cascade tables are created
+        assert table not in result.truncated_tables
+        assert table not in result.table_metrics
+        assert schema.tables[table]["write_disposition"] == "replace"
+    # no pseudo-root is ever recomputed as a root, so no spurious cascade tables are created
     assert "items__sub_items__sub_items" not in schema.tables
     assert "other_items__sub_items__sub_items" not in schema.tables
 
 
 @pytest.mark.parametrize("dispatch", ["marked", "dynamic"])
-def test_handle_empty_tables_updates_dispatched_tables(
-    extract_step: Extract, dispatch: str
-) -> None:
+def test_handle_empty_tables_dispatched_tables(extract_step: Extract, dispatch: str) -> None:
     """Event-dispatch tables - created via with_table_name marks or a dynamic table_name function -
-    have their (static) write disposition refreshed on an empty run, and a replace table that gets
-    no data has an empty file written so it is truncated."""
+    keep their stored write disposition unchanged on an empty run, while a replace table that gets no
+    data is truncated via the load package state."""
     schema = dlt.Schema("empty_tables")
 
     def make_resource(wd: TWriteDisposition, data: Any) -> DltResource:
@@ -1436,31 +1433,31 @@ def test_handle_empty_tables_updates_dispatched_tables(
     assert object_extractor.tables_with_items == set(tables)
     assert object_extractor.tables_with_empty == set()
 
-    # run 2 (totally empty): every replace table gets an empty file (so it is truncated)
-    metrics = _extract_resource(extract_step, schema, make_resource("replace", []))
-    for table in tables:
-        assert metrics[table].items_count == 0
+    # run 2 (totally empty): every replace table is truncated via the package state
+    result = _extract_resource(extract_step, schema, make_resource("replace", []))
+    assert result.truncated_tables == set(tables)
 
-    # run 3 (only one table gets data): the table with data is loaded normally, the other still gets
-    # an empty file
-    metrics = _extract_resource(
+    # run 3 (only one table gets data): the table with data is loaded normally, the other is truncated
+    result = _extract_resource(
         extract_step, schema, make_resource("replace", [{"kind": "MyIssue", "id": 3}])
     )
-    assert metrics["my_issue"].items_count == 1
-    assert metrics["my_purchase"].items_count == 0
+    assert result.table_metrics["my_issue"].items_count == 1
+    assert result.truncated_tables == {"my_purchase"}
     # only the table that received an item is computed and tracked with items; the truncated
-    # `my_purchase` got its empty file from `_handle_empty_tables`, not the extractor, so it is in
+    # `my_purchase` was recorded by `_handle_empty_tables`, not the extractor, so it is in
     # neither set
     object_extractor = extract_step._last_extractors["object"]
     assert object_extractor.computed_tables == {"my_issue"}
     assert object_extractor.tables_with_items == {"my_issue"}
     assert object_extractor.tables_with_empty == set()
 
-    # run 4: switch to append with no data - tables are refreshed to append and NOT truncated
-    metrics = _extract_resource(extract_step, schema, make_resource("append", []))
+    # run 4: switch to append with no data - not truncated, and an empty run leaves the stored
+    # disposition unchanged (still replace); the switch to append only takes effect once data arrives
+    result = _extract_resource(extract_step, schema, make_resource("append", []))
     for table in tables:
-        assert table not in metrics
-        assert schema.tables[table]["write_disposition"] == "append"
+        assert table not in result.truncated_tables
+        assert table not in result.table_metrics
+        assert schema.tables[table]["write_disposition"] == "replace"
 
 
 @pytest.mark.parametrize("with_hints", [False, True], ids=["resource_columns", "import_hints"])
@@ -1523,9 +1520,10 @@ def test_handle_empty_tables_ignores_dynamic_write_disposition(extract_step: Ext
     assert schema.tables["my_issue"]["write_disposition"] == "replace"
 
     # no data: dynamic write disposition cannot be resolved, so the table is left untouched and is
-    # not truncated (no empty file written)
-    metrics = _extract_resource(extract_step, schema, make_resource([]))
-    assert "my_issue" not in metrics
+    # not truncated
+    result = _extract_resource(extract_step, schema, make_resource([]))
+    assert "my_issue" not in result.truncated_tables
+    assert "my_issue" not in result.table_metrics
     assert schema.tables["my_issue"]["write_disposition"] == "replace"
 
 
@@ -1606,9 +1604,9 @@ def test_handle_empty_tables_skips_tables_not_accepting_replace(
     schema.tables[member_table].pop("variant_name", None)
 
     # run 2: empty - only tables where the resource and the table both accept replace are truncated
-    metrics = _extract_resource(extract_step, schema, make_resource([]))
-    assert ("items" in metrics) is root_truncated
-    assert (member_table in metrics) is member_truncated
+    result = _extract_resource(extract_step, schema, make_resource([]))
+    assert ("items" in result.truncated_tables) is root_truncated
+    assert (member_table in result.truncated_tables) is member_truncated
 
 
 def test_handle_empty_tables_variant_not_redeclared_left_untouched(extract_step: Extract) -> None:
@@ -1664,17 +1662,14 @@ def test_handle_empty_tables_variant_not_redeclared_left_untouched(extract_step:
 
     # run 2: empty - no variant is re-declared, so none is in `_hints_variants`; the decision falls
     # back to the stored disposition
-    metrics = _extract_resource(extract_step, schema, make_resource(False, []))
+    result = _extract_resource(extract_step, schema, make_resource(False, []))
     # the stored-merge variant differs from the replace resource -> left untouched, not truncated
-    assert "other_items" not in metrics
+    assert "other_items" not in result.truncated_tables
     assert schema.tables["other_items"]["write_disposition"] == "merge"
-    # the stored-replace variant is truncated even though it cannot be re-derived
-    assert metrics["replace_items"].items_count == 0
-    # the replace pseudo-root under the (now absent) variant cannot be re-derived either, yet is
-    # truncated because its stored disposition is replace
-    assert metrics["replace_items__sub_items"].items_count == 0
-    # the replace root is truncated
-    assert metrics["items"].items_count == 0
+    # the stored-replace variant, its replace pseudo-root and the replace root are all truncated
+    # (the pseudo-root under the now-absent variant cannot be re-derived, yet is truncated because
+    # its stored disposition is replace)
+    assert result.truncated_tables == {"replace_items", "replace_items__sub_items", "items"}
 
 
 def test_handle_empty_tables_refresh_changed_to_replace_truncates(extract_step: Extract) -> None:
@@ -1694,11 +1689,12 @@ def test_handle_empty_tables_refresh_changed_to_replace_truncates(extract_step: 
     _mark_seen_data(schema, "items")
     assert schema.tables["items"]["write_disposition"] == "append"
 
-    # run 2: the resource switches to replace and yields no data. the table is not computed this
-    # run, so the refresh runs, flips the stored disposition to replace, and the table is truncated
-    metrics = _extract_resource(extract_step, schema, make_resource("replace", []))
-    assert metrics["items"].items_count == 0
-    assert schema.tables["items"]["write_disposition"] == "replace"
+    # run 2: the resource switches to replace and yields no data. the fresh disposition (replace) is
+    # computed in memory to truncate the table, but the stored schema is NOT modified - the
+    # disposition stays at its previous (append) value until data arrives
+    result = _extract_resource(extract_step, schema, make_resource("replace", []))
+    assert result.truncated_tables == {"items"}
+    assert schema.tables["items"]["write_disposition"] == "append"
 
 
 def test_handle_empty_tables_unseen_data_not_truncated(extract_step: Extract) -> None:
@@ -1714,14 +1710,15 @@ def test_handle_empty_tables_unseen_data_not_truncated(extract_step: Extract) ->
     _extract_resource(extract_step, schema, items([{"id": 1}]))
     assert "items" in schema.tables
 
-    # run 2: empty - the table never saw data, so it is not truncated (no empty file)
-    metrics = _extract_resource(extract_step, schema, items([]))
-    assert "items" not in metrics
+    # run 2: empty - the table never saw data, so it is not truncated
+    result = _extract_resource(extract_step, schema, items([]))
+    assert "items" not in result.truncated_tables
+    assert "items" not in result.table_metrics
 
     # once the table has seen data, an empty run truncates it
     _mark_seen_data(schema, "items")
-    metrics = _extract_resource(extract_step, schema, items([]))
-    assert metrics["items"].items_count == 0
+    result = _extract_resource(extract_step, schema, items([]))
+    assert result.truncated_tables == {"items"}
 
 
 def test_handle_empty_tables_materialized_empty_written_unconditionally(
@@ -1740,9 +1737,10 @@ def test_handle_empty_tables_materialized_empty_written_unconditionally(
     def materialized() -> Any:
         yield dlt.mark.materialize_table_schema()
 
-    metrics = _extract_resource(extract_step, schema, materialized())
-    # empty file written despite append disposition and no prior seen data
-    assert metrics["materialized"].items_count == 0
+    result = _extract_resource(extract_step, schema, materialized())
+    # empty file written (not a package-state truncation) despite append disposition and no seen data
+    assert result.table_metrics["materialized"].items_count == 0
+    assert "materialized" not in result.truncated_tables
     object_extractor = extract_step._last_extractors["object"]
     assert object_extractor.computed_tables == {"materialized"}
     assert object_extractor.tables_with_items == set()
@@ -1755,11 +1753,12 @@ def test_handle_empty_tables_materialized_empty_written_unconditionally(
     def nothing() -> Any:
         yield from []
 
-    metrics = _extract_resource(extract_step, schema, nothing())
-    assert "nothing" not in metrics
+    result = _extract_resource(extract_step, schema, nothing())
+    assert "nothing" not in result.table_metrics
+    assert "nothing" not in result.truncated_tables
 
 
-def test_handle_empty_tables_nested_child_not_truncated(extract_step: Extract) -> None:
+def test_handle_empty_tables_truncates_nested_chain(extract_step: Extract) -> None:
     schema = dlt.Schema("empty_tables")
 
     def make_resource(data: Any) -> DltResource:
@@ -1782,15 +1781,16 @@ def test_handle_empty_tables_nested_child_not_truncated(extract_step: Extract) -
     assert is_nested_table(schema.tables["items__children"]) is True
     _mark_seen_data(schema, "items", "items__children")
 
-    # run 2: empty - only the root gets an empty file; the nested child is not truncated directly
-    metrics = _extract_resource(extract_step, schema, make_resource([]))
-    assert metrics["items"].items_count == 0
-    assert "items__children" not in metrics
+    # run 2: empty - the replace root and its (seen-data) nested chain are registered for truncation
+    # (the package truncate list is not chain-extended at load, so the chain is recorded here)
+    result = _extract_resource(extract_step, schema, make_resource([]))
+    assert result.truncated_tables == {"items", "items__children"}
 
 
-def test_handle_empty_tables_pseudo_root_refreshed_then_truncated(extract_step: Extract) -> None:
-    """A pseudo-root is re-derived from the current nested hints on an empty run: when the nested hint
-    flips merge -> replace, the stored pseudo-root is updated to replace and then truncated."""
+def test_handle_empty_tables_pseudo_root_truncated_without_mutating(extract_step: Extract) -> None:
+    """A pseudo-root's fresh disposition is re-derived from the current nested hints on an empty run
+    only to decide truncation: when the nested hint changes merge -> replace, the pseudo-root is
+    truncated, but its stored disposition is NOT modified."""
     schema = dlt.Schema("empty_tables")
 
     def make_resource(nested_wd: TWriteDisposition, data: Any) -> DltResource:
@@ -1819,8 +1819,9 @@ def test_handle_empty_tables_pseudo_root_refreshed_then_truncated(extract_step: 
     _mark_seen_data(schema, "items", pseudo)
     assert schema.tables[pseudo]["write_disposition"] == "merge"
 
-    # run 2: the nested hint now declares replace; on the empty run the pseudo-root is re-derived,
-    # its stored disposition flips merge -> replace, and it is then truncated
-    metrics = _extract_resource(extract_step, schema, make_resource("replace", []))
-    assert schema.tables[pseudo]["write_disposition"] == "replace"
-    assert metrics[pseudo].items_count == 0
+    # run 2: the nested hint now declares replace; on the empty run the pseudo-root's fresh
+    # disposition re-derives to replace and it is truncated, but the stored schema is NOT modified
+    # (the disposition stays merge until data arrives)
+    result = _extract_resource(extract_step, schema, make_resource("replace", []))
+    assert pseudo in result.truncated_tables
+    assert schema.tables[pseudo]["write_disposition"] == "merge"

--- a/tests/extract/test_extract_pipe.py
+++ b/tests/extract/test_extract_pipe.py
@@ -11,7 +11,7 @@ from dlt.common import sleep
 from dlt.common.typing import TDataItems
 from dlt.extract.exceptions import CreatePipeException, ResourceExtractionError, UnclosablePipe
 from dlt.extract.items import DataItemWithMeta
-from dlt.extract.items_transform import FilterItem, FilteredEmptyList, MapItem, YieldMapItem
+from dlt.extract.items_transform import FilterItem, MapItem, YieldMapItem
 from dlt.extract.pipe import Pipe
 from dlt.extract.pipe_iterator import PipeIterator, ManagedPipeIterator, PipeItem
 
@@ -469,9 +469,7 @@ def test_filter_step() -> None:
     # also should work on the list which if fully filtered must become None
     p = Pipe.from_data("data", [[1, 3], 2, [3, 4]])
     p.append_step(FilterItem(lambda item, _: item % 2 == 0))
-    filtered_list = _f_items(list(PipeIterator.from_pipe(p)))
-    assert filtered_list == [[], 2, [4]]
-    assert isinstance(filtered_list[0], FilteredEmptyList)
+    assert _f_items(list(PipeIterator.from_pipe(p))) == [2, [4]]
     # also should filter based on meta
     data = [1, 2, 3]
     meta = [True, True, False]
@@ -488,7 +486,7 @@ def test_filter_step() -> None:
     # also should work on the list which if fully filtered must become None
     p = Pipe.from_data("data", [[1, 3], 2, [3, 4]])
     p.append_step(FilterItem(lambda item: item % 2 == 0))
-    assert _f_items(list(PipeIterator.from_pipe(p))) == [[], 2, [4]]
+    assert _f_items(list(PipeIterator.from_pipe(p))) == [2, [4]]
 
 
 def test_map_step() -> None:

--- a/tests/extract/test_extract_pipe.py
+++ b/tests/extract/test_extract_pipe.py
@@ -11,7 +11,7 @@ from dlt.common import sleep
 from dlt.common.typing import TDataItems
 from dlt.extract.exceptions import CreatePipeException, ResourceExtractionError, UnclosablePipe
 from dlt.extract.items import DataItemWithMeta
-from dlt.extract.items_transform import FilterItem, MapItem, YieldMapItem
+from dlt.extract.items_transform import FilterItem, FilteredEmptyList, MapItem, YieldMapItem
 from dlt.extract.pipe import Pipe
 from dlt.extract.pipe_iterator import PipeIterator, ManagedPipeIterator, PipeItem
 
@@ -469,7 +469,9 @@ def test_filter_step() -> None:
     # also should work on the list which if fully filtered must become None
     p = Pipe.from_data("data", [[1, 3], 2, [3, 4]])
     p.append_step(FilterItem(lambda item, _: item % 2 == 0))
-    assert _f_items(list(PipeIterator.from_pipe(p))) == [2, [4]]
+    filtered_list = _f_items(list(PipeIterator.from_pipe(p)))
+    assert filtered_list == [[], 2, [4]]
+    assert isinstance(filtered_list[0], FilteredEmptyList)
     # also should filter based on meta
     data = [1, 2, 3]
     meta = [True, True, False]
@@ -486,7 +488,7 @@ def test_filter_step() -> None:
     # also should work on the list which if fully filtered must become None
     p = Pipe.from_data("data", [[1, 3], 2, [3, 4]])
     p.append_step(FilterItem(lambda item: item % 2 == 0))
-    assert _f_items(list(PipeIterator.from_pipe(p))) == [2, [4]]
+    assert _f_items(list(PipeIterator.from_pipe(p))) == [[], 2, [4]]
 
 
 def test_map_step() -> None:

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -1514,11 +1514,13 @@ def test_replace_resets_state(item_type: TestDataItemFormat) -> None:
     # state was reset (child is replace but parent is append! so it will not generate any more items due to incremental
     # so child will reset itself on replace and never set the state...)
     assert "child" not in s.state["resources"]
-    # there will be a load package to reset the state but also a load package to update the child table
-    assert len(info.load_packages[0].jobs["completed_jobs"]) == 2
+    # there will be a load package to reset the state
+    assert len(info.load_packages[0].jobs["completed_jobs"]) == 1
     assert {
         job.job_file_info.table_name for job in info.load_packages[0].jobs["completed_jobs"]
-    } == {"_dlt_pipeline_state", "child"}
+    } == {"_dlt_pipeline_state"}
+    # package state also contains truncate "child" table command
+    # TODO: check the above
 
     # now we add child that has parent_r as parent but we add another instance of standalone_some_data explicitly
     # so we have a resource with the same name as child parent but the pipe instance is different

--- a/tests/extract/test_validation.py
+++ b/tests/extract/test_validation.py
@@ -255,6 +255,28 @@ def test_validation_with_contracts(yield_list: bool) -> None:
     assert "c" not in items[2]
 
 
+def test_validator_returns_none_when_fully_filtered() -> None:
+    # a discard_row validator drops invalid items. when it consumes an entire batch it must return
+    # None - exactly like FilterItem and a filtered-out single item - so the empty batch does not
+    # reach the extractor. an incoming empty list is passed through unchanged.
+    r: DltResource = dlt.resource(
+        [{"a": 1, "b": "x"}], name="some_data", schema_contract="discard_row", columns=SimpleModel
+    )
+    validator: PydanticValidator[SimpleModel] = r.validator  # type: ignore[assignment]
+    validator.bind(r._pipe)  # extractor binds the validator to the pipe (sets table_name)
+
+    invalid = {"a": "not_int", "b": "x"}
+    # single invalid item -> None
+    assert validator(invalid) is None
+    # non-empty list fully consumed by validation -> None (not an empty list)
+    assert validator([invalid, {"a": "also_bad", "b": "y"}]) is None
+    # a partially valid list keeps the surviving rows
+    assert validator([invalid, {"a": 1, "b": "ok"}]) == [{"a": 1, "b": "ok"}]
+    # an incoming empty list is passed through unchanged (same object, type preserved)
+    empty: TDataItems = []
+    assert validator(empty) is empty
+
+
 @pytest.mark.parametrize("return_models", [True, False])
 @pytest.mark.parametrize("yield_models", [True, False])
 @pytest.mark.parametrize("yield_list", [True, False])

--- a/tests/load/pipeline/test_drop.py
+++ b/tests/load/pipeline/test_drop.py
@@ -210,6 +210,11 @@ def test_drop_command_resources_and_state(
 
     assert_dropped_resources(attached, ["droppable_c", "droppable_d", "droppable_no_state"])
 
+    # the drop command records the dropped tables in the trace, without a refresh mode
+    drop_package = attached.last_trace.last_load_info.load_packages[0]
+    assert drop_package.refresh is None
+    assert {"droppable_c", "droppable_d", "droppable_no_state"} <= set(drop_package.dropped_tables)
+
     # Verify extra json paths are removed from state
     sources_state = pipeline.state["sources"]
     assert sources_state["droppable"]["data_from_d"] == {"foo1": {}, "foo2": {}}

--- a/tests/load/pipeline/test_refresh_modes.py
+++ b/tests/load/pipeline/test_refresh_modes.py
@@ -145,6 +145,10 @@ def test_refresh_drop_sources(
         refresh="drop_sources",
         **destination_config.run_kwargs,
     )
+    # the load package exposes the refresh mode and the tables dropped at the destination
+    package = info.load_packages[0]
+    assert package.refresh == "drop_sources"
+    assert {"some_data_one", "some_data_two", "some_data_three"} <= set(package.dropped_tables)
 
     assert set(t["name"] for t in pipeline.default_schema.data_tables(include_incomplete=True)) == {
         "some_data_one",
@@ -318,6 +322,11 @@ def test_refresh_drop_data_only(destination_config: DestinationTestConfiguration
         **destination_config.run_kwargs,
     )
     assert_load_info(info)
+    # the load package exposes the refresh mode and the tables truncated at the destination
+    package = info.load_packages[0]
+    assert package.refresh == "drop_data"
+    assert set(package.truncated_tables) == {"some_data_one", "some_data_two"}
+    assert package.dropped_tables is None
 
     # Schema should not be mutated
     assert pipeline.default_schema.version_hash == first_schema_hash
@@ -848,6 +857,10 @@ def test_refresh_drop_resources_incremental_empty_package_drops_all(
         items_resource(100, 200), refresh="drop_resources", **destination_config.run_kwargs
     )
     assert_load_info(info)
+    # the empty package still reports the refresh mode and the dropped table chain
+    package = info.load_packages[0]
+    assert package.refresh == "drop_resources"
+    assert set(package.dropped_tables) == {"items", "items__children"}
     # all tables are dropped and not recreated by the empty/replace run
     assert table_exists(pipeline, "items") is False
     assert table_exists(pipeline, "items__children") is False

--- a/tests/load/pipeline/test_refresh_modes.py
+++ b/tests/load/pipeline/test_refresh_modes.py
@@ -10,6 +10,7 @@ from dlt.common.pipeline import pipeline_state as current_pipeline_state, TRefre
 
 from dlt.destinations.sql_client import DBApiCursor
 from dlt.extract.source import DltSource
+from dlt.extract.resource import DltResource
 from dlt.extract.state import resource_state
 from dlt.pipeline.state_sync import load_pipeline_state_from_destination
 
@@ -801,3 +802,52 @@ def test_refresh_truncates_or_drops_when_no_data(
     if destination_config.destination_type != "filesystem":
         for table in ("items", "items__children"):
             assert table_exists(pipeline, table) is (refresh == "drop_data")
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["duckdb"]),
+    ids=lambda x: x.name,
+)
+def test_refresh_drop_resources_incremental_empty_package_drops_all(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """Makes sure that emitting empty package (no jobs) drops all resources"""
+    os.environ["DATA_WRITER__DISABLE_COMPRESSION"] = "TRUE"
+
+    def items_resource(initial_value: int, end_value: int) -> DltResource:
+        @dlt.resource(name="items", write_disposition="replace", primary_key="id")
+        def items(
+            updated: Any = dlt.sources.incremental(
+                "ts", initial_value=initial_value, end_value=end_value
+            )
+        ) -> Any:
+            yield [
+                {"id": 1, "ts": 1, "children": [{"cid": 1}]},
+                {"id": 2, "ts": 2, "children": [{"cid": 2}]},
+            ]
+
+        return items()
+
+    pipeline = destination_config.setup_pipeline("refresh_inc_empty" + uniq_id(), dev_mode=True)
+
+    # first refresh loads all data (ts within the [0, 10) window)
+    info = pipeline.run(
+        items_resource(0, 10), refresh="drop_resources", **destination_config.run_kwargs
+    )
+    assert_load_info(info)
+    assert load_table_counts(pipeline, "items", "items__children") == {
+        "items": 2,
+        "items__children": 2,
+    }
+    # the hint-only primary key was typed from the data
+    assert "primary_key" in pipeline.default_schema.tables["items"]["columns"]["id"]
+
+    # second refresh: the [100, 200) window selects nothing -> fully empty package
+    info = pipeline.run(
+        items_resource(100, 200), refresh="drop_resources", **destination_config.run_kwargs
+    )
+    assert_load_info(info)
+    # all tables are dropped and not recreated by the empty/replace run
+    assert table_exists(pipeline, "items") is False
+    assert table_exists(pipeline, "items__children") is False

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -344,8 +344,8 @@ def test_replace_table_clearing(
             "static_items__sub_items": 2,
         }
         assert_empty_tables(pipeline, "items", "other_items", "other_items__sub_items")
-        # check trace
-        assert pipeline.last_trace.last_normalize_info.row_counts == {"items": 0, "other_items": 0}
+        # check trace (no tables - they are truncated via package state)
+        assert pipeline.last_trace.last_normalize_info.row_counts == {}
 
     # see if yielding something next to other none entries still goes into db
     pipeline.run(items_with_subitems_yield_none, **destination_config.run_kwargs)

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -170,11 +170,17 @@ def test_replace_disposition(
         "append_items": 36,
     }
     assert_empty_tables(pipeline, "items", "items__sub_items", "items__sub_items__sub_sub_items")
-    # check trace
+    # check trace: `items` produces no jobs, the whole chain is truncated via the package state
     assert pipeline.last_trace.last_normalize_info.row_counts == {
         "append_items": 12,
-        "items": 0,
     }
+    package = info.load_packages[0]
+    assert set(package.truncated_tables) == {
+        "items",
+        "items__sub_items",
+        "items__sub_items__sub_sub_items",
+    }
+    assert package.dropped_tables is None
 
     # create a pipeline with different name but loading to the same dataset as above - this is to provoke truncating non existing tables
     pipeline_2 = destination_config.setup_pipeline(
@@ -338,7 +344,7 @@ def test_replace_table_clearing(
     # see if yield none clears everything
     for empty_resource in [yield_none, no_yield, yield_empty_list]:
         pipeline.run(items_with_subitems, **destination_config.run_kwargs)
-        pipeline.run(empty_resource, **destination_config.run_kwargs)
+        info = pipeline.run(empty_resource, **destination_config.run_kwargs)
         assert load_table_counts(pipeline, "static_items", "static_items__sub_items") == {
             "static_items": 1,
             "static_items__sub_items": 2,
@@ -346,6 +352,15 @@ def test_replace_table_clearing(
         assert_empty_tables(pipeline, "items", "other_items", "other_items__sub_items")
         # check trace (no tables - they are truncated via package state)
         assert pipeline.last_trace.last_normalize_info.row_counts == {}
+        # both dispatched table chains are truncated, tables of unselected resources are not
+        package = info.load_packages[0]
+        assert set(package.truncated_tables) == {
+            "items",
+            "items__sub_items",
+            "other_items",
+            "other_items__sub_items",
+        }
+        assert package.dropped_tables is None
 
     # see if yielding something next to other none entries still goes into db
     pipeline.run(items_with_subitems_yield_none, **destination_config.run_kwargs)

--- a/tests/load/test_dummy_client.py
+++ b/tests/load/test_dummy_client.py
@@ -1431,8 +1431,10 @@ def test_init_client_staging_dlt_tables_with_jobs() -> None:
         assert staging_truncate == {"event_user", "_dlt_loads"}
 
 
-def test_init_client_unseen_data_tables_excluded() -> None:
-    """Tables without seen-data are excluded from both final and staging datasets."""
+def test_init_client_unseen_data_chain_tables_excluded() -> None:
+    """Tables with jobs always enter final DDL - the normalizer marks seen-data on every table
+    it emits jobs for. Never-seen tables are excluded from table chains (staging DDL, truncation).
+    """
     load = setup_loader()
     _, schema = prepare_load_package(
         load.load_storage, ["event_user.b1d32c6660b242aaabbf3fc27245b7e6.0.insert_values"]
@@ -1457,14 +1459,14 @@ def test_init_client_unseen_data_tables_excluded() -> None:
             init_client(client, schema, [event_user, event_bot], {}, nothing_, all_, all_)
 
         assert update_stored_schema.call_count == 2
-        # final DDL: event_user + dlt tables, bot excluded (in tables_no_data)
+        # final DDL: tables with jobs are trusted and migrated, the jobless never-seen
+        # nested bot tables are not
         final_ddl = update_stored_schema.call_args_list[0].kwargs["only_tables"]
-        assert "event_user" in final_ddl
-        assert not (bot_chain & final_ddl)
-        # staging DDL: all data tables EXCEPT bot chain + _dlt_version
+        assert {"event_user", "event_bot"} <= final_ddl
+        assert not ((bot_chain - {"event_bot"}) & final_ddl)
+        # staging DDL: the whole never-seen bot chain is excluded by the chain filter
         staging_ddl = update_stored_schema.call_args_list[1].kwargs["only_tables"]
         assert staging_ddl == (all_data - bot_chain) | {"_dlt_version"}
-        assert not (bot_chain & staging_ddl)
         # staging truncation: only event_user
         staging_truncate = initialize_storage.call_args_list[2].kwargs["truncate_tables"]
         assert staging_truncate == {"event_user"}

--- a/tests/load/test_dummy_client.py
+++ b/tests/load/test_dummy_client.py
@@ -1298,7 +1298,12 @@ def test_init_client_initial_truncate_tables_from_package_state() -> None:
             dummy_impl.DummyClient, "update_stored_schema", return_value={}
         ) as update_stored_schema,
     ):
-        load.initialize_package(load_id, schema, new_jobs)
+        with Container().injectable_context(
+            LoadPackageStateInjectableContext(
+                storage=load.load_storage.normalized_packages, load_id=load_id
+            )
+        ):
+            load.initialize_package(load_id, schema, new_jobs)
 
     # schema migration is forced because there are tables to truncate via refresh
     assert update_stored_schema.call_args_list[0].kwargs["force"] is True
@@ -1310,6 +1315,10 @@ def test_init_client_initial_truncate_tables_from_package_state() -> None:
         if "truncate_tables" in c.kwargs
     ]
     assert truncate_calls == [{"event_bot"}]
+    # the actually truncated tables are recorded in the package state
+    state = packages.get_load_package_state(load_id)
+    assert state["applied_truncated_tables"] == ["event_bot"]
+    assert "applied_dropped_tables" not in state
 
 
 def test_init_client_staging_ddl_includes_jobless_tables() -> None:

--- a/tests/normalize/test_normalize.py
+++ b/tests/normalize/test_normalize.py
@@ -436,35 +436,45 @@ def test_normalize_drops_empty_package_keeps_refresh(raw_normalize: Normalize) -
 
 @pytest.mark.parametrize("caps", INSERT_CAPS + JSONL_CAPS, indirect=True)
 @pytest.mark.parametrize("write_disposition", ["append", "replace", "merge"])
-def test_normalize_contract_discard_all_rows_writes_empty_job(
-    caps: DestinationCapabilitiesContext, write_disposition: str, raw_normalize: Normalize
+@pytest.mark.parametrize("seen_data", [True, False], ids=["seen_data", "never_seen"])
+def test_normalize_contract_discard_all_rows(
+    caps: DestinationCapabilitiesContext,
+    write_disposition: str,
+    seen_data: bool,
+    raw_normalize: Normalize,
 ) -> None:
     """When a `columns: discard_row` contract eliminates ALL rows of a root table, an empty job is
-    still written (so a `replace` table is truncated) with a post-filter row count of 0 - for every
-    write disposition and output writer."""
+    written only if the table has already seen data (so an existing table is truncated). A table
+    that never seen data is not materialized - no job is produced for it."""
     schema = Schema("contracts")
-    schema.update_table(
-        new_table(
-            "items",
-            write_disposition=write_disposition,  # type: ignore[arg-type]
-            schema_contract={"columns": "discard_row"},
-            columns=[{"name": "id", "data_type": "bigint", "nullable": True}],
-        )
+    table = new_table(
+        "items",
+        write_disposition=write_disposition,  # type: ignore[arg-type]
+        schema_contract={"columns": "discard_row"},
+        columns=[{"name": "id", "data_type": "bigint", "nullable": True}],
     )
+    if seen_data:
+        table["x-normalizer"] = {"seen-data": True}
+    schema.update_table(table)
     # every row carries a NEW column `name` so `discard_row` drops all of them
     items = [{"id": i, "name": f"n{i}"} for i in range(5)]
     load_id = extract_items(raw_normalize.normalize_storage, items, schema, "items")
     normalize_pending(raw_normalize)
 
-    # an empty root-table job is written, physically present, and the package is retained
-    files = raw_normalize.load_storage.list_new_jobs(load_id)
-    assert [ParsedLoadJobFileName.parse(f).table_name for f in files] == ["items"]
-    assert raw_normalize.load_storage.normalized_packages.storage.has_file(files[0])
-    assert load_id in raw_normalize.load_storage.list_normalized_packages()
-    # per-job row count is the post-filter value: 0
-    step_info = raw_normalize.get_step_info(MockPipeline("contracts_pipeline", True))  # type: ignore[abstract]
-    assert step_info.row_counts["items"] == 0
-    assert step_info.metrics[load_id][0]["table_metrics"]["items"].items_count == 0
+    normalized = raw_normalize.load_storage.list_normalized_packages()
+    if seen_data:
+        # existing table is truncated via an empty job with a post-filter row count of 0
+        assert load_id in normalized
+        files = raw_normalize.load_storage.list_new_jobs(load_id)
+        assert [ParsedLoadJobFileName.parse(f).table_name for f in files] == ["items"]
+        assert raw_normalize.load_storage.normalized_packages.storage.has_file(files[0])
+        step_info = raw_normalize.get_step_info(MockPipeline("contracts_pipeline", True))  # type: ignore[abstract]
+        assert step_info.row_counts["items"] == 0
+        assert step_info.metrics[load_id][0]["table_metrics"]["items"].items_count == 0
+    else:
+        # never-seen table is not materialized: no job is produced for it
+        files = raw_normalize.load_storage.list_new_jobs(load_id) if load_id in normalized else []
+        assert "items" not in [ParsedLoadJobFileName.parse(f).table_name for f in files]
 
 
 @pytest.mark.parametrize("caps", INSERT_CAPS + JSONL_CAPS, indirect=True)

--- a/tests/pipeline/cases/contracts/trace.schema.yaml
+++ b/tests/pipeline/cases/contracts/trace.schema.yaml
@@ -1,5 +1,5 @@
-version: 9
-version_hash: P8E7cjYovKZVIFpXOcuizgzCVXmUriPYEZ1FxBt63Tc=
+version: 13
+version_hash: JPyWY81x+lB6dVBEvUD5A67wl16qwvd2QQIoDhevaBw=
 engine_version: 11
 name: trace
 tables:
@@ -506,6 +506,9 @@ tables:
       completed_at:
         data_type: timestamp
         nullable: true
+      refresh:
+        data_type: text
+        nullable: true
     parent: trace__steps
   trace__steps__step_info__load_packages__jobs:
     description: Individual load jobs within a package (file path, state, size, retry
@@ -997,6 +1000,42 @@ tables:
         unique: true
         row_key: true
     parent: trace__steps__extract_info__resource_metrics
+  trace__steps__step_info__load_packages__dropped_tables:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+    parent: trace__steps__step_info__load_packages
+  trace__steps__step_info__load_packages__truncated_tables:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+    parent: trace__steps__step_info__load_packages
 settings:
   detections:
   - iso_timestamp
@@ -1021,11 +1060,13 @@ normalizers:
     module: dlt.common.normalizers.json.relational
   use_break_path_on_normalize: false
 previous_hashes:
+- QRhfna2wTZv+INSEUUmkKiH+Upb6yGg1cDBBbR8kEMo=
+- txv310BO0KgmKJ/8I/spuLPaMMOt+TarI8ytKq19cjo=
+- 7I1eufBNCdmIem6hEiD0CjKgFQNlg0MCHkJgCTtghxk=
+- P8E7cjYovKZVIFpXOcuizgzCVXmUriPYEZ1FxBt63Tc=
 - lZ/04BwFLOm7fouDWZwxKImlCEdyHBO+SUUgIVLGm1k=
 - nNzjL9RAoVnFRkAEXVSu6FPXKDHlW1gQ5pJN0o12msk=
 - z//eAZyEIH4IFhc95OmWN6Uv4QBb8o4o9puK23yw9Ww=
 - zsNXwXS2tlD1Or0sGgLOMI7clOz978WoyDuzVx+KU1s=
 - JE62zVwqT2T/qHTi2Qdnn2d1A/JzCzyGtDwc+qUmbTs=
 - 9Ysjq/W0xpxkI/vBiYm8Qbr2nDP3JMt6KvGKUS/FCyI=
-- NYeAxJ2r+T+dKFnXFhBEPzBP6SO+ORdhOfgQRo/XqBU=
-- RV9jvZSD5dM+ZGjEL3HqokLvtf22K4zMNc3zWRahEw4=

--- a/tests/pipeline/cases/github_pipeline/legacy_upsert_pipeline.py
+++ b/tests/pipeline/cases/github_pipeline/legacy_upsert_pipeline.py
@@ -1,0 +1,50 @@
+"""Reproduces a case where very old schema engine (8) added "seen-data" hint to all tables, also
+those including incomplete primary key columns. such tables never received any data. now when
+pipeline runs and there's still no data - the run shoud succeed. later when data comes - pipeline
+should recompute hints and recover.
+
+Usage: legacy_upsert_pipeline.py [old|current|load]
+"""
+import sys
+from typing import Any
+
+import dlt
+
+# nullable primary key declared on `id`; it is the customer's reflected key that never got a type
+COLUMNS: Any = {"id": {"primary_key": True, "nullable": True}}
+UPSERT: Any = {"disposition": "merge", "strategy": "upsert"}
+
+
+@dlt.source(name="legacy_upsert")
+def legacy_source(phase: str):
+    if phase == "old":
+        # old dlt (engine 8): data has no `id`, so the declared primary key stays incomplete
+        @dlt.resource(name="renamed_store", columns=COLUMNS, write_disposition="merge")
+        def store():
+            yield [{"ts": 1, "val": "a"}, {"ts": 2, "val": "b"}]
+
+    elif phase == "load":
+        # current dlt: a row inside the incremental window (ts >= 100) is loaded and completes `id`
+        @dlt.resource(name="renamed_store", columns=COLUMNS, write_disposition=UPSERT)
+        def store(updated=dlt.sources.incremental("ts", initial_value=100)):
+            yield [{"id": 1, "ts": 200, "val": "c"}]
+
+    else:
+        # current dlt ("current"): upsert with an incremental whose window (ts >= 100) excludes every
+        # yielded row, so the resource yields nothing past the cursor - the empty incremental run
+        @dlt.resource(name="renamed_store", columns=COLUMNS, write_disposition=UPSERT)
+        def store(updated=dlt.sources.incremental("ts", initial_value=100)):
+            yield [{"ts": 1, "val": "a"}, {"ts": 2, "val": "b"}]
+
+    return store
+
+
+if __name__ == "__main__":
+    phase = sys.argv[1] if len(sys.argv) > 1 else "old"
+    pipeline = dlt.pipeline(
+        pipeline_name="legacy_upsert",
+        destination="duckdb",
+        dataset_name="legacy_data",
+    )
+    info = pipeline.run(legacy_source(phase))
+    print(info)

--- a/tests/pipeline/cases/github_pipeline/refresh_normalized_pipeline.py
+++ b/tests/pipeline/cases/github_pipeline/refresh_normalized_pipeline.py
@@ -1,0 +1,38 @@
+"""Creates a load package with refresh on an old dlt and loads it with the current dlt.
+
+- "old" (old dlt): run 1 loads `items`. run 2 extracts with refresh="drop_sources" and normalizes
+  but does not load - the package with `dropped_tables` in its state is left in normalized.
+- "load" (current dlt): loads the pending package and prints refresh and dropped tables.
+
+Usage: refresh_normalized_pipeline.py [old|load]
+"""
+import sys
+
+import dlt
+
+
+@dlt.resource(write_disposition="append")
+def items():
+    yield [{"id": 1, "val": "a"}]
+
+
+if __name__ == "__main__":
+    phase = sys.argv[1] if len(sys.argv) > 1 else "old"
+    pipeline = dlt.pipeline(
+        pipeline_name="refresh_normalized",
+        destination="duckdb",
+        dataset_name="refresh_data",
+    )
+    if phase == "old":
+        print(pipeline.run(items()))
+        # leave a normalized package with refresh drops, do not load it
+        pipeline.extract(items(), refresh="drop_sources")
+        pipeline.normalize()
+        print(pipeline.list_normalized_load_packages())
+    else:
+        info = pipeline.load()
+        print(info)
+        package = info.load_packages[0]
+        print("REFRESH:", package.refresh)
+        print("DROPPED:", sorted(package.dropped_tables or []))
+        print("TRUNCATED:", sorted(package.truncated_tables or []))

--- a/tests/pipeline/test_dlt_versions.py
+++ b/tests/pipeline/test_dlt_versions.py
@@ -736,3 +736,44 @@ def test_engine_8_upsert_seen_data_migration_update(test_storage: FileStorage) -
             rows = client.execute_sql("SELECT id, ts, val FROM renamed_store WHERE id = 1")
         assert len(rows) == 1
         assert rows[0][0] == 1 and rows[0][2] == "c"
+
+
+def test_load_normalized_refresh_package_from_1_25(test_storage: FileStorage) -> None:
+    """read refresh_normalized_pipeline.py docstring for test case details."""
+    shutil.copytree(
+        "tests/pipeline/cases/github_pipeline", get_test_storage_root(), dirs_exist_ok=True
+    )
+
+    with test_workspace(
+        {"DESTINATION__DUCKDB__CREDENTIALS": "duckdb:///test_refresh_normalized.duckdb"}
+    ):
+        # dlt 1.25.0 leaves a normalized package with refresh `dropped_tables` in its state
+        with Venv.create(tempfile.mkdtemp(), ["dlt[duckdb]==1.25.0"]) as venv:
+            # force a compatible duckdb so the current version can open the same database file
+            venv.install_deps(venv.context, ["duckdb==" + pkg_version("duckdb")])
+            try:
+                print(venv.run_script("refresh_normalized_pipeline.py", "old"))
+            except CalledProcessError as cpe:
+                print(f"script output: {cpe.output}")
+                raise
+
+        # the current dlt loads the pending package: drops are applied and recorded. the old
+        # package state has no `refresh` key so it stays None
+        venv = Venv.restore_current()
+        try:
+            output = venv.run_script("refresh_normalized_pipeline.py", "load")
+            print(output)
+        except CalledProcessError as cpe:
+            print(f"script output: {cpe.output}")
+            raise
+        assert "REFRESH: None" in output
+        assert "DROPPED: ['items']" in output
+        assert "TRUNCATED: []" in output
+
+        # the loaded package state records the applied drops
+        pipeline = dlt.attach("refresh_normalized")
+        load_id = pipeline.list_completed_load_packages()[-1]
+        package_state = pipeline.get_load_package_state(load_id)
+        assert package_state["applied_dropped_tables"] == ["items"]
+        # `items` was dropped and re-created with only the second run's row
+        assert load_table_counts(pipeline, "items") == {"items": 1}

--- a/tests/pipeline/test_dlt_versions.py
+++ b/tests/pipeline/test_dlt_versions.py
@@ -680,3 +680,59 @@ def test_seen_null_first_columns_cleaned_on_upgrade(test_storage: FileStorage) -
         assert_load_info(load_info)
         # optional_field still not in schema (it's null-only)
         assert "optional_field" not in pipeline.default_schema.tables["items"]["columns"]
+
+
+@skip_on_312
+def test_engine_8_upsert_seen_data_migration_update(test_storage: FileStorage) -> None:
+    """read legacy_upsert_pipeline.py docstring for test case details."""
+    shutil.copytree(
+        "tests/pipeline/cases/github_pipeline", get_test_storage_root(), dirs_exist_ok=True
+    )
+
+    with test_workspace({"DESTINATION__DUCKDB__CREDENTIALS": "duckdb:///test_legacy.duckdb"}):
+        # old dlt 0.4.4 writes a schema at engine 8 (before seen-data). the data has no `id`, so the
+        # declared primary key stays incomplete; the table still gets a `_dlt_id` column.
+        with Venv.create(tempfile.mkdtemp(), ["dlt[duckdb]==0.4.4", "setuptools<80"]) as venv:
+            # force a compatible duckdb so the current version can open the same database file
+            venv.install_deps(venv.context, ["duckdb==" + pkg_version("duckdb")])
+            try:
+                print(venv.run_script("legacy_upsert_pipeline.py", "old"))
+            except CalledProcessError as cpe:
+                print(f"script output: {cpe.output}")
+                raise
+
+        # sanity: the persisted schema is engine 8 with an incomplete, seen-data-less primary key
+        legacy_schema = json.loads(
+            test_storage.load(".dlt/pipelines/legacy_upsert/schemas/legacy_upsert.schema.json")
+        )
+        assert legacy_schema["engine_version"] == 8
+        renamed = legacy_schema["tables"]["renamed_store"]
+        assert "x-normalizer" not in renamed
+        assert "_dlt_id" in renamed["columns"]
+        # primary key is declared but incomplete (no data_type) and nullable
+        assert renamed["columns"]["id"]["primary_key"] is True
+        assert "data_type" not in renamed["columns"]["id"]
+        assert renamed["columns"]["id"]["nullable"] is True
+
+        venv = Venv.restore_current()
+        try:
+            # 2nd run on the current dlt: an incremental whose window selects no rows. loading
+            # migrates engine 8 -> current and the 8 -> 9 migration stamps seen-data on the legacy
+            # table. the run yields no rows, so `_handle_empty_tables` no longer rewrites the stored
+            # disposition - the table stays merge/delete-insert and loads cleanly instead of raising
+            # "No primary key defined".
+            print(venv.run_script("legacy_upsert_pipeline.py", "current"))
+            # 3rd run: load a row that carries the primary key. the incomplete `id` column gets a
+            # type and is added (nullable) to the destination table, and the row is upserted.
+            print(venv.run_script("legacy_upsert_pipeline.py", "load"))
+        except CalledProcessError as cpe:
+            print(f"script output: {cpe.output}")
+            raise
+
+        # the primary key column is now complete and the row was actually loaded
+        pipeline = dlt.attach("legacy_upsert")
+        assert "data_type" in pipeline.default_schema.tables["renamed_store"]["columns"]["id"]
+        with pipeline.sql_client() as client:
+            rows = client.execute_sql("SELECT id, ts, val FROM renamed_store WHERE id = 1")
+        assert len(rows) == 1
+        assert rows[0][0] == 1 and rows[0][2] == "c"

--- a/tests/pipeline/test_drop_helpers.py
+++ b/tests/pipeline/test_drop_helpers.py
@@ -66,7 +66,7 @@ def test_drop_helper_utils(seen_data: bool) -> None:
     if seen_data:
         assert {t["name"] for t in package_state["dropped_tables"]} == tables_to_drop
     else:
-        assert package_state == {}
+        assert package_state == {"refresh": "drop_sources"}
     assert source_clone.schema.data_tables(include_incomplete=True) == []
 
     # drop only selected resources
@@ -94,7 +94,7 @@ def test_drop_helper_utils(seen_data: bool) -> None:
     if seen_data:
         assert {t["name"] for t in package_state["dropped_tables"]} == tables_to_drop
     else:
-        assert package_state == {}
+        assert package_state == {"refresh": "drop_resources"}
     assert set(source_clone.schema.data_table_names(include_incomplete=True)) == left_in_schema
 
     # truncate only
@@ -130,7 +130,7 @@ def test_drop_helper_utils(seen_data: bool) -> None:
     if seen_data:
         assert {t["name"] for t in package_state["truncated_tables"]} == tables_to_truncate
     else:
-        assert package_state == {}
+        assert package_state == {"refresh": "drop_data"}
     assert set(source_clone.schema.data_table_names(include_incomplete=True)) == all_in_schema
 
 
@@ -149,7 +149,8 @@ def test_drop_unknown_resource() -> None:
     package_state = prepare_refresh_source(
         pipeline, source.with_resources("💰Budget"), refresh="drop_resources"
     )
-    assert package_state == {}
+    # refresh mode is recorded even when there is nothing to drop
+    assert package_state == {"refresh": "drop_resources"}
 
     info = pipeline.run(source.with_resources("💰Budget"), refresh="drop_resources")
     # nothing loaded
@@ -176,8 +177,11 @@ def test_modified_state_in_package() -> None:
     info = pipeline.extract(airtable_emojis().with_resources("🦚Peacock"), refresh="drop_resources")
     normalize_storage = pipeline._get_normalize_storage()
     package_state = normalize_storage.extracted_packages.get_load_package_state(info.loads_ids[0])
-    # nothing to drop
+    # nothing to drop but the refresh mode is recorded and exposed on the package info
     assert "dropped_tables" not in package_state
+    assert package_state["refresh"] == "drop_resources"
+    assert info.load_packages[0].refresh == "drop_resources"
+    assert info.load_packages[0].dropped_tables is None
     pipeline_state = decompress_state(package_state["pipeline_state"]["state"])
     # the state was reset to the original
     assert pipeline_state["sources"]["airtable_emojis"] == {

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -3737,8 +3737,11 @@ def test_replace_empty_resource_truncates_variant_tables() -> None:
     assert load_table_counts(pipeline, "items", "other_items") == {"items": 1, "other_items": 1}
 
     # the resource yields no data: the root and the variant are both truncated
-    pipeline.run(items_resource(False))
+    info = pipeline.run(items_resource(False))
     assert load_table_counts(pipeline, "items", "other_items") == {"items": 0, "other_items": 0}
+    package = info.load_packages[0]
+    assert set(package.truncated_tables) == {"items", "other_items"}
+    assert package.dropped_tables is None
 
 
 def test_replace_empty_resource_truncates_via_package_state() -> None:
@@ -3767,10 +3770,17 @@ def test_replace_empty_resource_truncates_via_package_state() -> None:
     # instead `items` is registered for truncation via the package state
     state = pipeline.get_load_package_state(load_id)
     assert "items" in [table["name"] for table in state.get("truncated_tables", [])]
+    # package info exposes the requested truncation, no refresh was set
+    assert package.refresh is None
+    assert package.truncated_tables == ["items"]
 
     # finishing the load truncates the table
-    pipeline.load()
+    info = pipeline.load()
     assert load_table_counts(pipeline, "items") == {"items": 0}
+    # the load step recorded the actually truncated table, still without refresh
+    loaded_package = info.load_packages[0]
+    assert loaded_package.refresh is None
+    assert loaded_package.truncated_tables == ["items"]
 
 
 def test_replace_empty_resource_keeps_append_pseudo_root() -> None:
@@ -3819,10 +3829,12 @@ def test_replace_empty_resource_keeps_append_pseudo_root() -> None:
 
     # empty run: the replace roots (default and variant) are emptied, but their append pseudo-roots
     # are kept - we cannot re-derive a pseudo-root's effective disposition, so it is not truncated
-    pipeline.run(items_resource(False))
+    info = pipeline.run(items_resource(False))
     assert load_table_counts(
         pipeline, "items", "items__sub_items", "other_items", "other_items__sub_items"
     ) == {"items": 0, "items__sub_items": 1, "other_items": 0, "other_items__sub_items": 1}
+    # only the replace roots appear in the truncated tables record
+    assert set(info.load_packages[0].truncated_tables) == {"items", "other_items"}
 
 
 def test_replace_keeps_pseudo_root_when_root_has_data() -> None:

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -3741,6 +3741,38 @@ def test_replace_empty_resource_truncates_variant_tables() -> None:
     assert load_table_counts(pipeline, "items", "other_items") == {"items": 0, "other_items": 0}
 
 
+def test_replace_empty_resource_truncates_via_package_state() -> None:
+    """A replace resource that yields no data registers its tables in the load package
+    `truncated_tables` state instead of writing an empty-file job."""
+
+    @dlt.resource(name="items", write_disposition="replace")
+    def items(emit: bool) -> Any:
+        if emit:
+            yield [{"id": 1}, {"id": 2}]
+
+    pipeline = dlt.pipeline(
+        pipeline_name="replace_truncate_state_" + uniq_id(), destination="duckdb", dev_mode=True
+    )
+    # seed the table so it has seen data
+    pipeline.run(items(True))
+    assert load_table_counts(pipeline, "items") == {"items": 2}
+
+    # no data: inspect the normalized load package before loading
+    pipeline.extract(items(False))
+    pipeline.normalize()
+    load_id = pipeline.list_normalized_load_packages()[0]
+    package = pipeline.get_load_package_info(load_id)
+    # no empty-file job is written for `items`
+    assert "items" not in [job.job_file_info.table_name for job in package.jobs["new_jobs"]]
+    # instead `items` is registered for truncation via the package state
+    state = pipeline.get_load_package_state(load_id)
+    assert "items" in [table["name"] for table in state.get("truncated_tables", [])]
+
+    # finishing the load truncates the table
+    pipeline.load()
+    assert load_table_counts(pipeline, "items") == {"items": 0}
+
+
 def test_replace_empty_resource_keeps_append_pseudo_root() -> None:
     """When a replace resource yields no data, its root (and variant root) are truncated, but a
     pseudo-root (nested table broken out by a primary key) whose own write disposition differs from
@@ -3867,8 +3899,9 @@ def test_replace_event_dispatch_truncates_missing_table(dispatch: str) -> None:
     pipeline.run(events(["a"]), write_disposition="replace")
     # "a" received data and is replaced with the new row
     assert load_tables_to_dicts(pipeline, "a")["a"][0]["id"] == 0
+    # tables with no data have their hints unmodified
+    assert pipeline.default_schema.tables["b"]["write_disposition"] == "merge"
     # missing "b" is refreshed to replace and truncated even though it received no data
-    assert pipeline.default_schema.tables["b"]["write_disposition"] == "replace"
     assert load_table_counts(pipeline, "a", "b") == {"a": 1, "b": 0}
 
 
@@ -5915,6 +5948,48 @@ def test_no_coercion_normalizer_creates_variant_columns() -> None:
     assert rows[1][2] == 42
     assert rows[1][3] is None
     assert rows[1][4] == "not_a_number"
+
+
+def test_upsert_on_seen_data_table_empty_incremental_run() -> None:
+    """A merge/delete-insert resource loads a row without a primary key (only a warning), then the
+    resource switches to upsert and an incremental run selects no rows. The empty run must not turn
+    the seen-data table into a keyless upsert table: it stays delete-insert and loads cleanly, and
+    the upsert key is applied only once data arrives.
+    """
+    pipeline = dlt.pipeline(
+        pipeline_name="upsert_seen_data" + uniq_id(),
+        destination="duckdb",
+        dataset_name="upsert_seen_data",
+    )
+
+    # 1st run: delete-insert merge with no primary key declared. loading a row only warns about the
+    # missing key, so `store` is created with seen-data and `id` as a plain (keyless) column.
+    @dlt.resource(name="store", write_disposition="merge")
+    def store_delete_insert():
+        yield [{"id": 1, "ts": 1, "val": "a"}]
+
+    pipeline.run(store_delete_insert())
+    assert pipeline.default_schema.tables["store"]["columns"]["id"].get("primary_key") is None
+
+    # 2nd run: switch to upsert with the correct key, but the incremental selects no rows
+    # (initial_value is past the only row). the table is not recomputed, and `_handle_empty_tables`
+    # no longer mutates it, so the stored disposition stays merge/delete-insert and the run succeeds.
+    @dlt.resource(
+        name="store",
+        primary_key="id",
+        write_disposition={"disposition": "merge", "strategy": "upsert"},
+    )
+    def store_upsert(updated=dlt.sources.incremental("ts", initial_value=10)):
+        yield [{"id": 1, "ts": 1, "val": "a"}]
+
+    info = pipeline.run(store_upsert())
+    assert_load_info(info)
+    # the empty run left the stored merge strategy unchanged and did not apply the primary key
+    store = pipeline.default_schema.tables["store"]
+    assert store.get("x-merge-strategy") != "upsert"
+    assert store["columns"]["id"].get("primary_key") is None
+    # the row loaded by the first run is intact
+    assert load_table_counts(pipeline, "store")["store"] == 1
 
 
 def test_cleanup() -> None:

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -5952,9 +5952,9 @@ def test_no_coercion_normalizer_creates_variant_columns() -> None:
 
 def test_upsert_on_seen_data_table_empty_incremental_run() -> None:
     """A merge/delete-insert resource loads a row without a primary key (only a warning), then the
-    resource switches to upsert and an incremental run selects no rows. The empty run must not turn
-    the seen-data table into a keyless upsert table: it stays delete-insert and loads cleanly, and
-    the upsert key is applied only once data arrives.
+    resource switches to upsert but an incremental run selects no rows. The fully-filtered run
+    yields None, so the table is not recomputed: the stored delete-insert strategy and keyless `id`
+    are left unchanged and the run still loads cleanly.
     """
     pipeline = dlt.pipeline(
         pipeline_name="upsert_seen_data" + uniq_id(),
@@ -5984,7 +5984,8 @@ def test_upsert_on_seen_data_table_empty_incremental_run() -> None:
 
     info = pipeline.run(store_upsert())
     assert_load_info(info)
-    # the empty run left the stored merge strategy unchanged and did not apply the primary key
+    # the fully-filtered incremental yields None, so the table is not recomputed: the stored
+    # delete-insert strategy stays and the primary key is not applied
     store = pipeline.default_schema.tables["store"]
     assert store.get("x-merge-strategy") != "upsert"
     assert store["columns"]["id"].get("primary_key") is None

--- a/tests/pipeline/test_pipeline_trace.py
+++ b/tests/pipeline/test_pipeline_trace.py
@@ -3,7 +3,7 @@ import io
 import os
 import asyncio
 import datetime  # noqa: 251
-from typing import Any, List
+from typing import Any, List, Set
 from unittest.mock import patch
 import pytest
 import requests_mock
@@ -18,8 +18,8 @@ from dlt.common.configuration.utils import get_resolved_traces
 from dlt.common.pipeline import ExtractInfo, NormalizeInfo, LoadInfo
 from dlt.common.schema import Schema
 from dlt.common.runtime.telemetry import stop_telemetry
-from dlt.common.typing import DictStrAny, DictStrStr, TSecretValue
-from dlt.common.utils import digest128
+from dlt.common.typing import DictStrAny, DictStrStr, TRefreshMode, TSecretValue
+from dlt.common.utils import digest128, uniq_id
 
 from dlt.destinations import dummy, filesystem
 
@@ -348,6 +348,10 @@ def test_trace_schema() -> None:
     os.environ["SOURCES__MANY_HINTS__CREDENTIALS"] = "CREDS"
 
     pipeline.run([many_hints(), github()])
+    # run again with refresh so the traces carry refresh mode and dropped/truncated tables
+    pipeline.run([many_hints(), github()], refresh="drop_sources")
+    trace_drop_sources = pipeline.last_trace
+    pipeline.run([many_hints(), github()], refresh="drop_data")
 
     trace = pipeline.last_trace
     pipeline._schema_storage.storage.save("trace.json", json.dumps(trace, pretty=True))
@@ -360,7 +364,7 @@ def test_trace_schema() -> None:
     trace_pipeline = dlt.pipeline(
         pipeline_name="test_trace_schema_traces", destination=dummy(completed_prob=1.0)
     )
-    trace_pipeline.run([trace], table_name="trace", schema=evolving_schema)
+    trace_pipeline.run([trace, trace_drop_sources], table_name="trace", schema=evolving_schema)
 
     # add exception trace
     with pytest.raises(PipelineStepFailed):
@@ -394,7 +398,7 @@ def test_trace_schema() -> None:
         pipeline_name="test_trace_schema_traces_contract", destination=dummy(completed_prob=1.0)
     )
     contract_trace_pipeline.run(
-        [trace_exception, trace],
+        [trace_exception, trace, trace_drop_sources],
         table_name="trace",
         schema=trace_contract,
         schema_contract="freeze",
@@ -407,6 +411,55 @@ def test_trace_schema() -> None:
 
 
 # def test_trace_schema_contract() -> None:
+
+
+@pytest.mark.parametrize(
+    "refresh,expected_dropped,expected_truncated",
+    [
+        ("drop_sources", {"items", "other"}, set()),
+        ("drop_data", set(), {"items", "other"}),
+    ],
+    ids=["drop-sources", "drop-data"],
+)
+def test_trace_refresh_and_table_drops(
+    refresh: TRefreshMode, expected_dropped: Set[str], expected_truncated: Set[str]
+) -> None:
+    """Refresh mode and dropped/truncated tables are exposed on step infos and in printouts."""
+    pipeline = dlt.pipeline(
+        pipeline_name="test_trace_refresh_" + uniq_id(),
+        destination="duckdb",
+        dev_mode=True,
+    )
+
+    @dlt.resource(write_disposition="replace")
+    def items():
+        yield [{"id": 1}, {"id": 2}]
+
+    @dlt.resource(write_disposition="append")
+    def other():
+        yield [{"x": "a"}]
+
+    info = pipeline.run([items(), other()])
+    # no refresh: the regular truncation of the replace table is not recorded
+    package = info.load_packages[0]
+    assert package.refresh is None
+    assert package.dropped_tables is None
+    assert package.truncated_tables is None
+    assert "with refresh" not in str(info)
+
+    info = pipeline.run([items(), other()], refresh=refresh)
+    package = info.load_packages[0]
+    assert package.refresh == refresh
+    assert set(package.dropped_tables or []) == expected_dropped
+    assert set(package.truncated_tables or []) == expected_truncated
+    assert f"with refresh '{refresh}'" in str(info)
+    # extract package exposes the tables requested to be dropped/truncated
+    extract_package = pipeline.last_trace.last_extract_info.load_packages[0]
+    assert extract_package.refresh == refresh
+    assert set(extract_package.dropped_tables or []) == expected_dropped
+    assert set(extract_package.truncated_tables or []) == expected_truncated
+
+    assert_trace_serializable(pipeline.last_trace)
 
 
 def test_save_load_trace() -> None:

--- a/tests/pipeline/test_schema_contracts.py
+++ b/tests/pipeline/test_schema_contracts.py
@@ -9,6 +9,8 @@ from dlt.common.schema.typing import (
     TSchemaEvolutionMode,
 )
 from dlt.common.utils import uniq_id
+from dlt.common.schema import Schema
+from dlt.common.schema.utils import new_table
 from dlt.common.schema.exceptions import DataValidationError
 from dlt.common.typing import TDataItems
 from dlt.extract.hints import make_hints
@@ -1147,6 +1149,45 @@ def test_replace_contract_discard_all_rows_truncates() -> None:
     assert load_table_counts(pipeline).get("items", 0) == 0
     # the new column was blocked by the contract
     assert "extra" not in pipeline.default_schema.get_table("items")["columns"]
+
+
+def test_upsert_contract_discard_all_rows_never_seen_table_not_verified() -> None:
+    """A never-seen `upsert` table whose rows are all dropped by a contract must not be materialized
+    or verified. Before the fix the normalizer wrote an empty job for it, which both flagged the
+    table seen-data that triggered various schema checks that were failing."""
+    pipeline = get_pipeline()
+
+    # establish `items` in the schema (so `evolve-columns-once` does not apply) WITHOUT data:
+    # complete `val`, hint-only (untyped) primary key `id`, upsert, columns: discard_row
+    schema = Schema("contracts")
+    table = new_table(
+        "items", write_disposition="merge", schema_contract={"columns": "discard_row"}
+    )
+    table["x-merge-strategy"] = "upsert"  # type: ignore[typeddict-unknown-key]
+    table["columns"] = {
+        "val": {"name": "val", "data_type": "text"},
+        "id": {"name": "id", "primary_key": True, "nullable": False},
+    }
+    schema.update_table(table, normalize_identifiers=False)
+
+    @dlt.resource(name="items")
+    def items() -> Any:
+        # every row carries a NEW column `extra` so discard_row drops them all
+        yield [{"id": i, "val": "x", "extra": i} for i in range(3)]
+
+    # before the fix this raised `No primary key defined` during verify_schema at the load step
+    info = pipeline.run(items(), schema=schema)
+    assert_load_info(info)
+    # the table that never received data is not created at the destination
+    with pipeline.sql_client() as client:
+        existing = [
+            row[0]
+            for row in client.execute_sql(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema ="
+                " current_schema()"
+            )
+        ]
+    assert "items" not in existing
 
 
 @pytest.mark.parametrize("contract_setting", ["freeze", "discard_value", "discard_row"])


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
* uses `truncate_tables` mechanism via load package state to truncate "replace" tables when no data got extracted - previously empty files were used which produced side-effects
* does not modify table hints of tables that didn't receive data - rollbacks 1.28.x behavior as it had (rare) sideffects (producing inconsistent hints)
* stores refresh mode, truncate and dropped tables in traces and displays refresh mode in load info
* handles situation when data contract filters out all data from a new table correctly
