### PR TITLE
fix(schema): interpolate table name in missing root_key error

### DIFF
--- a/dlt/common/schema/utils.py
+++ b/dlt/common/schema/utils.py
@@ -1129,7 +1129,7 @@ def create_root_child_reference(tables: TSchemaTables, table_name: str) -> TTabl
     child_root_key: str = get_first_column_name_with_prop(child_table, "root_key")
     if child_root_key is None:
         raise ValueError(
-            "No `root_key` found for table `{table_name}`. Set `root_key=True` on"
+            f"No `root_key` found for table `{table_name}`. Set `root_key=True` on"
             " the `@dlt.source` producing this data to generate a `_dlt_root_id` column."
         )
     root_row_key: str = get_first_column_name_with_prop(root_table, "row_key")

--- a/tests/common/schema/test_references.py
+++ b/tests/common/schema/test_references.py
@@ -356,6 +356,17 @@ def test_root_child_reference_from_child(schema: dlt.Schema) -> None:
     assert all(ref.get("label") == "_dlt_root" for ref in [nested_ref1, nested_ref2])
 
 
+def test_root_child_reference_without_root_key(schema: dlt.Schema) -> None:
+    """`create_root_child_reference()` on a nested table missing a `root_key`
+    column should raise a message that names the offending table.
+    """
+    del schema.tables["root_table1__child1"]["columns"]["_dlt_root_id"]
+
+    with pytest.raises(ValueError) as e:
+        create_root_child_reference(schema.tables, "root_table1__child1")
+    assert e.match("No `root_key` found for table `root_table1__child1`.")
+
+
 def test_get_all_root_child_references_from_root(schema: dlt.Schema) -> None:
     nested_ref1 = create_root_child_reference(schema.tables, "root_table1__child1")
     nested_ref2 = create_root_child_reference(schema.tables, "root_table1__child1__child2")


### PR DESCRIPTION
### Description

`create_root_child_reference()` in `dlt/common/schema/utils.py` raises a `ValueError` when a nested table has no `root_key` column. The message string was a plain non-f-string literal, so the `{table_name}` placeholder was emitted verbatim instead of being interpolated:

```text
No `root_key` found for table `{table_name}`. Set `root_key=True` on the `@dlt.source` producing this data to generate a `_dlt_root_id` column.
```

Every other `table_name` error in the same function is already an f-string, so this one line was simply missing its `f` prefix. This adds it so the error names the offending table.

Also adds a colocated regression test in `tests/common/schema/test_references.py` that drops the `_dlt_root_id` column from a nested fixture table and asserts the raised message contains the real table name.

### Related Issues

- No linked issue: this is a small better-exception quality-of-life fix. Happy to open a tracking issue first if preferred.

### Additional Context

- Diff is 2 files, +12/-1.
- `pytest tests/common/schema/test_references.py` passes locally.
- Verified red -> green: with the original non-f literal the new test fails because the assertion sees the literal `{table_name}`; with the `f` prefix it passes.
- `ruff`, `black --check`, `flake8` with the repo's `lint-core` settings, and `mypy` are clean on both changed files.
