### PR TITLE
fix(filesystem): append extension when layout omits ext

### DIFF
--- a/dlt/destinations/path_utils.py
+++ b/dlt/destinations/path_utils.py
@@ -235,12 +235,12 @@ def create_path(
     datetime_params = prepare_datetime_params(current_datetime, load_package_timestamp)
     params.update(datetime_params)
 
-    placeholders, _ = check_layout(layout, params)
+    _, placeholders = check_layout(layout, params)
     path = layout.format(**params)
 
     # if extension is not defined, we append it at the end
     if "ext" not in placeholders:
-        path = job_info.full_extension()
+        path += f".{job_info.full_extension()}"
 
     return path
 

--- a/tests/destinations/test_path_utils.py
+++ b/tests/destinations/test_path_utils.py
@@ -250,29 +250,34 @@ ALL_LAYOUTS = (  # type: ignore
         True,
         [],
     ),
-    ("{timestamp}{table_name}", f"{int(frozen_datetime.timestamp())}mocked-table", True, []),
-    ("{ddd}/{MMM}/{table_name}", "sun/apr/mocked-table", True, []),
+    ("{timestamp}{table_name}", f"{int(frozen_datetime.timestamp())}mocked-table.jsonl", True, []),
+    ("{ddd}/{MMM}/{table_name}", "sun/apr/mocked-table.jsonl", True, []),
     (
         "{Y}/{timestamp}/{table_name}",
-        f"{frozen_datetime.format('YYYY')}/{int(frozen_datetime.timestamp())}/mocked-table",
+        f"{frozen_datetime.format('YYYY')}/{int(frozen_datetime.timestamp())}/mocked-table.jsonl",
         True,
         [],
     ),
     (
         "{Y}/{timestamp_ms}/{table_name}",
-        f"{frozen_datetime.year}/{str(int(frozen_datetime.timestamp()*1000))}/mocked-table",
+        f"{frozen_datetime.year}/{str(int(frozen_datetime.timestamp()*1000))}/mocked-table.jsonl",
         True,
         [],
     ),
     (
         "{Y}/{load_package_timestamp_ms}/{table_name}",
-        f"{frozen_datetime.year}/{str(int(frozen_datetime.timestamp()*1000))}/mocked-table",
+        f"{frozen_datetime.year}/{str(int(frozen_datetime.timestamp()*1000))}/mocked-table.jsonl",
         True,
         [],
     ),
     ("{load_id}/{ext}/{table_name}", "mocked-load-id/jsonl/mocked-table", True, []),
-    ("{HH}/{mm}/{schema_name}", f"{frozen_datetime.format('HH/mm')}/schema-name", True, []),
-    ("{type}/{bobo}/{table_name}", "one-for-all/is-name/mocked-table", True, []),
+    (
+        "{HH}/{mm}/{schema_name}",
+        f"{frozen_datetime.format('HH/mm')}/schema-name.jsonl",
+        True,
+        [],
+    ),
+    ("{type}/{bobo}/{table_name}", "one-for-all/is-name/mocked-table.jsonl", True, []),
     # invalid placeholders
     ("{illegal_placeholder}{table_name}", "", False, ["illegal_placeholder"]),
     ("{unknown_placeholder}/{volume}/{table_name}", "", False, ["unknown_placeholder", "volume"]),
@@ -355,12 +360,26 @@ def test_create_path(test_load: TestLoad) -> None:
 
     # extension gets added automatically
     path = create_path(
-        "{schema_name}/{table_name}/{load_id}.{ext}",
+        "{schema_name}/{table_name}/{load_id}.{file_id}",
         schema_name="schema_name",
         load_id=load_id,
         file_name=job_info.file_name(),
     )
-    assert path == f"schema_name/mock_table/{load_id}.{job_info.file_format}"
+    assert (
+        path == f"schema_name/mock_table/{load_id}.{job_info.file_id}.{job_info.full_extension()}"
+    )
+
+    compressed_job_info = job_info._replace(is_compressed=True)
+    path = create_path(
+        "{schema_name}/{table_name}/{load_id}.{file_id}",
+        schema_name="schema_name",
+        load_id=load_id,
+        file_name=compressed_job_info.file_name(),
+    )
+    assert (
+        path
+        == f"schema_name/mock_table/{load_id}.{compressed_job_info.file_id}.{compressed_job_info.full_extension()}"
+    )
 
 
 def test_get_table_prefix_layout() -> None:


### PR DESCRIPTION
### Description

Fix filesystem path generation when a layout omits `{ext}`. `create_path` was checking all allowed placeholders instead of the placeholders present in the layout, making the documented extension fallback unreachable. It now preserves the formatted path and appends the job's full extension.

Update the existing layout expectations and cover both uncompressed and compressed job names so `.jsonl.gz` remains intact.

### Related Issues

- Fixes #4219

### Additional Context

Validation:
- `make format-check` (1,269 files unchanged)
- `make lint` (mypy, Ruff, Flake8, Bandit, lockfile, dependency, extras-version, and API compatibility checks passed)
- Full `make test-common` scope with no exclusions on Python 3.11.12 (7,050 parallel-safe tests passed with 57 expected skips; all 213 serial/fork-sensitive tests passed)
- `pytest tests/destinations/test_path_utils.py -q` (70 passed)
- End-to-end filesystem pipeline write and dataset readback with a layout omitting `{ext}`
