### PR TITLE
fix(normalizers): collapse all-underscore identifiers to _ in sql naming

### DIFF
--- a/dlt/common/normalizers/naming/sql_cs_v1.py
+++ b/dlt/common/normalizers/naming/sql_cs_v1.py
@@ -35,8 +35,8 @@ class NamingConvention(BaseNamingConvention):
         # remove trailing underscores to not mess with how we break paths
         if norm_identifier != "_":
             norm_identifier = self.RE_ENDING_UNDERSCORES.sub("", norm_identifier)
-        # contract multiple __
-        norm_identifier = self.RE_UNDERSCORES.sub("_", norm_identifier)
+        # contract multiple __, collapsing an all-underscore identifier to a single _
+        norm_identifier = self.RE_UNDERSCORES.sub("_", norm_identifier) or "_"
         return self.shorten_identifier(norm_identifier, identifier, self.max_length)
 
     @property

--- a/tests/common/normalizers/test_naming_sql.py
+++ b/tests/common/normalizers/test_naming_sql.py
@@ -24,6 +24,12 @@ def test_normalize_identifier(convention: Type[NamingConvention]) -> None:
     assert naming.normalize_identifier("+-!$*@#=|:") == "_"
     # leave single underscore
     assert naming.normalize_identifier("_") == "_"
+    # all-underscore identifiers collapse to a single _ instead of an empty string
+    assert naming.normalize_identifier("__") == "_"
+    assert naming.normalize_identifier("___") == "_"
+    assert naming.normalize_identifier("-_-") == "_"
+    assert naming.normalize_identifier("#_#") == "_"
+    assert naming.normalize_identifier("  __  ") == "_"
     # some other cases
     assert naming.normalize_identifier("+1") == "_1"
     assert naming.normalize_identifier("-1") == "_1"


### PR DESCRIPTION


The `sql_cs_v1` naming convention (and `sql_ci_v1`, which subclasses it) returns an
**empty string** for any identifier that reduces to two or more underscores after
non-alphanumeric characters are replaced. Examples that currently normalize to `""`:
`"__"`, `"___"`, `"-_-"`, `"#_#"`, `"  __  "`.

This violates the convention's own documented contract - "Multiples of `_` are
converted into single `_`" - and the base `NamingConvention`, which raises
`ValueError` on an empty identifier. Every other bundled convention already collapses
these inputs safely (for example `snake_case` -> `xx`, `duck_case` -> `_`).

Root cause is in `NamingConvention.normalize_identifier`
(`dlt/common/normalizers/naming/sql_cs_v1.py`):

```python
# remove trailing underscores to not mess with how we break paths
if norm_identifier != "_":
    norm_identifier = self.RE_ENDING_UNDERSCORES.sub("", norm_identifier)  # strips ALL trailing _
# contract multiple __
norm_identifier = self.RE_UNDERSCORES.sub("_", norm_identifier)            # "" stays ""
```

The `!= "_"` guard only protects an already-single `"_"`. For an input like `"__"`,
the guard is true, `RE_ENDING_UNDERSCORES` (`_+$`) strips the whole string to `""`,
and the subsequent multi-underscore contraction cannot restore it, so the method
returns `""`.

Because an empty identifier survives when it reaches the relational normalizer
(the raw key is non-empty and not whitespace, so it is normalized rather than
skipped), a column can arrive at the destination with an empty name - a silent
data-loss / column-collision vector for these edge-case source names.

The fix coalesces an emptied result back to a single `_`, matching the documented
"collapse to `_`" behavior:

```python
# contract multiple __, collapsing an all-underscore identifier to a single _
norm_identifier = self.RE_UNDERSCORES.sub("_", norm_identifier) or "_"
```

The single-underscore guard is left untouched, and only the previously-empty cases
change; all other inputs (`"_"`, `"@@"`, `"+-!$*@#=|:"`, `"___a___b" -> "_a_b"`,
`"+1" -> "_1"`, ...) normalize exactly as before.

Regression assertions were added to the existing parametrized
`test_normalize_identifier` in `tests/common/normalizers/test_naming_sql.py`, which
runs over both `sql_cs_v1` and `sql_ci_v1`.

Note on scope: this fixes identifier normalization only. `normalize_path("__")` still
returns `""` on purpose, because `"__"` is the path separator (`PATH_SEPARATOR`) and
`break_path` legitimately drops empty segments; that is separate path-parsing
behavior and is intentionally left out of this change.

### Related Issues

<!-- No upstream issue exists yet. dlt requires a ticket for `fix` PRs; see
