### PR TITLE
Docs/release highlights 1.22

### DIFF
--- a/docs/website/docs/release-notes/1.22.md
+++ b/docs/website/docs/release-notes/1.22.md
@@ -12,82 +12,153 @@ keywords: [dlt, data-pipelines, etl, release-notes, data-engineering]
 These changes may require updates to your pipelines.
 :::
 
-- **(1.22)** Pydantic v1 support removed. All Pydantic v1 compatibility code has been removed. dlt now requires Pydantic v2. If your project still depends on Pydantic v1, upgrade to Pydantic v2 before updating dlt.
-- **(1.22)** `data_type` schema contract now covers full data type. The `data_type` contract previously applied only to variant column changes. It now applies to the full data type, including `nullable`, `precision`, and `scale`. Users who have `data_type: freeze` configured and relied on being able to alter `nullable`, `precision`, or `scale` on existing columns will be blocked by the contract after upgrading.
+- **(1.22.1)** MCP server defaults to streamable-http transport and `/mcp` path. The workspace and pipeline MCP servers now use `streamable-http` transport by default instead of `sse`. The server path also changed from `/` to `/mcp`.
 
-Review your schema contract settings and adjust column definitions before upgrading if your pipelines depend on this behavior.
-- **(1.22)** `merge_columns` now removes compound properties before merging. The `merge_columns` schema utility was previously purely additive. When the source columns carried non-default values for compound properties such as `merge_key`, `primary_key`, `partition`, or `cluster`, those properties are now first cleared from the target columns before the merge is applied.
+If you have existing MCP client configurations, update the URL:
 
