### PR TITLE
fix: use default format for uv exports

### DIFF
--- a/dlt/_workspace/deployment/requirements.py
+++ b/dlt/_workspace/deployment/requirements.py
@@ -409,8 +409,6 @@ def _export_from_pyproject(
                     "--no-hashes",
                     "--no-emit-project",
                     "--no-default-groups",
-                    "--format",
-                    "requirements.txt",
                 ],
                 cwd=workspace_root,
             )
@@ -425,8 +423,6 @@ def _export_from_pyproject(
                         "--no-default-groups",
                         "--only-group",
                         name,
-                        "--format",
-                        "requirements.txt",
                     ],
                     cwd=workspace_root,
                 )

--- a/tests/workspace/deployment/test_requirements.py
+++ b/tests/workspace/deployment/test_requirements.py
@@ -123,6 +123,43 @@ def test_pyproject_with_lock_resolves_all_groups() -> None:
     assert "numpy" in gpu_names
 
 
+def test_pyproject_with_lock_export_uses_default_uv_format(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\n"
+        'name = "deps-locked"\n'
+        'version = "0.0.1"\n'
+        'dependencies = ["requests>=2.0"]\n'
+        "\n"
+        "[dependency-groups]\n"
+        'dev = ["pytest>=7.0"]\n'
+    )
+    (tmp_path / "uv.lock").write_text("")
+
+    commands: List[List[str]] = []
+
+    def fake_run_uv(args: List[str], cwd: Path) -> str:
+        commands.append(args)
+        if args[0] == "lock":
+            return ""
+        if "--only-group" in args:
+            return "pytest==7.4.0\n"
+        return "requests==2.31.0\n"
+
+    monkeypatch.setattr("dlt._workspace.deployment.requirements._require_uv", lambda: None)
+    monkeypatch.setattr("dlt._workspace.deployment.requirements._run_uv", fake_run_uv)
+
+    result = export_workspace_requirements(tmp_path)
+
+    assert result["groups"][MAIN_GROUP] == ["requests==2.31.0"]
+    assert result["groups"]["dev"] == ["pytest==7.4.0"]
+    export_commands = [command for command in commands if command[0] == "export"]
+    assert len(export_commands) == 2
+    for command in export_commands:
+        assert "--format" not in command
+
+
 def test_pyproject_lock_out_of_sync_raises() -> None:
     with isolated_workspace("deps_pyproject") as ctx:
         # empty lockfile is guaranteed to be out of sync


### PR DESCRIPTION
## Description

Fixes #4133.

`uv export` has used different explicit format values across uv versions. This PR removes the explicit `--format` argument so uv uses its default requirements output format, avoiding the version-specific invalid-format error.

Added regression coverage for the `uv.lock` export path. It verifies that both generated `uv export` commands omit `--format`.

## Related Issues

- Fixes #4133

## Additional Context

Focused validation completed:

- `uv run pytest tests/workspace/deployment/test_requirements.py -q` — 99 passed
- Real `uv.lock` export-path test passed
- Black, Ruff, targeted mypy, `git diff --check`, and `uv lock --check` passed

A broader `tests/workspace` run completed with 1,669 passed and 24 unrelated local Windows/environment failures: missing Streamlit, unavailable symlink privilege, and local file-URL/path handling. The requirements suite passed.