### PR TITLE
fix(filesystem): apply extra_placeholders in get_table_prefix

### DIFF
--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -990,14 +990,20 @@ class FilesystemClient(
             # it is crucial to append and keep "/" at the end
             table_prefix = self.pathlib.join(table_name, "")
         else:
+            prefix_placeholders = set(path_utils.get_placeholders(self.table_prefix_layout))
+            prefix_extra_placeholders = {
+                key: value
+                for key, value in (self.config.extra_placeholders or {}).items()
+                if key in prefix_placeholders
+            }
             params = path_utils.prepare_params(
-                extra_placeholders=self.config.extra_placeholders,
+                extra_placeholders=prefix_extra_placeholders,
                 schema_name=schema_name or self.schema.name,
                 table_name=table_name,
             )
             table_prefix = self.table_prefix_layout.format(
                 schema_name=params.get("schema_name", schema_name or self.schema.name),
-                table_name=table_name,
+                table_name=params.get("table_name", table_name),
             )
         return self.pathlib.join(  # type: ignore[no-any-return]
             self.dataset_path, path_utils.normalize_path_sep(self.pathlib, table_prefix)

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -990,8 +990,14 @@ class FilesystemClient(
             # it is crucial to append and keep "/" at the end
             table_prefix = self.pathlib.join(table_name, "")
         else:
+            params = path_utils.prepare_params(
+                extra_placeholders=self.config.extra_placeholders,
+                schema_name=schema_name or self.schema.name,
+                table_name=table_name,
+            )
             table_prefix = self.table_prefix_layout.format(
-                schema_name=schema_name or self.schema.name, table_name=table_name
+                schema_name=params.get("schema_name", schema_name or self.schema.name),
+                table_name=table_name,
             )
         return self.pathlib.join(  # type: ignore[no-any-return]
             self.dataset_path, path_utils.normalize_path_sep(self.pathlib, table_prefix)

--- a/dlt/destinations/path_utils.py
+++ b/dlt/destinations/path_utils.py
@@ -130,9 +130,9 @@ def prepare_params(
     job_info: Optional[ParsedLoadJobFileName] = None,
     schema_name: Optional[str] = None,
     load_id: Optional[str] = None,
+    table_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     params: Dict[str, Any] = {}
-    table_name = None
     file_id = None
     ext = None
     if job_info:
@@ -146,6 +146,8 @@ def prepare_params(
                 "ext": ext,
             }
         )
+    elif table_name:
+        params["table_name"] = table_name
 
     if schema_name:
         params["schema_name"] = schema_name

--- a/tests/load/filesystem/test_filesystem_client.py
+++ b/tests/load/filesystem/test_filesystem_client.py
@@ -159,6 +159,37 @@ def test_trailing_separators(layout: str, with_gdrive_buckets_env: str) -> None:
         assert client.get_table_prefix("letters").endswith("_data/letters.")
 
 
+def test_table_prefix_resolves_schema_name_extra_placeholder() -> None:
+    client = _client_factory(
+        filesystem(
+            bucket_url=get_test_storage_root(),
+            layout="{schema_name}/{table_name}/{load_id}.{file_id}.{ext}",
+            extra_placeholders={"schema_name": "custom", "load_id": "custom_load_id"},
+        )
+    )
+
+    assert client.get_table_prefix("letters").endswith("/custom/letters/")
+
+    def custom_schema_name(
+        schema_name: str,
+        table_name: str,
+        load_id: str,
+        file_id: str,
+        ext: str,
+    ) -> str:
+        assert (schema_name, table_name, load_id, file_id, ext) == (
+            "test",
+            "letters",
+            None,
+            None,
+            None,
+        )
+        return "custom_callable"
+
+    client.config.extra_placeholders["schema_name"] = custom_schema_name
+    assert client.get_table_prefix("letters").endswith("/custom_callable/letters/")
+
+
 @pytest.mark.parametrize("write_disposition", ("replace", "append", "merge"))
 @pytest.mark.parametrize("layout", TEST_FILE_LAYOUTS)
 def test_successful_load(write_disposition: str, layout: str, default_buckets_env: str) -> None:

--- a/tests/load/filesystem/test_filesystem_client.py
+++ b/tests/load/filesystem/test_filesystem_client.py
@@ -159,16 +159,23 @@ def test_trailing_separators(layout: str, with_gdrive_buckets_env: str) -> None:
         assert client.get_table_prefix("letters").endswith("_data/letters.")
 
 
-def test_table_prefix_resolves_schema_name_extra_placeholder() -> None:
+def test_table_prefix_resolves_standard_extra_placeholders() -> None:
+    def unused_load_id(*args: str) -> str:
+        raise AssertionError("placeholder outside table prefix must not be resolved")
+
     client = _client_factory(
         filesystem(
             bucket_url=get_test_storage_root(),
             layout="{schema_name}/{table_name}/{load_id}.{file_id}.{ext}",
-            extra_placeholders={"schema_name": "custom", "load_id": "custom_load_id"},
+            extra_placeholders={
+                "schema_name": "custom",
+                "table_name": "custom_table",
+                "load_id": unused_load_id,
+            },
         )
     )
 
-    assert client.get_table_prefix("letters").endswith("/custom/letters/")
+    assert client.get_table_prefix("letters").endswith("/custom/custom_table/")
 
     def custom_schema_name(
         schema_name: str,
@@ -186,8 +193,25 @@ def test_table_prefix_resolves_schema_name_extra_placeholder() -> None:
         )
         return "custom_callable"
 
+    def custom_table_name(
+        schema_name: str,
+        table_name: str,
+        load_id: str,
+        file_id: str,
+        ext: str,
+    ) -> str:
+        assert (schema_name, table_name, load_id, file_id, ext) == (
+            "test",
+            "letters",
+            None,
+            None,
+            None,
+        )
+        return "custom_table_callable"
+
     client.config.extra_placeholders["schema_name"] = custom_schema_name
-    assert client.get_table_prefix("letters").endswith("/custom_callable/letters/")
+    client.config.extra_placeholders["table_name"] = custom_table_name
+    assert client.get_table_prefix("letters").endswith("/custom_callable/custom_table_callable/")
 
 
 @pytest.mark.parametrize("write_disposition", ("replace", "append", "merge"))


### PR DESCRIPTION
## Summary

When `extra_placeholders` overrides `{schema_name}`, filesystem writes land under the overridden segment, but `get_table_prefix` still used the real schema name. Replace truncation and table listing therefore matched zero files and silently left old data in place.

## Changes

- Resolve `schema_name` for `get_table_prefix` through `path_utils.prepare_params` so constant and callable `extra_placeholders` overrides match the write path.
- Pass only resolved `schema_name` and the method `table_name` into the prefix layout format, so unrelated extra placeholders do not break prefix formatting.
- Allow optional `table_name` on `prepare_params` so prefix-time callables receive the table name (with load/file fields as `None`).
- Add a regression test for constant and callable schema overrides with an unrelated extra placeholder present.

## Verification

- `pytest tests/load/filesystem/test_filesystem_client.py::test_table_prefix_resolves_schema_name_extra_placeholder -q`
- `pytest tests/destinations/test_path_utils.py -q` (path utils suite)

Fixes #4224
