### PR TITLE
feat: add client_secret_basic support to OAuth2ClientCredentials

### DIFF
--- a/dlt/sources/helpers/rest_client/auth.py
+++ b/dlt/sources/helpers/rest_client/auth.py
@@ -161,6 +161,7 @@ class OAuth2ClientCredentials(OAuth2AuthBase):
     client_secret: TSecretStrValue = None
     access_token_request_data: Dict[str, Any] = None
     default_token_expiration: int = 3600
+    client_auth_method: Literal["client_secret_post", "client_secret_basic"] = "client_secret_post"
     session: Annotated[BaseSession, NotResolved()] = None
 
     def __post_init__(self) -> None:
@@ -191,18 +192,29 @@ class OAuth2ClientCredentials(OAuth2AuthBase):
         self.token_expiry = pendulum.now().add(seconds=expires_in_seconds)
 
     def build_access_token_request(self) -> Dict[str, Any]:
-        return {
-            "headers": {
-                "Content-Type": "application/x-www-form-urlencoded",
-            },
-            "data": {
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
-                "grant_type": "client_credentials",
-                **self.access_token_request_data,
-            },
+        data = {
+            "grant_type": "client_credentials",
+            **self.access_token_request_data,
+        }
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
         }
 
+        client_id_str = str(self.client_id)
+        client_secret_str = str(self.client_secret)
+
+        if self.client_auth_method == "client_secret_basic":
+            credentials = f"{client_id_str}:{client_secret_str}"
+            encoded_credentials = b64encode(credentials.encode("utf-8")).decode("utf-8")
+            headers["Authorization"] = f"Basic {encoded_credentials}"
+        else:
+            data["client_id"] = client_id_str
+            data["client_secret"] = client_secret_str
+        return{
+            "headers": headers,
+            "data": data,
+        }    
+    
     def parse_expiration_in_seconds(self, response_json: Any) -> int:
         return int(response_json.get("expires_in", self.default_token_expiration))
 

--- a/dlt/sources/helpers/rest_client/auth.py
+++ b/dlt/sources/helpers/rest_client/auth.py
@@ -210,11 +210,11 @@ class OAuth2ClientCredentials(OAuth2AuthBase):
         else:
             data["client_id"] = client_id_str
             data["client_secret"] = client_secret_str
-        return{
+        return {
             "headers": headers,
             "data": data,
-        }    
-    
+        }
+
     def parse_expiration_in_seconds(self, response_json: Any) -> int:
         return int(response_json.get("expires_in", self.default_token_expiration))
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
This PR introduces a client_auth_method parameter to the OAuth2ClientCredentials class, enabling support for the client_secret_basic authentication method defined in RFC 6749.

Currently, the class defaults to client_secret_post (sending credentials in the payload body). However, many major OAuth 2.0 authorization servers (e.g., eBay, Reddit, Spotify) strictly require credentials to be Base64-encoded and sent in the HTTP Authorization header as a Basic token.

By adding this configuration, developers can natively authenticate with these APIs without needing to write custom authenticators. The new parameter defaults to "client_secret_post", ensuring 100% backwards compatibility for existing dlt pipelines

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Resolves #4206 

<!--
Provide any additional context about the PR here.
-->
### Additional Context

- Implemented explicit string casting (str(self.client_id)) during the Base64 encoding step to ensure that dlt configuration objects (like TSecretStrValue) are properly evaluated before text transformation.
- Tested locally with an eBay Browse Search API pipeline, successfully resolving previous 401 Unauthorized errors without the need for an external custom Auth class.
- I have read the [Contributing to dlt](https://github.com/dlt-hub/dlt/compare/CONTRIBUTING.md) guide and verified that the changes run cleanly.

**Test Output:**
Successfully tested locally against the eBay Browse API:
Pipeline ebay_browse_ingestion load step completed in 6.34 seconds
1 load package(s) were loaded to destination filesystem and into dataset ebay
Load package is LOADED and contains no failed jobs

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
