### PR TITLE
fix(snowflake): reject DECFLOAT columns in parquet files

### DIFF
--- a/dlt/common/destination/capabilities.py
+++ b/dlt/common/destination/capabilities.py
@@ -10,7 +10,6 @@ from typing import (
     Tuple,
     Set,
     Protocol,
-    Type,
     TYPE_CHECKING,
 )
 
@@ -151,7 +150,7 @@ class DestinationCapabilitiesContext(ContainerInjectableContext):
     """Callable that adapts `preferred_loader_file_format` and `supported_loader_file_formats` at runtime."""
     preferred_table_format: TTableFormat = None
     supported_table_formats: Sequence[TTableFormat] = None
-    type_mapper: Optional[Type[DataTypeMapper]] = None
+    type_mapper: Optional[Callable[..., DataTypeMapper]] = None
     recommended_file_size: Optional[int] = None
     """Recommended file size in bytes when writing extract/load files"""
     preferred_staging_file_format: Optional[TLoaderFileFormat] = None

--- a/dlt/destinations/impl/snowflake/factory.py
+++ b/dlt/destinations/impl/snowflake/factory.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Any, Dict, Sequence, Tuple, Type, Union, TYPE_CHECKING, Optional
 
 from dlt.common.destination.configuration import CsvFormatConfiguration
@@ -6,7 +7,9 @@ from dlt.common.data_writers.escape import escape_snowflake_identifier
 from dlt.common.arithmetics import DEFAULT_NUMERIC_PRECISION, DEFAULT_NUMERIC_SCALE
 from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.exceptions import TerminalValueError
+from dlt.common.normalizers.naming import NamingConvention
 from dlt.common.schema.typing import TColumnSchema, TColumnType
