### PR TITLE
fix(workspace): discover __all__ jobs exposed via module __getattr__ (PEP 562)

### DIFF
--- a/dlt/_workspace/deployment/manifest.py
+++ b/dlt/_workspace/deployment/manifest.py
@@ -517,7 +517,9 @@ def generate_manifest(
             names = list(deployment_module.__dict__.keys())
 
         for name in names:
-            obj = deployment_module.__dict__.get(name)
+            # use getattr so names exposed via module-level __getattr__ (PEP 562)
+            # are resolved, not just those present in __dict__
+            obj = getattr(deployment_module, name, None)
             if obj is None and iterate_all:
                 warnings.append(f"name {name!r} listed in __all__ but not found in module")
                 continue

--- a/tests/workspace/cases/runtime_workspace/deployment_lazy.py
+++ b/tests/workspace/cases/runtime_workspace/deployment_lazy.py
@@ -1,0 +1,21 @@
+"""Deployment that exposes jobs lazily via module-level __getattr__ (PEP 562).
+
+The names in ``__all__`` are not present in the module ``__dict__``; they are
+resolved on access through ``__getattr__``. This mirrors modules that build
+their public surface lazily.
+"""
+
+from typing import Any
+
+from tests.workspace.cases.runtime_workspace import batch_jobs
+
+__all__ = ["backfill", "daily_ingest"]  # noqa: F822 -- resolved via __getattr__
+
+_LAZY = {"backfill": batch_jobs.backfill, "daily_ingest": batch_jobs.daily_ingest}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        return _LAZY[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/workspace/deployment/test_manifest_generator.py
+++ b/tests/workspace/deployment/test_manifest_generator.py
@@ -129,6 +129,19 @@ def test_batch_only_deployment() -> None:
         assert j["entry_point"]["job_type"] == "batch"
 
 
+def test_lazy_all_via_module_getattr() -> None:
+    """Jobs exposed through module-level __getattr__ (PEP 562) and listed in
+    __all__ are discovered, not dropped as 'not found in module'."""
+    mod = import_module(f"{WORKSPACE}.deployment_lazy")
+    manifest, warnings = generate_manifest(mod)
+
+    job_refs = {j["job_ref"] for j in _user_jobs(manifest["jobs"])}
+    assert "jobs.batch_jobs.backfill" in job_refs
+    assert "jobs.batch_jobs.daily_ingest" in job_refs
+    assert len(_user_jobs(manifest["jobs"])) == 2
+    assert not any("not found in module" in w for w in warnings)
+
+
 def test_deployment_with_unknown_warns() -> None:
     """Unknown items in __all__ produce warnings."""
     mod = import_module(f"{WORKSPACE}.deployment_with_unknown")


### PR DESCRIPTION
Fixes #4214.

`generate_manifest()` in `dlt/_workspace/deployment/manifest.py` resolved each `__all__` entry with `deployment_module.__dict__.get(name)`. When a deployment module exposes its jobs lazily through a module-level `__getattr__` (PEP 562), those names aren't in `__dict__`, so they came back as `None`, produced a spurious "listed in `__all__` but not found in module" warning, and were dropped from the manifest.

Switched to `getattr(deployment_module, name, None)`, which respects the import protocol. The `__dict__`-scan path is unaffected since those names are always real attributes.

Added a regression test (`test_lazy_all_via_module_getattr`) and a `deployment_lazy` case module that exports its jobs via `__getattr__`. The test fails on the old code and passes with the fix.

Ran locally on the changed files: ruff, flake8 and mypy are clean, and the manifest-generator tests pass (the framework-detection tests need the marimo/streamlit/fastmcp extras and are unrelated to this change).