### PR TITLE
fix: Normalize crashes with ArrowInvalid when adding _dlt_id to an empty Arrow table

### DIFF
--- a/dlt/normalize/items_normalizers/arrow.py
+++ b/dlt/normalize/items_normalizers/arrow.py
@@ -98,7 +98,7 @@ class ArrowItemsNormalizer(ItemsNormalizer):
                 (
                     -1,
                     pa.field(data_normalizer.c_dlt_id, pyarrow.pyarrow.string(), nullable=False),
-                    lambda batch: pa.array(generate_dlt_ids(batch.num_rows)),
+                    lambda batch: pa.array(generate_dlt_ids(batch.num_rows),type=pa.string()),
                 )
             )
 

--- a/dlt/normalize/items_normalizers/arrow.py
+++ b/dlt/normalize/items_normalizers/arrow.py
@@ -98,7 +98,7 @@ class ArrowItemsNormalizer(ItemsNormalizer):
                 (
                     -1,
                     pa.field(data_normalizer.c_dlt_id, pyarrow.pyarrow.string(), nullable=False),
-                    lambda batch: pa.array(generate_dlt_ids(batch.num_rows),type=pa.string()),
+                    lambda batch: pa.array(generate_dlt_ids(batch.num_rows), type=pa.string()),
                 )
             )
 

--- a/tests/normalize/test_normalize_arrow.py
+++ b/tests/normalize/test_normalize_arrow.py
@@ -88,13 +88,14 @@ def test_normalize_empty_arrow_input_writes_empty_job(
     step_info = raw_normalize.get_step_info(MockPipeline("arrow_empty_pipeline", True))  # type: ignore[abstract]
     assert step_info.metrics[load_id][0]["table_metrics"]["items"].items_count == 0
 
+
 @pytest.mark.parametrize("add_dlt_id", [True, False])
 def test_normalize_empty_arrow_input_parquet_output(
     parquet_caps: DestinationCapabilitiesContext, raw_normalize: Normalize, add_dlt_id: bool
 ) -> None:
     """An empty arrow input file yields an empty root-table job with a physically present empty
     parquet file (num_rows == 0)."""
-    raw_normalize.config.parquet_normalizer.add_dlt_id= add_dlt_id
+    raw_normalize.config.parquet_normalizer.add_dlt_id = add_dlt_id
     schema = _items_schema()
     empty = pyarrow.table({"id": pyarrow.array([], type=pyarrow.int64())})
     load_id = extract_arrow_items(raw_normalize.normalize_storage, empty, schema, "items")

--- a/tests/normalize/test_normalize_arrow.py
+++ b/tests/normalize/test_normalize_arrow.py
@@ -88,12 +88,13 @@ def test_normalize_empty_arrow_input_writes_empty_job(
     step_info = raw_normalize.get_step_info(MockPipeline("arrow_empty_pipeline", True))  # type: ignore[abstract]
     assert step_info.metrics[load_id][0]["table_metrics"]["items"].items_count == 0
 
-
+@pytest.mark.parametrize("add_dlt_id", [True, False])
 def test_normalize_empty_arrow_input_parquet_output(
-    parquet_caps: DestinationCapabilitiesContext, raw_normalize: Normalize
+    parquet_caps: DestinationCapabilitiesContext, raw_normalize: Normalize, add_dlt_id: bool
 ) -> None:
     """An empty arrow input file yields an empty root-table job with a physically present empty
     parquet file (num_rows == 0)."""
+    raw_normalize.config.parquet_normalizer.add_dlt_id= add_dlt_id
     schema = _items_schema()
     empty = pyarrow.table({"id": pyarrow.array([], type=pyarrow.int64())})
     load_id = extract_arrow_items(raw_normalize.normalize_storage, empty, schema, "items")


### PR DESCRIPTION
### Related Issues

- Fixes #4175 


### Description
As described in [Issue #4175](https://github.com/dlt-hub/dlt/issues/4175), loading an empty Arrow table or DataFrame with `add_dlt_id=True` causes the normalization step to fail with the following error:
`pyarrow.lib.ArrowInvalid: Field type did not match data type`.

### Root Cause
The error occurs because, when a table is empty, PyArrow automatically infers the data type of the generated ID column as `null` (the `DataType: null` in Arrow) instead of the expected `string`. 

### Solution
This fix ensures that the correct data type is explicitly assigned during the ID generation process, even for empty datasets, preventing the type mismatch.

