### PR TITLE
(fix) uses empty files to truncate top level tables

### DIFF
--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -2,7 +2,7 @@ import contextlib
 from collections.abc import Sequence as C_Sequence
 from copy import copy
 import itertools
-from typing import Iterator, List, Dict, Any, Optional
+from typing import Iterator, List, Dict, Any, Optional, cast
 import yaml
 
 from dlt.common import logger
@@ -24,6 +24,7 @@ from dlt.common.runtime.collector import Collector, NULL_COLLECTOR
 from dlt.common.schema import Schema, utils
 from dlt.common.schema.typing import (
     TAnySchemaColumns,
+    TPartialTableSchema,
     TSchemaContract,
     TTableFormat,
     TTableSchema,
@@ -306,9 +307,6 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
     _last_extractors: Dict[TDataItemFormat, Extractor] = None
     """Most recently used extractors"""
 
-    _tables_to_truncate: List[TTableSchema]
-    """Tables to truncate via package state"""
-
     def __init__(
         self,
         schema_storage: SchemaStorage,
@@ -458,17 +456,22 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                         # fall back to the stored disposition when it can't be re-derived
                         else (wd_config or table.get("write_disposition"))
                     )
+                    # apply the fresh disposition so the load package schema replaces the table
+                    if disposition == "replace" and table.get("write_disposition") != "replace":
+                        partial_table: Dict[str, Any] = {
+                            "name": table_name,
+                            "columns": {},
+                            "write_disposition": wd_config,
+                        }
+                        resource._merge_write_disposition_dict(partial_table)
+                        schema.update_table(cast(TPartialTableSchema, partial_table))
                 else:
                     disposition = table.get("write_disposition")
 
                 # table itself must accept replace
                 if disposition == "replace":
-                    # collect tables to truncate via package state
-                    self._tables_to_truncate.extend(
-                        nested_table
-                        for nested_table in utils.get_nested_tables(schema.tables, table_name)
-                        if utils.has_table_seen_data(nested_table)
-                    )
+                    # write empty file so a replace root is truncated even though it received no data
+                    json_extractor.write_empty_items_file(table_name)
 
         # collect tables that received empty materialized lists and had no items
         tables_with_empty = (
@@ -488,7 +491,6 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
         workers: int,
     ) -> None:
         schema = source.schema
-        self._tables_to_truncate = []
         collector = self.collector
         extractors: Dict[TDataItemFormat, Extractor] = {
             "object": ObjectExtractor(
@@ -601,14 +603,6 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                     max_parallel_items=max_parallel_items,
                     workers=workers,
                 )
-                # register replace tables that yielded no data for truncation via the load package
-                if self._tables_to_truncate:
-                    truncated = load_package.state.setdefault("truncated_tables", [])
-                    existing_names = {table["name"] for table in truncated}
-                    for table in self._tables_to_truncate:
-                        if table["name"] not in existing_names:
-                            existing_names.add(table["name"])
-                            truncated.append(table)
                 commit_load_package_state()
         return load_id
 

--- a/dlt/load/utils.py
+++ b/dlt/load/utils.py
@@ -158,9 +158,7 @@ def init_client(
 
         # if there are tables to drop, we should also drop them in the staging dataset
         if all_staging_tables or drop_table_names:
-            # the staging dataset holds only staging-eligible tables so the stored schema is
-            # trimmed to that subset. version hash then detects when the subset grows without
-            # a schema change ie. after a switch to a staging replace strategy (#4152)
+            # trim the schema on staging dataset to tables that will be actually materialized
             job_client_schema = job_client.schema
             with job_client.with_staging_dataset():
                 job_client.schema = _trim_schema_to_tables(schema, all_staging_tables)

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, NamedTuple, Optional, Set, Any
+from typing import Dict, List, NamedTuple, Optional, Any
 import pytest
 import os
 
@@ -1192,28 +1192,19 @@ def _mark_seen_data(schema: dlt.Schema, *table_names: str) -> None:
         schema.tables[table_name].setdefault("x-normalizer", {})["seen-data"] = True
 
 
-class _ExtractResult(NamedTuple):
-    table_metrics: Dict[str, Any]
-    """writer metrics per table - data writes and materialized (empty-file) tables"""
-    truncated_tables: Set[str]
-    """tables registered for truncation via the load package state (a replace resource with no data)"""
-
-
 def _extract_resource(
     extract_step: Extract, schema: dlt.Schema, resource: DltResource
-) -> _ExtractResult:
+) -> Dict[str, Any]:
     """Extract a single resource into the shared `schema` (mirrors the per-run extraction) and
-    return its per-table writer metrics together with the tables registered for truncation via the
-    load package state."""
+    return its per-table writer metrics (table name -> DataWriterMetrics)."""
     source = DltSource(schema, "module", [resource])
     load_id = extract_step.extract_storage.create_load_package(schema)
     extract_step._extract_single_source(load_id, source, max_parallel_items=5, workers=1)
     table_metrics: Dict[str, Any] = extract_step._step_info_metrics(load_id)[0]["table_metrics"]
-    truncated_tables = {table["name"] for table in extract_step._tables_to_truncate}
     extract_step.extract_storage.commit_new_load_package(load_id, schema)
     for extractor in extract_step._last_extractors.values():
         assert_written_tables_are_computed(extractor)
-    return _ExtractResult(table_metrics, truncated_tables)
+    return table_metrics
 
 
 @pytest.mark.parametrize(
@@ -1254,10 +1245,11 @@ def test_handle_empty_tables_does_not_mutate_disposition(
     assert object_extractor.tables_with_items == {expected}
     assert object_extractor.tables_with_empty == set()
 
-    # a replace table that yields no data is truncated by recording it in the load package state
-    result = _extract_resource(extract_step, schema, items_replace([]))
-    assert result.truncated_tables == {expected}
-    # an empty run computes nothing and writes no items; the truncation came from
+    # a replace table that yields no data still gets an empty file (so it is truncated): it appears
+    # in the writer metrics with zero items
+    metrics = _extract_resource(extract_step, schema, items_replace([]))
+    assert metrics[expected].items_count == 0
+    # an empty run computes nothing and writes no items; the empty file came from
     # `_handle_empty_tables`, not the extractor
     object_extractor = extract_step._last_extractors["object"]
     assert object_extractor.computed_tables == set()
@@ -1277,10 +1269,9 @@ def test_handle_empty_tables_does_not_mutate_disposition(
     def items_merge() -> Any:
         yield from []
 
-    # a non-replace table that yields no data must NOT be truncated or written
-    result = _extract_resource(extract_step, schema, items_merge())
-    assert expected not in result.truncated_tables
-    assert expected not in result.table_metrics
+    # a non-replace table that yields no data must NOT get an empty file - it is absent from metrics
+    metrics = _extract_resource(extract_step, schema, items_merge())
+    assert expected not in metrics
 
     # an empty run does NOT modify the table: the stored disposition and hints are left untouched,
     # and the new scd2 merge config (incl. validity columns) is only applied once data arrives
@@ -1359,10 +1350,11 @@ def test_handle_empty_tables_variant_pseudo_root_no_cascade(extract_step: Extrac
 
     # run 2: replace with no data - every table (roots and pseudo-roots) is replace, so each gets an
     # empty file written (so it is truncated), and no spurious cascade table is created
-    result = _extract_resource(
+    metrics = _extract_resource(
         extract_step, schema, make_resource("replace", "replace", "replace", [])
     )
-    assert result.truncated_tables == set(all_tables)
+    for table in all_tables:
+        assert metrics[table].items_count == 0
     assert "items__sub_items__sub_items" not in schema.tables
     assert "other_items__sub_items__sub_items" not in schema.tables
     # an empty run computes nothing and writes no items - the empty files came from
@@ -1376,10 +1368,9 @@ def test_handle_empty_tables_variant_pseudo_root_no_cascade(extract_step: Extrac
     # all with no data. nothing is replace, so no table is truncated. an empty run does not modify
     # the schema, so every stored disposition stays at its previous (replace) value - the new hints
     # would only be applied once data arrives
-    result = _extract_resource(extract_step, schema, make_resource("append", "merge", "merge", []))
+    metrics = _extract_resource(extract_step, schema, make_resource("append", "merge", "merge", []))
     for table in all_tables:
-        assert table not in result.truncated_tables
-        assert table not in result.table_metrics
+        assert table not in metrics
         assert schema.tables[table]["write_disposition"] == "replace"
     # no pseudo-root is ever recomputed as a root, so no spurious cascade tables are created
     assert "items__sub_items__sub_items" not in schema.tables
@@ -1390,7 +1381,7 @@ def test_handle_empty_tables_variant_pseudo_root_no_cascade(extract_step: Extrac
 def test_handle_empty_tables_dispatched_tables(extract_step: Extract, dispatch: str) -> None:
     """Event-dispatch tables - created via with_table_name marks or a dynamic table_name function -
     keep their stored write disposition unchanged on an empty run, while a replace table that gets no
-    data is truncated via the load package state."""
+    data has an empty file written so it is truncated."""
     schema = dlt.Schema("empty_tables")
 
     def make_resource(wd: TWriteDisposition, data: Any) -> DltResource:
@@ -1433,18 +1424,20 @@ def test_handle_empty_tables_dispatched_tables(extract_step: Extract, dispatch: 
     assert object_extractor.tables_with_items == set(tables)
     assert object_extractor.tables_with_empty == set()
 
-    # run 2 (totally empty): every replace table is truncated via the package state
-    result = _extract_resource(extract_step, schema, make_resource("replace", []))
-    assert result.truncated_tables == set(tables)
+    # run 2 (totally empty): every replace table gets an empty file (so it is truncated)
+    metrics = _extract_resource(extract_step, schema, make_resource("replace", []))
+    for table in tables:
+        assert metrics[table].items_count == 0
 
-    # run 3 (only one table gets data): the table with data is loaded normally, the other is truncated
-    result = _extract_resource(
+    # run 3 (only one table gets data): the table with data is loaded normally, the other still gets
+    # an empty file
+    metrics = _extract_resource(
         extract_step, schema, make_resource("replace", [{"kind": "MyIssue", "id": 3}])
     )
-    assert result.table_metrics["my_issue"].items_count == 1
-    assert result.truncated_tables == {"my_purchase"}
+    assert metrics["my_issue"].items_count == 1
+    assert metrics["my_purchase"].items_count == 0
     # only the table that received an item is computed and tracked with items; the truncated
-    # `my_purchase` was recorded by `_handle_empty_tables`, not the extractor, so it is in
+    # `my_purchase` got its empty file from `_handle_empty_tables`, not the extractor, so it is in
     # neither set
     object_extractor = extract_step._last_extractors["object"]
     assert object_extractor.computed_tables == {"my_issue"}
@@ -1453,10 +1446,9 @@ def test_handle_empty_tables_dispatched_tables(extract_step: Extract, dispatch: 
 
     # run 4: switch to append with no data - not truncated, and an empty run leaves the stored
     # disposition unchanged (still replace); the switch to append only takes effect once data arrives
-    result = _extract_resource(extract_step, schema, make_resource("append", []))
+    metrics = _extract_resource(extract_step, schema, make_resource("append", []))
     for table in tables:
-        assert table not in result.truncated_tables
-        assert table not in result.table_metrics
+        assert table not in metrics
         assert schema.tables[table]["write_disposition"] == "replace"
 
 
@@ -1520,10 +1512,9 @@ def test_handle_empty_tables_ignores_dynamic_write_disposition(extract_step: Ext
     assert schema.tables["my_issue"]["write_disposition"] == "replace"
 
     # no data: dynamic write disposition cannot be resolved, so the table is left untouched and is
-    # not truncated
-    result = _extract_resource(extract_step, schema, make_resource([]))
-    assert "my_issue" not in result.truncated_tables
-    assert "my_issue" not in result.table_metrics
+    # not truncated (no empty file written)
+    metrics = _extract_resource(extract_step, schema, make_resource([]))
+    assert "my_issue" not in metrics
     assert schema.tables["my_issue"]["write_disposition"] == "replace"
 
 
@@ -1604,9 +1595,9 @@ def test_handle_empty_tables_skips_tables_not_accepting_replace(
     schema.tables[member_table].pop("variant_name", None)
 
     # run 2: empty - only tables where the resource and the table both accept replace are truncated
-    result = _extract_resource(extract_step, schema, make_resource([]))
-    assert ("items" in result.truncated_tables) is root_truncated
-    assert (member_table in result.truncated_tables) is member_truncated
+    metrics = _extract_resource(extract_step, schema, make_resource([]))
+    assert ("items" in metrics) is root_truncated
+    assert (member_table in metrics) is member_truncated
 
 
 def test_handle_empty_tables_variant_not_redeclared_left_untouched(extract_step: Extract) -> None:
@@ -1662,14 +1653,16 @@ def test_handle_empty_tables_variant_not_redeclared_left_untouched(extract_step:
 
     # run 2: empty - no variant is re-declared, so none is in `_hints_variants`; the decision falls
     # back to the stored disposition
-    result = _extract_resource(extract_step, schema, make_resource(False, []))
+    metrics = _extract_resource(extract_step, schema, make_resource(False, []))
     # the stored-merge variant differs from the replace resource -> left untouched, not truncated
-    assert "other_items" not in result.truncated_tables
+    assert "other_items" not in metrics
     assert schema.tables["other_items"]["write_disposition"] == "merge"
     # the stored-replace variant, its replace pseudo-root and the replace root are all truncated
     # (the pseudo-root under the now-absent variant cannot be re-derived, yet is truncated because
     # its stored disposition is replace)
-    assert result.truncated_tables == {"replace_items", "replace_items__sub_items", "items"}
+    assert metrics["replace_items"].items_count == 0
+    assert metrics["replace_items__sub_items"].items_count == 0
+    assert metrics["items"].items_count == 0
 
 
 def test_handle_empty_tables_refresh_changed_to_replace_truncates(extract_step: Extract) -> None:
@@ -1689,12 +1682,11 @@ def test_handle_empty_tables_refresh_changed_to_replace_truncates(extract_step: 
     _mark_seen_data(schema, "items")
     assert schema.tables["items"]["write_disposition"] == "append"
 
-    # run 2: the resource switches to replace and yields no data. the fresh disposition (replace) is
-    # computed in memory to truncate the table, but the stored schema is NOT modified - the
-    # disposition stays at its previous (append) value until data arrives
-    result = _extract_resource(extract_step, schema, make_resource("replace", []))
-    assert result.truncated_tables == {"items"}
-    assert schema.tables["items"]["write_disposition"] == "append"
+    # run 2: the resource switches to replace and yields no data. the table is not computed this
+    # run, so the refresh runs, flips the stored disposition to replace, and the table is truncated
+    metrics = _extract_resource(extract_step, schema, make_resource("replace", []))
+    assert metrics["items"].items_count == 0
+    assert schema.tables["items"]["write_disposition"] == "replace"
 
 
 def test_handle_empty_tables_unseen_data_not_truncated(extract_step: Extract) -> None:
@@ -1710,15 +1702,14 @@ def test_handle_empty_tables_unseen_data_not_truncated(extract_step: Extract) ->
     _extract_resource(extract_step, schema, items([{"id": 1}]))
     assert "items" in schema.tables
 
-    # run 2: empty - the table never saw data, so it is not truncated
-    result = _extract_resource(extract_step, schema, items([]))
-    assert "items" not in result.truncated_tables
-    assert "items" not in result.table_metrics
+    # run 2: empty - the table never saw data, so it is not truncated (no empty file)
+    metrics = _extract_resource(extract_step, schema, items([]))
+    assert "items" not in metrics
 
     # once the table has seen data, an empty run truncates it
     _mark_seen_data(schema, "items")
-    result = _extract_resource(extract_step, schema, items([]))
-    assert result.truncated_tables == {"items"}
+    metrics = _extract_resource(extract_step, schema, items([]))
+    assert metrics["items"].items_count == 0
 
 
 def test_handle_empty_tables_materialized_empty_written_unconditionally(
@@ -1737,10 +1728,9 @@ def test_handle_empty_tables_materialized_empty_written_unconditionally(
     def materialized() -> Any:
         yield dlt.mark.materialize_table_schema()
 
-    result = _extract_resource(extract_step, schema, materialized())
-    # empty file written (not a package-state truncation) despite append disposition and no seen data
-    assert result.table_metrics["materialized"].items_count == 0
-    assert "materialized" not in result.truncated_tables
+    metrics = _extract_resource(extract_step, schema, materialized())
+    # empty file written despite append disposition and no prior seen data
+    assert metrics["materialized"].items_count == 0
     object_extractor = extract_step._last_extractors["object"]
     assert object_extractor.computed_tables == {"materialized"}
     assert object_extractor.tables_with_items == set()
@@ -1753,12 +1743,11 @@ def test_handle_empty_tables_materialized_empty_written_unconditionally(
     def nothing() -> Any:
         yield from []
 
-    result = _extract_resource(extract_step, schema, nothing())
-    assert "nothing" not in result.table_metrics
-    assert "nothing" not in result.truncated_tables
+    metrics = _extract_resource(extract_step, schema, nothing())
+    assert "nothing" not in metrics
 
 
-def test_handle_empty_tables_truncates_nested_chain(extract_step: Extract) -> None:
+def test_handle_empty_tables_nested_child_not_truncated(extract_step: Extract) -> None:
     schema = dlt.Schema("empty_tables")
 
     def make_resource(data: Any) -> DltResource:
@@ -1781,16 +1770,15 @@ def test_handle_empty_tables_truncates_nested_chain(extract_step: Extract) -> No
     assert is_nested_table(schema.tables["items__children"]) is True
     _mark_seen_data(schema, "items", "items__children")
 
-    # run 2: empty - the replace root and its (seen-data) nested chain are registered for truncation
-    # (the package truncate list is not chain-extended at load, so the chain is recorded here)
-    result = _extract_resource(extract_step, schema, make_resource([]))
-    assert result.truncated_tables == {"items", "items__children"}
+    # run 2: empty - only the root gets an empty file; the nested child is not truncated directly
+    metrics = _extract_resource(extract_step, schema, make_resource([]))
+    assert metrics["items"].items_count == 0
+    assert "items__children" not in metrics
 
 
-def test_handle_empty_tables_pseudo_root_truncated_without_mutating(extract_step: Extract) -> None:
-    """A pseudo-root's fresh disposition is re-derived from the current nested hints on an empty run
-    only to decide truncation: when the nested hint changes merge -> replace, the pseudo-root is
-    truncated, but its stored disposition is NOT modified."""
+def test_handle_empty_tables_pseudo_root_refreshed_then_truncated(extract_step: Extract) -> None:
+    """A pseudo-root is re-derived from the current nested hints on an empty run: when the nested hint
+    flips merge -> replace, the stored pseudo-root is updated to replace and then truncated."""
     schema = dlt.Schema("empty_tables")
 
     def make_resource(nested_wd: TWriteDisposition, data: Any) -> DltResource:
@@ -1819,9 +1807,8 @@ def test_handle_empty_tables_pseudo_root_truncated_without_mutating(extract_step
     _mark_seen_data(schema, "items", pseudo)
     assert schema.tables[pseudo]["write_disposition"] == "merge"
 
-    # run 2: the nested hint now declares replace; on the empty run the pseudo-root's fresh
-    # disposition re-derives to replace and it is truncated, but the stored schema is NOT modified
-    # (the disposition stays merge until data arrives)
-    result = _extract_resource(extract_step, schema, make_resource("replace", []))
-    assert pseudo in result.truncated_tables
-    assert schema.tables[pseudo]["write_disposition"] == "merge"
+    # run 2: the nested hint now declares replace; on the empty run the pseudo-root is re-derived,
+    # its stored disposition flips merge -> replace, and it is then truncated
+    metrics = _extract_resource(extract_step, schema, make_resource("replace", []))
+    assert schema.tables[pseudo]["write_disposition"] == "replace"
+    assert metrics[pseudo].items_count == 0

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -1514,13 +1514,11 @@ def test_replace_resets_state(item_type: TestDataItemFormat) -> None:
     # state was reset (child is replace but parent is append! so it will not generate any more items due to incremental
     # so child will reset itself on replace and never set the state...)
     assert "child" not in s.state["resources"]
-    # there will be a load package to reset the state
-    assert len(info.load_packages[0].jobs["completed_jobs"]) == 1
+    # there will be a load package to reset the state but also a load package to update the child table
+    assert len(info.load_packages[0].jobs["completed_jobs"]) == 2
     assert {
         job.job_file_info.table_name for job in info.load_packages[0].jobs["completed_jobs"]
-    } == {"_dlt_pipeline_state"}
-    # package state also contains truncate "child" table command
-    # TODO: check the above
+    } == {"_dlt_pipeline_state", "child"}
 
     # now we add child that has parent_r as parent but we add another instance of standalone_some_data explicitly
     # so we have a resource with the same name as child parent but the pipe instance is different

--- a/tests/load/pipeline/test_replace_disposition.py
+++ b/tests/load/pipeline/test_replace_disposition.py
@@ -1,9 +1,11 @@
-from typing import Dict
+from typing import Any, Dict
 import dlt, os, pytest
 from dlt.common.utils import uniq_id
 from pytest_mock import MockerFixture
 
 from dlt.common.schema.typing import REPLACE_STRATEGIES, TLoaderReplaceStrategy
+from dlt.destinations.sql_jobs import SqlStagingReplaceFollowupJob
+from dlt.pipeline.exceptions import PipelineStepFailed
 
 from tests.pipeline.utils import (
     assert_load_info,
@@ -170,17 +172,11 @@ def test_replace_disposition(
         "append_items": 36,
     }
     assert_empty_tables(pipeline, "items", "items__sub_items", "items__sub_items__sub_sub_items")
-    # check trace: `items` produces no jobs, the whole chain is truncated via the package state
+    # check trace
     assert pipeline.last_trace.last_normalize_info.row_counts == {
         "append_items": 12,
+        "items": 0,
     }
-    package = info.load_packages[0]
-    assert set(package.truncated_tables) == {
-        "items",
-        "items__sub_items",
-        "items__sub_items__sub_sub_items",
-    }
-    assert package.dropped_tables is None
 
     # create a pipeline with different name but loading to the same dataset as above - this is to provoke truncating non existing tables
     pipeline_2 = destination_config.setup_pipeline(
@@ -344,23 +340,14 @@ def test_replace_table_clearing(
     # see if yield none clears everything
     for empty_resource in [yield_none, no_yield, yield_empty_list]:
         pipeline.run(items_with_subitems, **destination_config.run_kwargs)
-        info = pipeline.run(empty_resource, **destination_config.run_kwargs)
+        pipeline.run(empty_resource, **destination_config.run_kwargs)
         assert load_table_counts(pipeline, "static_items", "static_items__sub_items") == {
             "static_items": 1,
             "static_items__sub_items": 2,
         }
         assert_empty_tables(pipeline, "items", "other_items", "other_items__sub_items")
-        # check trace (no tables - they are truncated via package state)
-        assert pipeline.last_trace.last_normalize_info.row_counts == {}
-        # both dispatched table chains are truncated, tables of unselected resources are not
-        package = info.load_packages[0]
-        assert set(package.truncated_tables) == {
-            "items",
-            "items__sub_items",
-            "other_items",
-            "other_items__sub_items",
-        }
-        assert package.dropped_tables is None
+        # check trace
+        assert pipeline.last_trace.last_normalize_info.row_counts == {"items": 0, "other_items": 0}
 
     # see if yielding something next to other none entries still goes into db
     pipeline.run(items_with_subitems_yield_none, **destination_config.run_kwargs)
@@ -688,3 +675,68 @@ def test_replace_strategy_switch_creates_staging_tables(
         "merge_items": 1,
         "nested_items": 1,
     }
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["duckdb"]),
+    ids=lambda x: x.name,
+)
+def test_replace_staging_empty_resource_aborted_package_keeps_data(
+    destination_config: DestinationTestConfiguration, mocker: MockerFixture
+) -> None:
+    """Makes sure that insert-from-staging does not truncate upfront when no data on resource"""
+    os.environ["DESTINATION__REPLACE_STRATEGY"] = "insert-from-staging"
+    pipeline = destination_config.setup_pipeline("replace_empty_abort", dev_mode=True)
+
+    @dlt.resource(write_disposition="replace")
+    def items(rows: Any) -> Any:
+        yield from rows
+
+    info = pipeline.run(items([{"id": 1}, {"id": 2}]), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    # fail the replace followup so the package aborts after the 0-row job loaded to staging
+    mocker.patch.object(
+        SqlStagingReplaceFollowupJob, "generate_sql", side_effect=Exception("compute failed")
+    )
+    with pytest.raises(PipelineStepFailed):
+        pipeline.run(items([]), **destination_config.run_kwargs)
+    assert load_table_counts(pipeline, "items") == {"items": 2}
+
+    # the pending package completes once the fault is gone and the table is replaced with no rows
+    mocker.stopall()
+    info = pipeline.run(items([]), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(pipeline, "items") == {"items": 0}
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["duckdb", "snowflake"]),
+    ids=lambda x: x.name,
+)
+@pytest.mark.parametrize("replace_strategy", REPLACE_STRATEGIES)
+def test_replace_refreshed_disposition_no_data(
+    destination_config: DestinationTestConfiguration, replace_strategy: TLoaderReplaceStrategy
+) -> None:
+    """A table whose write disposition is refreshed to replace on a run without data for it is
+    truncated under every replace strategy."""
+    skip_if_unsupported_replace_strategy(destination_config, replace_strategy)
+    os.environ["DESTINATION__REPLACE_STRATEGY"] = replace_strategy
+
+    pipeline = destination_config.setup_pipeline("replace_refresh_empty", dev_mode=True)
+
+    @dlt.resource(name="events", table_name=lambda e: e["kind"], primary_key="id")
+    def events(kinds: Any) -> Any:
+        for idx, kind in enumerate(kinds):
+            yield {"id": idx, "kind": kind}
+
+    pipeline.run(events(["a", "b"]), write_disposition="merge", **destination_config.run_kwargs)
+    assert load_table_counts(pipeline, "a", "b") == {"a": 1, "b": 1}
+    assert pipeline.default_schema.tables["b"]["write_disposition"] == "merge"
+
+    # switch to replace with data only for "a": "b" is refreshed to replace and truncated
+    pipeline.run(events(["a"]), write_disposition="replace", **destination_config.run_kwargs)
+    assert pipeline.default_schema.tables["b"]["write_disposition"] == "replace"
+    assert load_table_counts(pipeline, "a", "b") == {"a": 1, "b": 0}

--- a/tests/load/test_dummy_client.py
+++ b/tests/load/test_dummy_client.py
@@ -1190,41 +1190,21 @@ def test_init_client_truncate_tables() -> None:
                 all_,  # drop tables
                 drop_tables=[schema.get_table("event_user")],
             )
-        print(update_stored_schema.call_args_list)
         # drop tables trigger staging dataset schema change on top of final dataset schema change
         assert update_stored_schema.call_count == 2
-        assert "event_user" in update_stored_schema.call_args_list[0][1]["only_tables"]
-        assert "_dlt_version" in update_stored_schema.call_args_list[1][1]["only_tables"]
+        assert update_stored_schema.call_args_list[0].kwargs["force"] is True
+        assert "event_user" in update_stored_schema.call_args_list[0].kwargs["only_tables"]
+        # no staging-eligible tables so only the version table is migrated on staging
+        assert update_stored_schema.call_args_list[1].kwargs["only_tables"] == {"_dlt_version"}
         assert initialize_storage.call_count == 3
         assert initialize_storage.call_args_list[0].args == ()
         assert initialize_storage.call_args_list[1].kwargs["truncate_tables"] == {"event_user"}
         # dropped on staging dataset and final
         assert drop_tables.call_count == 2
 
-        # now we push all to stage
         initialize_storage.reset_mock()
         update_stored_schema.reset_mock()
         drop_tables.reset_mock()
-
-        with load.get_destination_client(schema) as client:
-            init_client(client, schema, [event_user, event_bot], {}, nothing_, all_, all_)
-        assert update_stored_schema.call_count == 2
-        # first call main dataset
-        assert {"event_user", "event_bot"} <= set(
-            update_stored_schema.call_args_list[0].kwargs["only_tables"]
-        )
-        # second one staging dataset
-        assert {"event_user", "event_bot"} <= set(
-            update_stored_schema.call_args_list[1].kwargs["only_tables"]
-        )
-        assert initialize_storage.call_count == 3
-        assert initialize_storage.call_args_list[0].args == ()
-        assert initialize_storage.call_args_list[1].args == ()
-        # all tables that will be used on staging must be truncated
-        assert initialize_storage.call_args_list[2].kwargs["truncate_tables"] == {
-            "event_user",
-            "event_bot",
-        }
 
         replace_ = (
             lambda table_name: client.prepare_load_table(table_name)["write_disposition"]
@@ -1322,16 +1302,58 @@ def test_init_client_initial_truncate_tables_from_package_state() -> None:
     assert "applied_dropped_tables" not in state
 
 
+def test_init_client_replace_job_no_forced_migration() -> None:
+    """A job for a replace table (ie. the 0-row job of an empty replace resource) truncates the
+    table chain via the regular truncate filter and does not force a schema migration."""
+    load = setup_loader()
+    load_id, schema = prepare_load_package(
+        load.load_storage, ["event_user.b1d32c6660b242aaabbf3fc27245b7e6.0.insert_values"]
+    )
+    schema.tables["event_user"]["write_disposition"] = "replace"
+
+    new_jobs = [ParsedLoadJobFileName("event_user", "event_user_id", 0, "jsonl")]
+    with (
+        patch.object(dummy_impl.DummyClient, "initialize_storage") as initialize_storage,
+        patch.object(
+            dummy_impl.DummyClient, "update_stored_schema", return_value={}
+        ) as update_stored_schema,
+    ):
+        with Container().injectable_context(
+            LoadPackageStateInjectableContext(
+                storage=load.load_storage.normalized_packages, load_id=load_id
+            )
+        ):
+            load.initialize_package(load_id, schema, new_jobs)
+
+    assert update_stored_schema.call_args_list[0].kwargs["force"] is False
+    truncate_calls = [
+        c.kwargs["truncate_tables"]
+        for c in initialize_storage.call_args_list
+        if "truncate_tables" in c.kwargs
+    ]
+    # nested user tables carry an explicit append disposition so only the root is truncated
+    assert truncate_calls == [{"event_user"}]
+    # nothing was applied via the package state
+    state = load.load_storage.normalized_packages.get_load_package_state(load_id)
+    assert "applied_truncated_tables" not in state
+    assert "applied_dropped_tables" not in state
+
+
 def test_init_client_staging_ddl_includes_jobless_tables() -> None:
-    """Issue #2862: staging DDL includes ALL staging-eligible data tables, not just those with jobs."""
+    """Issue #2862: a staging-eligible (merge) table chain without any jobs in the package still
+    gets staging DDL so its staging tables exist when followup jobs reference them ie. after the
+    staging dataset got dropped by the user."""
     load = setup_loader()
     _, schema = prepare_load_package(
         load.load_storage, ["event_user.b1d32c6660b242aaabbf3fc27245b7e6.0.insert_values"]
     )
     nothing_ = lambda _: False
-    all_ = lambda _: True
     event_user = ParsedLoadJobFileName("event_user", "event_user_id", 0, "jsonl")
-    all_data = set(schema.data_table_names())
+
+    # the bot chain is merge (staging-eligible) and gets no jobs in this package
+    bot_chain = {t["name"] for t in get_nested_tables(schema.tables, "event_bot")}
+    for table in get_nested_tables(schema.tables, "event_bot"):
+        table["write_disposition"] = "merge"
 
     with (
         patch.object(dummy_impl.DummyClient, "initialize_storage") as initialize_storage,
@@ -1339,25 +1361,26 @@ def test_init_client_staging_ddl_includes_jobless_tables() -> None:
         patch.object(dummy_impl.DummyClient, "drop_tables"),
     ):
         with load.get_destination_client(schema) as client:
-            init_client(client, schema, [event_user], {}, nothing_, all_, all_)
+            merge_ = (
+                lambda table_name: client.prepare_load_table(table_name)["write_disposition"]
+                == "merge"
+            )
+            init_client(client, schema, [event_user], {}, nothing_, merge_, nothing_)
 
         # main + staging
         assert update_stored_schema.call_count == 2
-        # main dataset: tables with jobs that have seen-data + dlt tables (always included)
+        # main dataset: tables with jobs + dlt tables (always included)
         assert update_stored_schema.call_args_list[0].kwargs["only_tables"] == {
             "event_user",
             "_dlt_loads",
             "_dlt_version",
         }
-        # staging DDL: all data tables with seen-data + _dlt_version (not just event_user)
-        # this guards agains situation where staging dataset got ie. dropped by the user
+        # staging DDL: the whole jobless merge chain; the append table with a job is not eligible
         staging_ddl = update_stored_schema.call_args_list[1].kwargs["only_tables"]
-        assert staging_ddl == all_data | {"_dlt_version"}
-        # staging truncation: only the table with a job
-        # main dataset has nothing to truncate so it makes only the bare init call (index 0),
-        # staging makes a bare init (index 1) + a truncate init (index 2)
-        staging_truncate = initialize_storage.call_args_list[2].kwargs["truncate_tables"]
-        assert staging_truncate == {"event_user"}
+        assert staging_ddl == bot_chain | {"_dlt_version"}
+        # no staging-eligible table has jobs so nothing is truncated: both init calls are bare
+        assert initialize_storage.call_count == 2
+        assert all("truncate_tables" not in c.kwargs for c in initialize_storage.call_args_list)
 
 
 def test_init_client_staging_selective_filter() -> None:
@@ -1502,47 +1525,6 @@ def test_init_client_staging_dlt_tables_with_jobs() -> None:
         assert staging_truncate == {"event_user", "_dlt_loads"}
 
 
-def test_init_client_unseen_data_chain_tables_excluded() -> None:
-    """Tables with jobs always enter final DDL - the normalizer marks seen-data on every table
-    it emits jobs for. Never-seen tables are excluded from table chains (staging DDL, truncation).
-    """
-    load = setup_loader()
-    _, schema = prepare_load_package(
-        load.load_storage, ["event_user.b1d32c6660b242aaabbf3fc27245b7e6.0.insert_values"]
-    )
-    nothing_ = lambda _: False
-    all_ = lambda _: True
-    event_user = ParsedLoadJobFileName("event_user", "event_user_id", 0, "jsonl")
-    event_bot = ParsedLoadJobFileName("event_bot", "event_bot_id", 0, "jsonl")
-    bot_chain = {t["name"] for t in get_nested_tables(schema.tables, "event_bot")}
-    all_data = set(schema.data_table_names())
-
-    # remove seen-data from bot chain
-    for name in bot_chain:
-        schema.tables[name].pop("x-normalizer", None)
-
-    with (
-        patch.object(dummy_impl.DummyClient, "initialize_storage") as initialize_storage,
-        patch.object(dummy_impl.DummyClient, "update_stored_schema") as update_stored_schema,
-        patch.object(dummy_impl.DummyClient, "drop_tables"),
-    ):
-        with load.get_destination_client(schema) as client:
-            init_client(client, schema, [event_user, event_bot], {}, nothing_, all_, all_)
-
-        assert update_stored_schema.call_count == 2
-        # final DDL: tables with jobs are trusted and migrated, the jobless never-seen
-        # nested bot tables are not
-        final_ddl = update_stored_schema.call_args_list[0].kwargs["only_tables"]
-        assert {"event_user", "event_bot"} <= final_ddl
-        assert not ((bot_chain - {"event_bot"}) & final_ddl)
-        # staging DDL: the whole never-seen bot chain is excluded by the chain filter
-        staging_ddl = update_stored_schema.call_args_list[1].kwargs["only_tables"]
-        assert staging_ddl == (all_data - bot_chain) | {"_dlt_version"}
-        # staging truncation: only event_user
-        staging_truncate = initialize_storage.call_args_list[2].kwargs["truncate_tables"]
-        assert staging_truncate == {"event_user"}
-
-
 def test_init_client_staging_destination_vs_final_destination() -> None:
     """Different staging filters for final vs staging destination produce different DDL sets."""
     load = setup_loader()
@@ -1659,10 +1641,10 @@ def test_init_client_staging_drop_tables_without_staging_eligible() -> None:
                 drop_tables=[dropped_table],
             )
 
-        # staging NOT entered: no staging-eligible tables AND drop_table_names is empty
-        # (nothing_ filter rejected the dropped table)
+        # nothing dropped anywhere: drop_staging_filter rejected the dropped table so
+        # drop_table_names is empty for both the main and the staging dataset
         assert update_stored_schema.call_count == 1
-        drop_tables.assert_not_called()  # is_storage_initialized check still gated it on main
+        drop_tables.assert_not_called()
 
 
 def test_dummy_staging_filesystem() -> None:

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -3737,16 +3737,13 @@ def test_replace_empty_resource_truncates_variant_tables() -> None:
     assert load_table_counts(pipeline, "items", "other_items") == {"items": 1, "other_items": 1}
 
     # the resource yields no data: the root and the variant are both truncated
-    info = pipeline.run(items_resource(False))
+    pipeline.run(items_resource(False))
     assert load_table_counts(pipeline, "items", "other_items") == {"items": 0, "other_items": 0}
-    package = info.load_packages[0]
-    assert set(package.truncated_tables) == {"items", "other_items"}
-    assert package.dropped_tables is None
 
 
-def test_replace_empty_resource_truncates_via_package_state() -> None:
-    """A replace resource that yields no data registers its tables in the load package
-    `truncated_tables` state instead of writing an empty-file job."""
+def test_replace_empty_resource_truncates_via_empty_job() -> None:
+    """A replace resource that yields no data writes a 0-row job for the root table and does NOT
+    register anything in the load package `truncated_tables` state."""
 
     @dlt.resource(name="items", write_disposition="replace")
     def items(emit: bool) -> Any:
@@ -3765,22 +3762,20 @@ def test_replace_empty_resource_truncates_via_package_state() -> None:
     pipeline.normalize()
     load_id = pipeline.list_normalized_load_packages()[0]
     package = pipeline.get_load_package_info(load_id)
-    # no empty-file job is written for `items`
-    assert "items" not in [job.job_file_info.table_name for job in package.jobs["new_jobs"]]
-    # instead `items` is registered for truncation via the package state
+    # an empty-file job is written for `items`
+    assert "items" in [job.job_file_info.table_name for job in package.jobs["new_jobs"]]
+    # nothing is registered for truncation via the package state
     state = pipeline.get_load_package_state(load_id)
-    assert "items" in [table["name"] for table in state.get("truncated_tables", [])]
-    # package info exposes the requested truncation, no refresh was set
+    assert "truncated_tables" not in state
     assert package.refresh is None
-    assert package.truncated_tables == ["items"]
+    assert package.truncated_tables is None
 
     # finishing the load truncates the table
     info = pipeline.load()
     assert load_table_counts(pipeline, "items") == {"items": 0}
-    # the load step recorded the actually truncated table, still without refresh
     loaded_package = info.load_packages[0]
     assert loaded_package.refresh is None
-    assert loaded_package.truncated_tables == ["items"]
+    assert loaded_package.truncated_tables is None
 
 
 def test_replace_empty_resource_keeps_append_pseudo_root() -> None:
@@ -3829,12 +3824,10 @@ def test_replace_empty_resource_keeps_append_pseudo_root() -> None:
 
     # empty run: the replace roots (default and variant) are emptied, but their append pseudo-roots
     # are kept - we cannot re-derive a pseudo-root's effective disposition, so it is not truncated
-    info = pipeline.run(items_resource(False))
+    pipeline.run(items_resource(False))
     assert load_table_counts(
         pipeline, "items", "items__sub_items", "other_items", "other_items__sub_items"
     ) == {"items": 0, "items__sub_items": 1, "other_items": 0, "other_items__sub_items": 1}
-    # only the replace roots appear in the truncated tables record
-    assert set(info.load_packages[0].truncated_tables) == {"items", "other_items"}
 
 
 def test_replace_keeps_pseudo_root_when_root_has_data() -> None:
@@ -3911,9 +3904,8 @@ def test_replace_event_dispatch_truncates_missing_table(dispatch: str) -> None:
     pipeline.run(events(["a"]), write_disposition="replace")
     # "a" received data and is replaced with the new row
     assert load_tables_to_dicts(pipeline, "a")["a"][0]["id"] == 0
-    # tables with no data have their hints unmodified
-    assert pipeline.default_schema.tables["b"]["write_disposition"] == "merge"
     # missing "b" is refreshed to replace and truncated even though it received no data
+    assert pipeline.default_schema.tables["b"]["write_disposition"] == "replace"
     assert load_table_counts(pipeline, "a", "b") == {"a": 1, "b": 0}
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
partially reverts #4153 - using package state to truncate empty "replace" tables had a side effect: for optimized replace strategies that happened upfront and not within transaction in particular jobs.
- uses empty file to truncate tables
- updates write disposition of empty resource but ONLY when switching to replace

