### PR TITLE
(master) relaxes dlthub-client dep, bumps to 1.28.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dlt"
-version = "1.28.1"
+version = "1.28.2"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 authors = [{ name = "dltHub Inc.", email = "services@dlthub.com" }]
 requires-python = ">=3.10, <3.15"
@@ -65,7 +65,7 @@ dependencies = [
 [project.optional-dependencies]
 hub = [
     "dlthub>=0.27.0, <0.29",
-    "dlthub-client>=0.27.7, <0.29",
+    "dlthub-client>=0.28.1",
 ]
 gcp = [
     "grpcio>=1.50.0",

--- a/tools/check_hub_extras.py
+++ b/tools/check_hub_extras.py
@@ -3,8 +3,9 @@
 # flake8: noqa: T201
 """Check that hub extras version requirements match the dlt version.
 
-When dlt is bumped from X.Y to X.Z, the hub extras (dlthub, dlt-runtime) should
-also be bumped to require version 0.Z.
+When dlt is bumped from X.Y to X.Z, the version-coupled hub extras (dlthub) should
+also be bumped to require version 0.Z. Extras listed in INFO_ONLY_PKGS are displayed
+but not checked.
 
 This ensures that dlt and its hub plugins are released together with matching versions.
 """
@@ -18,6 +19,9 @@ from packaging.version import Version
 
 from dlt.common.runtime.run_context import ensure_plugin_version_match
 from dlt.version import __version__ as dlt_version, DLT_PKG_NAME
+
+# hub extras not version-coupled to dlt: shown for info, version match never enforced
+INFO_ONLY_PKGS = {"dlthub-client"}
 
 
 class HubExtraInfo(NamedTuple):
@@ -36,13 +40,10 @@ def get_hub_extras() -> List[HubExtraInfo]:
     extras = []
     for req_str in dist.requires:
         req = Requirement(req_str)
-        # Check if this requirement is for the "hub" extra by looking for
-        # 'extra == "hub"' in the marker string. We can't use marker.evaluate()
-        # because on Python 3.9, markers like 'extra == "hub" and python_version >= "3.10"'
-        # would evaluate to False due to the python_version constraint.
+        # match the hub extra on the marker string instead of marker.evaluate() so that
+        # hub deps gated on python_version stay visible on any interpreter
         if req.marker:
             marker_str = str(req.marker)
-            # Check for extra == "hub" or "hub" == extra patterns
             if 'extra == "hub"' in marker_str or '"hub" == extra' in marker_str:
                 extras.append(HubExtraInfo(pkg_name=req.name, requirement=req))
 
@@ -90,6 +91,10 @@ def check_hub_extras() -> int:
 
     errors = []
     for extra in hub_extras:
+        if extra.pkg_name in INFO_ONLY_PKGS:
+            print(f"Checking {extra.pkg_name}: {extra.requirement.specifier}")
+            print("  ✓ not version-coupled to dlt, any version accepted")
+            continue
         print(f"Checking {extra.pkg_name}: {extra.requirement.specifier}")
 
         try:
@@ -115,7 +120,6 @@ def check_hub_extras() -> int:
         print("When bumping dlt version, also update hub extras in pyproject.toml.")
         print("For example, if dlt is 1.20.0, hub extras should allow 0.20.x:")
         print('  "dlthub>=0.20.0a0,<0.21"')
-        print('  "dlt-runtime>=0.20.0a0,<0.21"')
         return 1
     else:
         print("SUCCESS: All hub extras version requirements match dlt version!")

--- a/uv.lock
+++ b/uv.lock
@@ -2501,7 +2501,7 @@ wheels = [
 
 [[package]]
 name = "dlt"
-version = "1.28.1"
+version = "1.28.2"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -2843,7 +2843,7 @@ requires-dist = [
     { name = "db-dtypes", marker = "extra == 'gcp'", specifier = ">=1.2.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=0.25.1" },
     { name = "dlthub", marker = "extra == 'hub'", specifier = ">=0.27.0,<0.29" },
-    { name = "dlthub-client", marker = "extra == 'hub'", specifier = ">=0.27.7,<0.29" },
+    { name = "dlthub-client", marker = "extra == 'hub'", specifier = ">=0.28.1" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
     { name = "duckdb", marker = "extra == 'ducklake'", specifier = ">=1.2.0" },
     { name = "duckdb", marker = "extra == 'lance'", specifier = ">=1.4.3" },
@@ -3063,7 +3063,7 @@ wheels = [
 
 [[package]]
 name = "dlthub-client"
-version = "0.27.7"
+version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3074,9 +3074,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/28/a8b3a1b3a5557ca0bf819fce52697ccdb9731ea73bda96b352a1f65ef3f1/dlthub_client-0.27.7.tar.gz", hash = "sha256:85ee09a03e4c4a505c1d12fd1f514d03bd26e1cec74d7b6b1f6397e926577177", size = 132851, upload-time = "2026-06-11T19:43:57.897Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/87/53412615805aadf53d3c95e9d94e7f703b33a8fe8f441ff3bf9d73e0f7ea/dlthub_client-0.28.1.tar.gz", hash = "sha256:2a47d950aa5e1ba77409655b2cecb5f3e626a2964a3952fb32a9d3292e6ba1db", size = 146048, upload-time = "2026-07-07T11:09:04.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/bd/026ee4fa2d489a9aaf8cf058ed15173baa2d4cec1cfaccefe42f80fdd1f9/dlthub_client-0.27.7-py3-none-any.whl", hash = "sha256:35b32a8350bab9feed00c1ed1cb5349b7819ba0fd84dfcd71e561db54550fb3e", size = 296295, upload-time = "2026-06-11T19:43:56.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/93/453841023154ef23d8def64cc4d48ee4e61a76451303a3046fe405230bb6/dlthub_client-0.28.1-py3-none-any.whl", hash = "sha256:04f7b86181e09db69714ac297ad7fa829c7c939096bbc2a65cb781df511082bf", size = 336690, upload-time = "2026-07-07T11:09:02.927Z" },
 ]
 
 [[package]]
@@ -8380,14 +8380,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Allows 1.28.x dlt to be used with future dlthub-client versions
