### PR TITLE
fix(extract): call arrow callable primary key with a row, not the table

### DIFF
--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -431,7 +431,17 @@ class ArrowIncremental(IncrementalTransform):
 
             tbl = polars_to_arrow(tbl)
 
-        primary_key = self._primary_key(tbl) if callable(self._primary_key) else self._primary_key
+        if callable(self._primary_key):
+            # dynamic hints are always called with a single representative row, same as
+            # `resolve_column_value` does for the JSON path
+            representative_row = (
+                tbl.slice(0, 1).to_pylist()[0]
+                if tbl.num_rows > 0
+                else {name: None for name in tbl.schema.names}
+            )
+            primary_key = self._primary_key(representative_row)
+        else:
+            primary_key = self._primary_key
         if primary_key:
             # create a list of unique columns
             if isinstance(primary_key, str):
@@ -447,6 +457,9 @@ class ArrowIncremental(IncrementalTransform):
                 self._dlt_index = primary_key
         elif primary_key is None:
             unique_columns = tbl.schema.names
+        else:
+            # primary key resolved to an empty sequence: disable deduplication
+            unique_columns = []
 
         start_out_of_range = end_out_of_range = False
         if not tbl:  # row is None or empty arrow table

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -226,6 +226,79 @@ def test_unique_keys_are_deduplicated(item_type: TestDataItemFormat) -> None:
     assert rows == [(1, "a"), (2, "b"), (3, "c"), (3, "d"), (3, "e"), (3, "f"), (4, "g")]
 
 
+@pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
+def test_callable_primary_key_receives_single_row(item_type: TestDataItemFormat) -> None:
+    """A callable primary key must be called with a single representative row (dict-like),
+    same convention as other dynamic hints, not with the whole arrow table/dataframe.
+    """
+    data = [
+        {"created_at": 1, "id": "a"},
+        {"created_at": 2, "id": "b"},
+        {"created_at": 3, "id": "c"},
+    ]
+    source_items = data_to_item_format(item_type, data)
+
+    def dynamic_pk(item: Any) -> str:
+        # written the standard way: a membership check on `item`. `item` must be a single
+        # row, not the whole table -- else this always takes the wrong branch
+        return "id" if "id" in item else "column_that_does_not_exist"
+
+    @dlt.resource
+    def some_data(created_at=dlt.sources.incremental("created_at")):
+        yield from source_items
+
+    r = some_data()
+    r.incremental.primary_key = dynamic_pk
+
+    p = dlt.pipeline(
+        pipeline_name="p" + uniq_id(),
+        destination=dlt.destinations.duckdb(credentials=duckdb.connect(":memory:")),
+    )
+    p.run(r)
+    p.run(r)
+
+    with p.sql_client() as c:
+        with c.execute_query("SELECT created_at, id FROM some_data order by created_at") as cur:
+            rows = cur.fetchall()
+
+    # `dynamic_pk` resolves to "id": rows already loaded in the first run are deduplicated
+    assert rows == [(1, "a"), (2, "b"), (3, "c")]
+
+
+@pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
+def test_callable_primary_key_resolving_to_empty_tuple_disables_dedup(
+    item_type: TestDataItemFormat,
+) -> None:
+    """A callable primary key resolving to `()` (the official "disable dedup" sentinel) must
+    disable deduplication, not raise `UnboundLocalError` on `unique_columns`.
+    """
+    data = [
+        {"created_at": 1, "id": "a"},
+        {"created_at": 1, "id": "a"},
+    ]
+    source_items = data_to_item_format(item_type, data)
+
+    @dlt.resource
+    def some_data(created_at=dlt.sources.incremental("created_at")):
+        yield from source_items
+
+    r = some_data()
+    r.incremental.primary_key = lambda item: ()
+
+    p = dlt.pipeline(
+        pipeline_name="p" + uniq_id(),
+        destination=dlt.destinations.duckdb(credentials=duckdb.connect(":memory:")),
+    )
+    p.run(r)
+
+    with p.sql_client() as c:
+        with c.execute_query("SELECT created_at, id FROM some_data order by created_at") as cur:
+            rows = cur.fetchall()
+
+    # deduplication disabled: both identical rows are kept
+    assert len(rows) == 2
+
+
 def test_pandas_index_as_dedup_key() -> None:
     from dlt.common.libs.pandas import pandas_to_arrow, pandas as pd
 


### PR DESCRIPTION
### Description

`ArrowIncremental.__call__` in `dlt/extract/incremental/transform.py` invokes a **callable** `primary_key` with the whole arrow table instead of a single row:

```python
primary_key = self._primary_key(tbl) if callable(self._primary_key) else self._primary_key
```

Every other dynamic hint in dlt calls a callable with a single data item (a dict-like row) — see the JSON path (`resolve_column_value`). Passing the whole table breaks the convention.

**(a) Standard-style callables take the wrong branch.** A callable written the documented way — a membership check like `"id" if "id" in item else ...` — evaluates `"id" in tbl` against a pyarrow `Table`, which is always `False`. It silently returns the wrong key; if that key doesn't exist the run fails with `IncrementalPrimaryKeyMissing`. The same hint on an equivalent `list[dict]` resource works, so behavior diverges by item format.

**(b) A callable resolving to `()` crashes.** `()` is the documented "disable dedup" sentinel, but on the arrow path it raises `UnboundLocalError: cannot access local variable 'unique_columns'` — that variable is only assigned inside `if`/`elif` branches with no `else`.

Full repro in #4232.

**Fix**

- Call the callable with a single representative row — `tbl.slice(0, 1).to_pylist()[0]` — mirroring the JSON path. For a zero-row table, pass a dict of `None`s keyed by the schema field names so the callable can still run without an `IndexError`.
- Add an `else: unique_columns = []` branch so a callable resolving to a falsy-but-non-`None` value (like `()`) disables dedup instead of crashing.

Only `dlt/extract/incremental/transform.py` changes (+15/-1).

### Related Issues

- Fixes #4232

### Additional Context

**Testing**

Added two tests to `tests/extract/test_incremental.py`, both `@pytest.mark.parametrize`'d across `ALL_TEST_DATA_ITEM_FORMATS` (object / pandas / arrow-table / arrow-batch):

- `test_callable_primary_key_receives_single_row` — a callable using `"id" in item` with a fallback to a non-existent column, so a wrong resolution necessarily fails rather than passing by accident.
- `test_callable_primary_key_resolving_to_empty_tuple_disables_dedup` — a callable returning `()` must keep both duplicate rows and not raise.

Before the fix: 6 failed (the three arrow/pandas formats × 2 tests) / 2 passed (object — the JSON path was already correct, confirming the bug is arrow-specific). After: 8/8 pass.

Verified: full `tests/extract/test_incremental.py` (615 passed), plus `tests/extract/test_sources.py` + `tests/extract/test_extract.py` + `tests/normalize/test_normalize_arrow.py` (128 passed), no regressions. `ruff check`, `black --check`, `mypy`, and `flake8 --extend-ignore=D --max-line-length=200` clean on the changed files.

---
Disclosure: this PR was drafted with AI assistance (Claude); I reviewed, tested, and take responsibility for the change.


