### PR TITLE
docs: add Tigris to S3-compatible storage options

### DIFF
--- a/docs/website/docs/dlt-ecosystem/destinations/clickhouse.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/clickhouse.md
@@ -473,7 +473,7 @@ The ClickHouse GCS table function only supports authentication using Hash-based 
 To enable this, GCS provides an S3
 compatibility mode that emulates the S3 API, allowing ClickHouse to access GCS buckets via its S3 integration.
 
-For detailed instructions on setting up S3-compatible storage with dlt, including AWS S3, MinIO, and Cloudflare R2, refer to
+For detailed instructions on setting up S3-compatible storage with dlt, including AWS S3, MinIO, Tigris, and Cloudflare R2, refer to
 the [dlt documentation on filesystem destinations](../../dlt-ecosystem/destinations/filesystem#using-s3-compatible-storage).
 
 To set up GCS staging with HMAC authentication in dlt:

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -112,7 +112,7 @@ You need to create an S3 bucket and a user who can access that bucket. dlt does 
 
 #### Using S3 compatible storage
 
-To use an S3 compatible storage other than AWS S3, such as [MinIO](https://min.io/), [Cloudflare R2](https://www.cloudflare.com/en-ca/developer-platform/r2/) or [Google
+To use an S3 compatible storage other than AWS S3, such as [MinIO](https://min.io/), [Tigris](https://www.tigrisdata.com), [Cloudflare R2](https://www.cloudflare.com/en-ca/developer-platform/r2/), or [Google
 Cloud Storage](https://cloud.google.com/storage/docs/interoperability), you may supply an `endpoint_url` in the config. This should be set along with AWS credentials:
 
 ```toml
@@ -124,6 +124,8 @@ aws_access_key_id = "please set me up!" # copy the access key here
 aws_secret_access_key = "please set me up!" # copy the secret access key here
 endpoint_url = "https://<account_id>.r2.cloudflarestorage.com" # copy your endpoint URL here
 ```
+
+For Tigris, set `endpoint_url = "https://t3.storage.dev"` and use your Tigris access key ID (prefixed `tid_`) and secret access key (prefixed `tsec_`). Tigris uses a single global endpoint and doesn't charge egress fees, which matters when warehouses in different regions load from the same staging bucket.
 
 #### Adding additional configuration
 


### PR DESCRIPTION
## Summary

Adds Tigris to the list of S3-compatible storage options documented in the dlt filesystem destination page, alongside the existing MinIO, Cloudflare R2, and Google Cloud Storage entries. Also adds Tigris to the ClickHouse destination page's cross-reference to the filesystem docs, which already names S3-compatible providers.

## Why

The "Using S3 compatible storage" subsection in `filesystem.md` already documents the `endpoint_url` pattern for non-AWS S3 backends. Tigris is a widely used S3-compatible store that fits the same configuration pattern, so it's a natural addition.

For dlt users specifically, the value is on the warehouse-staging side of the pipeline. The filesystem destination is often used as a staging area for Snowflake / BigQuery / Databricks / ClickHouse `COPY INTO` operations. When those loads pull from the staged bucket, they generate egress bytes on AWS S3. Tigris doesn't charge egress fees, and its single global endpoint means the same `endpoint_url` works from warehouses in any region.

## Changes

- **`filesystem.md`**: added `[Tigris]` to the list of examples in the "Using S3 compatible storage" section intro, plus a short follow-up paragraph after the R2 toml block with the Tigris-specific `endpoint_url` (`https://t3.storage.dev`) and access-key prefixes (`tid_` for the ID, `tsec_` for the secret).
- **`clickhouse.md`**: added Tigris to the existing list of S3-compatible providers in the cross-reference to filesystem docs (previously: "AWS S3, MinIO, and Cloudflare R2").
- R2 toml example and everything else unchanged.

Docs only; no code changes.