### PR TITLE
fix(bigquery): separate auth project_id from destination project_id in Client

### DIFF
--- a/dlt/destinations/impl/bigquery/sql_client.py
+++ b/dlt/destinations/impl/bigquery/sql_client.py
@@ -94,7 +94,6 @@ class BigQuerySqlClient(SqlClientBase[bigquery.Client], DBTransaction):
         ] = credentials
         self.location = location
         self.project_id = project_id or self.credentials.project_id
-        self._auth_project_id = self.credentials.project_id
         self.http_timeout = http_timeout
         super().__init__(self.project_id, dataset_name, staging_dataset_name, capabilities)
 
@@ -107,7 +106,6 @@ class BigQuerySqlClient(SqlClientBase[bigquery.Client], DBTransaction):
     @raise_open_connection_error
     def open_connection(self) -> bigquery.Client:
         self._client = bigquery.Client(
-            self._auth_project_id,
             credentials=self.credentials.to_native_credentials(),
             location=self.location,
         )

--- a/dlt/destinations/impl/bigquery/sql_client.py
+++ b/dlt/destinations/impl/bigquery/sql_client.py
@@ -94,6 +94,7 @@ class BigQuerySqlClient(SqlClientBase[bigquery.Client], DBTransaction):
         ] = credentials
         self.location = location
         self.project_id = project_id or self.credentials.project_id
+        self._auth_project_id = self.credentials.project_id
         self.http_timeout = http_timeout
         super().__init__(self.project_id, dataset_name, staging_dataset_name, capabilities)
 
@@ -106,7 +107,7 @@ class BigQuerySqlClient(SqlClientBase[bigquery.Client], DBTransaction):
     @raise_open_connection_error
     def open_connection(self) -> bigquery.Client:
         self._client = bigquery.Client(
-            self.project_id,
+            self._auth_project_id,
             credentials=self.credentials.to_native_credentials(),
             location=self.location,
         )


### PR DESCRIPTION
When a BigQuery destination uses separate auth credentials (e.g. service account from project A to write to project B), the client initialization conflates both into a single project_id parameter, causing 404 Not Found errors.

This fix ensures the auth and destination project IDs are passed independently to the BigQuery client, matching the documented multi-project setup.

Closes #4160