### PR TITLE
fix(rest_client): preserve paginator stop conditions

### DIFF
--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -202,7 +202,7 @@ class RangePaginator(BasePaginator):
                 elif not isinstance(has_more, bool):
                     self._handle_invalid_has_more(has_more)
 
-                self._has_next_page = has_more
+                self._has_next_page = self._has_next_page and has_more
 
     def _stop_after_this_page(self, data: Optional[List[Any]] = None) -> bool:
         return self.stop_after_empty_page and not data

--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -903,7 +903,7 @@ class JSONResponseCursorPaginator(BaseReferencePaginator):
             elif not isinstance(has_more, bool):
                 self._handle_invalid_has_more(has_more)
 
-            self._has_next_page = has_more
+            self._has_next_page = self._has_next_page and has_more
 
     def _handle_invalid_has_more(self, has_more: Any) -> None:
         raise ValueError(

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -975,6 +975,12 @@ class TestJSONResponseCursorPaginator:
             excinfo.value
         )
 
+    def test_update_state_when_cursor_path_is_empty_string(self):
+        paginator = JSONResponseCursorPaginator(cursor_path="next_cursor")
+        response = Mock(Response, json=lambda: {"next_cursor": "", "results": []})
+        paginator.update_state(response)
+        assert paginator.has_next_page is False
+
     def test_has_more_does_not_override_missing_cursor(self):
         paginator = JSONResponseCursorPaginator(cursor_path="next_cursor", has_more_path="has_more")
         response = Mock(Response, json=lambda: {"next_cursor": "", "results": [], "has_more": True})

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -349,6 +349,20 @@ class TestRangePaginator:
 
         assert paginator.has_next_page is False
 
+    def test_has_more_does_not_override_total(self) -> None:
+        paginator = RangePaginator(
+            param_name="page",
+            initial_value=0,
+            value_step=1,
+            total_path="total",
+            has_more_path="has_more",
+        )
+        response = Mock(Response, json=lambda: {"total": 1, "has_more": True})
+
+        paginator.update_state(response, data=NON_EMPTY_PAGE)
+
+        assert paginator.has_next_page is False
+
 
 @pytest.mark.usefixtures("mock_api_server")
 class TestOffsetPaginator:

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -335,6 +335,20 @@ class TestRangePaginator:
         with pytest.raises(ValueError, match="body_path.*must not be empty"):
             RangePaginator._update_request_with_body_path(request, "", 0)
 
+    def test_has_more_does_not_override_maximum_value(self) -> None:
+        paginator = RangePaginator(
+            param_name="page",
+            initial_value=0,
+            value_step=1,
+            maximum_value=1,
+            has_more_path="has_more",
+        )
+        response = Mock(Response, json=lambda: {"has_more": True})
+
+        paginator.update_state(response, data=NON_EMPTY_PAGE)
+
+        assert paginator.has_next_page is False
+
 
 @pytest.mark.usefixtures("mock_api_server")
 class TestOffsetPaginator:

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -975,9 +975,9 @@ class TestJSONResponseCursorPaginator:
             excinfo.value
         )
 
-    def test_update_state_when_cursor_path_is_empty_string(self):
-        paginator = JSONResponseCursorPaginator(cursor_path="next_cursor")
-        response = Mock(Response, json=lambda: {"next_cursor": "", "results": []})
+    def test_has_more_does_not_override_missing_cursor(self):
+        paginator = JSONResponseCursorPaginator(cursor_path="next_cursor", has_more_path="has_more")
+        response = Mock(Response, json=lambda: {"next_cursor": "", "results": [], "has_more": True})
         paginator.update_state(response)
         assert paginator.has_next_page is False
 


### PR DESCRIPTION
### Description

Preserve existing stop decisions when an API returns `has_more=true`.

For numeric range pagination, `RangePaginator.update_state()` first stops at `maximum_offset`, `maximum_page`, or the response total. For cursor pagination, assigning a missing cursor stops `JSONResponseCursorPaginator`. Both methods previously replaced those decisions with the API's `has_more` flag, which could request another page without a valid cursor or beyond a hard limit.

`has_more=false` can still stop pagination early; `true` can no longer re-enable a paginator that has already reached another stop condition. Regression tests cover maximum limits, total-based limits, and missing cursors.

### Related Issues

- Fixes #4225

### Additional Context

Validation:

- `make lint`
- common parallel-safe tests: 7,051 passed, 57 skipped
- non-forked serial tests: 192 passed, 1 skipped
- forked tests: 21 passed, 1 skipped
- `.venv/bin/pytest tests/sources/helpers/rest_client/test_paginators.py -q` (100 passed)
- Black, Ruff, and mypy on the changed files

On macOS, forked tests were run in a fresh pytest process with `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`.