### PR TITLE
fix(normalize): normalize timezone on the coerce-row happy path

### DIFF
--- a/dlt/normalize/items_normalizers/jsonl.py
+++ b/dlt/normalize/items_normalizers/jsonl.py
@@ -251,6 +251,9 @@ class JsonLItemsNormalizer(ItemsNormalizer):
                         py_type = type_map.get(type(v))
                         if py_type == col_type:
                             # happy path: complete column, type matches, no coercion needed
+                            if col_type == "timestamp":
+                                timezone = existing_column.get("timezone", True)
+                                v = normalize_timezone(v, timezone)
                             new_row[col_name] = v
                             continue
                         if py_type and can_coerce_type(col_type, py_type):

--- a/tests/normalize/test_json_item_inference.py
+++ b/tests/normalize/test_json_item_inference.py
@@ -314,6 +314,32 @@ def test_coerce_timestamp_timezone_existing_column_normalize_utc(
     assert new_table_2 is None
 
 
+def test_coerce_timestamp_timezone_existing_column_happy_path(
+    item_normalizer: JsonLItemsNormalizer,
+):
+    """Existing timestamp column + a value whose inferred type already matches
+    ("happy path", no type coercion needed) must still get timezone-normalized,
+    the same as a value that does need coercion.
+    """
+    # create the column first, then force it to timezone=False (naive)
+    row_1 = {"event_time": "2022-05-10T00:17:15.300000+02:00"}
+    _, new_table = item_normalizer._coerce_row("events", None, row_1)
+    new_table["columns"]["event_time"]["timezone"] = False
+    item_normalizer.schema.update_table(new_table)
+
+    # row_2's value is already a pendulum.DateTime, so its inferred type equals
+    # the column's type exactly -- this takes the "happy path", not the
+    # type-coercion path that the sibling test above exercises
+    row_2 = {"event_time": pendulum.parse("2022-05-10T05:30:45.500000-03:00")}
+    coerced_row_2, new_table_2 = item_normalizer._coerce_row("events", None, row_2)
+
+    expected_utc = ensure_pendulum_datetime_non_utc("2022-05-10T08:30:45.500000+00:00")
+    expected_naive = expected_utc.naive()
+    assert coerced_row_2["event_time"] == expected_naive
+    assert coerced_row_2["event_time"].tzinfo is None
+    assert new_table_2 is None
+
+
 def test_coerce_timestamp_timezone_incomplete_column(item_normalizer: JsonLItemsNormalizer):
     """Test timezone normalization when column exists but is incomplete (no data_type)."""
     # Create an incomplete column first


### PR DESCRIPTION
### Description

`JsonLItemsNormalizer._coerce_row`'s "happy path" (column already complete in the schema, incoming value's inferred type already matches the column type — no coercion needed) skips `normalize_timezone()` entirely:

```python
if py_type == col_type:
    # happy path: complete column, type matches, no coercion needed
    new_row[col_name] = v
    continue
```

The sibling branch just below (type *does* need coercion) calls `normalize_timezone()`, and so does the slow path (`_coerce_non_null_value`) whenever `col_type == "timestamp"`. The happy path is the one place that call is missing — an inconsistency, not a design choice.

A `timestamp` value's stored representation silently depends on which branch happens to fire for a given row, rather than on the column's `timezone` hint. Concretely: with `timezone=False` (destination expects a naive/UTC-implied timestamp) and the happy path firing on the very first row (e.g. via a pre-declared `columns=` hint), a tz-aware input like `2024-01-01T10:00:00+05:00` (== `05:00:00` UTC) gets stored completely unconverted as `10:00:00` — a silent 5-hour data corruption with no error anywhere in the pipeline. Repro and full explanation in #4228.

**Fix**

Call `normalize_timezone(v, existing_column.get("timezone", True))` in the happy-path branch too, mirroring the sibling branch and the slow path.

### Related Issues

- Fixes #4228

### Additional Context

**Testing**

Added `test_coerce_timestamp_timezone_existing_column_happy_path` to `tests/normalize/test_json_item_inference.py` — deliberately feeds a `pendulum.DateTime` object (not a string) as the second row's value so its inferred type already matches the existing column, exercising the happy path specifically (the existing sibling test in that file only exercises the coercion path, via a string input). Fails before the fix, passes after.

Verified: `black --check`, `flake8 --extend-ignore=D --max-line-length=200`, and `mypy` all clean on the changed files; full `tests/normalize/test_json_item_inference.py` (49 tests) and `tests/normalize/test_normalize.py` (109 tests) pass, no regressions.

---
Disclosure: this PR was drafted with AI assistance (Claude); I reviewed, tested, and take responsibility for the change.


