### PR TITLE
fix: use getattr() instead of __dict__.get() in generate_manifest

### DIFF
--- a/dlt/_workspace/deployment/manifest.py
+++ b/dlt/_workspace/deployment/manifest.py
@@ -508,7 +508,7 @@ def generate_manifest(
             names = list(deployment_module.__dict__.keys())
 
         for name in names:
-            obj = deployment_module.__dict__.get(name)
+            obj = getattr(deployment_module, name, None)
             if obj is None and iterate_all:
                 warnings.append(f"name {name!r} listed in __all__ but not found in module")
                 continue


### PR DESCRIPTION
## Summary

Fixes #4214

**Problem:** `generate_manifest()` uses `deployment_module.__dict__.get(name)` to look up deployment classes, which fails for **PEP 562** modules that define `__getattr__` at the module level (e.g., `croniter`). The `__dict__` of such modules is empty at import time — the resolver never finds the deployment class.

**Fix:** Replace `__dict__.get(name)` with `getattr(deployment_module, name, None)`, which respects `__getattr__` on the module.

**Verification:**
1. Normal module with regular class → `getattr` works identically to `__dict__.get`
2. PEP 562 module (custom `__getattr__`) → `getattr` finds the class, `__dict__.get` returns `None`
3. Both scenarios tested with assertions in isolation

**Pre-existing failures:** A separate test (`test_cron_deployment`) fails on both `devel` and this branch due to a missing `croniter` dependency — unrelated to this change.