### PR TITLE
fix(rest_client): handle non-scalar total in range paginator

### DIFF
--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -178,7 +178,7 @@ class RangePaginator(BasePaginator):
 
                 try:
                     total = int(total)
-                except ValueError:
+                except (ValueError, TypeError):
                     self._handle_invalid_total(total)
 
             self.current_value += self.value_step

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -378,6 +378,13 @@ class TestOffsetPaginator:
         with pytest.raises(ValueError):
             paginator.update_state(response, data=NON_EMPTY_PAGE)
 
+    def test_update_state_with_non_scalar_total(self):
+        paginator = OffsetPaginator(0, 10)
+        for total in ({"count": 5}, [100]):
+            response = Mock(Response, json=lambda total=total: {"total": total})
+            with pytest.raises(ValueError, match="is not an `int`"):
+                paginator.update_state(response, data=NON_EMPTY_PAGE)
+
     def test_update_state_without_total(self):
         paginator = OffsetPaginator(0, 10)
         response = Mock(Response, json=lambda: {})
@@ -706,6 +713,13 @@ class TestPageNumberPaginator:
         response = Mock(Response, json=lambda: {"total_pages": "invalid"})
         with pytest.raises(ValueError):
             paginator.update_state(response, data=NON_EMPTY_PAGE)
+
+    def test_update_state_with_non_scalar_total_pages(self):
+        paginator = PageNumberPaginator(base_page=1, page=1)
+        for total in ({"count": 5}, [100]):
+            response = Mock(Response, json=lambda total=total: {"total": total})
+            with pytest.raises(ValueError, match="is not an `int`"):
+                paginator.update_state(response, data=NON_EMPTY_PAGE)
 
     def test_update_state_without_total_pages(self):
         paginator = PageNumberPaginator(base_page=1, page=1)


### PR DESCRIPTION
### Description

`RangePaginator.update_state`, the base of `OffsetPaginator` and `PageNumberPaginator`, reads the total straight from the response body and converts it with `int(total)`. That conversion was wrapped in `except ValueError`, but when `total_path` resolves to a non-scalar, such as a JSON object or array, `int()` raises `TypeError`, not `ValueError`. The error was not caught, so pagination failed with an opaque `TypeError`.

The paginator already has an actionable error for a bad total: `_handle_invalid_total`, which raises a clear `ValueError` explaining that the value is not an integer. This change broadens the `except` so a non-scalar total routes to that message instead of escaping as a raw `TypeError`. This mirrors the sibling `has_more` branch in the same method, which is already type-guarded before conversion.

There is no behavior change for valid `int` or `str` totals.

```python
# dlt/sources/helpers/rest_client/paginators.py, RangePaginator.update_state
try:
    total = int(total)
except (ValueError, TypeError):
    self._handle_invalid_total(total)
```

Reproduction before this change:

```python
from unittest.mock import Mock
from requests import Response
from dlt.sources.helpers.rest_client.paginators import OffsetPaginator

paginator = OffsetPaginator(0, 10)
response = Mock(Response, json=lambda: {"total": {"count": 5}})
paginator.update_state(response, data=[1])
# TypeError: int() argument must be ... not 'dict'
```

### Related Issues

No existing issue. This is a small robustness fix found while reading the REST client paginators.

### Additional Context

- Regression tests added for both `OffsetPaginator` and `PageNumberPaginator` in `tests/sources/helpers/rest_client/test_paginators.py`, each asserting a `ValueError` for dict and list totals.
- `uv run pytest tests/sources/helpers/rest_client/test_paginators.py` passes locally.
- Verified red -> green: with the old `except ValueError`, the two new tests fail with the raw `TypeError`; with the fix they pass.
- `black --check`, `ruff check`, and `mypy` are clean on both changed files.
