### PR TITLE
fix(test) stop flaky gather_metrics on early sleep return

### DIFF
--- a/tests/extract/data_writers/test_buffered_writer.py
+++ b/tests/extract/data_writers/test_buffered_writer.py
@@ -343,20 +343,22 @@ def test_gather_metrics(disable_compression: bool, writer_type: Type[DataWriter]
     now = time.time()
     c1 = new_column("col1", "bigint")
     t1 = {"col1": c1}
+    clock = [0.0]
     with get_writer(
         writer_type, disable_compression=disable_compression, buffer_max_items=2, file_max_items=2
     ) as writer:
-        time.sleep(0.55)
+        assert writer._created >= now
+        writer._clock = lambda: clock[0]  # type: ignore[assignment]
+        writer._created = clock[0]
+        clock[0] += 0.55
         count = writer.write_data_item([{"col1": 182812}, {"col1": -1}], t1)
         assert count == 2
         # file rotated
         assert len(writer.closed_files) == 1
         metrics = writer.closed_files[0]
         assert metrics.items_count == 2
-        # sleep may return early, assert a lower bound with headroom
-        assert metrics.last_modified - metrics.created >= 0.5
-        assert metrics.created >= now
-        time.sleep(0.35)
+        assert metrics.last_modified - metrics.created == pytest.approx(0.55)
+        clock[0] += 0.35
         count = writer.write_data_item([{"col1": 182812}, {"col1": -1}, {"col1": 182811}], t1)
         assert count == 3
         # file rotated
@@ -364,7 +366,7 @@ def test_gather_metrics(disable_compression: bool, writer_type: Type[DataWriter]
         metrics_2 = writer.closed_files[1]
         assert metrics_2.items_count == 3
         assert metrics_2.created >= metrics.last_modified
-        assert metrics_2.last_modified - metrics_2.created >= 0.3
+        assert metrics_2.last_modified - metrics_2.created == pytest.approx(0.35)
 
     assert len(writer.closed_files) == 2
     if not disable_compression and writer.writer_spec.supports_compression:

--- a/tests/extract/data_writers/test_buffered_writer.py
+++ b/tests/extract/data_writers/test_buffered_writer.py
@@ -353,7 +353,8 @@ def test_gather_metrics(disable_compression: bool, writer_type: Type[DataWriter]
         assert len(writer.closed_files) == 1
         metrics = writer.closed_files[0]
         assert metrics.items_count == 2
-        assert metrics.last_modified - metrics.created >= 0.55
+        # sleep may return early, assert a lower bound with headroom
+        assert metrics.last_modified - metrics.created >= 0.5
         assert metrics.created >= now
         time.sleep(0.35)
         count = writer.write_data_item([{"col1": 182812}, {"col1": -1}, {"col1": 182811}], t1)
@@ -363,7 +364,7 @@ def test_gather_metrics(disable_compression: bool, writer_type: Type[DataWriter]
         metrics_2 = writer.closed_files[1]
         assert metrics_2.items_count == 3
         assert metrics_2.created >= metrics.last_modified
-        assert metrics_2.last_modified - metrics_2.created >= 0.35
+        assert metrics_2.last_modified - metrics_2.created >= 0.3
 
     assert len(writer.closed_files) == 2
     if not disable_compression and writer.writer_spec.supports_compression:


### PR DESCRIPTION
Fix CI failure: https://github.com/dlt-hub/dlt/actions/runs/29436958012/job/87549917933?pr=4227