### PR TITLE
fix(rest-client): allow JWT auth without scopes

### DIFF
--- a/dlt/sources/helpers/rest_client/auth.py
+++ b/dlt/sources/helpers/rest_client/auth.py
@@ -227,7 +227,8 @@ class OAuthJWTAuth(BearerTokenAuth):
     session: Annotated[BaseSession, NotResolved()] = None
 
     def __post_init__(self) -> None:
-        self.scopes = self.scopes if isinstance(self.scopes, str) else " ".join(self.scopes)
+        if self.scopes is not None and not isinstance(self.scopes, str):
+            self.scopes = " ".join(self.scopes)
         self.token = None
         self.token_expiry: Optional[pendulum.DateTime] = None
         # use default system session unless specified otherwise
@@ -270,14 +271,16 @@ class OAuthJWTAuth(BearerTokenAuth):
 
     def create_jwt_payload(self) -> Dict[str, Union[str, int]]:
         now = pendulum.now()
-        return {
+        payload: Dict[str, Union[str, int]] = {
             "iss": self.client_id,
             "sub": self.client_id,
             "aud": self.auth_endpoint,
             "exp": math.floor((now.add(hours=1)).timestamp()),
             "iat": math.floor(now.timestamp()),
-            "scope": cast(str, self.scopes),
         }
+        if self.scopes is not None:
+            payload["scope"] = cast(str, self.scopes)
+        return payload
 
     def load_private_key(self) -> "PrivateKeyTypes":
         try:

--- a/tests/sources/helpers/rest_client/test_client.py
+++ b/tests/sources/helpers/rest_client/test_client.py
@@ -322,6 +322,17 @@ class TestRESTClient:
 
         assert_pagination(list(pages_iter))
 
+    def test_oauth_jwt_auth_without_scopes(self):
+        auth = OAuthJWTAuth(
+            client_id="test-client-id",
+            private_key=TEST_PRIVATE_KEY,
+            auth_endpoint="https://api.example.com/oauth/token",
+            session=Client().session,
+        )
+
+        assert auth.scopes is None
+        assert "scope" not in auth.create_jwt_payload()
+
     def test_oauth_jwt_auth_success(self, rest_client: RESTClient):
         auth = OAuthJWTAuth(
             client_id="test-client-id",


### PR DESCRIPTION
### Description

- Preserve `None` when normalizing optional JWT scopes instead of passing it to `str.join`.
- Omit the `scope` claim when no scopes were configured while preserving existing string and list behavior.
- Add a regression test for construction and payload generation without scopes.

`OAuthJWTAuth.scopes` is declared optional and defaults to `None`, but `__post_init__` treated every non-string value as an iterable. Using the declared default therefore raised `TypeError: can only join an iterable` before authentication could begin.

This restores the documented type contract for scope-less JWT bearer configurations without changing existing behavior for configured scopes.

### Related Issues

- Fixes #4234

### Additional Context

Validation completed:

- `uv run black dlt/sources/helpers/rest_client/auth.py tests/sources/helpers/rest_client/test_client.py`
- `python -m pytest tests/sources/helpers/rest_client -q` — 277 passed, 1 skipped
- Direct behavior matrix for omitted, empty-string, and list scopes
- `make lint` — mypy, Ruff, Flake8, Bandit, lockfile, dependency, and API-breaking checks passed
- `make test-common-p` — 7,008 passed and 64 skipped; 36 unrelated environment/upstream-facing tests failed because optional `streamlit` was unavailable, worktree/venv subprocess tests assume a different environment, and a live GitHub example hit the unauthenticated API rate limit

No documentation currently references `OAuthJWTAuth`; this change aligns runtime behavior with the existing optional annotation and default.