-This corrects a longstanding bug where compound properties like `merge_key` could accumulate stale values from earlier pipeline runs instead of reflecting the current resource definition. Pipelines that relied on the old additive behavior for compound column properties will see different schema results after upgrading.
+```json
+{
+  "mcpServers": {
+    "dlt-workspace": {
+      "url": "http://127.0.0.1:43654/mcp"
+    },
+    "dlt-pipeline-mcp": {
+      "url": "http://127.0.0.1:43656/mcp"
+    }
+  }
+}
+```
+
+Legacy `sse` transport remains available via the `--sse` flag. Stdio transport is unchanged. (PR [#3624](https://github.com/dlt-hub/dlt/pull/3624))
+- **(1.22)** Pydantic v1 support removed. All Pydantic v1 compatibility code has been removed. Projects that import from `pydantic.v1`, use `@validator`, `orm_mode`, `parse_obj`, or other v1-specific APIs must migrate to Pydantic v2 before upgrading to 1.22.
+- **(1.22)** `data_type` schema contract now covers full type definition. The `data_type` schema contract previously applied only when a column changed to the variant data type. It now applies to the full type definition, including precision, scale, and nullability. If you use `data_type: freeze` and expected to freely change `nullable`, `precision`, or `scale` on existing columns, those changes will now be blocked by the contract.
+- **(1.22)** `merge_columns` now removes compound properties before merging. `merge_columns` was previously purely additive and never cleared existing compound column properties. It now correctly removes compound properties such as `merge_key`, `primary_key`, `partition`, and `cluster` from the target columns before applying the source definition. Pipelines that relied on the old additive behavior may see different key assignments after upgrade.
 
 ## Pydantic data validation overhaul
 
-The Pydantic integration has been substantially reworked in this release. Discriminated union `RootModel` types are now supported, enabling validation of event streams that carry multiple event types in a single resource. Schema contracts now properly distinguish between resource-defined hints and data-derived hints, so Pydantic model columns bypass contract checks when they are authoritative. Arrow table items and Pydantic model items are both fully supported with schema contract enforcement. This work also prepares the codebase for Pydantic v3.
-
-Note: Pydantic v1 is no longer supported. See the breaking changes section for details.
+The Pydantic integration has been significantly reworked. Pydantic v1 support is fully removed (see breaking changes). The new implementation supports discriminated union `RootModel` types, which allows validating event streams where different events carry different shapes. Schema contracts now properly separate resource-defined hints from data-derived hints, and Pydantic model columns bypass contract checks when the model is considered authoritative. Arrow items and model items both support full schema contract enforcement. The codebase is also prepared for future Pydantic v3 compatibility. See [PR #3572](https://github.com/dlt-hub/dlt/pull/3572) for full details.
 
 ## Snowflake atomic table swap for `replace`
 
-When using the `staging-optimized` replace strategy on Snowflake, dlt now performs an `ALTER TABLE ... SWAP` operation instead of dropping and recreating the destination table. This eliminates table downtime during data replacement, making atomic swaps the default path for Snowflake staging-optimized loads.
+When using the `staging-optimized` replace strategy on Snowflake, dlt now uses `ALTER TABLE ... SWAP` to swap the staging table into place. This eliminates table downtime during data replacement: the destination table remains available for queries throughout the operation and the swap is atomic. No changes are required to existing pipelines that already use the `staging-optimized` strategy. See [PR #3540](https://github.com/dlt-hub/dlt/pull/3540) for details.
 
-## Custom backends for `sql_database`
+## `rest_api`: parallelized dependent resources
 
-You can now register custom `TableLoader` implementations as named backends for the `sql_database` source. This lets you plug in alternative loading strategies alongside the built-in backends. The ConnectorX backend has been ported as a proof of concept, and ADBC and a paginated loader are available as test-case references.
+Dependent resources (transformers) in `rest_api` sources now support a `parallelized` flag that lets child resource fetches run concurrently. This can significantly improve throughput when a parent resource produces many IDs that each require a separate API call. See [PR #3574](https://github.com/dlt-hub/dlt/pull/3574) for usage details and configuration.
 
-## SQLAlchemy destination dialect customization
+## `dlt.Relation`: filter by load ID
 
-The SQLAlchemy destination now supports per-dialect customization. You can supply a custom type mapper to change how dlt types translate to SQL column types, adjust `Table` schemas before they are created, and override destination capabilities for non-standard dialects. This makes it practical to use the SQLAlchemy destination against specialized or exotic databases without forking the destination code.
-
-## Parallelized dependent resources in `rest_api`
-
-The `rest_api` source now accepts a `parallelized` flag on dependent resources (transformers). When set, child resource fetches run concurrently instead of sequentially. Pipelines that fan out from a parent resource to many child endpoints benefit immediately from this flag without any other changes.
-
-## `dlt.Relation` and `dlt.Dataset`: filter rows by load ID
-
-Datasets and relations now expose first-class helpers for working with load IDs. `dataset.load_ids()` retrieves all load IDs recorded for the dataset, and `dataset.latest_load_id()` returns the most recent one. Pass `load_ids` to `dataset.table()` or call `relation.from_loads()` to get back only the rows that belong to the specified loads.
-
-This feature is experimental.
+`dlt.Dataset` now provides helpers to work with load IDs directly and to filter any relation to rows from a specific set of loads. This feature is marked experimental.
 
 ```py
-import dlt
-
-pipeline = dlt.pipeline(pipeline_name="my_pipeline", destination="duckdb")
 dataset = pipeline.dataset()
 
-# Retrieve all recorded load IDs
-load_ids = dataset.load_ids()
+# Retrieve all load IDs recorded for this dataset
+all_ids = dataset.load_ids()
 
-# Read only rows from the most recent load
-latest = dataset.latest_load_id()
-df = dataset.table("orders", load_ids=[latest]).df()
+# Or retrieve just the latest load ID
+latest_id = dataset.latest_load_id()
 
-# Or filter an existing relation
-rel = dataset.table("orders").from_loads([load_ids[-1]])
+# Filter a table to rows from the latest load only
+df = dataset.table("users", load_ids=[latest_id]).df()
 ```
-
-## Source preprocessors on `dlt.source` factory
-
-The `dlt.source` factory now accepts preprocessor hooks. A preprocessor receives a freshly created source instance and can modify it before the pipeline runs it. This is useful for applying cross-cutting configuration, injecting resources, or normalizing options in one place across all calls to the same source factory.
 
 ## `engine_kwargs` for `sql_database` and `sql_table`
 
-Both the `sql_database` source and the `sql_table` resource now accept an `engine_kwargs` parameter that is forwarded directly to SQLAlchemy's `create_engine()`. Use it to configure connection pooling, statement timeouts, SSL settings, or any other engine-level option without subclassing the source.
+The `sql_database` and `sql_table` sources now accept an `engine_kwargs` parameter that is forwarded directly to SQLAlchemy's `create_engine()`. This lets you set connection pool settings, SSL options, and other driver-specific arguments without patching the source. See [PR #3414](https://github.com/dlt-hub/dlt/pull/3414) for details.
+
+## Updates in 1.22.2
+
+### Hugging Face Datasets destination
+
+The `filesystem` destination now supports loading directly into [Hugging Face Datasets](https://huggingface.co/docs/datasets/index) repositories using the `hf://` protocol.
+
+Install the extra and point your `bucket_url` at your namespace:
+
+```sh
+pip install "dlt[hf]"
+```
+
+```toml
+[destination.filesystem]
+bucket_url = "hf://datasets/my-org"
+
+[destination.filesystem.credentials]
+hf_token = "hf_..."    # or set HF_TOKEN env var, or use huggingface-cli login
+```
+
+The destination automatically writes Parquet files (required by the HF dataset viewer), batches all file writes for a table into a single atomic commit to stay within HF rate limits, and creates one HF dataset repository per dlt dataset. Delta and Iceberg table formats are not supported for this protocol.
+
+See the new [Hugging Face destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/huggingface) for the full setup guide.
+
+### Hugging Face dataset cards with subset metadata
+
+When loading to Hugging Face, dlt now creates and updates a dataset card (`README.md`) with YAML metadata that configures a named subset for each table. This is required for the [HF dataset viewer](https://huggingface.co/docs/dataset-viewer/index) to display individual tables correctly in the Hub UI.
+
+The behavior is enabled by default and is controlled by the `hf_dataset_card` config option:
+
+```toml
+[destination.filesystem]
+hf_dataset_card = true    # default; set to false to skip dataset card updates
+```
+
+### Composable marimo widgets
+
+The marimo helpers in `dlt[workspace]` now ship composable widgets: each widget can accept inputs and expose outputs, enabling you to wire widgets together in a notebook. This requires Python 3.11+ and the `mowidgets` package (included in `dlt[workspace]`).
+
+Three widgets are available: `pipeline_selector` (new), `load_package_viewer` (updated), and `schema_viewer` (updated). Import them and pass them to `render()`:
 
 ```py
-import dlt
-from dlt.sources.sql_database import sql_database
+#%% cell 1
+from dlt.helpers.marimo import render, load_package_viewer, pipeline_selector
 
-source = sql_database(
-    "postgresql://user:pass@host/db",
-    engine_kwargs={"pool_size": 5, "connect_args": {"connect_timeout": 10}},
-)
+#%% cell 2
+render(pipeline_selector)
+
+#%% cell 3
+render(load_package_viewer, pipeline_path="/path/to/pipeline")
 ```
+
+For marimo versions below 0.19, the older read-only widget behavior is used. See the [marimo docs page](https://dlthub.com/docs/general-usage/dataset-access/marimo) for details.
+
+### Dashboard UX improvements
+
+The dlt workspace dashboard received several layout improvements. Collapsed sections now display the title and a short subtitle on a single line (subtitle is hidden on viewports narrower than 900px), reducing vertical clutter. The Ibis backend section is now hidden in app/read mode because it is a developer-only tool.
+
+## Updates in 1.22.1
+
+### ClickHouse reads are now sequentially consistent by default
+
+dlt now sets `select_sequential_consistency = 1` on all ClickHouse connections by default. This ensures `SELECT` queries always see the results of preceding writes on ClickHouse Cloud (SharedMergeTree) and self-hosted clusters where queries may be routed to different nodes.
+
+If you run read-only workloads and want to avoid the small metadata check overhead, you can opt out:
+
+```toml
+[destination.clickhouse]
+select_sequential_consistency = 0
+```
+
+(PR [#3651](https://github.com/dlt-hub/dlt/pull/3651))
+
+### `WorkspaceFileSelector` ships with built-in exclude patterns
+
+`WorkspaceFileSelector` now includes `DEFAULT_EXCLUDES` that automatically filter out well-known non-deployable paths such as `.git/`, `.venv/`, `__pycache__/`, and `node_modules/`. These patterns apply even when no `.gitignore` file is present in the workspace. (PR [#3661](https://github.com/dlt-hub/dlt/pull/3661))
+
+### `WorkspaceFileSelector` exposes `ignore_file_found`
+
+`WorkspaceFileSelector` now has an `ignore_file_found` attribute. Use it to check at runtime whether the configured ignore file (for example `.gitignore`) was actually found in the workspace. (PR [#3663](https://github.com/dlt-hub/dlt/pull/3663))
+
+### `.to_mermaid()` handles incomplete columns
+
+`.to_mermaid()` no longer raises an error when a column in the schema is missing its `data_type` field. Columns without a known type are now rendered as `no_data_seen <column_name>` instead of crashing. (PR [#3659](https://github.com/dlt-hub/dlt/pull/3659))
+
+### Dashboard data quality checks section fixed
+
+The data quality checks section of the dlt dashboard was silently broken by a change in the upstream `dlthub` package. It is now repaired and reads results correctly. (PR [#3647](https://github.com/dlt-hub/dlt/pull/3647))
 
 ## Shout-out to new contributors
 
 Welcome to our new contributors who made their first contribution in this release: @Shadesfear (#3574), @ShreyasGS (#3603), @arel (#3566), @karlanka (#3606), @kien-truong (#3571), and @thecaptain789 (#3616).
-
-Thank you to everyone who contributed to this release: @anuunchin, @rudolfix, @Travior, @zilto, @Shadesfear, @tetelio, @ivasio, @arel, @warje, @karlanka, @kien-truong, @thecaptain789, @ShreyasGS, @djudjuu, @dat-a-man, @kaliole, @michelzurkirchen, @VioletM, and @timH6502.
 
 **Full release notes**
 

--- a/docs/website/docs/release-notes/1.22.md
+++ b/docs/website/docs/release-notes/1.22.md
@@ -8,158 +8,144 @@ keywords: [dlt, data-pipelines, etl, release-notes, data-engineering]
 
 ## Breaking changes
 
-:::warning
-These changes may require updates to your pipelines.
-:::
+- **Pydantic v1 support removed.** All Pydantic v1 compatibility code has been removed. dlt now requires Pydantic v2. If your pipeline uses v1-only APIs such as `.dict()`, `@validator`, `@root_validator`, `orm_mode`, `__root__`, or `parse_obj`, you must migrate to their Pydantic v2 equivalents before upgrading. See [PR #3572](https://github.com/dlt-hub/dlt/pull/3572).
+- **`data_type` contract semantic change.** The `data_type` schema contract now applies to the full data type, including precision, nullability, and scale, not only to variant column changes. Users who relied on `data_type: freeze` while still modifying `nullable`, `precision`, or `scale` on existing columns will now see those modifications blocked. Adjust your schema contracts or column hints accordingly. See [PR #3572](https://github.com/dlt-hub/dlt/pull/3572).
+- **`merge_columns` now removes compound properties.** `merge_columns` now correctly removes compound properties such as `merge_key`, `primary_key`, `partition`, and `cluster` from the target columns when the source specifies new values for those properties. Previously the function was purely additive, which caused incorrect merges when keys changed between runs. Pipelines that relied on the old additive behavior for compound properties should review their schema hints. See [PR #3431](https://github.com/dlt-hub/dlt/pull/3431).
 
-- **(1.22.1)** MCP server defaults to streamable-http transport and `/mcp` path. The workspace and pipeline MCP servers now use `streamable-http` transport by default instead of `sse`. The server path also changed from `/` to `/mcp`.
+## Pydantic v2 data validation overhaul
 
-If you have existing MCP client configurations, update the URL:
+dlt now requires Pydantic v2 exclusively and ships a major rework of its Pydantic validation layer. Discriminated union `RootModel` types are now supported, letting you validate event streams where different event types share a common root schema. Schema contracts now properly distinguish resource-defined hints from data-derived ones, so Pydantic model columns bypass contract checks when they act as the authoritative schema source. Arrow tables and model items are both covered by full schema contract enforcement. This release also lays the groundwork for Pydantic v3 compatibility. See [PR #3572](https://github.com/dlt-hub/dlt/pull/3572) for migration guidance.
 
-```json
-{
-  "mcpServers": {
-    "dlt-workspace": {
-      "url": "http://127.0.0.1:43654/mcp"
-    },
-    "dlt-pipeline-mcp": {
-      "url": "http://127.0.0.1:43656/mcp"
-    }
-  }
-}
-```
+## Snowflake atomic table swap for replace
 
-Legacy `sse` transport remains available via the `--sse` flag. Stdio transport is unchanged. (PR [#3624](https://github.com/dlt-hub/dlt/pull/3624))
-- **(1.22)** Pydantic v1 support removed. All Pydantic v1 compatibility code has been removed. Projects that import from `pydantic.v1`, use `@validator`, `orm_mode`, `parse_obj`, or other v1-specific APIs must migrate to Pydantic v2 before upgrading to 1.22.
-- **(1.22)** `data_type` schema contract now covers full type definition. The `data_type` schema contract previously applied only when a column changed to the variant data type. It now applies to the full type definition, including precision, scale, and nullability. If you use `data_type: freeze` and expected to freely change `nullable`, `precision`, or `scale` on existing columns, those changes will now be blocked by the contract.
-- **(1.22)** `merge_columns` now removes compound properties before merging. `merge_columns` was previously purely additive and never cleared existing compound column properties. It now correctly removes compound properties such as `merge_key`, `primary_key`, `partition`, and `cluster` from the target columns before applying the source definition. Pipelines that relied on the old additive behavior may see different key assignments after upgrade.
+When you use the `staging-optimized` replace strategy on Snowflake, dlt now executes `ALTER TABLE ... SWAP` to replace the target table atomically. This eliminates the window between the old table being dropped and the new one becoming available during a replace load. No configuration change is required. The swap is applied automatically for Snowflake pipelines using this replace strategy.
 
-## Pydantic data validation overhaul
+## Parallelized dependent resources in `rest_api`
 
-The Pydantic integration has been significantly reworked. Pydantic v1 support is fully removed (see breaking changes). The new implementation supports discriminated union `RootModel` types, which allows validating event streams where different events carry different shapes. Schema contracts now properly separate resource-defined hints from data-derived hints, and Pydantic model columns bypass contract checks when the model is considered authoritative. Arrow items and model items both support full schema contract enforcement. The codebase is also prepared for future Pydantic v3 compatibility. See [PR #3572](https://github.com/dlt-hub/dlt/pull/3572) for full details.
+Dependent resources (transformers) in the `rest_api` source now support a `parallelized` flag. Setting it on a child resource causes its HTTP requests to run concurrently rather than sequentially, reducing total extraction time for APIs with many parent-child relationships. See [PR #3574](https://github.com/dlt-hub/dlt/pull/3574) for configuration details.
 
-## Snowflake atomic table swap for `replace`
+## Filter `dlt.Relation` by load ID
 
-When using the `staging-optimized` replace strategy on Snowflake, dlt now uses `ALTER TABLE ... SWAP` to swap the staging table into place. This eliminates table downtime during data replacement: the destination table remains available for queries throughout the operation and the swap is atomic. No changes are required to existing pipelines that already use the `staging-optimized` strategy. See [PR #3540](https://github.com/dlt-hub/dlt/pull/3540) for details.
-
-## `rest_api`: parallelized dependent resources
-
-Dependent resources (transformers) in `rest_api` sources now support a `parallelized` flag that lets child resource fetches run concurrently. This can significantly improve throughput when a parent resource produces many IDs that each require a separate API call. See [PR #3574](https://github.com/dlt-hub/dlt/pull/3574) for usage details and configuration.
-
-## `dlt.Relation`: filter by load ID
-
-`dlt.Dataset` now provides helpers to work with load IDs directly and to filter any relation to rows from a specific set of loads. This feature is marked experimental.
+Datasets now expose methods to list load IDs and relations can be scoped to a specific set of loads. This is an experimental feature.
 
 ```py
+import dlt
+
+pipeline = dlt.pipeline(pipeline_name="my_pipeline", destination="duckdb")
 dataset = pipeline.dataset()
 
-# Retrieve all load IDs recorded for this dataset
-all_ids = dataset.load_ids()
+# List all load IDs or retrieve the most recent one
+load_ids = dataset.load_ids()
+latest = dataset.latest_load_id()
 
-# Or retrieve just the latest load ID
-latest_id = dataset.latest_load_id()
+# Fetch only rows written in the latest load
+users = dataset.table("users", load_ids=[latest])
 
-# Filter a table to rows from the latest load only
-df = dataset.table("users", load_ids=[latest_id]).df()
+# Or filter an existing relation
+users_from_load = dataset.table("users").from_loads([latest])
+df = users_from_load.df()
 ```
 
-## `engine_kwargs` for `sql_database` and `sql_table`
+## Engine options for `sql_database` sources
 
-The `sql_database` and `sql_table` sources now accept an `engine_kwargs` parameter that is forwarded directly to SQLAlchemy's `create_engine()`. This lets you set connection pool settings, SSL options, and other driver-specific arguments without patching the source. See [PR #3414](https://github.com/dlt-hub/dlt/pull/3414) for details.
+The `sql_database` and `sql_table` verified sources now accept an `engine_kwargs` parameter that is forwarded directly to SQLAlchemy's `create_engine()`. Use it to pass driver-specific options, connection pool settings, or other engine configuration when defining your source without needing to subclass or patch the source. See [PR #3414](https://github.com/dlt-hub/dlt/pull/3414) for usage examples.
+
+## Athena managed results bucket now optional
+
+The `query_result_bucket` configuration option for the Athena destination is now optional. You can omit it or set it to `None` to use Athena's own managed results bucket, removing the requirement to provision and specify an S3 location for query outputs. See [PR #3566](https://github.com/dlt-hub/dlt/pull/3566) for details.
+
+## SQLAlchemy destination dialect customization
+
+The SQLAlchemy destination now supports per-dialect customization. You can supply a custom type mapper to change how dlt maps its data types to SQLAlchemy column types, adjust table schemas before they are created, and override destination capabilities for a specific dialect. This makes it practical to target databases that need non-default type or constraint handling. See [PR #3600](https://github.com/dlt-hub/dlt/pull/3600) for the customization API.
+
+## ClickHouse role-based S3 authentication
+
+The ClickHouse destination now supports an `extra_credentials` configuration key for role-based S3 authentication. This allows ClickHouse to access S3 buckets using IAM roles instead of explicit access key credentials. See [PR #2888](https://github.com/dlt-hub/dlt/pull/2888) for configuration details.
 
 ## Updates in 1.22.2
 
-### Hugging Face Datasets destination
+### Hugging Face as a filesystem destination
 
-The `filesystem` destination now supports loading directly into [Hugging Face Datasets](https://huggingface.co/docs/datasets/index) repositories using the `hf://` protocol.
+The `filesystem` destination now supports loading directly into [Hugging Face Datasets](https://huggingface.co/docs/datasets/index) repositories via the `hf://` protocol. Install the extra with `pip install "dlt[hf]"`, set `bucket_url` to `hf://datasets/<namespace>`, and provide a Hugging Face User Access Token.
 
-Install the extra and point your `bucket_url` at your namespace:
+Each dlt dataset becomes a separate Hugging Face dataset repository. The destination defaults to Parquet with page index and content-defined chunking so the Hugging Face dataset viewer can preview tables correctly. All files for a table are committed atomically in a single API call to keep commit counts low and avoid rate limits.
 
-```sh
-pip install "dlt[hf]"
-```
+A dataset card (`README.md`) with subset metadata is written automatically, giving each table its own subset in the dataset viewer. This behavior is controlled by the `hf_dataset_card` setting, which defaults to `true`. Delta and Iceberg table formats are not supported for this protocol.
 
 ```toml
 [destination.filesystem]
 bucket_url = "hf://datasets/my-org"
 
 [destination.filesystem.credentials]
-hf_token = "hf_..."    # or set HF_TOKEN env var, or use huggingface-cli login
+hf_token = "hf_..."  # or use HF_TOKEN env var, or huggingface-cli login
 ```
 
-The destination automatically writes Parquet files (required by the HF dataset viewer), batches all file writes for a table into a single atomic commit to stay within HF rate limits, and creates one HF dataset repository per dlt dataset. Delta and Iceberg table formats are not supported for this protocol.
-
-See the new [Hugging Face destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/huggingface) for the full setup guide.
-
-### Hugging Face dataset cards with subset metadata
-
-When loading to Hugging Face, dlt now creates and updates a dataset card (`README.md`) with YAML metadata that configures a named subset for each table. This is required for the [HF dataset viewer](https://huggingface.co/docs/dataset-viewer/index) to display individual tables correctly in the Hub UI.
-
-The behavior is enabled by default and is controlled by the `hf_dataset_card` config option:
-
-```toml
-[destination.filesystem]
-hf_dataset_card = true    # default; set to false to skip dataset card updates
-```
+See the [Hugging Face destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/huggingface) for the full setup guide.
 
 ### Composable marimo widgets
 
-The marimo helpers in `dlt[workspace]` now ship composable widgets: each widget can accept inputs and expose outputs, enabling you to wire widgets together in a notebook. This requires Python 3.11+ and the `mowidgets` package (included in `dlt[workspace]`).
+The `dlt.helpers.marimo` module now exposes composable widgets built with the `mowidgets` library (Python 3.11 and above). Unlike the previous read-only widgets, composable widgets accept inputs and return outputs, making them easy to chain inside a marimo notebook.
 
-Three widgets are available: `pipeline_selector` (new), `load_package_viewer` (updated), and `schema_viewer` (updated). Import them and pass them to `render()`:
+This release adds a new `pipeline_selector` widget and refreshed versions of `schema_viewer` and `load_package_viewer`. Install with `pip install "dlt[workspace]"`.
 
 ```py
-#%% cell 1
 from dlt.helpers.marimo import render, load_package_viewer, pipeline_selector
 
-#%% cell 2
+# display the pipeline selector widget
 render(pipeline_selector)
 
-#%% cell 3
+# display the load package viewer for a specific pipeline path
 render(load_package_viewer, pipeline_path="/path/to/pipeline")
 ```
 
-For marimo versions below 0.19, the older read-only widget behavior is used. See the [marimo docs page](https://dlthub.com/docs/general-usage/dataset-access/marimo) for details.
+See the [marimo docs](https://dlthub.com/docs/general-usage/dataset-access/marimo) for details and examples.
 
-### Dashboard UX improvements
+### Dashboard layout improvements
 
-The dlt workspace dashboard received several layout improvements. Collapsed sections now display the title and a short subtitle on a single line (subtitle is hidden on viewports narrower than 900px), reducing vertical clutter. The Ibis backend section is now hidden in app/read mode because it is a developer-only tool.
+The marimo pipeline dashboard now shows the section title and subtitle on a single line when a section is collapsed, reducing vertical space. On viewports narrower than 900px the subtitle is hidden and only the title and toggle remain visible. Long subtitles for the trace, loads, and Ibis backend sections have been shortened. The Ibis backend section is now hidden in read and app mode because it is a developer-only tool.
 
 ## Updates in 1.22.1
 
-### ClickHouse reads are now sequentially consistent by default
+### MCP servers now default to streamable-http transport
 
-dlt now sets `select_sequential_consistency = 1` on all ClickHouse connections by default. This ensures `SELECT` queries always see the results of preceding writes on ClickHouse Cloud (SharedMergeTree) and self-hosted clusters where queries may be routed to different nodes.
+The `dlt pipeline mcp` and `dlt workspace mcp` commands now use `streamable-http` (MCP spec 2025-03-26) as the default transport instead of `sse`. The server path also changed from `/` to `/mcp`, so update any MCP client configuration to the new URLs:
 
-If you run read-only workloads and want to avoid the small metadata check overhead, you can opt out:
+```text
+http://127.0.0.1:43654/mcp   # workspace MCP
+http://127.0.0.1:43656/mcp   # pipeline MCP
+```
+
+Legacy `sse` and `stdio` transports remain available via `--sse` and `--stdio` flags. The `mcp` dependency requirement was bumped accordingly. See [PR #3624](https://github.com/dlt-hub/dlt/pull/3624).
+
+### ClickHouse enforces sequential read consistency by default
+
+dlt now sets `select_sequential_consistency=1` on all ClickHouse connections. This ensures `SELECT` queries see preceding writes on ClickHouse Cloud (SharedMergeTree) and self-hosted clusters where queries can be routed to different nodes. To opt out for read-only workloads:
 
 ```toml
 [destination.clickhouse]
 select_sequential_consistency = 0
 ```
 
-(PR [#3651](https://github.com/dlt-hub/dlt/pull/3651))
+The setting can also be passed to the factory: `clickhouse(select_sequential_consistency=0)`. See [PR #3651](https://github.com/dlt-hub/dlt/pull/3651).
 
-### `WorkspaceFileSelector` ships with built-in exclude patterns
+### WorkspaceFileSelector ships with built-in exclude patterns
 
-`WorkspaceFileSelector` now includes `DEFAULT_EXCLUDES` that automatically filter out well-known non-deployable paths such as `.git/`, `.venv/`, `__pycache__/`, and `node_modules/`. These patterns apply even when no `.gitignore` file is present in the workspace. (PR [#3661](https://github.com/dlt-hub/dlt/pull/3661))
+`WorkspaceFileSelector` now includes `DEFAULT_EXCLUDES` covering well-known non-deployable paths such as `.git/`, `.venv/`, `__pycache__/`, and `node_modules/`. These paths are excluded automatically even without a `.gitignore` file present.
 
-### `WorkspaceFileSelector` exposes `ignore_file_found`
+A companion `ignore_file_found` attribute lets callers verify whether the configured ignore file (e.g., `.gitignore`) was actually located on disk. See [PR #3661](https://github.com/dlt-hub/dlt/pull/3661) and [PR #3663](https://github.com/dlt-hub/dlt/pull/3663).
 
-`WorkspaceFileSelector` now has an `ignore_file_found` attribute. Use it to check at runtime whether the configured ignore file (for example `.gitignore`) was actually found in the workspace. (PR [#3663](https://github.com/dlt-hub/dlt/pull/3663))
+### Fix: `.to_mermaid()` no longer crashes on columns without a data type
 
-### `.to_mermaid()` handles incomplete columns
+Schema columns that have not yet recorded a `data_type` (arising from seen-null-first propagation) caused `.to_mermaid()` to raise a `KeyError`. The method now gracefully handles these incomplete columns. See [PR #3659](https://github.com/dlt-hub/dlt/pull/3659).
 
-`.to_mermaid()` no longer raises an error when a column in the schema is missing its `data_type` field. Columns without a known type are now rendered as `no_data_seen <column_name>` instead of crashing. (PR [#3659](https://github.com/dlt-hub/dlt/pull/3659))
+### Fix: data quality checks dashboard component restored
 
-### Dashboard data quality checks section fixed
-
-The data quality checks section of the dlt dashboard was silently broken by a change in the upstream `dlthub` package. It is now repaired and reads results correctly. (PR [#3647](https://github.com/dlt-hub/dlt/pull/3647))
+The data quality checks section of the dlt dashboard was silently broken after an upstream `dlthub` API change. It now correctly uses `dq.read_check()` to query results. See [PR #3647](https://github.com/dlt-hub/dlt/pull/3647).
 
 ## Shout-out to new contributors
 
-Welcome to our new contributors who made their first contribution in this release: @Shadesfear (#3574), @ShreyasGS (#3603), @arel (#3566), @karlanka (#3606), @kien-truong (#3571), and @thecaptain789 (#3616).
+Welcome to our new contributors: @Shadesfear, @ShreyasGS, @arel, @karlanka, @kien-truong, and @thecaptain789 made their first contributions to dlt in this release.
 
 **Full release notes**
 
-[View the complete list of changes](https://github.com/dlt-hub/dlt/releases)
+[View the 1.22.0 release notes](https://github.com/dlt-hub/dlt/releases/tag/1.22.0)

--- a/docs/website/docs/release-notes/1.22.md
+++ b/docs/website/docs/release-notes/1.22.md
@@ -8,139 +8,129 @@ keywords: [dlt, data-pipelines, etl, release-notes, data-engineering]
 
 ## Breaking changes
 
-- **Pydantic v1 support removed.** All Pydantic v1 compatibility code has been removed. dlt now requires Pydantic v2. If your pipeline uses v1-only APIs such as `.dict()`, `@validator`, `@root_validator`, `orm_mode`, `__root__`, or `parse_obj`, you must migrate to their Pydantic v2 equivalents before upgrading. See [PR #3572](https://github.com/dlt-hub/dlt/pull/3572).
-- **`data_type` contract semantic change.** The `data_type` schema contract now applies to the full data type, including precision, nullability, and scale, not only to variant column changes. Users who relied on `data_type: freeze` while still modifying `nullable`, `precision`, or `scale` on existing columns will now see those modifications blocked. Adjust your schema contracts or column hints accordingly. See [PR #3572](https://github.com/dlt-hub/dlt/pull/3572).
-- **`merge_columns` now removes compound properties.** `merge_columns` now correctly removes compound properties such as `merge_key`, `primary_key`, `partition`, and `cluster` from the target columns when the source specifies new values for those properties. Previously the function was purely additive, which caused incorrect merges when keys changed between runs. Pipelines that relied on the old additive behavior for compound properties should review their schema hints. See [PR #3431](https://github.com/dlt-hub/dlt/pull/3431).
+- **Pydantic v1 support removed.** All Pydantic v1 compatibility code has been removed. dlt now requires Pydantic v2. Upgrade your project to Pydantic v2 before updating to dlt 1.22. [See PR #3572](https://github.com/dlt-hub/dlt/pull/3572).
+- **`data_type` schema contract now covers full column type.** The `data_type` schema contract previously applied only when a column's data type changed (variant column detection). It now applies to the full column type definition, including `precision`, `scale`, and `nullable`. Pipelines that use `data_type: freeze` and previously allowed changing `nullable` or `precision` on an existing column will have those changes blocked after upgrading. Review your schema contract settings and column hint usage before upgrading. [See PR #3572](https://github.com/dlt-hub/dlt/pull/3572).
+- **`merge_columns` now removes compound properties.** The `merge_columns` schema utility was previously purely additive, which caused compound column properties (`merge_key`, `primary_key`, `cluster`, `partition`) to accumulate rather than be properly replaced. When source columns assign a non-default value to a compound property, `merge_columns` now removes that property from all target columns before merging, making the source assignment the sole authoritative value. If you relied on the old additive behavior for these hints, review your schema update logic. [See PR #3431](https://github.com/dlt-hub/dlt/pull/3431).
 
-## Pydantic v2 data validation overhaul
+## Pydantic data validation overhaul
 
-dlt now requires Pydantic v2 exclusively and ships a major rework of its Pydantic validation layer. Discriminated union `RootModel` types are now supported, letting you validate event streams where different event types share a common root schema. Schema contracts now properly distinguish resource-defined hints from data-derived ones, so Pydantic model columns bypass contract checks when they act as the authoritative schema source. Arrow tables and model items are both covered by full schema contract enforcement. This release also lays the groundwork for Pydantic v3 compatibility. See [PR #3572](https://github.com/dlt-hub/dlt/pull/3572) for migration guidance.
+The Pydantic integration has been substantially reworked. Discriminated union `RootModel` types are now supported, letting you validate event streams that contain multiple event types with a single model. Schema contracts now correctly separate resource-defined hints from data-derived hints, so Pydantic model columns skip contract enforcement when they are the authoritative source of truth. Pydantic models now work with Arrow-backed resources and enforce schema contracts on model items. The release also prepares the integration for Pydantic v3 compatibility.
 
-## Snowflake atomic table swap for replace
+Note that Pydantic v1 support has been removed in this release (see breaking changes). [See PR #3572](https://github.com/dlt-hub/dlt/pull/3572) for full details.
 
-When you use the `staging-optimized` replace strategy on Snowflake, dlt now executes `ALTER TABLE ... SWAP` to replace the target table atomically. This eliminates the window between the old table being dropped and the new one becoming available during a replace load. No configuration change is required. The swap is applied automatically for Snowflake pipelines using this replace strategy.
+## Snowflake atomic table swap for `replace`
+
+The `staging-optimized` replace strategy on Snowflake now uses `ALTER TABLE ... SWAP WITH` to atomically swap the staging table into place. This eliminates the window during which the destination table is empty, so readers that query the table during a load no longer see missing data. No configuration change is required. The behavior activates automatically for any Snowflake pipeline that already uses the `staging-optimized` replace strategy. [See PR #3540](https://github.com/dlt-hub/dlt/pull/3540).
 
 ## Parallelized dependent resources in `rest_api`
 
-Dependent resources (transformers) in the `rest_api` source now support a `parallelized` flag. Setting it on a child resource causes its HTTP requests to run concurrently rather than sequentially, reducing total extraction time for APIs with many parent-child relationships. See [PR #3574](https://github.com/dlt-hub/dlt/pull/3574) for configuration details.
+Dependent resources (transformers) in the `rest_api` source now support a `parallelized` flag. When set to `true`, child resource requests are dispatched concurrently rather than one at a time, which can substantially reduce total pipeline run time for APIs with many parent records and per-record child endpoints. [See PR #3574](https://github.com/dlt-hub/dlt/pull/3574).
 
-## Filter `dlt.Relation` by load ID
+## Filter dataset relations by load ID
 
-Datasets now expose methods to list load IDs and relations can be scoped to a specific set of loads. This is an experimental feature.
+Dataset relations can now be filtered to rows associated with a specific pipeline run. The new `from_loads()` method on `Relation` and the `load_ids` parameter on `dataset.table()` handle the join to `_dlt_loads` automatically. Helper methods on `Dataset` return available load IDs. This feature is experimental.
 
 ```py
-import dlt
-
-pipeline = dlt.pipeline(pipeline_name="my_pipeline", destination="duckdb")
 dataset = pipeline.dataset()
 
-# List all load IDs or retrieve the most recent one
-load_ids = dataset.load_ids()
+# get all load IDs or the most recent one
+all_ids = dataset.load_ids()
 latest = dataset.latest_load_id()
 
-# Fetch only rows written in the latest load
-users = dataset.table("users", load_ids=[latest])
+# filter a table to rows from a specific load
+rel = dataset.table("users", load_ids=[latest])
 
-# Or filter an existing relation
-users_from_load = dataset.table("users").from_loads([latest])
-df = users_from_load.df()
+# alternative: filter after constructing the relation
+rel = dataset.table("users").from_loads([latest])
 ```
 
-## Engine options for `sql_database` sources
-
-The `sql_database` and `sql_table` verified sources now accept an `engine_kwargs` parameter that is forwarded directly to SQLAlchemy's `create_engine()`. Use it to pass driver-specific options, connection pool settings, or other engine configuration when defining your source without needing to subclass or patch the source. See [PR #3414](https://github.com/dlt-hub/dlt/pull/3414) for usage examples.
-
-## Athena managed results bucket now optional
-
-The `query_result_bucket` configuration option for the Athena destination is now optional. You can omit it or set it to `None` to use Athena's own managed results bucket, removing the requirement to provision and specify an S3 location for query outputs. See [PR #3566](https://github.com/dlt-hub/dlt/pull/3566) for details.
-
-## SQLAlchemy destination dialect customization
-
-The SQLAlchemy destination now supports per-dialect customization. You can supply a custom type mapper to change how dlt maps its data types to SQLAlchemy column types, adjust table schemas before they are created, and override destination capabilities for a specific dialect. This makes it practical to target databases that need non-default type or constraint handling. See [PR #3600](https://github.com/dlt-hub/dlt/pull/3600) for the customization API.
-
-## ClickHouse role-based S3 authentication
-
-The ClickHouse destination now supports an `extra_credentials` configuration key for role-based S3 authentication. This allows ClickHouse to access S3 buckets using IAM roles instead of explicit access key credentials. See [PR #2888](https://github.com/dlt-hub/dlt/pull/2888) for configuration details.
+[See PR #3547](https://github.com/dlt-hub/dlt/pull/3547).
 
 ## Updates in 1.22.2
 
-### Hugging Face as a filesystem destination
+### Load data to Hugging Face Datasets
 
-The `filesystem` destination now supports loading directly into [Hugging Face Datasets](https://huggingface.co/docs/datasets/index) repositories via the `hf://` protocol. Install the extra with `pip install "dlt[hf]"`, set `bucket_url` to `hf://datasets/<namespace>`, and provide a Hugging Face User Access Token.
+The `filesystem` destination now supports the `hf://` protocol, enabling direct loading into [Hugging Face Datasets](https://huggingface.co/docs/datasets/index) repositories. Install with `pip install "dlt[hf]"`, set your `bucket_url` to `hf://datasets/<your-namespace>`, and dlt creates the dataset repository, commits all files for a table atomically (to avoid Hub rate limits), and writes dataset cards with subset metadata so the Hugging Face dataset viewer displays tables correctly.
 
-Each dlt dataset becomes a separate Hugging Face dataset repository. The destination defaults to Parquet with page index and content-defined chunking so the Hugging Face dataset viewer can preview tables correctly. All files for a table are committed atomically in a single API call to keep commit counts low and avoid rate limits.
-
-A dataset card (`README.md`) with subset metadata is written automatically, giving each table its own subset in the dataset viewer. This behavior is controlled by the `hf_dataset_card` setting, which defaults to `true`. Delta and Iceberg table formats are not supported for this protocol.
+The destination always writes Parquet with page index and content-defined chunking. Delta and Iceberg table formats are not supported.
 
 ```toml
+# .dlt/secrets.toml
 [destination.filesystem]
 bucket_url = "hf://datasets/my-org"
 
 [destination.filesystem.credentials]
-hf_token = "hf_..."  # or use HF_TOKEN env var, or huggingface-cli login
+hf_token = "hf_..."
 ```
 
-See the [Hugging Face destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/huggingface) for the full setup guide.
+```py
+import dlt
+
+@dlt.resource
+def my_data():
+    yield [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
+
+pipeline = dlt.pipeline(
+    pipeline_name="my_pipeline",
+    destination="filesystem",
+    dataset_name="my_dataset",
+)
+pipeline.run(my_data(), write_disposition="append")
+```
+
+See the [Hugging Face destination docs](https://dlthub.com/docs/dlt-ecosystem/destinations/huggingface) for the full configuration reference, including private Hub endpoints and authentication options.
 
 ### Composable marimo widgets
 
-The `dlt.helpers.marimo` module now exposes composable widgets built with the `mowidgets` library (Python 3.11 and above). Unlike the previous read-only widgets, composable widgets accept inputs and return outputs, making them easy to chain inside a marimo notebook.
-
-This release adds a new `pipeline_selector` widget and refreshed versions of `schema_viewer` and `load_package_viewer`. Install with `pip install "dlt[workspace]"`.
+The dlt marimo helper now ships composable widgets built on `mowidgets` (Python 3.11 and later, available via `dlt[workspace]`). Unlike the previous read-only widgets, composable widgets accept inputs and expose outputs so you can wire them together in a notebook. A new `pipeline_selector` widget lets you pick any local pipeline interactively. The `schema_viewer` and `load_package_viewer` widgets are updated to the composable API.
 
 ```py
-from dlt.helpers.marimo import render, load_package_viewer, pipeline_selector
+from dlt.helpers.marimo import render, pipeline_selector, load_package_viewer
 
-# display the pipeline selector widget
+# cell 1: interactive pipeline picker
 render(pipeline_selector)
 
-# display the load package viewer for a specific pipeline path
+# cell 2: browse load package files for the chosen pipeline
 render(load_package_viewer, pipeline_path="/path/to/pipeline")
 ```
 
-See the [marimo docs](https://dlthub.com/docs/general-usage/dataset-access/marimo) for details and examples.
-
-### Dashboard layout improvements
-
-The marimo pipeline dashboard now shows the section title and subtitle on a single line when a section is collapsed, reducing vertical space. On viewports narrower than 900px the subtitle is hidden and only the title and toggle remain visible. Long subtitles for the trace, loads, and Ibis backend sections have been shortened. The Ibis backend section is now hidden in read and app mode because it is a developer-only tool.
-
 ## Updates in 1.22.1
 
-### MCP servers now default to streamable-http transport
+### MCP server defaults to streamable-http transport
 
-The `dlt pipeline mcp` and `dlt workspace mcp` commands now use `streamable-http` (MCP spec 2025-03-26) as the default transport instead of `sse`. The server path also changed from `/` to `/mcp`, so update any MCP client configuration to the new URLs:
+The `dlt pipeline mcp` and `dlt mcp` commands now start the MCP server with `streamable-http` transport (MCP spec 2025-03-26) instead of `sse`. The server path also moved from `/` to `/mcp`, so any hardcoded client URLs need updating.
 
-```text
-http://127.0.0.1:43654/mcp   # workspace MCP
-http://127.0.0.1:43656/mcp   # pipeline MCP
+Use the `--sse` flag to keep the legacy SSE transport. The stdio transport is unchanged.
+
+Update your MCP client config to use the new paths:
+
+```json
+{
+  "mcpServers": {
+    "dlt-workspace": {
+      "url": "http://127.0.0.1:43654/mcp"
+    },
+    "dlt-pipeline-mcp": {
+      "url": "http://127.0.0.1:43656/mcp"
+    }
+  }
+}
 ```
 
-Legacy `sse` and `stdio` transports remain available via `--sse` and `--stdio` flags. The `mcp` dependency requirement was bumped accordingly. See [PR #3624](https://github.com/dlt-hub/dlt/pull/3624).
+### ClickHouse enforces read-after-write consistency by default
 
-### ClickHouse enforces sequential read consistency by default
+dlt now sets `select_sequential_consistency=1` on all ClickHouse connections by default. This prevents stale reads on ClickHouse Cloud (SharedMergeTree) and self-hosted clusters where queries can be routed to different nodes after a write.
 
-dlt now sets `select_sequential_consistency=1` on all ClickHouse connections. This ensures `SELECT` queries see preceding writes on ClickHouse Cloud (SharedMergeTree) and self-hosted clusters where queries can be routed to different nodes. To opt out for read-only workloads:
+To disable the overhead for read-only workloads, set it to `0` in your configuration:
 
 ```toml
 [destination.clickhouse]
 select_sequential_consistency = 0
 ```
 
-The setting can also be passed to the factory: `clickhouse(select_sequential_consistency=0)`. See [PR #3651](https://github.com/dlt-hub/dlt/pull/3651).
+### Mermaid schema diagrams handle null-typed columns
 
-### WorkspaceFileSelector ships with built-in exclude patterns
-
-`WorkspaceFileSelector` now includes `DEFAULT_EXCLUDES` covering well-known non-deployable paths such as `.git/`, `.venv/`, `__pycache__/`, and `node_modules/`. These paths are excluded automatically even without a `.gitignore` file present.
-
-A companion `ignore_file_found` attribute lets callers verify whether the configured ignore file (e.g., `.gitignore`) was actually located on disk. See [PR #3661](https://github.com/dlt-hub/dlt/pull/3661) and [PR #3663](https://github.com/dlt-hub/dlt/pull/3663).
-
-### Fix: `.to_mermaid()` no longer crashes on columns without a data type
-
-Schema columns that have not yet recorded a `data_type` (arising from seen-null-first propagation) caused `.to_mermaid()` to raise a `KeyError`. The method now gracefully handles these incomplete columns. See [PR #3659](https://github.com/dlt-hub/dlt/pull/3659).
-
-### Fix: data quality checks dashboard component restored
-
-The data quality checks section of the dlt dashboard was silently broken after an upstream `dlthub` API change. It now correctly uses `dq.read_check()` to query results. See [PR #3647](https://github.com/dlt-hub/dlt/pull/3647).
+`schema.to_mermaid()` no longer raises a `KeyError` when a column has no `data_type` yet. This situation arises when a column's first observed values were all null and the type has not been inferred. The column is now rendered as `no_data_seen` in the diagram instead of crashing.
 
 ## Shout-out to new contributors
 

--- a/docs/website/docs/release-notes/1.22.md
+++ b/docs/website/docs/release-notes/1.22.md
@@ -1,0 +1,94 @@
+---
+title: "Release highlights: 1.22"
+description: Release highlights provide a concise overview of the most important new features, improvements, and fixes in a software update.
+keywords: [dlt, data-pipelines, etl, release-notes, data-engineering]
+---
+
+# Release highlights: 1.22
+
+## Breaking changes
+
+:::warning
+These changes may require updates to your pipelines.
+:::
+
+- **(1.22)** Pydantic v1 support removed. All Pydantic v1 compatibility code has been removed. dlt now requires Pydantic v2. If your project still depends on Pydantic v1, upgrade to Pydantic v2 before updating dlt.
+- **(1.22)** `data_type` schema contract now covers full data type. The `data_type` contract previously applied only to variant column changes. It now applies to the full data type, including `nullable`, `precision`, and `scale`. Users who have `data_type: freeze` configured and relied on being able to alter `nullable`, `precision`, or `scale` on existing columns will be blocked by the contract after upgrading.
+
+Review your schema contract settings and adjust column definitions before upgrading if your pipelines depend on this behavior.
+- **(1.22)** `merge_columns` now removes compound properties before merging. The `merge_columns` schema utility was previously purely additive. When the source columns carried non-default values for compound properties such as `merge_key`, `primary_key`, `partition`, or `cluster`, those properties are now first cleared from the target columns before the merge is applied.
+
+This corrects a longstanding bug where compound properties like `merge_key` could accumulate stale values from earlier pipeline runs instead of reflecting the current resource definition. Pipelines that relied on the old additive behavior for compound column properties will see different schema results after upgrading.
+
+## Pydantic data validation overhaul
+
+The Pydantic integration has been substantially reworked in this release. Discriminated union `RootModel` types are now supported, enabling validation of event streams that carry multiple event types in a single resource. Schema contracts now properly distinguish between resource-defined hints and data-derived hints, so Pydantic model columns bypass contract checks when they are authoritative. Arrow table items and Pydantic model items are both fully supported with schema contract enforcement. This work also prepares the codebase for Pydantic v3.
+
+Note: Pydantic v1 is no longer supported. See the breaking changes section for details.
+
+## Snowflake atomic table swap for `replace`
+
+When using the `staging-optimized` replace strategy on Snowflake, dlt now performs an `ALTER TABLE ... SWAP` operation instead of dropping and recreating the destination table. This eliminates table downtime during data replacement, making atomic swaps the default path for Snowflake staging-optimized loads.
+
+## Custom backends for `sql_database`
+
+You can now register custom `TableLoader` implementations as named backends for the `sql_database` source. This lets you plug in alternative loading strategies alongside the built-in backends. The ConnectorX backend has been ported as a proof of concept, and ADBC and a paginated loader are available as test-case references.
+
+## SQLAlchemy destination dialect customization
+
+The SQLAlchemy destination now supports per-dialect customization. You can supply a custom type mapper to change how dlt types translate to SQL column types, adjust `Table` schemas before they are created, and override destination capabilities for non-standard dialects. This makes it practical to use the SQLAlchemy destination against specialized or exotic databases without forking the destination code.
+
+## Parallelized dependent resources in `rest_api`
+
+The `rest_api` source now accepts a `parallelized` flag on dependent resources (transformers). When set, child resource fetches run concurrently instead of sequentially. Pipelines that fan out from a parent resource to many child endpoints benefit immediately from this flag without any other changes.
+
+## `dlt.Relation` and `dlt.Dataset`: filter rows by load ID
+
+Datasets and relations now expose first-class helpers for working with load IDs. `dataset.load_ids()` retrieves all load IDs recorded for the dataset, and `dataset.latest_load_id()` returns the most recent one. Pass `load_ids` to `dataset.table()` or call `relation.from_loads()` to get back only the rows that belong to the specified loads.
+
+This feature is experimental.
+
+```py
+import dlt
+
+pipeline = dlt.pipeline(pipeline_name="my_pipeline", destination="duckdb")
+dataset = pipeline.dataset()
+
+# Retrieve all recorded load IDs
+load_ids = dataset.load_ids()
+
+# Read only rows from the most recent load
+latest = dataset.latest_load_id()
+df = dataset.table("orders", load_ids=[latest]).df()
+
+# Or filter an existing relation
+rel = dataset.table("orders").from_loads([load_ids[-1]])
+```
+
+## Source preprocessors on `dlt.source` factory
+
+The `dlt.source` factory now accepts preprocessor hooks. A preprocessor receives a freshly created source instance and can modify it before the pipeline runs it. This is useful for applying cross-cutting configuration, injecting resources, or normalizing options in one place across all calls to the same source factory.
+
+## `engine_kwargs` for `sql_database` and `sql_table`
+
+Both the `sql_database` source and the `sql_table` resource now accept an `engine_kwargs` parameter that is forwarded directly to SQLAlchemy's `create_engine()`. Use it to configure connection pooling, statement timeouts, SSL settings, or any other engine-level option without subclassing the source.
+
+```py
+import dlt
+from dlt.sources.sql_database import sql_database
+
+source = sql_database(
+    "postgresql://user:pass@host/db",
+    engine_kwargs={"pool_size": 5, "connect_args": {"connect_timeout": 10}},
+)
+```
+
+## Shout-out to new contributors
+
+Welcome to our new contributors who made their first contribution in this release: @Shadesfear (#3574), @ShreyasGS (#3603), @arel (#3566), @karlanka (#3606), @kien-truong (#3571), and @thecaptain789 (#3616).
+
+Thank you to everyone who contributed to this release: @anuunchin, @rudolfix, @Travior, @zilto, @Shadesfear, @tetelio, @ivasio, @arel, @warje, @karlanka, @kien-truong, @thecaptain789, @ShreyasGS, @djudjuu, @dat-a-man, @kaliole, @michelzurkirchen, @VioletM, and @timH6502.
+
+**Full release notes**
+
+[View the complete list of changes](https://github.com/dlt-hub/dlt/releases)

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -74,6 +74,7 @@ const sidebars = {
             keywords: ["release notes", "release highlights"],
           },
           items: [
+            { type: "doc", id: "release-notes/1.22", label: "1.22" },
             { type: "doc", id: "release-notes/1.21.2", label: "1.21.2" },
             { type: "doc", id: "release-notes/1.19", label: "1.19" },
             { type: "doc", id: "release-notes/1.18", label: "1.18" },


### PR DESCRIPTION
Release highlights for `1.22`, covering the 1.22.0 release plus the folded patch releases 1.22.1 and 1.22.2.

## Breaking changes
- Pydantic v1 support removed. Migrate v1-only APIs to Pydantic v2.
- `data_type` schema contract now applies to the full type definition (precision, scale, nullability), not only variant-column changes.
- `merge_columns` now removes compound properties (`merge_key`, `primary_key`, `partition`, `cluster`) before merging.

## Highlights (1.22.0)
- Pydantic v2 data validation overhaul.
- Snowflake atomic table swap for the `replace` strategy.
- Parallelized dependent resources in `rest_api`.
- Filter dataset relations by load ID (experimental).

## Folded patch releases
- 1.22.1: MCP server default transport change, ClickHouse read-after-write consistency, Mermaid null-typed column fix.
- 1.22.2: load to Hugging Face Datasets, composable marimo widgets.

## Selection
Kept to changes that alter what a typical pipeline author does. Left out of the headline set: destination- and source-specific config toggles (Athena results bucket, `engine_kwargs`, ClickHouse S3 auth), extension-author hooks (source preprocessors, custom backends), dialect customization, bug fixes, and chores. Each feature carries a code example or a link to its PR on the page.

## Docs tickets
- pydantic: https://github.com/dlt-hub/dlt/issues/4193
- data_type: https://github.com/dlt-hub/dlt/issues/4194
- merge_columns: https://github.com/dlt-hub/dlt/issues/4195
