### PR TITLE
(fix) moves misplaced merge subqueries to post-qualify

### DIFF
--- a/dlt/_workspace/cli/dlthub/_init_command.py
+++ b/dlt/_workspace/cli/dlthub/_init_command.py
@@ -39,8 +39,13 @@ def init_dlthub_workspace(
         # uses the platform separator and matches paths built by callers via os.path.join
         dest_path = os.path.join(run_dir, *file_name.split("/"))
         if os.path.basename(file_name) == "config.toml":
+            # workspaces always emit _dlt_load_id for arrow/parquet data too (json data
+            # already gets it) so every row carries its load id regardless of source format
             body = (
                 templates.load(file_name)
+                + "\n[normalize.parquet_normalizer]\n"
+                + "# emit _dlt_load_id for arrow/parquet data\n"
+                + "add_dlt_load_id = true\n"
                 + f"\n[workspace.settings]\nname = {workspace_name_literal}\n"
             )
             # always preserve existing config.toml — even with --force

--- a/dlt/common/libs/sqlglot.py
+++ b/dlt/common/libs/sqlglot.py
@@ -1083,9 +1083,15 @@ def bind_query(
     is_casefolding = casefold_identifier is not str
 
     # bind ORDER BY references to output aliases back to their source expressions. dialects
-    # like tsql cannot resolve a select alias inside an ORDER BY expression (NULLS emulation)
+    # like tsql cannot resolve a select alias inside an ORDER BY expression (NULLS emulation).
+    # under DISTINCT/GROUP BY the sort key must stay an output column (source is out of scope)
     order = qualified_query.args.get("order")
-    if order is not None and isinstance(qualified_query, sge.Select):
+    if (
+        order is not None
+        and isinstance(qualified_query, sge.Select)
+        and not qualified_query.args.get("distinct")
+        and not qualified_query.args.get("group")
+    ):
         alias_sources = {
             proj.output_name: proj.this
             for proj in qualified_query.selects

--- a/dlt/common/libs/sqlglot.py
+++ b/dlt/common/libs/sqlglot.py
@@ -1082,6 +1082,22 @@ def bind_query(
     qualified_query = qualified_query.copy()
     is_casefolding = casefold_identifier is not str
 
+    # bind ORDER BY references to output aliases back to their source expressions. dialects
+    # like tsql cannot resolve a select alias inside an ORDER BY expression (NULLS emulation)
+    order = qualified_query.args.get("order")
+    if order is not None and isinstance(qualified_query, sge.Select):
+        alias_sources = {
+            proj.output_name: proj.this
+            for proj in qualified_query.selects
+            if isinstance(proj, sge.Alias)
+        }
+        for col in list(order.find_all(sge.Column)):
+            if col.args.get("table") is not None or col.parent_select is not qualified_query:
+                continue
+            source = alias_sources.get(col.name)
+            if source is not None and not isinstance(source, sge.Star):
+                col.replace(source.copy())
+
     # preserve "column" names in original selects which are done in dlt schema namespace
     orig_selects: Dict[int, str] = None
     if is_casefolding:

--- a/dlt/common/libs/sqlglot.py
+++ b/dlt/common/libs/sqlglot.py
@@ -1144,3 +1144,66 @@ def bind_query(
                 qualified_query.selects[i] = sge.alias_(sel_expr, orig, quoted=True)
 
     return qualified_query
+
+
+def has_pure_column_projection(query: sge.Query) -> bool:
+    """True when every projection is a plain column or star, so it defines no output names."""
+    if not isinstance(query, sge.Select):
+        return False
+    # with multiple sources an unqualified replacement column turns ambiguous
+    if query.args.get("joins"):
+        return False
+    if any(query.args.get(key) for key in ("group", "having", "qualify", "distinct")):
+        return False
+    return all(
+        isinstance(sel, sge.Star)
+        or (isinstance(sel, sge.Column) and isinstance(sel.this, (sge.Identifier, sge.Star)))
+        for sel in query.selects
+    )
+
+
+def migrate_order_and_limit(inner: sge.Query, outer: sge.Select, qualifier: str) -> None:
+    """Move ORDER BY / LIMIT / OFFSET from a wrapped query onto the wrapping select."""
+    order = inner.args.get("order")
+    if order is not None:
+        exposed_names = {proj.output_name for proj in inner.selects}
+        has_star = any(
+            isinstance(proj, sge.Star)
+            or (isinstance(proj, sge.Column) and isinstance(proj.this, sge.Star))
+            for proj in inner.selects
+        )
+        hoisted: List[sge.Expression] = []
+        for ordered in order.expressions:
+            sort_key = ordered.this
+            if isinstance(sort_key, sge.Column) and sort_key.args.get("table") is None:
+                if not has_star and sort_key.name not in exposed_names:
+                    # a sort key dropped by the projection cannot survive the wrap, keep the unit inside
+                    return
+                hoisted.append(ordered.copy())
+                continue
+            # a qualified or computed sort key is only visible outside the wrap by its output name
+            output_name = next(
+                (
+                    proj.output_name
+                    for proj in inner.selects
+                    if (proj.this if isinstance(proj, sge.Alias) else proj) == sort_key
+                ),
+                None,
+            )
+            if output_name is None:
+                return
+            rewritten = ordered.copy()
+            rewritten.set(
+                "this",
+                sge.Column(
+                    table=sge.to_identifier(qualifier),
+                    this=sge.to_identifier(output_name, quoted=True),
+                ),
+            )
+            hoisted.append(rewritten)
+        outer.set("order", sge.Order(expressions=hoisted))
+        inner.set("order", None)
+    for clause in ("limit", "offset"):
+        if (value := inner.args.get(clause)) is not None:
+            outer.set(clause, value)
+            inner.set(clause, None)

--- a/dlt/dataset/_join.py
+++ b/dlt/dataset/_join.py
@@ -230,11 +230,10 @@ def _extract_joined_table_aliases(
     query: sge.Query, dataset_name: Optional[str] = None
 ) -> dict[str, str]:
     alias_map: dict[str, str] = {}
+    tables: list[sge.Table] = []
     from_this = _from_source(query)
-    if not isinstance(from_this, sge.Table):
-        return alias_map
-
-    tables: list[sge.Table] = [from_this]
+    if isinstance(from_this, sge.Table):
+        tables.append(from_this)
     for join in query.args.get("joins") or []:
         if isinstance(join.this, sge.Table):
             tables.append(join.this)
@@ -275,7 +274,13 @@ def _discover_join_params(
 
     qualifier_map = _extract_joined_table_aliases(expression, dataset_name)
     if left_table not in qualifier_map:
-        raise ValueError("Join query has no base table to resolve references.")
+        # the left base table may be embedded in a derived table; join via its alias
+        if (
+            not isinstance(_from_source(expression), sge.Subquery)
+            or (left_qualifier := _left_source_qualifier(expression)) is None
+        ):
+            raise ValueError("Join query has no base table to resolve references.")
+        qualifier_map[left_table] = left_qualifier
 
     attach_qualifier = qualifier_map[left_table]
 
@@ -426,6 +431,9 @@ def _apply_join(
     query = _copy_as_select(expression)
 
     left_source_qualifier = _left_source_qualifier(query) or left_table
+    where_must_apply_before_join = kind in ("right", "full") and query.args.get("where") is not None
+    if not _is_flat_select(query) or where_must_apply_before_join:
+        query = _wrap_as_derived_table(query, left_source_qualifier)
     _qualify_unscoped_predicate_columns(query, left_source_qualifier)
 
     join_params, target_qualifier = _discover_join_params(
@@ -463,8 +471,11 @@ def _apply_join(
     return query
 
 
-def _qualify_physical_tables_with_dataset(expression: sge.Expression, dataset_name: str) -> None:
-    """Bind every physical table reference in `expression` to `dataset_name`."""
+def _qualify_unscoped_tables_with_dataset(expression: sge.Expression, dataset_name: str) -> None:
+    """Set the logical `dataset_name` qualifier on table references that lack one.
+
+    Skips CTE references; physical (normalized) dataset resolution happens later in `bind_query`.
+    """
     cte_names = {cte.alias_or_name for cte in expression.find_all(sge.CTE)}
     db_identifier = sge.to_identifier(dataset_name, quoted=False)
     for table in expression.find_all(sge.Table):
@@ -561,7 +572,7 @@ def _apply_explicit_join(
         left_dataset_name: Dataset name for the left-hand side.
     """
     query = _copy_as_select(expression)
-    _qualify_physical_tables_with_dataset(query, left_dataset_name)
+    _qualify_unscoped_tables_with_dataset(query, left_dataset_name)
 
     from_this = _from_source(query)
     left_source_qualifier = _source_qualifier(from_this)
@@ -589,7 +600,7 @@ def _apply_explicit_join(
     if target.subquery is not None:
         # transformed relation: embed its query as a subquery
         rhs_inner = target.subquery.copy()
-        _qualify_physical_tables_with_dataset(rhs_inner, target.dataset_name)
+        _qualify_unscoped_tables_with_dataset(rhs_inner, target.dataset_name)
         target_expr = _aliased_subquery(rhs_inner, target_qualifier)
     else:
         target_expr = sge.Table(

--- a/dlt/dataset/_join.py
+++ b/dlt/dataset/_join.py
@@ -508,29 +508,23 @@ def _is_flat_select(query: sge.Select) -> bool:
 def _qualify_unscoped_predicate_columns(query: sge.Select, source_qualifier: str) -> None:
     """Bind unqualified WHERE/ORDER BY columns to the single source.
 
-    ORDER BY references to select output aliases are expanded to their source
-    expressions first, so qualification cannot produce nonexistent columns.
+    ORDER BY references to select output aliases stay bare; `bind_query` resolves them.
     """
     if query.args.get("joins"):
         return
     qualifier_identifier = sge.to_identifier(source_qualifier, quoted=False)
-    alias_sources = {
-        sel.output_name: sel.this for sel in query.selects if isinstance(sel, sge.Alias)
-    }
-    order_clause = query.args.get("order")
-    if order_clause is not None and alias_sources:
-        for col in list(order_clause.find_all(sge.Column)):
-            if col.args.get("table") is None and col.parent_select is query:
-                source = alias_sources.get(col.name)
-                if source is not None:
-                    col.replace(source.copy())
+    output_aliases = {sel.output_name for sel in query.selects if isinstance(sel, sge.Alias)}
     for clause_key in ("where", "order"):
         clause = query.args.get(clause_key)
         if clause is None:
             continue
         for col in clause.find_all(sge.Column):
-            if col.args.get("table") is None and col.parent_select is query:
-                col.set("table", qualifier_identifier.copy())
+            if col.args.get("table") is not None or col.parent_select is not query:
+                continue
+            # ORDER BY resolves output aliases first; WHERE is pre-projection and sees columns
+            if clause_key == "order" and col.name in output_aliases:
+                continue
+            col.set("table", qualifier_identifier.copy())
 
 
 def _aliased_subquery(query: sge.Query, qualifier: str) -> sge.Subquery:

--- a/dlt/dataset/_join.py
+++ b/dlt/dataset/_join.py
@@ -431,9 +431,7 @@ def _apply_join(
     query = _copy_as_select(expression)
 
     left_source_qualifier = _left_source_qualifier(query) or left_table
-    where_must_apply_before_join = kind in ("right", "full") and query.args.get("where") is not None
-    if not _is_flat_select(query) or where_must_apply_before_join:
-        query = _wrap_as_derived_table(query, left_source_qualifier)
+    query = _seal_left_side(query, left_source_qualifier, kind)
     _qualify_unscoped_predicate_columns(query, left_source_qualifier)
 
     join_params, target_qualifier = _discover_join_params(
@@ -544,6 +542,18 @@ def _wrap_as_derived_table(query: sge.Select, qualifier: str) -> sge.Select:
     )
 
 
+def _seal_left_side(query: sge.Select, left_source_qualifier: str, kind: TJoinType) -> sge.Select:
+    """Seal the left side in a derived table when its rows must be fixed before the join.
+
+    A non-flat left side (LIMIT/OFFSET/DISTINCT/GROUP/aggregate), or a WHERE that must precede a
+    RIGHT/FULL join, would otherwise leak past the join and change which rows survive.
+    """
+    where_must_apply_before_join = kind in ("right", "full") and query.args.get("where") is not None
+    if not _is_flat_select(query) or where_must_apply_before_join:
+        return _wrap_as_derived_table(query, left_source_qualifier)
+    return query
+
+
 def _apply_explicit_join(
     expression: sge.Query,
     target: _JoinTarget,
@@ -576,9 +586,7 @@ def _apply_explicit_join(
             "in its FROM clause (a base table or an aliased derived table)."
         )
 
-    where_must_apply_before_join = kind in ("right", "full") and query.args.get("where") is not None
-    if not _is_flat_select(query) or where_must_apply_before_join:
-        query = _wrap_as_derived_table(query, left_source_qualifier)
+    query = _seal_left_side(query, left_source_qualifier, kind)
 
     _qualify_unscoped_predicate_columns(query, left_source_qualifier)
 

--- a/dlt/dataset/relation.py
+++ b/dlt/dataset/relation.py
@@ -53,7 +53,7 @@ from dlt.dataset._join import (
     _extract_joined_table_aliases,
     _JoinTarget,
     _left_source_qualifier,
-    _qualify_physical_tables_with_dataset,
+    _qualify_unscoped_tables_with_dataset,
 )
 
 
@@ -268,12 +268,15 @@ class Relation(WithSqlClient):
             self._opened_sql_client = None
 
     def to_sql(self, pretty: bool = False, *, _raw_query: bool = False) -> str:
-        """Get the normalize query string in the correct sql dialect for this relation"""
+        """Get the query string in the destination dialect. `pretty` flattens subqueries and formats the SQL."""
 
         if self._execute_raw_query or _raw_query:
             query = self.sqlglot_expression
         else:
             _, _qualified_query = _get_relation_output_columns_schema(self)
+            if pretty:
+                # optimize only for readable output; executed SQL stays as constructed
+                _qualified_query = _optimize_query(_qualified_query)
             query = bind_query(
                 qualified_query=_qualified_query,
                 sqlglot_schema=self._relation_sqlglot_schema(),
@@ -340,16 +343,21 @@ class Relation(WithSqlClient):
         """
         return self.limit(limit)
 
-    def select(self, *columns: str, _allow_merge_subqueries: bool = True) -> Self:
+    def select(self, *columns: str) -> Self:
         """Create a `Relation` with the selected columns using a `SELECT` clause."""
         proj = [sge.Column(this=sge.to_identifier(col, quoted=True)) for col in columns]
-        subquery = self.sqlglot_expression.subquery()
-        new_expr = sge.select(*proj).from_(subquery)
         rel = self.__copy__()
-        if _allow_merge_subqueries:
-            rel._sqlglot_expression = merge_subqueries(new_expr)
-        else:
-            rel._sqlglot_expression = new_expr
+        if _has_pure_column_projection(self.sqlglot_expression):
+            expr = self.sqlglot_expression.copy()
+            expr.set("expressions", proj)
+            rel._sqlglot_expression = expr
+            return rel
+        # a defining projection (aliases, expressions, distinct, group) must become a derived table
+        qualifier = _left_source_qualifier(self.sqlglot_expression) or "subquery"
+        subquery = self.sqlglot_expression.subquery(qualifier)
+        new_expr = sge.select(*proj).from_(subquery)
+        _hoist_order_and_limit(subquery.this, new_expr, qualifier)
+        rel._sqlglot_expression = new_expr
         return rel
 
     def order_by(self, column_name: str, direction: TSortOrder = "asc") -> Self:
@@ -367,22 +375,12 @@ class Relation(WithSqlClient):
                 f"`{direction}` is an invalid sort order, allowed values are: `asc` and `desc`"
             )
         order_expr = sge.Ordered(
-            this=self._resolve_output_column(column_name),
+            this=sge.Column(this=sge.to_identifier(column_name, quoted=True)),
             desc=(direction == "desc"),
         )
         rel = self.__copy__()
         rel._sqlglot_expression = rel.sqlglot_expression.order_by(order_expr)
         return rel
-
-    def _resolve_output_column(self, column_name: str) -> sge.Expression:
-        """Resolve an output column name to its projected source expression."""
-        for proj in self.sqlglot_expression.selects:
-            if isinstance(proj, sge.Star) or proj.output_name != column_name:
-                continue
-            source = proj.this if isinstance(proj, sge.Alias) else proj
-            if not isinstance(source, sge.Star):
-                return source.copy()
-        return sge.Column(this=sge.to_identifier(column_name, quoted=True))
 
     @overload
     def join(
@@ -494,7 +492,7 @@ class Relation(WithSqlClient):
                 left_dataset_name=self._dataset.dataset_name,
             )
 
-        _qualify_physical_tables_with_dataset(query, self._dataset.dataset_name)
+        _qualify_unscoped_tables_with_dataset(query, self._dataset.dataset_name)
 
         rel = self.__copy__()
         rel._sqlglot_expression = query
@@ -537,12 +535,12 @@ class Relation(WithSqlClient):
                     f" '{target_dataset.destination_client.config}'"
                 )
 
-            dataset_same_name = this_dataset.dataset_name == target_dataset.dataset_name
-            # at this moment we cannot join datasets with the same name on two different locations
+            # unreachable until `can_read_from` is relaxed for attached locations: same-named
+            # datasets on two locations cannot be disambiguated by the dataset name alone
             if (
-                this_dataset.destination_client.config.physical_location()
-                != other._dataset.destination_client.config.physical_location()
-                and dataset_same_name
+                this_dataset.dataset_name == target_dataset.dataset_name
+                and this_dataset.destination_client.config.physical_location()
+                != target_dataset.destination_client.config.physical_location()
             ):
                 raise ValueError(
                     "Cannot join datasets with the same name located on two different destinations"
@@ -976,7 +974,7 @@ class Relation(WithSqlClient):
         return (
             filtered_rel_with_load_id
             if add_load_id_column
-            else filtered_rel_with_load_id.select(*initial_columns, _allow_merge_subqueries=False)
+            else filtered_rel_with_load_id.select(*initial_columns)
         )
 
     # TODO move this to the WithSqlClient / data accessor mixin.
@@ -1084,3 +1082,71 @@ def _find_table_columns(schemas: Sequence[dlt.Schema], table_name: str) -> TTabl
         if table_name in schema.tables:
             return schema.get_table_columns(table_name)
     raise ValueError(f"Table `{table_name}` not found in dataset schema")
+
+
+def _optimize_query(qualified_query: sge.Query) -> sge.Query:
+    """Flatten a qualified query for readable SQL output."""
+    return merge_subqueries(qualified_query)
+
+
+def _has_pure_column_projection(query: sge.Query) -> bool:
+    """True when every projection is a plain column or star, so it defines no output names."""
+    if not isinstance(query, sge.Select):
+        return False
+    # with multiple sources an unqualified replacement column turns ambiguous
+    if query.args.get("joins"):
+        return False
+    if any(query.args.get(key) for key in ("group", "having", "qualify", "distinct")):
+        return False
+    return all(
+        isinstance(sel, sge.Star)
+        or (isinstance(sel, sge.Column) and isinstance(sel.this, (sge.Identifier, sge.Star)))
+        for sel in query.selects
+    )
+
+
+def _hoist_order_and_limit(inner: sge.Query, outer: sge.Select, qualifier: str) -> None:
+    """Move ORDER BY / LIMIT / OFFSET from a wrapped query onto the wrapping select."""
+    order = inner.args.get("order")
+    if order is not None:
+        exposed_names = {proj.output_name for proj in inner.selects}
+        has_star = any(
+            isinstance(proj, sge.Star)
+            or (isinstance(proj, sge.Column) and isinstance(proj.this, sge.Star))
+            for proj in inner.selects
+        )
+        hoisted: list[sge.Expression] = []
+        for ordered in order.expressions:
+            sort_key = ordered.this
+            if isinstance(sort_key, sge.Column) and sort_key.args.get("table") is None:
+                if not has_star and sort_key.name not in exposed_names:
+                    # a sort key dropped by the projection cannot survive the wrap, keep the unit inside
+                    return
+                hoisted.append(ordered.copy())
+                continue
+            # a qualified or computed sort key is only visible outside the wrap by its output name
+            output_name = next(
+                (
+                    proj.output_name
+                    for proj in inner.selects
+                    if (proj.this if isinstance(proj, sge.Alias) else proj) == sort_key
+                ),
+                None,
+            )
+            if output_name is None:
+                return
+            rewritten = ordered.copy()
+            rewritten.set(
+                "this",
+                sge.Column(
+                    table=sge.to_identifier(qualifier),
+                    this=sge.to_identifier(output_name, quoted=True),
+                ),
+            )
+            hoisted.append(rewritten)
+        outer.set("order", sge.Order(expressions=hoisted))
+        inner.set("order", None)
+    for clause in ("limit", "offset"):
+        if (value := inner.args.get(clause)) is not None:
+            outer.set(clause, value)
+            inner.set(clause, None)

--- a/dlt/dataset/relation.py
+++ b/dlt/dataset/relation.py
@@ -24,7 +24,14 @@ import sqlglot.expressions as sge
 
 import dlt
 from dlt.common.destination.dataset import TFilterOperation
-from dlt.common.libs.sqlglot import to_sqlglot_type, build_typed_literal, TSqlGlotDialect
+from dlt.common.libs.sqlglot import (
+    to_sqlglot_type,
+    build_typed_literal,
+    migrate_order_and_limit,
+    DLT_SUBQUERY_NAME,
+    TSqlGlotDialect,
+    has_pure_column_projection,
+)
 from dlt.common.libs import is_instance_lib
 from dlt.common.schema.typing import (
     TTableSchema,
@@ -347,16 +354,16 @@ class Relation(WithSqlClient):
         """Create a `Relation` with the selected columns using a `SELECT` clause."""
         proj = [sge.Column(this=sge.to_identifier(col, quoted=True)) for col in columns]
         rel = self.__copy__()
-        if _has_pure_column_projection(self.sqlglot_expression):
+        if has_pure_column_projection(self.sqlglot_expression):
             expr = self.sqlglot_expression.copy()
             expr.set("expressions", proj)
             rel._sqlglot_expression = expr
             return rel
         # a defining projection (aliases, expressions, distinct, group) must become a derived table
-        qualifier = _left_source_qualifier(self.sqlglot_expression) or "subquery"
+        qualifier = _left_source_qualifier(self.sqlglot_expression) or DLT_SUBQUERY_NAME
         subquery = self.sqlglot_expression.subquery(qualifier)
         new_expr = sge.select(*proj).from_(subquery)
-        _hoist_order_and_limit(subquery.this, new_expr, qualifier)
+        migrate_order_and_limit(subquery.this, new_expr, qualifier)
         rel._sqlglot_expression = new_expr
         return rel
 
@@ -669,13 +676,12 @@ class Relation(WithSqlClient):
             self.sqlglot_expression, self._dataset.dataset_name
         ):
             raise ValueError(
-                f"Incremental cursor `{incremental.cursor_path}` requires a "
-                f"base-table relation to resolve the join to `{table_name}`. "
-                f"This relation is derived from base table `{self._table_name}` "
-                "(e.g. via `.from_loads()`, `dataset.table(load_ids=...)`, or "
-                "`.select()`), so a dotted cursor cannot be applied. Use a "
-                f"cursor on a column of `{self._table_name}` instead, or drop "
-                "the derivation."
+                f"Incremental cursor `{incremental.cursor_path}` requires base table "
+                f"`{self._table_name}` to stay directly in the FROM clause to resolve the join "
+                f"to `{table_name}`, but this relation embeds it in a subquery (e.g. a projection "
+                "with aliases or aggregates, or a raw `dataset(query)` relation). Use a cursor on "
+                f"a column of `{self._table_name}` instead, or apply `.incremental()` before the "
+                "step that wrapped the base table."
             )
 
         query = _apply_join(
@@ -1087,66 +1093,3 @@ def _find_table_columns(schemas: Sequence[dlt.Schema], table_name: str) -> TTabl
 def _optimize_query(qualified_query: sge.Query) -> sge.Query:
     """Flatten a qualified query for readable SQL output."""
     return merge_subqueries(qualified_query)
-
-
-def _has_pure_column_projection(query: sge.Query) -> bool:
-    """True when every projection is a plain column or star, so it defines no output names."""
-    if not isinstance(query, sge.Select):
-        return False
-    # with multiple sources an unqualified replacement column turns ambiguous
-    if query.args.get("joins"):
-        return False
-    if any(query.args.get(key) for key in ("group", "having", "qualify", "distinct")):
-        return False
-    return all(
-        isinstance(sel, sge.Star)
-        or (isinstance(sel, sge.Column) and isinstance(sel.this, (sge.Identifier, sge.Star)))
-        for sel in query.selects
-    )
-
-
-def _hoist_order_and_limit(inner: sge.Query, outer: sge.Select, qualifier: str) -> None:
-    """Move ORDER BY / LIMIT / OFFSET from a wrapped query onto the wrapping select."""
-    order = inner.args.get("order")
-    if order is not None:
-        exposed_names = {proj.output_name for proj in inner.selects}
-        has_star = any(
-            isinstance(proj, sge.Star)
-            or (isinstance(proj, sge.Column) and isinstance(proj.this, sge.Star))
-            for proj in inner.selects
-        )
-        hoisted: list[sge.Expression] = []
-        for ordered in order.expressions:
-            sort_key = ordered.this
-            if isinstance(sort_key, sge.Column) and sort_key.args.get("table") is None:
-                if not has_star and sort_key.name not in exposed_names:
-                    # a sort key dropped by the projection cannot survive the wrap, keep the unit inside
-                    return
-                hoisted.append(ordered.copy())
-                continue
-            # a qualified or computed sort key is only visible outside the wrap by its output name
-            output_name = next(
-                (
-                    proj.output_name
-                    for proj in inner.selects
-                    if (proj.this if isinstance(proj, sge.Alias) else proj) == sort_key
-                ),
-                None,
-            )
-            if output_name is None:
-                return
-            rewritten = ordered.copy()
-            rewritten.set(
-                "this",
-                sge.Column(
-                    table=sge.to_identifier(qualifier),
-                    this=sge.to_identifier(output_name, quoted=True),
-                ),
-            )
-            hoisted.append(rewritten)
-        outer.set("order", sge.Order(expressions=hoisted))
-        inner.set("order", None)
-    for clause in ("limit", "offset"):
-        if (value := inner.args.get(clause)) is not None:
-            outer.set(clause, value)
-            inner.set(clause, None)

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -108,7 +108,7 @@ from dlt.extract.exceptions import SourceExhausted
 from dlt.extract.extract import Extract, data_to_sources
 from dlt.normalize import Normalize
 from dlt.normalize.configuration import NormalizeConfiguration
-from dlt.destinations.sql_client import SqlClientBase, WithSqlClient
+from dlt.destinations.sql_client import SqlClientBase, WithSqlClient, WithSchemas
 from dlt.destinations.fs_client import FSClientBase
 from dlt.destinations.job_client_impl import SqlJobClientBase
 from dlt.destinations.dataset import get_destination_clients
@@ -1185,7 +1185,13 @@ class Pipeline(SupportsPipeline):
         schema = self._get_schema_or_create(schema_name)
         client = self._get_destination_clients(schema)[0]
         if isinstance(client, WithSqlClient):
-            return client.sql_client
+            sql_client = client.sql_client
+            if isinstance(sql_client, WithSchemas):
+                # expose views for all pipeline schemas so cross-schema tables resolve; `schema`
+                # stays first as the default that sets the qualified-name search path
+                other = [self.schemas[name] for name in self.schema_names if name != schema.name]
+                sql_client.set_schemas([schema, *other])
+            return sql_client
         else:
             raise SqlClientNotAvailable(
                 "pipeline", self.pipeline_name, self._destination.destination_name

--- a/tests/dataset/test_relation.py
+++ b/tests/dataset/test_relation.py
@@ -719,6 +719,45 @@ def test_query_builder(mock_dataset: dlt.Dataset) -> None:
     )
 
 
+def test_select_projection_shapes(mock_dataset: dlt.Dataset) -> None:
+    relation = mock_dataset.my_table
+
+    # pure column projections are replaced in place; ORDER BY column may be unprojected
+    selected = relation.order_by("col1", "desc").limit(3).select("col2")
+    expr = selected.sqlglot_expression
+    assert expr.find(sge.Subquery) is None
+    assert [sel.output_name for sel in expr.selects] == ["col2"]
+    assert expr.args.get("order") is not None
+    assert expr.args.get("limit") is not None
+
+    # aggregate applies at the same level
+    agg = relation.select("col1").max()
+    assert isinstance(agg.sqlglot_expression.selects[0], sge.Max)
+    assert agg.sqlglot_expression.find(sge.Subquery) is None
+
+    # a defining projection wraps as a derived table; ORDER BY and LIMIT hoist onto the wrap
+    defining = mock_dataset("SELECT col1 AS c FROM my_table ORDER BY c LIMIT 3").select("c")
+    expr = defining.sqlglot_expression
+    derived = expr.find(sge.Subquery)
+    assert derived is not None
+    assert derived.this.args.get("order") is None
+    assert derived.this.args.get("limit") is None
+    assert expr.args.get("order") is not None
+    assert expr.args.get("limit") is not None
+
+    # select over the wrap replaces its projection in place, no second wrap
+    chained = defining.select("c")
+    assert chained.sqlglot_expression.find(sge.Subquery).this.find(sge.Subquery) is None
+
+    # a sort key dropped by the projection keeps ORDER BY and LIMIT inside the wrap
+    kept = mock_dataset("SELECT col1 AS c FROM my_table ORDER BY col2 LIMIT 3").select("c")
+    derived = kept.sqlglot_expression.find(sge.Subquery)
+    assert derived.this.args.get("order") is not None
+    assert derived.this.args.get("limit") is not None
+    assert kept.sqlglot_expression.args.get("order") is None
+    assert kept.sqlglot_expression.args.get("limit") is None
+
+
 def test_copy_and_chaining() -> None:
     dataset = dlt.dataset(
         dlt.destinations.duckdb(destination_name="duck_db"),

--- a/tests/dataset/test_relation.py
+++ b/tests/dataset/test_relation.py
@@ -758,6 +758,21 @@ def test_select_projection_shapes(mock_dataset: dlt.Dataset) -> None:
     assert kept.sqlglot_expression.args.get("limit") is None
 
 
+def test_order_by_output_alias_binding(mock_dataset: dlt.Dataset) -> None:
+    """ORDER BY an output alias binds to its source, except under DISTINCT/GROUP BY."""
+    # plain select: bind resolves the alias to its source column (tsql/snowflake need this)
+    plain = mock_dataset("SELECT col1 FROM my_table ORDER BY col1").to_sql()
+    assert 'ORDER BY "my_table"."col1"' in plain
+
+    # DISTINCT: sort key must stay the output column (databricks rejects a source column here)
+    distinct = mock_dataset("SELECT DISTINCT col1 FROM my_table ORDER BY col1").to_sql()
+    assert 'ORDER BY "col1"' in distinct
+    assert "my_table" not in distinct.split("ORDER BY")[1]
+
+    grouped = mock_dataset("SELECT col1 FROM my_table GROUP BY col1 ORDER BY col1").to_sql()
+    assert "my_table" not in grouped.split("ORDER BY")[1]
+
+
 def test_copy_and_chaining() -> None:
     dataset = dlt.dataset(
         dlt.destinations.duckdb(destination_name="duck_db"),

--- a/tests/dataset/test_relation_incremental.py
+++ b/tests/dataset/test_relation_incremental.py
@@ -747,30 +747,35 @@ def test_incremental_chained_call_raises(incremental_dataset: dlt.Dataset) -> No
 
 
 @pytest.mark.parametrize(
-    "build_relation",
+    "build_relation,expected_rows",
     [
         pytest.param(
             lambda ds, load_ids, incremental: ds.table(
-                "events", load_ids=load_ids, incremental=incremental
+                "events", load_ids=load_ids[:1], incremental=incremental
             ),
+            len(EVENTS_LOAD_0),
             id="kwargs",
         ),
         pytest.param(
             lambda ds, load_ids, incremental: ds.table("events")
-            .from_loads(load_ids)
+            .from_loads(load_ids[:1])
             .incremental(incremental),
+            len(EVENTS_LOAD_0),
             id="chained",
+        ),
+        pytest.param(
+            lambda ds, load_ids, incremental: ds.table("events")
+            .select("id", "value")
+            .incremental(incremental),
+            len(EVENTS_LOAD_0) + len(EVENTS_LOAD_1),
+            id="after-select",
         ),
     ],
 )
-def test_incremental_dotted_cursor_after_from_loads_raises(
-    incremental_pipeline: dlt.Pipeline, build_relation: Any
+def test_incremental_dotted_cursor_on_derived_relation(
+    incremental_pipeline: dlt.Pipeline, build_relation: Any, expected_rows: int
 ) -> None:
-    """`.from_loads()` wraps FROM in a subquery, so a subsequent dotted-cursor
-    `.incremental()` cannot resolve the join. Both the kwargs combo on
-    `dataset.table()` and the chained form must fail with a clear, user-facing
-    message rather than the internal `_discover_join_params` error.
-    """
+    """Root-table derivations keep the base table in FROM, so a dotted cursor still applies."""
     dataset = incremental_pipeline.dataset()
     load_ids = dataset.load_ids()
     assert load_ids, "fixture must produce at least one load"
@@ -780,8 +785,8 @@ def test_incremental_dotted_cursor_after_from_loads_raises(
         initial_value=pendulum.datetime(2026, 1, 1, tz="UTC"),
         end_value=END_VALUE_DT,
     )
-    with pytest.raises(ValueError, match="dotted cursor cannot be applied"):
-        build_relation(dataset, load_ids, incremental)
+    relation = build_relation(dataset, load_ids, incremental)
+    assert len(relation.fetchall()) == expected_rows
 
 
 @pytest.mark.parametrize(

--- a/tests/dataset/test_relation_join.py
+++ b/tests/dataset/test_relation_join.py
@@ -1367,6 +1367,22 @@ def test_order_by_join_output_alias_survives_select(
     assert [float(x) for x in df[f"{prefix}__amount"]] == [30.0, 200.0, 75.0, 50.0]
 
 
+def test_order_by_join_output_binds_to_source_column(
+    dataset_with_relational_tables: dlt.Dataset,
+) -> None:
+    """tsql cannot resolve a select alias inside an ORDER BY expression (NULLS emulation)."""
+    rel = (
+        dataset_with_relational_tables.table("customers")
+        .join("orders", on="customers.customer_id = orders.customer_id")
+        .order_by("orders__order_id")
+    )
+    sql = rel.to_sql()
+    assert 'ORDER BY "orders"."order_id"' in sql
+    order_by = sqlglot.transpile(sql, read="duckdb", write="tsql")[0].split("ORDER BY", 1)[1]
+    assert "[orders__order_id]" not in order_by
+    assert "[orders].[order_id]" in order_by
+
+
 def test_explicit_on_projection_alias_collision_rejected(
     dataset_with_relational_tables: dlt.Dataset,
 ) -> None:

--- a/tests/dataset/test_relation_join.py
+++ b/tests/dataset/test_relation_join.py
@@ -7,7 +7,9 @@ import sqlglot
 import sqlglot.expressions as sge
 
 import dlt
+from dlt.common.destination.client import DestinationClientConfiguration
 from dlt.common.schema.typing import TTableReference
+from dlt.dataset.exceptions import LineageFailedException
 from dlt.dataset._join import (
     _build_join_condition_from_pairs,
     _resolve_reference_chain,
@@ -248,7 +250,9 @@ def test_join_rejects_different_physical_destination(dataset_with_loads: TLoadsF
             rel.join(other_rel, on="users._dlt_id = other_data._dlt_id")
 
 
-def test_join_rejects_same_name_on_different_physical_destinations() -> None:
+def test_join_rejects_same_name_on_different_physical_destinations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = pathlib.Path(tmp)
         shared_dataset_name = "same_name_diff_dest"
@@ -279,6 +283,13 @@ def test_join_rejects_same_name_on_different_physical_destinations() -> None:
 
         assert "a.duckdb" in str(exc_info.value)
         assert "b.duckdb" in str(exc_info.value)
+
+        # once `can_read_from` is relaxed (e.g. duckdb ATTACH), the same-name guard must hold
+        monkeypatch.setattr(
+            DestinationClientConfiguration, "can_read_from", lambda self, other: True
+        )
+        with pytest.raises(ValueError, match="same name located on two different destinations"):
+            ds_a.table("users").join(ds_b.table("orders"), on="users.id = orders.user_id")
 
 
 @pytest.mark.parametrize(
@@ -404,12 +415,6 @@ def test_resolve_reference_chain_matrix(
             "users__orders",
             "no base table",
             id="query-relation-not-joinable",
-        ),
-        pytest.param(
-            lambda ds: ds.table("users__orders").limit(5).select("order_id"),
-            "users",
-            "no base table to resolve references",
-            id="subquery-hides-base-table",
         ),
     ],
 )
@@ -541,24 +546,6 @@ def test_join_does_not_project_incomplete_target_columns(
     assert len(rows) == 3
 
 
-_MAGIC_LIMIT_LEAKS_PAST_JOIN = pytest.mark.xfail(
-    reason=(
-        "magic join does not wrap a limited left relation as a derived table, so LIMIT is "
-        "rendered on the joined query instead of the limited left relation"
-    ),
-    strict=True,
-)
-
-
-_MAGIC_WHERE_LEAKS_PAST_OUTER_JOIN = pytest.mark.xfail(
-    reason=(
-        "magic join does not wrap a filtered left relation as a derived table, so its WHERE is "
-        "evaluated after the join and drops unmatched right-side rows of right/full joins"
-    ),
-    strict=True,
-)
-
-
 @pytest.mark.parametrize(
     "build_rel,expected_session_ids",
     [
@@ -566,7 +553,6 @@ _MAGIC_WHERE_LEAKS_PAST_OUTER_JOIN = pytest.mark.xfail(
             lambda ds: ds.table("users").order_by("id").limit(1).join("user_sessions"),
             ["s1", "s2"],
             id="limit-magic",
-            marks=_MAGIC_LIMIT_LEAKS_PAST_JOIN,
         ),
         pytest.param(
             lambda ds: ds.table("users")
@@ -592,13 +578,11 @@ _MAGIC_WHERE_LEAKS_PAST_OUTER_JOIN = pytest.mark.xfail(
             lambda ds: ds.table("users").where("id", "eq", 1).join("user_sessions", kind="right"),
             ["s1", "s2", "s3"],
             id="filter-magic-right",
-            marks=_MAGIC_WHERE_LEAKS_PAST_OUTER_JOIN,
         ),
         pytest.param(
             lambda ds: ds.table("users").where("id", "eq", 1).join("user_sessions", kind="full"),
             ["s1", "s2", "s3"],
             id="filter-magic-full",
-            marks=_MAGIC_WHERE_LEAKS_PAST_OUTER_JOIN,
         ),
         pytest.param(
             lambda ds: ds.table("users")
@@ -1041,6 +1025,22 @@ def test_select_then_join_preserves_narrow_projection(dataset_with_loads: TLoads
     assert "users__name" in df.columns
 
 
+def test_limit_and_select_then_magic_join(dataset_with_loads: TLoadsFixture) -> None:
+    """LIMIT and select() on the left relation apply before the magic join."""
+    dataset, _, _ = dataset_with_loads
+    limited = dataset.table("users__orders").order_by("order_id").limit(1)
+
+    joined = limited.select("order_id", "_dlt_parent_id").join("users")
+    df = joined.df()
+    assert len(df) == 1
+    assert "order_id" in df.columns
+    assert "users__name" in df.columns
+
+    # a projection that drops the join key cannot be joined once LIMIT seals it
+    with pytest.raises(LineageFailedException, match="_dlt_parent_id"):
+        limited.select("order_id").join("users").df()
+
+
 @pytest.mark.parametrize(
     "build_joined",
     [
@@ -1349,58 +1349,22 @@ def test_explicit_on_projection_prefix(
     assert right_aliases == expected
 
 
-def _order_by_sort_key(rel: dlt.Relation) -> sge.Column:
-    """Return the single ORDER BY sort-key column of a relation."""
-    order = rel.sqlglot_expression.args.get("order")
-    assert order is not None and len(order.expressions) == 1
-    sort_key = order.expressions[0].this
-    assert isinstance(sort_key, sge.Column)
-    return sort_key
-
-
-@pytest.mark.parametrize(
-    "build_join,order_column",
-    [
-        pytest.param(
-            lambda ds: ds.table("customers").join(
-                "orders", on="customers.customer_id = orders.customer_id"
-            ),
-            "orders__order_id",
-            id="default-prefix",
-        ),
-        pytest.param(
-            lambda ds: ds.table("customers").join(
-                "orders", on="customers.customer_id = orders.customer_id", alias="o"
-            ),
-            "o__order_id",
-            id="custom-alias",
-        ),
-    ],
-)
-def test_order_by_join_output_resolves_to_source_column(
+@pytest.mark.parametrize("alias", [None, "o"], ids=["default-prefix", "custom-alias"])
+def test_order_by_join_output_alias_survives_select(
     dataset_with_relational_tables: dlt.Dataset,
-    build_join: Callable[[dlt.Dataset], dlt.Relation],
-    order_column: str,
+    alias: Optional[str],
 ) -> None:
-    rel = build_join(dataset_with_relational_tables).order_by(order_column)
-    sort_key = _order_by_sort_key(rel)
-    assert sort_key.table == "orders"
-    assert sort_key.name == "order_id"
-
-
-def test_order_by_join_output_renders_resolvable_tsql(
-    dataset_with_relational_tables: dlt.Dataset,
-) -> None:
+    """Ordering by a join output alias survives a later projection change."""
+    prefix = alias or "orders"
     rel = (
         dataset_with_relational_tables.table("customers")
-        .join("orders", on="customers.customer_id = orders.customer_id")
-        .order_by("orders__order_id")
+        .join("orders", on="customers.customer_id = orders.customer_id", alias=alias)
+        .order_by(f"{prefix}__order_id", "desc")
+        .select("name", f"{prefix}__amount")
     )
-    order_by = sqlglot.transpile(rel.to_sql(), read="duckdb", write="tsql")[0].split("ORDER BY", 1)[
-        1
-    ]
-    assert "[orders__order_id]" not in order_by
-    assert "[orders].[order_id]" in order_by
+    df = rel.df()
+    assert list(df.columns) == ["name", f"{prefix}__amount"]
+    assert [float(x) for x in df[f"{prefix}__amount"]] == [30.0, 200.0, 75.0, 50.0]
 
 
 def test_explicit_on_projection_alias_collision_rejected(

--- a/tests/libs/test_sqlglot.py
+++ b/tests/libs/test_sqlglot.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Set, cast
+from typing import List, Optional, Set, Tuple, cast
 import importlib
 import pytest
 import sqlglot
@@ -10,12 +10,14 @@ from dlt.common.libs.sqlglot import (
     filter_select_column_names,
     from_sqlglot_type,
     get_select_column_names,
+    migrate_order_and_limit,
     to_sqlglot_type,
     uuid_expr_for_dialect,
     validate_no_star_select,
     build_outer_select_statement,
     reorder_or_adjust_outer_select,
     normalize_query_identifiers,
+    has_pure_column_projection,
 )
 from dlt.common.normalizers.naming.snake_case import NamingConvention as SnakeCaseNaming
 from dlt.common.schema.typing import TDataType, TColumnType, TTableSchemaColumns
@@ -664,3 +666,101 @@ def test_normalize_query_identifiers_table_qualified_columns() -> None:
     assert f"{expected_table}.my_col" in normalized_sql
     assert f"{expected_table}.other_col" in normalized_sql
     assert f"{expected_table}.id" in normalized_sql
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("SELECT a, b FROM t", True),
+        ("SELECT * FROM t", True),
+        ("SELECT a AS x FROM t", False),
+        ("SELECT COUNT(a) FROM t", False),
+        ("SELECT DISTINCT a FROM t", False),
+        ("SELECT a FROM t GROUP BY a", False),
+        ("SELECT t.a FROM t JOIN u ON t.id = u.id", False),
+    ],
+    ids=["plain-columns", "star", "alias", "aggregate", "distinct", "group-by", "join"],
+)
+def test_has_pure_column_projection(query: str, expected: bool) -> None:
+    assert has_pure_column_projection(cast(sge.Query, sqlglot.parse_one(query))) is expected
+
+
+def _wrap_and_migrate(query: str, *projection: str) -> Tuple[sge.Select, sge.Query]:
+    """Wrap `query` as a derived table selecting `projection`, then migrate its ORDER BY/LIMIT."""
+    subquery = cast(sge.Query, sqlglot.parse_one(query)).subquery(DLT_SUBQUERY_NAME)
+    outer = sge.select(
+        *(sge.Column(this=sge.to_identifier(col, quoted=True)) for col in projection)
+    ).from_(subquery)
+    migrate_order_and_limit(subquery.this, outer, DLT_SUBQUERY_NAME)
+    return outer, subquery.this
+
+
+# dialects that render ORDER BY/LIMIT differently (tsql TOP/FETCH, trino OFFSET..LIMIT, NULLS)
+_MIGRATE_DIALECTS: List[TSqlGlotDialect] = [
+    "duckdb",
+    "postgres",
+    "tsql",
+    "trino",
+    "snowflake",
+    "databricks",
+]
+
+
+@pytest.mark.parametrize(
+    "query,projection,hoisted",
+    [
+        pytest.param(
+            "SELECT col1 AS c FROM my_table ORDER BY c LIMIT 3 OFFSET 1",
+            ("c",),
+            True,
+            id="alias-key",
+        ),
+        pytest.param(
+            "SELECT col1 + 1 AS c FROM my_table ORDER BY col1 + 1 LIMIT 3",
+            ("c",),
+            True,
+            id="computed-key",
+        ),
+        pytest.param(
+            "SELECT DISTINCT col1 FROM my_table ORDER BY col1 LIMIT 3",
+            ("col1",),
+            True,
+            id="distinct",
+        ),
+        pytest.param(
+            "SELECT col1, COUNT(*) AS cnt FROM my_table GROUP BY col1 ORDER BY cnt LIMIT 3",
+            ("col1", "cnt"),
+            True,
+            id="group-by",
+        ),
+        pytest.param(
+            "SELECT col1 AS c FROM my_table ORDER BY col2 LIMIT 3", ("c",), False, id="dropped-key"
+        ),
+    ],
+)
+def test_migrate_order_and_limit_across_dialects(
+    query: str, projection: Tuple[str, ...], hoisted: bool
+) -> None:
+    """ORDER BY/LIMIT move onto the wrap only when the sort key survives the projection."""
+    outer, inner = _wrap_and_migrate(query, *projection)
+    # sort/limit leave the inner and land on the outer exactly when they can be hoisted
+    assert (inner.args.get("order") is None) is hoisted
+    assert (inner.args.get("limit") is None) is hoisted
+    assert (outer.args.get("order") is not None) is hoisted
+    assert (outer.args.get("limit") is not None) is hoisted
+    # the sort must render at the level that owns it in every dialect (outer tail vs inner body)
+    for dialect in _MIGRATE_DIALECTS:
+        before_alias, _, after_alias = outer.sql(dialect=dialect).partition(DLT_SUBQUERY_NAME)
+        assert ("ORDER BY" in after_alias) is hoisted
+        assert ("ORDER BY" in before_alias) is (not hoisted)
+
+
+def test_migrate_order_and_limit_rewrites_computed_key_to_output_name() -> None:
+    """A computed sort key is rewritten to reference the wrap's exposed output column."""
+    outer, inner = _wrap_and_migrate("SELECT col1 + 1 AS c FROM my_table ORDER BY col1 + 1", "c")
+    assert inner.args.get("order") is None
+    order = outer.args.get("order")
+    assert order is not None
+    sort_key = order.expressions[0].this
+    assert isinstance(sort_key, sge.Column)
+    assert sort_key.name == "c" and sort_key.table == DLT_SUBQUERY_NAME

--- a/tests/load/filesystem/test_sql_client.py
+++ b/tests/load/filesystem/test_sql_client.py
@@ -508,3 +508,60 @@ def test_auto_views_not_created_for_other_dataset_qualified_table(
         # schema that is not the dataset name, so the dataset's own `items` table is left untouched
         views = conn.execute("SELECT view_name FROM duckdb_views()").fetchall()
         assert "items" not in [v[0] for v in views]
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(local_filesystem_configs=True),
+    ids=lambda x: x.name,
+)
+def test_pipeline_sql_client_exposes_all_pipeline_schemas(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """`pipeline.sql_client()` must register every pipeline schema so the scanner creates views for
+    tables that live in a non-default schema of the same dataset."""
+    if destination_config.file_format not in ["parquet", "jsonl"]:
+        pytest.skip(
+            f"Test only works for jsonl and parquet, given: {destination_config.file_format}"
+        )
+
+    pipeline = destination_config.setup_pipeline(
+        "multi_schema_pipeline",
+        dataset_name="test_multi_schema_sql_client",
+        dev_mode=True,
+    )
+
+    @dlt.source(name="schema_a")
+    def source_a():
+        @dlt.resource(name="items_a")
+        def items_a():
+            yield [{"id": i} for i in range(3)]
+
+        return items_a
+
+    @dlt.source(name="schema_b")
+    def source_b():
+        @dlt.resource(name="items_b")
+        def items_b():
+            yield [{"id": i} for i in range(5)]
+
+        return items_b
+
+    # both sources land in the same dataset under different schemas
+    pipeline.run(source_a(), **destination_config.run_kwargs)
+    pipeline.run(source_b(), **destination_config.run_kwargs)
+    assert {"schema_a", "schema_b"}.issubset(set(pipeline.schema_names))
+
+    # the default-schema client must resolve tables from every schema of the dataset
+    with pipeline.sql_client() as c:
+        for table_name, expected in [("items_a", 3), ("items_b", 5)]:
+            qualified = c.make_qualified_table_name(table_name)
+            with c.execute_query(f"SELECT COUNT(*) FROM {qualified}") as cursor:
+                assert cursor.fetchone()[0] == expected
+
+    # an explicit schema_name keeps its own default while still exposing the other schema's views
+    with pipeline.sql_client(schema_name="schema_b") as c:
+        qualified = c.make_qualified_table_name("items_a")
+        with c.execute_query(f"SELECT COUNT(*) FROM {qualified}") as cursor:
+            assert cursor.fetchone()[0] == 3

--- a/tests/load/test_read_interfaces.py
+++ b/tests/load/test_read_interfaces.py
@@ -781,6 +781,14 @@ def test_order_by(populated_pipeline: Pipeline) -> None:
 
 
 @pytest.mark.no_load
+def test_distinct_order_by(populated_pipeline: Pipeline) -> None:
+    """DISTINCT restricts ORDER BY to output columns; strict engines (databricks) reject a source column."""
+    query = "SELECT DISTINCT id FROM items ORDER BY id"
+    ids = [row[0] for row in populated_pipeline.dataset()(query).limit(5).fetchall()]
+    assert ids == list(range(5))
+
+
+@pytest.mark.no_load
 @pytest.mark.essential
 def test_where(populated_pipeline: Pipeline) -> None:
     total_records = _total_records(populated_pipeline.destination.destination_type)

--- a/tests/load/test_relation_join.py
+++ b/tests/load/test_relation_join.py
@@ -33,9 +33,6 @@ from tests.utils import (
 
 def _skip_unsupported(destination_config: DestinationTestConfiguration) -> None:
     skip_if_unsupported_filesystem_format(destination_config)
-    # TODO: remove once https://github.com/dlt-hub/dlt/pull/4011 is merged
-    if destination_config.destination_type == "databricks":
-        pytest.skip("databricks foreign-key emission breaks this fixture. see dlt-hub/dlt#4011")
 
 
 @pytest.fixture(scope="module")

--- a/tests/workspace/cli/dlthub/test_init_command.py
+++ b/tests/workspace/cli/dlthub/test_init_command.py
@@ -195,6 +195,8 @@ def test_init_dlthub_workspace_writes_full_scaffold(
     config = tomlkit.parse(_read(tmp_path / ".dlt" / "config.toml"))
     assert config["workspace"]["settings"]["name"] == "my-fancy-proj"  # type: ignore[index]
     assert "runtime" in config
+    # workspaces always emit _dlt_load_id, incl. for arrow/parquet data
+    assert config["normalize"]["parquet_normalizer"]["add_dlt_load_id"] is True  # type: ignore[index]
 
     # no pipelines, no deployment module
     assert not (tmp_path / "__deployment__.py").exists()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
- moves misplaced merge subqueries to post-qualify (pre qualify subqueries collapse cannot work correctly)
- pure column-pick projections are replaced in place (no subquery); only defining projections (aliases, aggregates, distinct, group) wrap as a derived table
- in-place replacement excluded for multi-source queries — unqualified picks turn ambiguous across joins
- wrap uses sqlglot's own .subquery(qualifier), aliased with the left source qualifier so on= predicates and magic refs keep resolving
- optimization now runs only in to_sql(pretty=True) via the _optimize_query seam; executed SQL is sent as constructed

Magic-join correctness (#7)

- _apply_join seals a non-flat LHS (limit/distinct/group/agg) or WHERE-before-RIGHT/FULL-join in a derived table — fixes the LIMIT/WHERE leak, 3 strict xfails removed
- _discover_join_params seeds the left qualifier from the wrap's alias instead of raising "no base table"
- _extract_joined_table_aliases walks joins even when FROM is a subquery (still physical-table-only for the dotted-cursor guard)

Behavior restored/changed

- dotted-cursor incremental() after select()/root-table from_loads() works again (rejection test converted to positive with row-count assertions)
- pinned limitation: joining on a column the projection dropped under LIMIT raises LineageFailedException

Cleanups (slice A)

- renamed _qualify_physical_tables_with_dataset → _qualify_unscoped_tables_with_dataset + docstring says logical qualifier, physical resolution in bind_query
- removed the dead databricks skip in tests/load/test_relation_join.py (#4011 is in the base)
- ATTACH same-name guard got its rationale comment + a can_read_from-stubbed test proving it fires
