### PR TITLE
fix(destinations): match compound SCD2 merge keys exactly

### DIFF
--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -132,10 +132,14 @@ class AthenaMergeJob(SqlMergeFollowupJob):
         return sql, temp_table_name
 
     @classmethod
-    def gen_concat_sql(cls, columns: Sequence[str]) -> str:
-        # Athena requires explicit casting
-        columns = [f"CAST({c} AS VARCHAR)" for c in columns]
-        return f"CONCAT({', '.join(columns)})"
+    def gen_scd2_key_present_sql(
+        cls,
+        root_table_name: str,
+        staging_root_table_name: str,
+        merge_keys: Sequence[str],
+    ) -> str:
+        key_tuple = ", ".join(merge_keys)
+        return f"({key_tuple}) IN (SELECT {key_tuple} FROM {staging_root_table_name})"
 
     @classmethod
     def requires_temp_table_for_delete(cls) -> bool:

--- a/dlt/destinations/impl/clickhouse/clickhouse.py
+++ b/dlt/destinations/impl/clickhouse/clickhouse.py
@@ -294,6 +294,16 @@ class ClickHouseMergeJob(SqlMergeFollowupJob):
         return f"ALTER TABLE {table_name} UPDATE"
 
     @classmethod
+    def gen_scd2_key_present_sql(
+        cls,
+        root_table_name: str,
+        staging_root_table_name: str,
+        merge_keys: Sequence[str],
+    ) -> str:
+        key_tuple = ", ".join(merge_keys)
+        return f"({key_tuple}) IN (SELECT {key_tuple} FROM {staging_root_table_name})"
+
+    @classmethod
     def requires_temp_table_for_delete(cls) -> bool:
         return False
 

--- a/dlt/destinations/impl/sqlalchemy/merge_job.py
+++ b/dlt/destinations/impl/sqlalchemy/merge_job.py
@@ -1,5 +1,4 @@
-from typing import Sequence, Tuple, Optional, List, Union, cast
-import operator
+from typing import Sequence, Tuple, Optional, List, cast
 from dlt.common.libs.sql_alchemy import sa
 
 from dlt.common.typing import TAnyDateTime
@@ -335,20 +334,6 @@ class SqlalchemyMergeFollowupJob(SqlMergeFollowupJob):
             return sa.true()  # type: ignore[no-any-return]
 
     @classmethod
