### PR TITLE
fix(normalize): pass load id column name to remove_columns as a sequence

### DIFF
--- a/dlt/common/libs/pyarrow.py
+++ b/dlt/common/libs/pyarrow.py
@@ -694,7 +694,7 @@ def add_dlt_load_id_column(
     idx = item.schema.get_field_index(dlt_load_id_col_name)
     # if the column already exists, get rid of it
     if idx != -1:
-        item = remove_columns(item, dlt_load_id_col_name)
+        item = remove_columns(item, [dlt_load_id_col_name])
 
     # get pyarrow.string() type
     pyarrow_string = get_py_arrow_datatype(

--- a/tests/libs/pyarrow/test_pyarrow_normalizer.py
+++ b/tests/libs/pyarrow/test_pyarrow_normalizer.py
@@ -638,6 +638,26 @@ def test_add_dlt_load_id_column_replaces_existing(use_record_batch: bool) -> Non
 
 
 @pytest.mark.parametrize("use_record_batch", [False, True])
+def test_add_dlt_load_id_column_keeps_columns_named_like_load_id(use_record_batch: bool) -> None:
+    """Replacing _dlt_load_id must not drop columns whose name is a substring of it."""
+    _, naming, _ = import_normalizers(configured_normalizers())
+    caps = DestinationCapabilitiesContext()
+    caps.parquet_format = ParquetFormatConfiguration(supports_dictionary_encoding=False)
+
+    item = _make_item(
+        [{"_dlt_load_id": "old_load", "id": 1, "load_id": "L1", "keep": "x"}], use_record_batch
+    )
+    columns = {"_dlt_load_id": new_column("_dlt_load_id", "text")}
+
+    result = add_dlt_load_id_column(item, columns, caps, naming, "new_load_456")
+
+    assert result.column("_dlt_load_id")[0].as_py() == "new_load_456"
+    assert result.column("id")[0].as_py() == 1
+    assert result.column("load_id")[0].as_py() == "L1"
+    assert result.column("keep")[0].as_py() == "x"
+
+
+@pytest.mark.parametrize("use_record_batch", [False, True])
 def test_remove_null_columns_stores_metadata(use_record_batch: bool) -> None:
     """remove_null_columns should store removed column names in dlt.null_columns metadata."""
     item = _make_item([{"a": 1, "b": "x"}], use_record_batch)


### PR DESCRIPTION
### Description

Fixes #4240 — `add_dlt_load_id_column` silently dropped `RecordBatch` columns whose name is a substring of `_dlt_load_id` (`id`, `load_id`, `load`, `dlt`, …).

`dlt/common/libs/pyarrow.py:697` passed a bare `str` to `remove_columns`, which is declared `Sequence[str]`. Its `RecordBatch` branch tests membership with `n not in columns`, which against a string is a **substring** test. `Table.drop` accepts a `str`, so the `Table` branch was correct and only `RecordBatch` was affected. Every other call site (`pyarrow.py:412`, `extract/extractors.py:440`) already passes a list.

The dropped columns are still declared in the dlt schema, so they are re-added empty — rows land with `NULL` instead of the real values, with no error or warning. Reproduced end-to-end against duckdb:

```
actual:   [(None, None, 'a'), (None, None, 'b')]
expected: [(1, 'L1', 'a'), (2, 'L2', 'b')]
```

When `_dlt_load_id` isn't the first column it hard-crashes instead (`ArrowInvalid: Invalid column index to add field`), because the field index is captured before removal.

Triggered when a resource yields a `RecordBatch` that already carries `_dlt_load_id` (e.g. re-ingesting dlt output) with `normalize.parquet_normalizer.add_dlt_load_id` enabled.

**Fix**

`remove_columns(item, [dlt_load_id_col_name])` — one call site, no behavior change for `Table`.

### Related Issues

- Fixes #4240

### Additional Context

**Testing**

Added `test_add_dlt_load_id_column_keeps_columns_named_like_load_id`, parametrized over `use_record_batch` alongside the existing `test_add_dlt_load_id_column_replaces_existing`. The existing test is already parametrized but its only other column is `col1`, which isn't a substring of `_dlt_load_id`, so it passes today regardless.

Verified red before the fix (`KeyError: 'Field "id" does not exist in schema'` on the `RecordBatch` parametrization, `Table` green) and green after. `tests/libs/pyarrow/` 149 passed / 2 skipped; `tests/normalize/test_normalize_arrow.py` + `tests/extract/test_extract.py` 64 passed — no regressions. `ruff`, `black --check` and `mypy` clean.

Written with AI assistance (Claude). I reproduced the bug and ran every test and repro above myself; the root cause was traced through the real call chain rather than inferred.
