### PR TITLE
Add emphemeral storage caveat

### DIFF
--- a/dlt/pipeline/exceptions.py
+++ b/dlt/pipeline/exceptions.py
@@ -78,7 +78,7 @@ class PipelineStepFailed(PipelineException):
                     f"`dlt pipeline {pipeline.pipeline_name} info` for more information or `dlt"
                     f" pipeline {pipeline.pipeline_name} drop-pending-packages` to drop pending"
                     " packages."
-                    "\n\nNote: If the working directory is on ephemeral storage (e.g. dltHub"
+                    "\n\nNote: If the pipeline working directory is on ephemeral storage (e.g. dltHub"
                     " platform jobs, serverless functions, or CI runners without persistent"
                     " volumes), pending packages are lost and not retried."
                 )

--- a/dlt/pipeline/exceptions.py
+++ b/dlt/pipeline/exceptions.py
@@ -78,6 +78,9 @@ class PipelineStepFailed(PipelineException):
                     f"`dlt pipeline {pipeline.pipeline_name} info` for more information or `dlt"
                     f" pipeline {pipeline.pipeline_name} drop-pending-packages` to drop pending"
                     " packages."
+                    "\n\nNote: If the working directory is on ephemeral storage (e.g. dltHub"
+                    " platform jobs, serverless functions, or CI runners without persistent"
+                    " volumes), pending packages are lost and not retried."
                 )
             if load_id and step_info and load_id in step_info.loads_ids and step == "load":
                 # get package info

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -5557,6 +5557,7 @@ def test_pending_package_exception_warning() -> None:
     # none of the jobs passed so we have pending package but not partial
     assert pip_ex.value.step == "load"
     assert "Pending packages" in str(pip_ex.value)
+    assert "ephemeral storage" in str(pip_ex.value)
     assert "partially loaded" not in str(pip_ex.value)
     assert pip_ex.value.load_id is not None
     assert pip_ex.value.is_package_partially_loaded is False


### PR DESCRIPTION
This PR extends the error message from a load package so that its warned that machines that fail with an ephemeral storage will not retry the load package on next run. This is because files will not exist on disk (this includes how dlthub platform currently works).