### PR TITLE
fix: remove nonexistent `from_hints` arg from `DltResource.set_incremental` docstring

### DIFF
--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -480,7 +480,6 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
 
         Args:
             new_incremental: The Incremental instance/hint to set or replace
-            from_hints: If the incremental is set from hints. Defaults to False.
         """
         if new_incremental is Incremental.EMPTY:
             new_incremental = None


### PR DESCRIPTION
### Description

`DltResource.set_incremental` has a single data argument, `new_incremental`:

```python
def set_incremental(
    self, new_incremental: Union[Incremental[Any], IncrementalResourceWrapper]
) -> Optional[Union[Incremental[Any], IncrementalResourceWrapper]]:
```

but its docstring documented a second parameter that the signature does not have:

```python
Args:
    new_incremental: The Incremental instance/hint to set or replace
    from_hints: If the incremental is set from hints. Defaults to False.
```

The `from_hints` line belongs to `IncrementalResourceWrapper.set_incremental`, which really does accept `from_hints`. On `DltResource.set_incremental`, passing `from_hints=` raises `TypeError` because there is no such parameter.

This removes the stale docstring line so the documented arguments match the signature. Docs-only, no behavior change.

### Related Issues

- No related issue; noticed while reading the incremental code.

### Additional Context

- Only `dlt/extract/resource.py` changes.
- `uv run ruff check dlt/extract/resource.py` passes.
