### PR TITLE
fix(cli): make deploy origin error name the deployment method

### DIFF
--- a/dlt/_workspace/cli/_deploy_command.py
+++ b/dlt/_workspace/cli/_deploy_command.py
@@ -73,6 +73,8 @@ def deploy_command(
 
 
 class GithubActionDeployment(BaseDeployment):
+    deployment_method = DeploymentMethods.github_actions.value
+
     def __init__(
         self,
         pipeline_script_path: str,
@@ -199,8 +201,7 @@ class GithubActionDeployment(BaseDeployment):
         fmt.echo(
             "* The dependencies that will be used to run the pipeline are stored in %s. If you"
             " change add more dependencies, remember to refresh your deployment by running the same"
-            " 'deploy' command again."
-            % fmt.bold(self.artifacts["requirements_txt_name"])
+            " 'deploy' command again." % fmt.bold(self.artifacts["requirements_txt_name"])
         )
         fmt.echo()
         if len(self.secret_envs) == 0 and len(self.envs) == 0:
@@ -263,6 +264,8 @@ class GithubActionDeployment(BaseDeployment):
 
 
 class AirflowDeployment(BaseDeployment):
+    deployment_method = DeploymentMethods.airflow_composer.value
+
     def __init__(
         self,
         pipeline_script_path: str,

--- a/dlt/_workspace/cli/_deploy_command_helpers.py
+++ b/dlt/_workspace/cli/_deploy_command_helpers.py
@@ -103,14 +103,14 @@ class BaseDeployment(abc.ABC):
                 raise CliCommandInnerException(
                     "deploy",
                     f"Your current repository origin is not set to github but to {origin}.\nYou"
-                    " must change it to be able to run the pipelines with github actions:"
+                    f" must change it to be able to deploy with '{self.deployment_method}':"
                     " https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories",
                 )
         except ValueError:
             raise CliCommandInnerException(
                 "deploy",
-                "Your current repository has no origin set. Please set it up to be able to run the"
-                " pipelines with github actions:"
+                "Your current repository has no origin set. Please set it up to be able to deploy"
+                f" with '{self.deployment_method}':"
                 " https://docs.github.com/en/get-started/importing-your-projects-to-github/importing-source-code-to-github/adding-locally-hosted-code-to-github",
             )
 

--- a/tests/workspace/cli/test_deploy_command.py
+++ b/tests/workspace/cli/test_deploy_command.py
@@ -23,12 +23,40 @@ from dlt._workspace.cli.exceptions import CliCommandException
 # from tests.utils import reset_providers
 from tests.workspace.cli.utils import WORKSPACE_CLI_CASES_DIR
 
-
 DEPLOY_PARAMS = [
     ("github-action", {"schedule": "*/30 * * * *", "run_on_push": True, "run_manually": True}),
     ("airflow-composer", {"secrets_format": "toml"}),
     ("airflow-composer", {"secrets_format": "env"}),
 ]
+
+
+from dlt._workspace.cli._deploy_command import (
+    AirflowDeployment,
+    GithubActionDeployment,
+)
+
+
+@pytest.mark.parametrize(
+    "deployment_class,deployment_method",
+    [
+        (GithubActionDeployment, "github-action"),
+        (AirflowDeployment, "airflow-composer"),
+    ],
+)
+def test_get_origin_error_names_deployment_method(deployment_class, deployment_method) -> None:
+    # A non-github origin must raise an error that names the actual deployment
+    # method, not always "github actions" (https://github.com/dlt-hub/dlt/issues/2159).
+    deployment = deployment_class.__new__(deployment_class)
+    deployment.repo = object()
+    with patch(
+        "dlt._workspace.cli._deploy_command_helpers.get_origin",
+        return_value="https://gitlab.com/acme/repo.git",
+    ):
+        with pytest.raises(CliCommandInnerException) as py_ex:
+            deployment._get_origin()
+    message = str(py_ex.value)
+    assert deployment_method in message
+    assert "github actions" not in message
 
 
 @pytest.mark.parametrize("deployment_method,deployment_args", DEPLOY_PARAMS)


### PR DESCRIPTION
Fixes #2159

When deploying with `airflow-composer`, if the repository origin is not on GitHub, the error tells the user to "run the pipelines with github actions", which is misleading for a non-github-actions deployment.

`_get_origin()` runs during `_prepare_deployment` (before `deployment_method` was set on the instance), so the message could not reference the actual method. This sets `deployment_method` as a class attribute on `GithubActionDeployment` and `AirflowDeployment`, so the origin-check error now names the deployment method being used ("...to be able to deploy with 'airflow-composer'") for both the no-origin and non-github-origin cases.

The regression test (`test_get_origin_error_names_deployment_method`) parametrizes both deployment classes, patches `get_origin` to return a non-github origin, and asserts the raised message names the deployment method and no longer says "github actions". It fails before the change and passes after.

On the documentation point from the issue: the airflow-composer guide already states the GitHub-repository requirement under "Add your `dlt` project directory to GitHub", so I left the docs as-is; happy to expand that note if you'd prefer it more prominent.
