### PR TITLE
(docs) fix typos in comments, docstrings and docs

### DIFF
--- a/dlt/common/configuration/plugins.py
+++ b/dlt/common/configuration/plugins.py
@@ -123,7 +123,7 @@ class SupportsCliCommand(Protocol):
     help_string: str
     """the help string for argparse"""
     description: Optional[str]
-    """the more detailed description for argparse, may inlcude markdown for the docs"""
+    """the more detailed description for argparse, may include markdown for the docs"""
     docs_url: Optional[str]
     """the default docs url to be printed in case of an exception"""
 

--- a/dlt/common/data_types/type_helpers.py
+++ b/dlt/common/data_types/type_helpers.py
@@ -157,7 +157,7 @@ def _text_to_wei(value: str) -> Wei:
 
 
 def _float_to_decimal(value: float) -> Decimal:
-    """Uses `str` that produces most precise stable decimal representaion of given `value`"""
+    """Uses `str` that produces most precise stable decimal representation of given `value`"""
     return Decimal(str(value))
 
 

--- a/dlt/common/data_writers/escape.py
+++ b/dlt/common/data_writers/escape.py
@@ -305,6 +305,6 @@ def format_bigquery_datetime_literal(
 def format_clickhouse_datetime_literal(
     v: pendulum.DateTime, precision: int = 6, no_tz: bool = False
 ) -> str:
-    """Returns clickhouse compatibel function"""
+    """Returns clickhouse compatible function"""
     datetime = format_datetime_literal(v, precision, True)
     return f"toDateTime64({datetime}, {precision}, '{v.tzinfo}')"

--- a/dlt/common/destination/client.py
+++ b/dlt/common/destination/client.py
@@ -192,7 +192,7 @@ class DestinationClientConfiguration(BaseConfiguration):
         """Returns true if `self` can write data from `other`
         In case of SQL engines it is an ability to INSERT FROM
         """
-        # in most destinations, ability to read is also the same as abilty to write
+        # in most destinations, ability to read is also the same as ability to write
         return self.can_read_from(other)
 
     def __str__(self) -> str:

--- a/dlt/common/destination/dataset.py
+++ b/dlt/common/destination/dataset.py
@@ -27,7 +27,7 @@ class SupportsDataAccess(Protocol):
     def columns_schema(self) -> TTableSchemaColumns:
         """
         Returns the expected columns schema for the result of the relation. Column types are discovered with
-        sql glot query analysis and lineage. dlt hints for columns are kept in some cases. Refere to <docs-page> for more details.
+        sql glot query analysis and lineage. dlt hints for columns are kept in some cases. Refer to <docs-page> for more details.
         """
         ...
 

--- a/dlt/common/libs/git.py
+++ b/dlt/common/libs/git.py
@@ -227,7 +227,7 @@ def get_fresh_repo_files(
 
     url = giturlparse.parse(repo_location, check_domain=False)
     if not url.valid:
-        # repo is a directory so jus return storage
+        # repo is a directory so just return storage
         return FileStorage(repo_location, makedirs=False)
     else:
         # clone or update repo

--- a/dlt/common/schema/detections.py
+++ b/dlt/common/schema/detections.py
@@ -14,7 +14,7 @@ _FLOAT_TS_RANGE = 5 * 31536000.0  # seconds in year
 
 
 def is_timestamp(t: Type[Any], v: Any) -> Optional[TDataType]:
-    # autodetect int and float withing 1 year range of NOW
+    # autodetect int and float within 1 year range of NOW
     if t in [int, float]:
         if v >= _NOW_TS - _FLOAT_TS_RANGE and v <= _NOW_TS + _FLOAT_TS_RANGE:
             return "timestamp"

--- a/dlt/common/schema/typing.py
+++ b/dlt/common/schema/typing.py
@@ -48,7 +48,7 @@ C_DLT_ID = "_dlt_id"
 C_DLT_LOAD_ID = "_dlt_load_id"
 """load id to identify records loaded in a single load package"""
 # NOTE C_DLT_LOAD_ID != C_DLT_LOADS_TABLE_LOAD_ID but they refer to the exact same entity / value.
-# They differ for backwards compatiblity reasons
+# They differ for backwards compatibility reasons
 # TODO add schema migration to use `_dlt_load_id` in `_dlt_loads` table
 C_DLT_LOADS_TABLE_LOAD_ID = "load_id"
 """load id column in the table {LOADS_TABLE_NAME}. Meant to be joined with {C_DLT_LOAD_ID} of data tables"""

--- a/dlt/common/storages/load_storage.py
+++ b/dlt/common/storages/load_storage.py
@@ -200,7 +200,7 @@ class LoadStorage(VersionedStorage):
             return self.normalized_packages.get_load_package_info(load_id)
 
     def get_load_package_state(self, load_id: str) -> TLoadPackageState:
-        """Gets state of normlized or loaded package with given load_id, all jobs and their statuses."""
+        """Gets state of normalized or loaded package with given load_id, all jobs and their statuses."""
         try:
             return self.loaded_packages.get_load_package_state(load_id)
         except LoadPackageNotFound:

--- a/dlt/common/utils.py
+++ b/dlt/common/utils.py
@@ -622,7 +622,7 @@ def increase_row_count(row_counts: RowCounts, counter_name: str, count: int) -> 
 
 def merge_row_counts(row_counts_1: RowCounts, row_counts_2: RowCounts) -> None:
     """merges row counts_2 into row_counts_1"""
-    # only keys present in row_counts_2 are modifed
+    # only keys present in row_counts_2 are modified
     for counter_name in row_counts_2.keys():
         row_counts_1[counter_name] = row_counts_1.get(counter_name, 0) + row_counts_2[counter_name]
 

--- a/dlt/dataset/exceptions.py
+++ b/dlt/dataset/exceptions.py
@@ -10,7 +10,7 @@ class RelationHasQueryException(DatasetException):
     def __init__(self, attempted_change: str) -> None:
         msg = (
             "This readable relation was created with a provided sql query. You cannot change"
-            f" `{attempted_change}`. Please change the orignal sql query."
+            f" `{attempted_change}`. Please change the original sql query."
         )
         super().__init__(msg)
 

--- a/dlt/destinations/impl/clickhouse/configuration.py
+++ b/dlt/destinations/impl/clickhouse/configuration.py
@@ -21,7 +21,7 @@ class ClickHouseCredentials(ConnectionStringCredentials):
     """Native port ClickHouse server is bound to. Defaults to 9440."""
     http_port: int = 8443
     """HTTP Port to connect to ClickHouse server's HTTP interface.
-    The HTTP port is additionaly needed for loading files without a staging destination.
+    The HTTP port is additionally needed for loading files without a staging destination.
     Defaults to 8443."""
     username: str = "default"
     """Database user. Defaults to 'default'."""

--- a/dlt/destinations/impl/lancedb/sql_client.py
+++ b/dlt/destinations/impl/lancedb/sql_client.py
@@ -5,7 +5,7 @@ DuckDB instance with the `lance-duckdb` extension allows
 to read the `.lance` files (each maps to a single table).
 
 This SQL client makes LanceDB compatible with the `dlt.Dataset`
-inferface.
+interface.
 """
 from __future__ import annotations
 

--- a/dlt/destinations/impl/synapse/configuration.py
+++ b/dlt/destinations/impl/synapse/configuration.py
@@ -46,7 +46,7 @@ class SynapseClientConfiguration(MsSqlClientConfiguration):
     """
 
     # Set to False by default because the PRIMARY KEY and UNIQUE constraints
-    # are tricky in Synapse: they are NOT ENFORCED and can lead to innacurate
+    # are tricky in Synapse: they are NOT ENFORCED and can lead to inaccurate
     # results if the user does not ensure all column values are unique.
     # https://learn.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-table-constraints
     create_indexes: bool = False

--- a/dlt/destinations/impl/synapse/synapse.py
+++ b/dlt/destinations/impl/synapse/synapse.py
@@ -254,7 +254,7 @@ class SynapseCopyFileLoadJob(CopyRemoteFileLoadJob):
         as required by Synapse.
         """
         bucket_url = urlparse(bucket_path)
-        # "blob" endpoint has better performance than "dfs" endoint
+        # "blob" endpoint has better performance than "dfs" endpoint
         # https://learn.microsoft.com/en-us/sql/t-sql/statements/copy-into-transact-sql?view=azure-sqldw-latest#external-locations
         endpoint = "blob"
         _path = "/" + bucket_url.netloc + bucket_url.path

--- a/dlt/extract/items_transform.py
+++ b/dlt/extract/items_transform.py
@@ -166,7 +166,7 @@ class ValidateItem(ItemTransform[TDataItem, Dict[str, Any]]):
         """Computes table schema enforced by this validator. For dynamic (item dependent) or
         schemas with discriminator field use item and meta.
 
-        Return None if no authoratitative schema can be computed
+        Return None if no authoritative schema can be computed
         """
         return None
 

--- a/dlt/extract/pipe_iterator.py
+++ b/dlt/extract/pipe_iterator.py
@@ -212,7 +212,7 @@ class PipeIterator(Iterator[PipeItem]):
                             pipe_item.pipe.name,
                             f"Pipe item of type `{type(pipe_item.item).__name__}` was not fully"
                             f" evaluated at step `{pipe_item.step}`. This is an internal error or"
-                            " you're yielding unexpected object from resources (e.g., fucntions,"
+                            " you're yielding unexpected object from resources (e.g., functions,"
                             " awaitables).",
                         )
                     # mypy not able to figure out that item was resolved

--- a/dlt/extract/utils.py
+++ b/dlt/extract/utils.py
@@ -211,7 +211,7 @@ def wrap_async_iterator(
                 yield None
             busy = True
             yield run()
-    # this gets called from the main thread when the wrapping generater is closed
+    # this gets called from the main thread when the wrapping generator is closed
     except GeneratorExit:
         # mark as exhausted
         exhausted = True

--- a/dlt/helpers/graphviz.py
+++ b/dlt/helpers/graphviz.py
@@ -153,7 +153,7 @@ def _get_graph_header(schema_name: str, include_dlt_tables: bool) -> str:
     ref for graph layout: https://graphviz.org/pdf/dot.1.pdf
     Good options:
     - `layout="twopi", ranksep=5, root="_dlt_loads"`
-        `ranksep` should be increased to accomodate large tables
+        `ranksep` should be increased to accommodate large tables
         `root` can be changed to a more central node
     - `layout=circo` is efficient, but will have edges overlapping
     - `layout=fdp` will minimize overlap while reducing sprawl, but odd layouts

--- a/dlt/load/utils.py
+++ b/dlt/load/utils.py
@@ -317,7 +317,7 @@ def filter_new_jobs(
     running_jobs: Sequence[LoadJob],
     available_slots: int,
 ) -> Sequence[str]:
-    """Filters the list of new jobs to adhere to max_workers and parallellism strategy"""
+    """Filters the list of new jobs to adhere to max_workers and parallelism strategy"""
     """NOTE: in the current setup we only filter based on settings for the final destination"""
     """Support for differentiating staging destination jobs might come in the future if we need it"""
 

--- a/dlt/pipeline/pipeline.py
+++ b/dlt/pipeline/pipeline.py
@@ -202,7 +202,7 @@ def with_schemas_sync(f: TFun) -> TFun:
                 self._schema_storage.save_import_schema_if_not_exists(schema)
                 # only now save the schema, already linked to itself if saved as import schema
                 self._schema_storage.commit_live_schema(name)
-            # refresh only when default_schema_name is aleady set
+            # refresh only when default_schema_name is already set
             if self.default_schema_name:
                 self.schema_names = self._list_schemas_sorted()
             return rv
@@ -1858,7 +1858,7 @@ class Pipeline(SupportsPipeline):
         if self._staging:
             state["staging_type"] = self._staging.destination_type
             state["staging_name"] = self._staging.configured_name
-        # update schemas only when default_schema_name is aleady set
+        # update schemas only when default_schema_name is already set
         # prevents race condition (another process writes schemas)
         if self.default_schema_name:
             state["schema_names"] = self._list_schemas_sorted()

--- a/docs/website/docs/dlt-ecosystem/destinations/iceberg.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/iceberg.md
@@ -133,7 +133,7 @@ Apache Iceberg supports [table partitioning](https://iceberg.apache.org/docs/lat
 2. Using column-level [`partition`](#using-column-level-partition-property) property - for simple identity partitioning
 
 :::note
-Iceberg uses [hidden partioning](https://iceberg.apache.org/docs/latest/partitioning/).
+Iceberg uses [hidden partitioning](https://iceberg.apache.org/docs/latest/partitioning/).
 :::
 
 :::warning

--- a/docs/website/docs/reference/performance.md
+++ b/docs/website/docs/reference/performance.md
@@ -6,7 +6,7 @@ keywords: [scaling, parallelism, finetuning]
 
 # Optimizing dlt
 
-This page contains a collection of tips and tricks to optimize dlt pipelines for speed, scalability and memory footprint. Keep in mind that dlt works in [three discreet stages](./explainers/how-dlt-works) that all have their own performance characteristics.
+This page contains a collection of tips and tricks to optimize dlt pipelines for speed, scalability and memory footprint. Keep in mind that dlt works in [three discrete stages](./explainers/how-dlt-works) that all have their own performance characteristics.
 
 
 ## Optimizing the extract stage


### PR DESCRIPTION
Fixes small English spelling typos across code comments, docstrings, and documentation. No functional or API changes — only text in comments/docstrings and two docs pages.

| File | Before | After |
|------|--------|-------|
| dlt/pipeline/pipeline.py (x2) | aleady | already |
| dlt/destinations/impl/clickhouse/configuration.py | additionaly | additionally |
| dlt/destinations/impl/synapse/configuration.py | innacurate | inaccurate |
| dlt/destinations/impl/synapse/synapse.py | endoint | endpoint |
| dlt/dataset/exceptions.py | orignal | original |
| dlt/common/utils.py | modifed | modified |
| dlt/common/configuration/plugins.py | inlcude | include |
| dlt/common/data_types/type_helpers.py | representaion | representation |
| dlt/common/storages/load_storage.py | normlized | normalized |
| dlt/common/data_writers/escape.py | compatibel | compatible |
| dlt/common/destination/client.py | abilty | ability |
| dlt/common/destination/dataset.py | Refere | Refer |
| dlt/common/libs/git.py | jus | just |
| dlt/common/schema/detections.py | withing | within |
| dlt/common/schema/typing.py | compatiblity | compatibility |
| dlt/load/utils.py | parallellism | parallelism |
| dlt/extract/items_transform.py | authoratitative | authoritative |
| dlt/extract/pipe_iterator.py | fucntions | functions |
| dlt/extract/utils.py | generater | generator |
| dlt/helpers/graphviz.py | accomodate | accommodate |
| dlt/destinations/impl/lancedb/sql_client.py | inferface | interface |
| docs/website/docs/dlt-ecosystem/destinations/iceberg.md | partioning | partitioning |
| docs/website/docs/reference/performance.md | discreet | discrete |

Found with codespell and each verified in context.