### PR TITLE
docs(website): add status link to navbar and footer

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -179,6 +179,7 @@ const config = {
             label: "Education",
           },
           { to: "/release-highlights", label: "What's new?", position: "left" },
+          { type: "custom-statusItem", position: "left" },
           { to: "https://dlthub.com/blog", label: "Blog", position: "right" },
           {
             href: "https://dlthub.com/community",
@@ -227,6 +228,11 @@ const config = {
               {
                 label: "Twitter",
                 href: "https://twitter.com/dlthub",
+                className: "footer-link",
+              },
+              {
+                label: "Status",
+                href: "https://status.dlthub.com",
                 className: "footer-link",
               },
             ],

--- a/docs/website/src/components/StatusNavbarItem.jsx
+++ b/docs/website/src/components/StatusNavbarItem.jsx
@@ -12,14 +12,22 @@ export default function StatusNavbarItem() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch("https://status.dlthub.com/api/v2/status.json")
-      .then((r) => r.json())
-      .then((d) => {
-        if (!cancelled) setIndicator(d?.status?.indicator || "none");
-      })
-      .catch(() => {});
+
+    const fetchStatus = () => {
+      fetch("https://status.dlthub.com/api/v2/status.json")
+        .then((r) => r.json())
+        .then((d) => {
+          if (!cancelled) setIndicator(d?.status?.indicator || "none");
+        })
+        .catch(() => {});
+    };
+
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 60000);
+
     return () => {
       cancelled = true;
+      clearInterval(interval);
     };
   }, []);
 

--- a/docs/website/src/components/StatusNavbarItem.jsx
+++ b/docs/website/src/components/StatusNavbarItem.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+
+const COLORS = {
+  none: "#28a745",
+  minor: "#f4b400",
+  major: "#f57c00",
+  critical: "#d93025",
+};
+
+export default function StatusNavbarItem() {
+  const [indicator, setIndicator] = useState("none");
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("https://status.dlthub.com/api/v2/status.json")
+      .then((r) => r.json())
+      .then((d) => {
+        if (!cancelled) setIndicator(d?.status?.indicator || "none");
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <a
+      href="https://status.dlthub.com"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="navbar__item navbar__link"
+      aria-label="dltHub platform status"
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          display: "inline-block",
+          width: "8px",
+          height: "8px",
+          borderRadius: "50%",
+          background: COLORS[indicator] || "#8a8a8a",
+          marginRight: "6px",
+          verticalAlign: "middle",
+        }}
+      />
+      Status
+    </a>
+  );
+}

--- a/docs/website/src/theme/NavbarItem/ComponentTypes.js
+++ b/docs/website/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,7 @@
+import ComponentTypes from "@theme-original/NavbarItem/ComponentTypes";
+import StatusNavbarItem from "@site/src/components/StatusNavbarItem";
+
+export default {
+  ...ComponentTypes,
+  "custom-statusItem": StatusNavbarItem,
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Adds a Status link to the docs top nav (right after "What's new?") and to the footer's "More" column, both linking to https://status.dlthub.com. The top-nav entry includes a small colored dot that reflects real-time platform status:

- none → green (all systems operational)
- minor → yellow
- major → orange
- critical → red
- fetch fails → gray fallback

The dot is driven by status.dlthub.com/api/v2/status.json (incident.io endpoint, Statuspage-compatible schema). The component polls the endpoint every 60 seconds so the dot reflects live status while the tab is open.

Implementation

- src/components/StatusNavbarItem.jsx — React component with the fetch + 60s interval
- src/theme/NavbarItem/ComponentTypes.js — Docusaurus swizzle that registers a custom-statusItem navbar-item type alongside the stock types
- docusaurus.config.js — one navbar item, one footer link