-    def _gen_concat_sqla(
-        cls, columns: Sequence[sa.Column]
-    ) -> Union[sa.sql.elements.BinaryExpression, sa.Column]:
-        # Use col1 + col2 + col3 ... to generate a dialect specific concat expression
-        result = columns[0]
-        if len(columns) == 1:
-            return result
-        # Cast because CONCAT is only generated for string columns
-        result = sa.cast(result, sa.String)
-        for col in columns[1:]:
-            result = operator.add(result, sa.cast(col, sa.String))
-        return result  # type: ignore[no-any-return]
-
-    @classmethod
     def gen_scd2_sql(
         cls,
         table_chain: Sequence[PreparedTableSchema],
@@ -400,12 +385,18 @@ class SqlalchemyMergeFollowupJob(SqlMergeFollowupJob):
 
         merge_keys = get_columns_names_with_prop(root_table, "merge_key")
         if merge_keys:
-            root_merge_key_cols = [root_table_obj.c[key] for key in merge_keys]
-            staging_merge_key_cols = [staging_root_table_obj.c[key] for key in merge_keys]
-
             update_statement = update_statement.where(
-                cls._gen_concat_sqla(root_merge_key_cols).in_(
-                    sa.select(cls._gen_concat_sqla(staging_merge_key_cols))
+                sa.exists(
+                    sa.select(sa.literal(1))
+                    .where(
+                        sa.and_(
+                            *[
+                                root_table_obj.c[key] == staging_root_table_obj.c[key]
+                                for key in merge_keys
+                            ]
+                        )
+                    )
+                    .select_from(staging_root_table_obj)
                 )
             )
 

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -374,8 +374,14 @@ class SqlMergeFollowupJob(SqlFollowupJob):
         """
 
     @classmethod
-    def gen_concat_sql(cls, columns: Sequence[str]) -> str:
-        return f"CONCAT({', '.join(columns)})"
+    def gen_scd2_key_present_sql(
+        cls,
+        root_table_name: str,
+        staging_root_table_name: str,
+        merge_keys: Sequence[str],
+    ) -> str:
+        key_match = " AND ".join(f"{root_table_name}.{key} = s.{key}" for key in merge_keys)
+        return f"EXISTS (SELECT 1 FROM {staging_root_table_name} AS s WHERE {key_match})"
 
     @classmethod
     def _shorten_table_name(cls, ident: str, sql_client: SqlClientBase[Any]) -> str:
@@ -982,9 +988,13 @@ class SqlMergeFollowupJob(SqlFollowupJob):
         if len(merge_keys) > 0:
             if len(merge_keys) == 1:
                 key = merge_keys[0]
+                key_present = f"{key} IN (SELECT {key} FROM {staging_root_table_name})"
             else:
-                key = cls.gen_concat_sql(merge_keys)  # compound key
-            key_present = f"{key} IN (SELECT {key} FROM {staging_root_table_name})"
+                key_present = cls.gen_scd2_key_present_sql(
+                    escape_column_id(root_table["name"]),
+                    staging_root_table_name,
+                    merge_keys,
+                )
             retire_sql = retire_sql.rstrip()[:-1]  # remove semicolon
             retire_sql += f" AND {key_present}"
         sql.append(retire_sql)

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -380,8 +380,13 @@ class SqlMergeFollowupJob(SqlFollowupJob):
         staging_root_table_name: str,
         merge_keys: Sequence[str],
     ) -> str:
-        key_match = " AND ".join(f"{root_table_name}.{key} = s.{key}" for key in merge_keys)
-        return f"EXISTS (SELECT 1 FROM {staging_root_table_name} AS s WHERE {key_match})"
+        staging_alias = "s_" if root_table_name.strip('"`[]').casefold() == "s" else "s"
+        key_match = " AND ".join(
+            f"{root_table_name}.{key} = {staging_alias}.{key}" for key in merge_keys
+        )
+        return (
+            f"EXISTS (SELECT 1 FROM {staging_root_table_name} AS {staging_alias} WHERE {key_match})"
+        )
 
     @classmethod
     def _shorten_table_name(cls, ident: str, sql_client: SqlClientBase[Any]) -> str:

--- a/tests/load/pipeline/test_scd2.py
+++ b/tests/load/pipeline/test_scd2.py
@@ -921,39 +921,55 @@ def test_merge_key_compound_natural_key(
 
     # vary `first_name` type to test mixed compound `merge_key`
     if key_type == "text":
-        first_name = "John"
+        first_name: Any = "ab"
+        last_name = "c"
+        colliding_first_name: Any = "a"
+        colliding_last_name = "bc"
     elif key_type == "bigint":
-        first_name = 1  # type: ignore[assignment]
+        first_name = 12
+        last_name = "3"
+        colliding_first_name = 1
+        colliding_last_name = "23"
     # load 1 — initial load
     dim_snap = [
-        {"first_name": first_name, "last_name": "Doe", "age": 20},
+        {"first_name": first_name, "last_name": last_name, "age": 20},
         {"first_name": first_name, "last_name": "Dodo", "age": 20},
-    ]
-    info = p.run(dim_test_compound(dim_snap), **destination_config.run_kwargs)
-    assert_load_info(info)
-    assert load_table_counts(p, "dim_test_compound")["dim_test_compound"] == 2
-    # both records should be active (i.e. not retired)
-    assert [row[TO] for row in get_table(p, "dim_test_compound")] == [None, None]
-
-    # load 2 — "Dodo" is absent, "Doe" has changed
-    dim_snap = [
-        {"first_name": first_name, "last_name": "Doe", "age": 30},
+        {
+            "first_name": colliding_first_name,
+            "last_name": colliding_last_name,
+            "age": 20,
+        },
     ]
     info = p.run(dim_test_compound(dim_snap), **destination_config.run_kwargs)
     assert_load_info(info)
     assert load_table_counts(p, "dim_test_compound")["dim_test_compound"] == 3
+    # all records should be active (i.e. not retired)
+    assert [row[TO] for row in get_table(p, "dim_test_compound")] == [None, None, None]
+
+    # load 2 — "Dodo" and the colliding key are absent, while the first record has changed
+    dim_snap = [
+        {"first_name": first_name, "last_name": last_name, "age": 30},
+    ]
+    info = p.run(dim_test_compound(dim_snap), **destination_config.run_kwargs)
+    assert_load_info(info)
+    assert load_table_counts(p, "dim_test_compound")["dim_test_compound"] == 4
     ts3 = get_load_package_created_at(p, info)
-    # "Doe" should now have two records (one retired, one active)
+    # the changed key should have two records; unrelated absent keys must stay active
     actual = [
         {k: v for k, v in row.items() if k in ("first_name", "last_name", TO)}
         for row in get_table(p, "dim_test_compound", ts_columns=[FROM, TO])
     ]
     expected = [
-        {"first_name": first_name, "last_name": "Doe", TO: ts3},
-        {"first_name": first_name, "last_name": "Doe", TO: None},
+        {"first_name": first_name, "last_name": last_name, TO: ts3},
+        {"first_name": first_name, "last_name": last_name, TO: None},
         {"first_name": first_name, "last_name": "Dodo", TO: None},
+        {
+            "first_name": colliding_first_name,
+            "last_name": colliding_last_name,
+            TO: None,
+        },
     ]
-    assert_records_as_set(actual, expected)  # type: ignore[arg-type]
+    assert_records_as_set(actual, expected)
 
 
 @pytest.mark.essential

--- a/tests/load/pipeline/test_scd2.py
+++ b/tests/load/pipeline/test_scd2.py
@@ -913,6 +913,7 @@ def test_merge_key_compound_natural_key(
     p = destination_config.setup_pipeline("abstract", dev_mode=True)
 
     @dlt.resource(
+        name="s",  # ensure the staging alias cannot shadow the root table name
         merge_key=["first_name", "last_name"],
         write_disposition={"disposition": "merge", "strategy": "scd2"},
     )
@@ -942,9 +943,9 @@ def test_merge_key_compound_natural_key(
     ]
     info = p.run(dim_test_compound(dim_snap), **destination_config.run_kwargs)
     assert_load_info(info)
-    assert load_table_counts(p, "dim_test_compound")["dim_test_compound"] == 3
+    assert load_table_counts(p, "s")["s"] == 3
     # all records should be active (i.e. not retired)
-    assert [row[TO] for row in get_table(p, "dim_test_compound")] == [None, None, None]
+    assert [row[TO] for row in get_table(p, "s")] == [None, None, None]
 
     # load 2 — "Dodo" and the colliding key are absent, while the first record has changed
     dim_snap = [
@@ -952,12 +953,12 @@ def test_merge_key_compound_natural_key(
     ]
     info = p.run(dim_test_compound(dim_snap), **destination_config.run_kwargs)
     assert_load_info(info)
-    assert load_table_counts(p, "dim_test_compound")["dim_test_compound"] == 4
+    assert load_table_counts(p, "s")["s"] == 4
     ts3 = get_load_package_created_at(p, info)
     # the changed key should have two records; unrelated absent keys must stay active
     actual = [
         {k: v for k, v in row.items() if k in ("first_name", "last_name", TO)}
-        for row in get_table(p, "dim_test_compound", ts_columns=[FROM, TO])
+        for row in get_table(p, "s", ts_columns=[FROM, TO])
     ]
     expected = [
         {"first_name": first_name, "last_name": last_name, TO: ts3},


### PR DESCRIPTION
### Description

- Compare compound SCD2 merge keys by exact per-column equality instead of concatenating their values.
- Use correlated `EXISTS` predicates for standard SQL and SQLAlchemy, with dialect-safe tuple membership for Athena and ClickHouse.
- Avoid staging-alias shadowing when the destination table is named `s`; the regression test now covers that case explicitly.
- Extend the existing destination matrix with ambiguous text and numeric keys that previously retired an unrelated active record.

This fixes collisions such as `("a", "bc")` and `("ab", "c")`, which both became `"abc"` under the previous concatenation logic.

### Related Issues

- Closes #4244

### Additional Context

Validation:

- `make lint`
- Common parallel selection: 7,054 passed / 57 skipped; its only two failures were checkout-path URL assertions caused by the space in `/Volumes/Mac SSD`, and both passed from the identical no-space checkout
- Common serial/forked selection: 213 passed / 1 skipped; the three signal-launcher cases passed in fresh processes to avoid a macOS `pytest-forked` deadlock
- Local DuckDB/filesystem selection from the no-space checkout: 1,432 passed / 205 skipped
- 8 focused compound-key SCD2 cases passed across native DuckDB, DuckDB with Parquet staging, SQLAlchemy SQLite, and SQLAlchemy DuckDB under SQLAlchemy 2 (text and bigint keys)
- `.venv/bin/pytest tests/load/pipeline/test_scd2.py -k duckdb -q`: 45 passed / 6 skipped

The local-load serial selector has no active DuckDB/filesystem cases. On macOS, two inactive Databricks modules are not collectable because the Zerobus SDK is published only for Linux and Windows; those modules and dependency declarations are unchanged by this PR.