### PR TITLE
(feat) expose parquet compression codec

### DIFF
--- a/dlt/common/data_writers/writers.py
+++ b/dlt/common/data_writers/writers.py
@@ -36,6 +36,7 @@ from dlt.common.data_writers.exceptions import (
 from dlt.common.destination.configuration import (
     CsvFormatConfiguration,
     CsvQuoting,
+    ParquetCompression,
     ParquetFormatConfiguration,
 )
 from dlt.common.destination import (
@@ -326,6 +327,7 @@ class ParquetDataWriter(DataWriter):
         *,
         flavor: Optional[str] = None,
         version: Optional[str] = "2.4",
+        compression: Optional[ParquetCompression] = "snappy",
         data_page_size: Optional[int] = None,
         timestamp_timezone: str = "UTC",
         row_group_size: Optional[int] = None,
@@ -361,6 +363,7 @@ class ParquetDataWriter(DataWriter):
         parquet_writer_kwargs = {
             "flavor": self.parquet_format.flavor,
             "version": self.parquet_format.version,
+            "compression": self.parquet_format.compression,
             "data_page_size": self.parquet_format.data_page_size,
             "coerce_timestamps": self.parquet_format.coerce_timestamps,
             "allow_truncated_timestamps": self.parquet_format.allow_truncated_timestamps,

--- a/dlt/common/destination/configuration.py
+++ b/dlt/common/destination/configuration.py
@@ -5,6 +5,7 @@ from dlt.common.configuration.specs import BaseConfiguration
 from dlt.common.time import get_precision_from_datetime_unit
 
 CsvQuoting = Literal["quote_all", "quote_needed", "quote_minimal", "quote_none"]
+ParquetCompression = Literal["none", "snappy", "gzip", "brotli", "lz4", "zstd"]
 
 
 @configspec
@@ -28,6 +29,7 @@ class CsvFormatConfiguration(BaseConfiguration):
 class ParquetFormatConfiguration(BaseConfiguration):
     flavor: Optional[str] = None  # could be ie. "spark"
     version: Optional[str] = "2.4"
+    compression: Optional[ParquetCompression] = "snappy"
     data_page_size: Optional[int] = None
     timestamp_timezone: str = "UTC"
     row_group_size: Optional[int] = None

--- a/docs/website/docs/dlt-ecosystem/file-formats.md
+++ b/docs/website/docs/dlt-ecosystem/file-formats.md
@@ -36,6 +36,7 @@ Under the hood, `dlt` uses the [pyarrow parquet writer](https://arrow.apache.org
 
 - `flavor`: Sanitize schema or set other compatibility options to work with various target systems. Defaults to None, which is the **pyarrow** default.
 - `version`: Determine which Parquet logical types are available for use, whether the reduced set from the Parquet 1.x.x format or the expanded logical types added in later format versions. `dlt` defaults to "2.4".
+- `compression`: Select the internal Parquet compression codec. Choose from `"snappy"`, `"gzip"`, `"brotli"`, `"zstd"`, `"lz4"`, or `"none"`. Defaults to `"snappy"`. Make sure that your database can decompress the codec you select here.
 - `data_page_size`: Set a target threshold for the approximate encoded size of data pages within a column chunk (in bytes). Defaults to None, which is the **pyarrow** default.
 - `row_group_size`: Set the number of rows in a row group. [See here](#row-group-size) how this can optimize parallel processing of queries on your destination over the default setting of `pyarrow`.
 - `timestamp_timezone`: A string specifying the timezone, default is UTC.
@@ -60,6 +61,7 @@ Example:
 # example values
 flavor="spark"
 version="2.4"
+compression="zstd"
 data_page_size=1048576
 timestamp_timezone="Europe/Berlin"
 ```
@@ -69,6 +71,7 @@ Or using environment variables:
 ```sh
 DATA_WRITER__FLAVOR
 DATA_WRITER__VERSION
+DATA_WRITER__COMPRESSION
 DATA_WRITER__DATA_PAGE_SIZE
 DATA_WRITER__TIMESTAMP_TIMEZONE
 DATA_WRITER__ARROW_CONCAT_PROMOTE_OPTIONS
@@ -78,7 +81,9 @@ DATA_WRITER__ARROW_CONCAT_PROMOTE_OPTIONS
 You can apply data writer settings to parquet created in normalize stage only:
 `NORMALIZE__DATA_WRITER__FLAVOR=spark`
 
-or when your source/resource yields arrow tables / pandas DataFrames / polars DataFrames, you can control settings per source
+To set the Parquet codec for normalize-stage files, use `NORMALIZE__DATA_WRITER__COMPRESSION=zstd`. This setting applies to Parquet's internal codec only. It does not change `jsonl`, `csv`, or other text file compression; use `data_writer.disable_compression` to disable their gzip wrapper.
+
+When your source/resource yields arrow tables / pandas DataFrames / polars DataFrames, you can control settings per source:
 `SOURCES__<SOURCE_MODULE>__<SOURCE_NAME>__DATA_WRITER__FLAVOR=spark`
 
 Find more similar examples [here](../reference/performance.md#extract)

--- a/tests/libs/test_parquet_writer.py
+++ b/tests/libs/test_parquet_writer.py
@@ -176,8 +176,21 @@ def test_parquet_writer_size_file_rotation() -> None:
         assert table.column("col1").to_pylist() == list(range(4 * i_per_file, 5 * i_per_file))
 
 
+def test_parquet_writer_default_compression() -> None:
+    with inject_section(ConfigSectionContext(pipeline_name=None, sections=("normalize",))):
+        with get_writer(ParquetDataWriter, file_max_bytes=2**8, buffer_max_items=2) as writer:
+            writer.write_data_item([{"col1": 1}], {"col1": new_column("col1", "bigint")})
+            writer._flush_items()
+
+            assert writer._writer.parquet_format.compression == "snappy"
+
+        with pa.parquet.ParquetFile(writer.closed_files[0].file_path) as reader:
+            assert reader.metadata.row_group(0).column(0).compression == "SNAPPY"
+
+
 def test_parquet_writer_config() -> None:
     os.environ["NORMALIZE__DATA_WRITER__VERSION"] = "1.0"
+    os.environ["NORMALIZE__DATA_WRITER__COMPRESSION"] = "gzip"
     os.environ["NORMALIZE__DATA_WRITER__DATA_PAGE_SIZE"] = str(1024 * 512)
     os.environ["NORMALIZE__DATA_WRITER__TIMESTAMP_TIMEZONE"] = "America/New York"
     os.environ["NORMALIZE__DATA_WRITER__WRITE_PAGE_INDEX"] = "true"
@@ -194,6 +207,7 @@ def test_parquet_writer_config() -> None:
 
             # flavor can't be tested
             assert writer._writer.parquet_format.version == "1.0"
+            assert writer._writer.parquet_format.compression == "gzip"
             assert writer._writer.parquet_format.data_page_size == 1024 * 512
             assert writer._writer.parquet_format.timestamp_timezone == "America/New York"
             assert writer._writer.parquet_format.write_page_index is True
@@ -211,6 +225,7 @@ def test_parquet_writer_config() -> None:
             # page index is written (https://github.com/apache/parquet-format/blob/master/PageIndex.md)
             assert reader.metadata.row_group(0).column(0).has_column_index is True
             assert reader.metadata.row_group(0).column(0).has_offset_index is True
+            assert reader.metadata.row_group(0).column(0).compression == "GZIP"
 
 
 def test_parquet_writer_config_spark() -> None:


### PR DESCRIPTION
This PR exposes the `ParquetWriter` encoding parameter under either `(NORMALIZE__)DATA_WRITER__COMPRESSION` or 
```python
destination = duckdb(
    parquet_format=ParquetFormatConfiguration(compression="zstd")
)
```

Closes #4181 