### PR TITLE
fix(common): build boolean sqlglot literals as sge.Boolean, not numeric

### DIFF
--- a/dlt/common/libs/sqlglot.py
+++ b/dlt/common/libs/sqlglot.py
@@ -640,6 +640,8 @@ def build_typed_literal(
             lit = sge.Null()
         elif isinstance(v, str):
             lit = sge.Literal.string(v)
+        elif isinstance(v, bool):
+            lit = sge.Boolean(this=v)
         elif isinstance(v, (int, float)):
             lit = sge.Literal.number(v)
         elif isinstance(v, (bytes, bytearray)):

--- a/tests/libs/test_sqlglot.py
+++ b/tests/libs/test_sqlglot.py
@@ -3,10 +3,12 @@ import importlib
 import pytest
 import sqlglot
 import sqlglot.expressions as sge
+from sqlglot.optimizer.annotate_types import annotate_types
 
 from dlt.common.libs.sqlglot import (
     DLT_SUBQUERY_NAME,
     TSqlGlotDialect,
+    build_typed_literal,
     filter_select_column_names,
     from_sqlglot_type,
     get_select_column_names,
@@ -764,3 +766,29 @@ def test_migrate_order_and_limit_rewrites_computed_key_to_output_name() -> None:
     sort_key = order.expressions[0].this
     assert isinstance(sort_key, sge.Column)
     assert sort_key.name == "c" and sort_key.table == DLT_SUBQUERY_NAME
+
+
+def test_build_typed_literal_bool_produces_boolean_expression() -> None:
+    """A bool value must become sge.Boolean, not a numeric literal -- bool is an int
+    subclass, so an isinstance(v, (int, float)) check ahead of the bool check would
+    silently misclassify it and break sqlglot's type annotation pass downstream.
+    """
+    lit = build_typed_literal(True)
+    assert isinstance(lit, sge.Boolean)
+    assert lit.this is True
+
+    lit = build_typed_literal(False)
+    assert isinstance(lit, sge.Boolean)
+    assert lit.this is False
+
+
+def test_build_typed_literal_bool_survives_type_annotation() -> None:
+    """A WHERE clause built from a bool literal (as Relation.where()/.filter() do)
+    must survive sqlglot's annotate_types pass instead of raising decimal.InvalidOperation.
+    """
+    condition = sge.EQ(this=sge.column("is_active"), expression=build_typed_literal(True))
+    select = sqlglot.select("*").from_("my_table").where(condition)
+
+    annotated = annotate_types(select)
+
+    assert "TRUE" in annotated.sql()


### PR DESCRIPTION
### Description

`build_typed_literal()`'s inner `_literal()` helper had no dedicated branch for `bool`. Since `bool` is an `int` subclass, `True`/`False` fell into the `isinstance(v, (int, float))` branch and were built as `sge.Literal.number(v)` — a malformed numeric literal (text `"True"`/`"False"`) that crashes with `decimal.InvalidOperation` as soon as it goes through sqlglot's `annotate_types()` optimizer pass (used by `Relation.where()`/`.filter()`).

Fix: dedicated `isinstance(v, bool)` branch ahead of the `int`/`float` branch, producing `sge.Boolean(this=v)`.

Added two tests in `tests/libs/test_sqlglot.py`:
- `build_typed_literal(True/False)` produces `sge.Boolean` with the correct `.this`.
- A `WHERE` clause built from a bool literal survives `annotate_types()` (previously raised `decimal.InvalidOperation`).

Verified red (crash) before the fix, green after; full `tests/libs/test_sqlglot.py` suite passes (269 passed); `uv run ruff check` and `black --check` clean.

---
Disclosure: this PR was drafted with AI assistance (Claude) after I independently reproduced and fixed the bug; I reviewed the change and take responsibility for it.

### Related Issues

- Fixes #4230

### Additional Context

See the Description above for the repro, the fix and the test evidence.
