### PR TITLE
feat(extract): add add_limit to source factory

### DIFF
--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -121,14 +121,17 @@ class DltSourceFactoryWrapper(SourceFactory[TSourceFunParams, TDltSourceImpl]):
 
     def add_limit(
         self,
-        max_items: Optional[int] = None,
-        max_time: Optional[float] = None,
-        count_rows: Optional[bool] = False,
-    ) -> Self:
-        """Limits selected resources on every source created by this factory.
+        max_items: int | None = None,
+        max_time: float | None = None,
+        count_rows: bool | None = False,
+    ) -> None:
+        """Add a post-processor to the source factory that add limits to the source instance.
 
-        Same semantics as DltSource.add_limit. Returns the factory for chaining;
-        call the factory to obtain a source, e.g. ``factory.add_limit(10)()``.
+        This mutates the source factory globally. Sources instantiated after adding the post-processor
+        will all receive the limit.
+
+        Returns nothing to match `.add_postprocessor()` instead of `resource.add_limit()` which returns the
+        mutated resource
         """
 
         def _limit_postprocessor(
@@ -137,18 +140,16 @@ class DltSourceFactoryWrapper(SourceFactory[TSourceFunParams, TDltSourceImpl]):
             if inspect.isawaitable(src):
 
                 async def _limit_async() -> TDltSourceImpl:
-                    source = await src  # type: ignore[misc]
-                    return source.add_limit(
-                        max_items, max_time=max_time, count_rows=count_rows
-                    )
+                    source = await src
+                    source.add_limit(max_items, max_time=max_time, count_rows=count_rows)
+                    return source
 
                 return _limit_async()
-            return src.add_limit(  # type: ignore[union-attr]
-                max_items, max_time=max_time, count_rows=count_rows
-            )
+            else:
+                src.add_limit(max_items, max_time=max_time, count_rows=count_rows)
+                return src
 
-        self.add_postprocessor(_limit_postprocessor)  # type: ignore[arg-type]
-        return self
+        self.add_postprocessor(_limit_postprocessor)
 
     def _apply_postprocessors(self, source: TDltSourceImpl) -> TDltSourceImpl:
         for func in self._postprocessors:

--- a/dlt/extract/decorators.py
+++ b/dlt/extract/decorators.py
@@ -119,6 +119,37 @@ class DltSourceFactoryWrapper(SourceFactory[TSourceFunParams, TDltSourceImpl]):
         """Adds a callback that receives and returns a DltSource after it is created."""
         self._postprocessors.append(func)
 
+    def add_limit(
+        self,
+        max_items: Optional[int] = None,
+        max_time: Optional[float] = None,
+        count_rows: Optional[bool] = False,
+    ) -> Self:
+        """Limits selected resources on every source created by this factory.
+
+        Same semantics as DltSource.add_limit. Returns the factory for chaining;
+        call the factory to obtain a source, e.g. ``factory.add_limit(10)()``.
+        """
+
+        def _limit_postprocessor(
+            src: Union[TDltSourceImpl, Awaitable[TDltSourceImpl]],
+        ) -> Union[TDltSourceImpl, Awaitable[TDltSourceImpl]]:
+            if inspect.isawaitable(src):
+
+                async def _limit_async() -> TDltSourceImpl:
+                    source = await src  # type: ignore[misc]
+                    return source.add_limit(
+                        max_items, max_time=max_time, count_rows=count_rows
+                    )
+
+                return _limit_async()
+            return src.add_limit(  # type: ignore[union-attr]
+                max_items, max_time=max_time, count_rows=count_rows
+            )
+
+        self.add_postprocessor(_limit_postprocessor)  # type: ignore[arg-type]
+        return self
+
     def _apply_postprocessors(self, source: TDltSourceImpl) -> TDltSourceImpl:
         for func in self._postprocessors:
             source = func(source)  # type: ignore[assignment]

--- a/dlt/extract/reference.py
+++ b/dlt/extract/reference.py
@@ -6,6 +6,7 @@ from typing import (
     List,
     Any,
     Generic,
+    Optional,
     Tuple,
     Union,
     overload,
@@ -61,6 +62,18 @@ class SourceFactory(ABC, Generic[TSourceFunParams, TDltSourceImpl]):
         self, func: Callable[[TDltSourceImpl], Union[TDltSourceImpl, Awaitable[TDltSourceImpl]]]
     ) -> None:
         """Adds a callback that receives and returns a DltSource after it is created."""
+
+    @abstractmethod
+    def add_limit(
+        self,
+        max_items: Optional[int] = None,
+        max_time: Optional[float] = None,
+        count_rows: Optional[bool] = False,
+    ) -> None:
+        """Adds a post-processor to the source factory that adds limits to the source instance.
+
+        Returns `None` to match the behavior of `.add_postprocessor()`
+        """
 
     @abstractmethod
     def clone(

--- a/tests/extract/test_decorators.py
+++ b/tests/extract/test_decorators.py
@@ -24,8 +24,13 @@ from dlt.common.typing import TDataItem, TFun, TTableNames
 
 from dlt._workspace.cli.source_detection import detect_source_configs
 from dlt.common.utils import custom_environ
-from dlt.extract.decorators import _DltSingleSource, DltSourceFactoryWrapper, defer
+from dlt.extract.decorators import (
+    _DltSingleSource,
+    DltSourceFactoryWrapper,
+    defer,
+)
 from dlt.extract.hints import TResourceNestedHints
+from dlt.extract.items_transform import LimitItem
 from dlt.extract.reference import SourceReference
 from dlt.extract import DltResource, DltSource
 from dlt.extract.exceptions import (
@@ -1839,37 +1844,146 @@ async def test_async_source_postprocessor() -> None:
     assert list(source) == [1, 2, 3]
 
 
-def test_source_factory_add_limit() -> None:
-    @dlt.source
-    def limited_factory():
-        return dlt.resource([1, 2, 3], name="data")
+def test_add_limit_on_source_instance():
+    # NOTE the source needs to be defined within the test to avoid mutations.
+    USERS = [dict(id=1, name="Alice"), dict(id=2, name="Bob")]
+    CITIES = [dict(id=1, name="London"), dict(id=2, name="Paris")]
 
-    assert limited_factory.add_limit(1) is limited_factory
-    assert list(limited_factory()) == [1]
+    @dlt.source
+    def mock_source():
+        """Source used"""
+
+        @dlt.resource
+        def users():
+            return USERS
+
+        @dlt.resource
+        def cities():
+            return CITIES
+
+        return [users(), cities()]
+
+    instance = mock_source()
+
+    # check before setting the limit
+    for resource in instance.resources.values():
+        assert len(resource._pipe) == 1
+
+    output_instance = instance.add_limit(1)
+
+    # instance is mutated
+    assert output_instance is instance
+
+    # all resources now have a LimitItem step
+    for resource in instance.resources.values():
+        assert len(resource._pipe) == 2
+        assert isinstance(resource._pipe[-1], LimitItem)
+
+    # we retrieve the first record of each resource
+    # the resource order matches the order the source returns them
+    data = list(instance)
+    assert data[0] == USERS[0]
+    assert data[1] == CITIES[0]
+
+
+def test_add_limit_on_source_factory() -> None:
+    # NOTE the source needs to be defined within the test to avoid mutations.
+    USERS = [dict(id=1, name="Alice"), dict(id=2, name="Bob")]
+    CITIES = [dict(id=1, name="London"), dict(id=2, name="Paris")]
+
+    @dlt.source
+    def mock_source():
+        @dlt.resource
+        def users():
+            return USERS
+
+        @dlt.resource
+        def cities():
+            return CITIES
+
+        return [users(), cities()]
+
+    before_instance = mock_source()
+
+    # check before setting the limit
+    for resource in before_instance.resources.values():
+        assert len(resource._pipe) == 1
+
+    output_factory = mock_source.add_limit(1)
+
+    # .add_limit() on factory doesn't return
+    assert output_factory is None
+
+    after_instance = mock_source()
+
+    # the existing instance is not mutated
+    assert before_instance is not after_instance
+    for resource in before_instance.resources.values():
+        assert len(resource._pipe) == 1
+
+    # all resources now have a LimitItem step
+    for resource in after_instance.resources.values():
+        assert len(resource._pipe) == 2
+        assert isinstance(resource._pipe[-1], LimitItem)
+
+    # we retrieve the first record of each resource
+    # the resource order matches the order the source returns them
+    data = list(after_instance)
+    assert data[0] == USERS[0]
+    assert data[1] == CITIES[0]
 
 
 def test_source_factory_add_limit_preserved_on_clone() -> None:
     @dlt.source
-    def limited_factory():
-        return dlt.resource([1, 2, 3], name="data")
+    def mock_source():
+        @dlt.resource
+        def users():
+            return [dict(id=1, name="Alice"), dict(id=2, name="Bob")]
 
-    cloned = limited_factory.add_limit(1).clone(section="new_section")
-    assert list(cloned()) == [1]
+        @dlt.resource
+        def cities():
+            return [dict(id=1, name="London"), dict(id=2, name="Paris")]
+
+        return [users(), cities()]
+
+    cloned = mock_source().add_limit(1).clone()
+
+    # all resources now have a LimitItem step
+    for resource in cloned.resources.values():
+        assert len(resource._pipe) == 2
+        assert isinstance(resource._pipe[-1], LimitItem)
 
 
 @pytest.mark.asyncio
 async def test_async_source_factory_add_limit() -> None:
+    # NOTE the source needs to be defined within the test to avoid mutations.
+    USERS = [dict(id=1, name="Alice"), dict(id=2, name="Bob")]
+    CITIES = [dict(id=1, name="London"), dict(id=2, name="Paris")]
+
     @dlt.source
-    async def async_limited_factory():
-        return dlt.resource([1, 2, 3], name="data")
+    async def async_mock_source():
+        @dlt.resource
+        def users():
+            return USERS
 
-    source = await async_limited_factory.add_limit(1)()  # type: ignore[misc]
-    assert list(source) == [1]
+        @dlt.resource
+        def cities():
+            return CITIES
 
+        return [users(), cities()]
 
-def test_source_instance_add_limit_still_works() -> None:
-    @dlt.source
-    def unlimited_factory():
-        return dlt.resource([1, 2, 3], name="data")
+    async_mock_source.add_limit(1)
 
-    assert list(unlimited_factory().add_limit(1)) == [1]
+    # TODO there's a real typing error somewhere in the dlt source / source wrapper code
+    instance = await async_mock_source()  # type: ignore[misc]
+
+    # all resources now have a LimitItem step
+    for resource in instance.resources.values():
+        assert len(resource._pipe) == 2
+        assert isinstance(resource._pipe[-1], LimitItem)
+
+    # we retrieve the first record of each resource
+    # the resource order matches the order the source returns them
+    data = list(instance)
+    assert data[0] == USERS[0]
+    assert data[1] == CITIES[0]

--- a/tests/extract/test_decorators.py
+++ b/tests/extract/test_decorators.py
@@ -1837,3 +1837,39 @@ async def test_async_source_postprocessor() -> None:
     assert "alpha" in source.selected_resources
     assert "beta" not in source.selected_resources
     assert list(source) == [1, 2, 3]
+
+
+def test_source_factory_add_limit() -> None:
+    @dlt.source
+    def limited_factory():
+        return dlt.resource([1, 2, 3], name="data")
+
+    assert limited_factory.add_limit(1) is limited_factory
+    assert list(limited_factory()) == [1]
+
+
+def test_source_factory_add_limit_preserved_on_clone() -> None:
+    @dlt.source
+    def limited_factory():
+        return dlt.resource([1, 2, 3], name="data")
+
+    cloned = limited_factory.add_limit(1).clone(section="new_section")
+    assert list(cloned()) == [1]
+
+
+@pytest.mark.asyncio
+async def test_async_source_factory_add_limit() -> None:
+    @dlt.source
+    async def async_limited_factory():
+        return dlt.resource([1, 2, 3], name="data")
+
+    source = await async_limited_factory.add_limit(1)()  # type: ignore[misc]
+    assert list(source) == [1]
+
+
+def test_source_instance_add_limit_still_works() -> None:
+    @dlt.source
+    def unlimited_factory():
+        return dlt.resource([1, 2, 3], name="data")
+
+    assert list(unlimited_factory().add_limit(1)) == [1]


### PR DESCRIPTION
Description
Adds .add_limit() on @dlt.source factories (DltSourceFactoryWrapper) so a limit can be set before instantiating the source.

Instance-level DltSource.add_limit() already existed. This wires the same API on the factory via an async-aware postprocessor that calls the existing instance method, so both sync and async sources are supported. Factory clones preserve the limit because postprocessors are already copied on clone().

Example:

@dlt.source
def mock_source():
    return dlt.resource([1, 2, 3], name="data")
mock_source.add_limit(1)
assert list(mock_source()) == [1]
# instance path unchanged
assert list(mock_source().add_limit(1)) == [1]
Returns the factory for chaining — call it to get a source: factory.add_limit(10)().

Related Issues
Closes #4218

Additional Context
Implementation: DltSourceFactoryWrapper.add_limit in dlt/extract/decorators.py
Tests: sync, clone preservation, async, and instance regression in tests/extract/test_decorators.py
Local verification: pytest tests/extract/test_decorators.py -k "factory_add_limit or instance_add_limit_still" -v (4 passed)