+from dlt.common.typing import TLoaderFileFormat
 
 from dlt.destinations.type_mapping import TypeMapperImpl
 from dlt.destinations.impl.snowflake.configuration import (
@@ -119,6 +122,24 @@ class SnowflakeTypeMapper(TypeMapperImpl):
             return "DECFLOAT"
         return super().to_db_decimal_type(column)
 
+    def ensure_supported_type(
+        self,
+        column: TColumnSchema,
+        table: PreparedTableSchema,
+        loader_file_format: TLoaderFileFormat,
+    ) -> None:
+        # DECFLOAT columns can only be loaded from text-based staging formats
+        if (
+            loader_file_format == "parquet"
+            and column["data_type"] == "decimal"
+            and self.use_decfloat
+            and self.decimal_precision(column.get("precision"), column.get("scale")) is None
+        ):
+            raise TerminalValueError(
+                "DECFLOAT is not supported in parquet files, use jsonl or csv instead",
+                column["data_type"],
+            )
+
 
 class snowflake(Destination[SnowflakeClientConfiguration, "SnowflakeClient"]):
     spec = SnowflakeClientConfiguration
@@ -159,6 +180,18 @@ class snowflake(Destination[SnowflakeClientConfiguration, "SnowflakeClient"]):
         caps.sqlglot_dialect = "snowflake"
 
         return caps
+
+    @classmethod
+    def adjust_capabilities(
+        cls,
+        caps: DestinationCapabilitiesContext,
+        config: SnowflakeClientConfiguration,
+        naming: Optional[NamingConvention],
+    ) -> DestinationCapabilitiesContext:
+        # bind use_decfloat so the type mapper obtained via `get_type_mapper()` (ie. during
+        # schema verification) matches the one used when actually loading data
+        caps.type_mapper = partial(SnowflakeTypeMapper, use_decfloat=config.use_decfloat)
+        return super().adjust_capabilities(caps, config, naming)
 
     @property
     def client_class(self) -> Type["SnowflakeClient"]:

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -160,7 +160,7 @@ class SnowflakeClient(SqlJobClientWithStagingDataset, SupportsStagingDestination
         super().__init__(schema, config, sql_client)
         self.config: SnowflakeClientConfiguration = config
         self.sql_client: SnowflakeSqlClient = sql_client  # type: ignore
-        self.type_mapper = self.capabilities.get_type_mapper(config.use_decfloat)
+        self.type_mapper = self.capabilities.get_type_mapper()
         self.active_hints = SUPPORTED_HINTS if self.config.create_indexes else {}
 
     def create_load_job(

--- a/tests/common/destination/test_destination_capabilities.py
+++ b/tests/common/destination/test_destination_capabilities.py
@@ -275,6 +275,39 @@ def test_verify_capabilities_data_types() -> None:
     assert len(exceptions) == 1
     assert isinstance(exceptions[0], TerminalValueError)
 
+    # snowflake: unbound decimal maps to DECFLOAT when use_decfloat is on, not supported on parquet
+    from dlt.destinations import snowflake
+
+    schema_decfloat = Schema("decfloat")
+    table = new_table(
+        "table",
+        write_disposition="append",
+        columns=[
+            {"name": "unbound", "data_type": "decimal"},
+            {"name": "bound", "data_type": "decimal", "precision": 10, "scale": 2},
+        ],
+    )
+    schema_decfloat.update_table(table, normalize_identifiers=False)
+    exceptions = verify_supported_data_types(
+        schema_decfloat.tables.values(),  # type: ignore[arg-type]
+        new_jobs_parquet,
+        snowflake(use_decfloat=True).capabilities(),
+        "snowflake",
+    )
+    assert len(exceptions) == 1
+    assert isinstance(exceptions[0], UnsupportedDataType)
+    assert exceptions[0].column == "unbound"
+    assert set(exceptions[0].available_in_formats) == {"model", "csv", "jsonl"}
+    # bound decimal is not affected, jsonl is unaffected, and use_decfloat off is unaffected
+    exceptions = verify_supported_data_types(
+        schema_decfloat.tables.values(), new_jobs_jsonl, snowflake(use_decfloat=True).capabilities(), "snowflake"  # type: ignore[arg-type]
+    )
+    assert len(exceptions) == 0
+    exceptions = verify_supported_data_types(
+        schema_decfloat.tables.values(), new_jobs_parquet, snowflake().capabilities(), "snowflake"  # type: ignore[arg-type]
+    )
+    assert len(exceptions) == 0
+
 
 def test_prepare_load_table_drops_unsupported_precision_hints() -> None:
     schema = Schema("foo")

--- a/tests/load/sqlalchemy/test_sqlalchemy_dialect.py
+++ b/tests/load/sqlalchemy/test_sqlalchemy_dialect.py
@@ -86,7 +86,7 @@ def test_factory_caps_mysql() -> None:
     assert caps.max_column_identifier_length == 64
     assert caps.enforces_nulls_on_alter is False
     assert isinstance(caps.dialect_capabilities, MysqlDialectCapabilities)
-    assert issubclass(caps.type_mapper, MysqlVariantTypeMapper)
+    assert issubclass(caps.type_mapper, MysqlVariantTypeMapper)  # type: ignore[arg-type]
     # format_datetime_literal must be the mysql variant (no_tz=True)
     from dlt.destinations.impl.sqlalchemy.dialect import _format_mysql_datetime_literal
 
@@ -103,7 +103,7 @@ def test_factory_caps_mariadb() -> None:
     assert caps.max_identifier_length == 64
     assert caps.max_column_identifier_length == 64
     assert isinstance(caps.dialect_capabilities, MysqlDialectCapabilities)
-    assert issubclass(caps.type_mapper, MysqlVariantTypeMapper)
+    assert issubclass(caps.type_mapper, MysqlVariantTypeMapper)  # type: ignore[arg-type]
 
 
 def test_factory_caps_mssql() -> None:
@@ -115,7 +115,7 @@ def test_factory_caps_mssql() -> None:
     assert caps.max_identifier_length == 128
     assert caps.max_column_identifier_length == 128
     assert isinstance(caps.dialect_capabilities, MssqlDialectCapabilities)
-    assert issubclass(caps.type_mapper, MssqlVariantTypeMapper)
+    assert issubclass(caps.type_mapper, MssqlVariantTypeMapper)  # type: ignore[arg-type]
 
 
 def test_factory_caps_postgresql() -> None:
@@ -130,7 +130,7 @@ def test_factory_caps_postgresql() -> None:
     assert caps.has_case_sensitive_identifiers is True
     # no registered dialect caps -> falls back to base DialectCapabilities
     assert type(caps.dialect_capabilities) is DialectCapabilities
-    assert issubclass(caps.type_mapper, SqlalchemyTypeMapper)
+    assert issubclass(caps.type_mapper, SqlalchemyTypeMapper)  # type: ignore[arg-type]
 
 
 def test_factory_caps_sqlite() -> None:
@@ -143,7 +143,7 @@ def test_factory_caps_sqlite() -> None:
     assert caps.max_identifier_length == 9999
     assert caps.supports_native_boolean is False
     assert type(caps.dialect_capabilities) is DialectCapabilities
-    assert issubclass(caps.type_mapper, SqlalchemyTypeMapper)
+    assert issubclass(caps.type_mapper, SqlalchemyTypeMapper)  # type: ignore[arg-type]
 
 
 def test_factory_caps_always_sets_dialect_capabilities() -> None:
@@ -194,7 +194,7 @@ def test_factory_caps_oracle() -> None:
     assert caps.max_identifier_length == 128
     assert caps.max_column_identifier_length == 128
     assert isinstance(caps.dialect_capabilities, OracleDialectCapabilities)
-    assert issubclass(caps.type_mapper, SqlalchemyTypeMapper)
+    assert issubclass(caps.type_mapper, SqlalchemyTypeMapper)  # type: ignore[arg-type]
 
 
 def test_oracle_dialect_caps() -> None:


### PR DESCRIPTION
### Description

When `use_decfloat` is enabled, Snowflake maps unbound decimal columns to `DECFLOAT`, which cannot be loaded from parquet files (only text-based formats like jsonl and csv). This was documented in the `use_decfloat` docstring but not enforced, so such a combination would fail with an opaque error at load time.

`SnowflakeTypeMapper` now declares this via `ensure_supported_type`, so it is caught early by the standard capability check (at load time, and at normalize time once #4172 lands). To make the check effective, `use_decfloat` is bound into the type mapper via an `adjust_capabilities` override, so the mapper obtained during schema verification matches the one used when loading. The `type_mapper` capability annotation is widened to `Callable[..., DataTypeMapper]` to allow this binding.

This covers task 2 of the issue.

### Related Issues

- Refs #815

### Additional Context

Test: `tests/common/destination/test_destination_capabilities.py::test_verify_capabilities_data_types` now covers the Snowflake case — an unbound `decimal` column with `use_decfloat` on raises `UnsupportedDataType` for parquet, while a bound decimal, jsonl, and `use_decfloat` off are unaffected. This runs offline with no credentials. The Snowflake-specific integration tests require destination access and will run in CI. `make lint` (mypy/ruff/flake8/bandit/docstrings) is clean locally.