### PR TITLE
fix: allow key-only hard deletes with required columns

### DIFF
--- a/dlt/common/destination/utils.py
+++ b/dlt/common/destination/utils.py
@@ -16,6 +16,7 @@ from dlt.common.schema.exceptions import (
     TableNotFound,
 )
 from dlt.common.schema.typing import (
+    DLT_NAME_PREFIX,
     TColumnSchema,
     TColumnType,
     TLoaderMergeStrategy,
@@ -236,6 +237,34 @@ def prepare_load_table(
         return prep_table  # type: ignore[return-value]
     except KeyError:
         raise TableNotFound("<>", table_name)
+
+
+def prepare_hard_delete_table_for_staging(
+    table: TTableSchema, has_hard_delete: Optional[bool] = None
+) -> TTableSchema:
+    """Clone a merge table with nullable payload columns for key-only hard deletes."""
+    if has_hard_delete is None:
+        has_hard_delete = any(column.get("hard_delete") for column in table["columns"].values())
+    if table.get("write_disposition") != "merge" or not has_hard_delete:
+        return table
+
+    staging_table = table.copy()
+    staging_table["columns"] = {name: column.copy() for name, column in table["columns"].items()}
+    for column in staging_table["columns"].values():
+        if column["name"].casefold().startswith(DLT_NAME_PREFIX) or any(
+            column.get(hint)
+            for hint in (
+                "primary_key",
+                "merge_key",
+                "row_key",
+                "parent_key",
+                "root_key",
+                "hard_delete",
+            )
+        ):
+            continue
+        column["nullable"] = True
+    return staging_table
 
 
 def resolve_replace_strategy(

--- a/dlt/destinations/job_client_impl.py
+++ b/dlt/destinations/job_client_impl.py
@@ -25,7 +25,10 @@ from dlt.common.libs.sqlglot import TSqlGlotDialect
 from dlt.common import pendulum, logger
 from dlt.common.destination.capabilities import DataTypeMapper
 from dlt.common.destination.exceptions import WriteDispositionNotSupported
-from dlt.common.destination.utils import resolve_replace_strategy
+from dlt.common.destination.utils import (
+    prepare_hard_delete_table_for_staging,
+    resolve_replace_strategy,
+)
 from dlt.common.json import json
 from dlt.common.schema.typing import (
     C_DLT_LOAD_ID,
@@ -973,6 +976,72 @@ WHERE """
 
 class SqlJobClientWithStagingDataset(SqlJobClientBase, WithStagingDataset):
     in_staging_dataset_mode: bool = False
+
+    def prepare_load_table(self, table_name: str) -> PreparedTableSchema:
+        load_table = super().prepare_load_table(table_name)
+        if self.in_staging_dataset_mode:
+            has_hard_delete = any(
+                column.get("hard_delete")
+                for column in self.schema.tables[table_name]["columns"].values()
+            )
+            load_table = prepare_hard_delete_table_for_staging(
+                load_table, has_hard_delete=has_hard_delete
+            )
+        return load_table
+
+    def update_stored_schema(
+        self,
+        only_tables: Iterable[str] = None,
+        expected_update: TSchemaTables = None,
+        force: bool = False,
+    ) -> Optional[TSchemaTables]:
+        tables_to_check = (
+            tuple(only_tables) if only_tables is not None else tuple(self.schema.tables)
+        )
+        only_tables = tables_to_check if only_tables is not None else None
+        tables_to_recreate: List[str] = []
+        if self.in_staging_dataset_mode:
+            casefold_identifier = self.capabilities.casefold_identifier
+            for table_name in tables_to_check:
+                schema_table = self.schema.tables[table_name]
+                if schema_table.get("write_disposition") != "merge" or not any(
+                    column.get("hard_delete") for column in schema_table["columns"].values()
+                ):
+                    continue
+                load_table = super().prepare_load_table(table_name)
+                staging_table = prepare_hard_delete_table_for_staging(
+                    load_table, has_hard_delete=True
+                )
+                table_exists, storage_columns = self.get_storage_table(table_name)
+                if not table_exists:
+                    continue
+                folded_storage_columns = {
+                    casefold_identifier(name): column for name, column in storage_columns.items()
+                }
+                for name, column in load_table["columns"].items():
+                    staging_column = staging_table["columns"][name]
+                    storage_column = folded_storage_columns.get(casefold_identifier(name))
+                    if (
+                        not column.get("nullable", True)
+                        and staging_column.get("nullable", True)
+                        and storage_column is not None
+                        and not storage_column.get("nullable", True)
+                    ):
+                        tables_to_recreate.append(table_name)
+                        break
+
+        if tables_to_recreate:
+            self.drop_tables(*tables_to_recreate, delete_schema=False)
+            force = True
+        return super().update_stored_schema(only_tables, expected_update, force)
+
+    def _get_table_update_sql(
+        self, table_name: str, new_columns: Sequence[TColumnSchema], generate_alter: bool
+    ) -> List[str]:
+        if self.in_staging_dataset_mode:
+            staging_columns = self.prepare_load_table(table_name)["columns"]
+            new_columns = [staging_columns.get(column["name"], column) for column in new_columns]
+        return super()._get_table_update_sql(table_name, new_columns, generate_alter)
 
     @contextlib.contextmanager
     def with_staging_dataset(self) -> Iterator["SqlJobClientBase"]:

--- a/dlt/normalize/items_normalizers/jsonl.py
+++ b/dlt/normalize/items_normalizers/jsonl.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 
 from dlt.common.data_types.typing import TDataType
 from dlt.common.destination.capabilities import adjust_column_schema_to_capabilities
+from dlt.common.destination.utils import prepare_hard_delete_table_for_staging
 from dlt.common import logger
 from dlt.common.json import json
 from dlt.common.json import (
@@ -62,6 +63,7 @@ class JsonLItemsNormalizer(ItemsNormalizer):
         self._filtered_tables_columns: Dict[str, Dict[str, TSchemaEvolutionMode]] = {}
         # quick access to column schema for writers below
         self._column_schemas: Dict[str, TTableSchemaColumns] = {}
+        self._staging_column_schemas: Dict[str, TTableSchemaColumns] = {}
         self._null_only_columns: Dict[str, Set[str]] = {}
         self._shorten_fragments = lru_cache(maxsize=None)(self.schema.naming.shorten_fragments)
         # cache coercion interface from data item normalizer
@@ -183,6 +185,7 @@ class JsonLItemsNormalizer(ItemsNormalizer):
 
                         # update our columns
                         column_schemas[table_name] = schema.get_table_columns(table_name)
+                        self._staging_column_schemas.pop(table_name, None)
 
                         # apply new filters
                         if filtered_columns and filters:
@@ -202,8 +205,16 @@ class JsonLItemsNormalizer(ItemsNormalizer):
                     #   will be useful if we implement bad data sending to a table
                     # we skip write when discovering schema for empty file
                     if not skip_write:
+                        staging_columns = self._staging_column_schemas.get(table_name)
+                        if staging_columns is None:
+                            staging_table = schema.tables[table_name].copy()
+                            staging_table["columns"] = columns
+                            staging_columns = prepare_hard_delete_table_for_staging(staging_table)[
+                                "columns"
+                            ]
+                            self._staging_column_schemas[table_name] = staging_columns
                         self.item_storage.write_data_item(
-                            self.load_id, schema_name, table_name, row, columns
+                            self.load_id, schema_name, table_name, row, staging_columns
                         )
                         row_counts[table_name] = row_counts.get(table_name, 0) + 1
             except StopIteration:

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -1199,6 +1199,50 @@ def test_nested_column_missing(
     destinations_configs(default_sql_configs=True, supports_merge=True),
     ids=lambda x: x.name,
 )
+def test_hard_delete_key_only_record_with_non_nullable_column(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    table_name = "test_hard_delete_non_nullable"
+
+    @dlt.resource(
+        name=table_name,
+        write_disposition="merge",
+        primary_key="id",
+        columns={
+            "required": {"nullable": False},
+            "deleted": {"hard_delete": True},
+        },
+    )
+    def data_resource(data):
+        yield data
+
+    p = destination_config.setup_pipeline("hard_delete_non_nullable", dev_mode=True)
+    info = p.run(
+        data_resource([{"id": 1, "required": "value", "deleted": None}]),
+        **destination_config.run_kwargs,
+    )
+    assert_load_info(info)
+
+    if destination_config.destination_type == "duckdb":
+        # Mimic a staging table created before hard-delete payload constraints were relaxed.
+        with p.sql_client() as sql_client:
+            with sql_client.with_staging_dataset():
+                staging_table = sql_client.make_qualified_table_name(table_name)
+                sql_client.execute_sql(
+                    f'ALTER TABLE {staging_table} ALTER COLUMN "required" SET NOT NULL'
+                )
+
+    info = p.run(data_resource([{"id": 1, "deleted": True}]), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(p, table_name)[table_name] == 0
+    assert p.default_schema.tables[table_name]["columns"]["required"]["nullable"] is False
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, supports_merge=True),
+    ids=lambda x: x.name,
+)
 @pytest.mark.parametrize("key_type", ["primary_key", "merge_key", "no_key"])
 @pytest.mark.parametrize("merge_strategy", ("delete-insert", "upsert"))
 def test_hard_delete_hint(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Allow key-only hard-delete rows to pass through normalization and SQL staging without relaxing destination constraints. Non-key staging columns are made nullable, and legacy staging tables with stale `NOT NULL` payload constraints are recreated before loading.

<!--
Please link any related issues. This helps us keep the PR focused and merge it faster.
-->
### Related Issues

- Fixes #1066

<!--
Provide any additional context about the PR here.
-->
### Additional Context

The merge-disposition suite passes on DuckDB for both insert-values and Parquet paths: 76 passed, 9 skipped.

<!--
Please ensure that
    - you have read the [Contributing to dlt](../CONTRIBUTING.md) guide.
    - you have run the tests locally and they have passed before submitting your PR.
-->
