### PR TITLE
fix(deployment): disable fastmcp host-origin guard behind the runtime proxy

### DIFF
--- a/dlt/_workspace/deployment/configuration.py
+++ b/dlt/_workspace/deployment/configuration.py
@@ -55,3 +55,8 @@ class McpConfiguration(BaseConfiguration):
     """Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL."""
     stateless_http: bool = False
     """Stateless mode for horizontal scaling (no session affinity)."""
+    host_origin_protection: bool = False
+    """Enable FastMCP's DNS-rebinding (Host header) protection. Off by default because
+    the launcher runs behind the runtime's authenticated proxy, which rewrites the Host
+    header; FastMCP >= 3.4.3 turns this guard on by default and would otherwise reject
+    every proxied request with 421 "Invalid Host header"."""

--- a/dlt/_workspace/deployment/launchers/mcp.py
+++ b/dlt/_workspace/deployment/launchers/mcp.py
@@ -43,6 +43,21 @@ def _resolve_config(sections: Tuple[str, ...]) -> McpConfiguration:
     return resolve_configuration(McpConfiguration(), sections=sections)
 
 
+def _fastmcp_supports_host_origin_protection() -> bool:
+    """True if the installed FastMCP accepts the `host_origin_protection` run arg.
+
+    The DNS-rebinding guard (and this option) landed in FastMCP 3.4.3. Passing the
+    argument to an older FastMCP would raise `TypeError`, so gate on the version.
+    """
+    import semver
+    from importlib.metadata import version
+
+    try:
+        return semver.Version.parse(version("fastmcp")) >= semver.Version.parse("3.4.3")
+    except Exception:
+        return False
+
+
 def run_mcp_instance(instance: Any, port: int, sections: Tuple[str, ...]) -> None:
     """Run a FastMCP instance with resolved configuration.
 
@@ -50,7 +65,7 @@ def run_mcp_instance(instance: Any, port: int, sections: Tuple[str, ...]) -> Non
     and the job launcher (return value fallback).
     """
     config = _resolve_config(sections)
-    instance.run(
+    run_kwargs: Dict[str, Any] = dict(
         transport=config.transport,
         host="0.0.0.0",
         port=port,
@@ -58,6 +73,14 @@ def run_mcp_instance(instance: Any, port: int, sections: Tuple[str, ...]) -> Non
         log_level=config.log_level,
         stateless_http=config.stateless_http,
     )
+    # FastMCP >= 3.4.3 enables DNS-rebinding (Host header) protection by default. Behind
+    # the runtime's reverse proxy (modal / tower / local runner), which rewrites the Host
+    # header, that guard rejects every request with 421. These servers only receive traffic
+    # from the authenticated runtime proxy, so the guard is redundant; disable it by default
+    # (overridable via the `host_origin_protection` config). Older FastMCP has no such option.
+    if _fastmcp_supports_host_origin_protection():
+        run_kwargs["host_origin_protection"] = config.host_origin_protection
+    instance.run(**run_kwargs)
 
 
 def run(entry_point: TRuntimeEntryPoint) -> None:

--- a/tests/workspace/deployment/test_launchers.py
+++ b/tests/workspace/deployment/test_launchers.py
@@ -442,6 +442,42 @@ def test_mcp_config_override() -> None:
         del os.environ["JOBS__MCP_SERVER__MCP__STATELESS_HTTP"]
 
 
+def test_mcp_launcher_disables_host_origin_protection() -> None:
+    """Behind the runtime proxy the launcher disables FastMCP's DNS-rebinding guard
+    (off by default) when the installed FastMCP supports it, so requests don't 421."""
+    entry_point = _entry(f"{WORKSPACE}.mcp_server", port=5000)
+    with (
+        patch("fastmcp.FastMCP.run") as mock_run,
+        patch(
+            "dlt._workspace.deployment.launchers.mcp._fastmcp_supports_host_origin_protection",
+            return_value=True,
+        ),
+    ):
+        from dlt._workspace.deployment.launchers.mcp import run
+
+        run(entry_point)
+
+        assert mock_run.call_args[1]["host_origin_protection"] is False
+
+
+def test_mcp_launcher_omits_host_origin_protection_on_old_fastmcp() -> None:
+    """FastMCP < 3.4.3 has no `host_origin_protection` arg, so the launcher must not
+    pass it (doing so would raise TypeError)."""
+    entry_point = _entry(f"{WORKSPACE}.mcp_server", port=5000)
+    with (
+        patch("fastmcp.FastMCP.run") as mock_run,
+        patch(
+            "dlt._workspace.deployment.launchers.mcp._fastmcp_supports_host_origin_protection",
+            return_value=False,
+        ),
+    ):
+        from dlt._workspace.deployment.launchers.mcp import run
+
+        run(entry_point)
+
+        assert "host_origin_protection" not in mock_run.call_args[1]
+
+
 def test_launcher_fails_without_port() -> None:
     """Interactive launchers fail if run_args.port is not provided."""
     entry_point = _entry(f"{WORKSPACE}.mcp_server")  # no port in run_args


### PR DESCRIPTION
Fixes #4199.

## Summary

FastMCP >= 3.4.3 turns on DNS-rebinding (Host header) protection by default. The MCP launcher runs behind the runtime reverse proxy (modal / tower / local runner), which rewrites the `Host` header, so with the allowlist defaulting to localhost the guard rejects every request with `421 Misdirected Request`. The server starts but never serves a usable request.

## Fix

`run_mcp_instance` now passes `host_origin_protection` to `instance.run()`, driven by a new `McpConfiguration.host_origin_protection` field that defaults to `False` (these servers only receive traffic from the authenticated runtime proxy, so the guard is redundant). It stays overridable for anyone who wants it on.

Because dlt pins `fastmcp>=3.0.0` but the option only exists in `>=3.4.3`, the argument is passed only when the installed FastMCP supports it (version-gated) — passing it to an older FastMCP would raise `TypeError`. Older versions never had the guard, so they need no change.

This replaces the interim `fastmcp<3.4.3` pin in the test workspace: real deployments on the runtime were still broken until the launcher itself was fixed.

## Tests

Two unit tests in `tests/workspace/deployment/test_launchers.py`: the arg is passed as `False` when supported, and omitted when not. `black` / `ruff` / `mypy` pass on the changed files.

## Note

I went with option 1 from the issue (disable the guard for these proxied deployments) rather than a static allowlist, since the forwarded `Host` differs per backend (modal `*.modal.host`, tower, local `*.dltrun.*`) so no single allowlist works. Happy to switch to a config-driven per-backend allowlist if you prefer.