### PR TITLE
fix(cli): remove click dependency

### DIFF
--- a/dlt/_workspace/cli/echo.py
+++ b/dlt/_workspace/cli/echo.py
@@ -1,9 +1,30 @@
 """CLI prompting and output helpers."""
 
-import sys
 import contextlib
-from typing import Any, Iterable, Iterator, Optional, ContextManager
-import click
+import sys
+from typing import IO, Any, ContextManager, Iterable, Iterator, Optional
+
+from rich.console import Console
+from rich.text import Text
+
+_ANSI_COLORS = {
+    "black": 30,
+    "red": 31,
+    "green": 32,
+    "yellow": 33,
+    "blue": 34,
+    "magenta": 35,
+    "cyan": 36,
+    "white": 37,
+    "bright_black": 90,
+    "bright_red": 91,
+    "bright_green": 92,
+    "bright_yellow": 93,
+    "bright_blue": 94,
+    "bright_magenta": 95,
+    "bright_cyan": 96,
+    "bright_white": 97,
+}
 
 
 ALWAYS_CHOOSE_DEFAULT = False
@@ -28,7 +49,7 @@ def cli_cmd(rest: str = "") -> str:
     """Formats an example command line prefixed with the active CLI host name.
 
     Args:
-        rest: Argument string to append after the host name.
+        rest (str): Argument string to append after the host name.
 
     Returns:
         str: The full example, e.g. `"dlt pipeline my_pipe info"` or
@@ -63,9 +84,9 @@ def always_choose(
     """Temporarily answer all confirmations and prompts with preset values.
 
     Args:
-        always_choose_default: When True, confirm/prompt calls return their default.
-        always_choose_value: When set, confirm/prompt calls return this value instead.
-        always_confirm: When True, confirm calls always return True, regardless of
+        always_choose_default (bool): When True, confirm/prompt calls return their default.
+        always_choose_value (Any): When set, confirm/prompt calls return this value instead.
+        always_confirm (bool): When True, confirm calls always return True, regardless of
             `always_choose_default` and `always_choose_value`.
     """
     global ALWAYS_CHOOSE_DEFAULT, ALWAYS_CHOOSE_VALUE, ALWAYS_CONFIRM
@@ -110,29 +131,82 @@ def maybe_no_stdin() -> ContextManager[None]:
     )
 
 
-echo = click.echo
-secho = click.secho
-style = click.style
+def style(
+    text: Any,
+    fg: Optional[str] = None,
+    bold: Optional[bool] = None,
+    reset: bool = True,
+) -> str:
+    """Apply ANSI foreground color and bold styling to ``text``."""
+    codes = []
+    if fg is not None:
+        try:
+            codes.append(str(_ANSI_COLORS[fg]))
+        except KeyError as ex:
+            raise TypeError(f"Unknown color {fg!r}") from ex
+    if bold is not None:
+        codes.append("1" if bold else "22")
+
+    value = str(text)
+    if not codes:
+        return value
+    value = f"\033[{';'.join(codes)}m{value}"
+    return value + "\033[0m" if reset else value
+
+
+def echo(
+    message: Any = None,
+    file: Optional[IO[Any]] = None,
+    nl: bool = True,
+    err: bool = False,
+    color: Optional[bool] = None,
+) -> None:
+    """Write a message to stdout or stderr."""
+    output = file or (sys.stderr if err else sys.stdout)
+    value = "" if message is None else str(message)
+    console = Console(file=output, force_terminal=color)
+    console.print(Text.from_ansi(value), end="\n" if nl else "", soft_wrap=True)
+
+
+def secho(
+    message: Any = None,
+    file: Optional[IO[Any]] = None,
+    nl: bool = True,
+    err: bool = False,
+    color: Optional[bool] = None,
+    fg: Optional[str] = None,
+    bold: Optional[bool] = None,
+) -> None:
+    """Style a message and write it with :func:`echo`."""
+    echo(style(message if message is not None else "", fg=fg, bold=bold), file, nl, err, color)
 
 
 def bold(msg: str) -> str:
-    return click.style(msg, bold=True, reset=False) + click.style("", bold=False, reset=False)
+    return style(msg, bold=True, reset=False) + style("", bold=False, reset=False)
 
 
 def warning_style(msg: str) -> str:
-    return click.style(msg, fg="yellow", reset=True)
+    return style(msg, fg="yellow", reset=True)
 
 
 def error(msg: str) -> None:
-    click.secho("ERROR: " + msg, fg="red")
+    secho("ERROR: " + msg, fg="red")
 
 
 def warning(msg: str) -> None:
-    click.secho("WARNING: " + msg, fg="yellow")
+    secho("WARNING: " + msg, fg="yellow")
 
 
 def note(msg: str) -> None:
-    click.secho("NOTE: " + msg, fg="green")
+    secho("NOTE: " + msg, fg="green")
+
+
+def _read_input(label: str) -> str:
+    try:
+        return input(label)
+    except (EOFError, KeyboardInterrupt):
+        echo(err=True)
+        raise
 
 
 def _raise_no_default(text: str) -> None:
@@ -156,7 +230,16 @@ def confirm(text: str, default: Optional[bool] = None) -> bool:
         if default is None:
             _raise_no_default(text)
         return default
-    return click.confirm(text, default=default)
+    choices = "Y/n" if default is True else "y/N" if default is False else "y/n"
+    while True:
+        value = _read_input(f"{text} [{choices}]: ").strip().lower()
+        if not value and default is not None:
+            return default
+        if value in ("y", "yes"):
+            return True
+        if value in ("n", "no"):
+            return False
+        echo("Error: invalid input")
 
 
 def prompt(
@@ -173,21 +256,30 @@ def prompt(
         if default is None:
             _raise_no_default(text)
         return default
-    click_choices = click.Choice(choices)
-    return click.prompt(
-        text,
-        type=click_choices,
-        default=default,
-        show_choices=show_choices,
-        show_default=show_default,
-    )
+    available = tuple(choices)
+    label = text
+    if show_choices:
+        label += f" ({', '.join(available)})"
+    if show_default and default is not None:
+        label += f" [{default}]"
+    label += ": "
+
+    while True:
+        value = _read_input(label)
+        if not value and default is not None:
+            return default
+        if value in available:
+            return value
+        echo(f"Error: invalid choice: {value}. (choose from {', '.join(available)})")
 
 
-def text_input(text: str, default: str = None) -> str:
+def text_input(text: str, default: Optional[str] = None) -> str:
     if ALWAYS_CHOOSE_VALUE is not None:
         return str(ALWAYS_CHOOSE_VALUE)
     if ALWAYS_CHOOSE_DEFAULT or ALWAYS_CONFIRM:
         if default is None:
             _raise_no_default(text)
         return default
-    return click.prompt(text, default=default)  # type: ignore[no-any-return]
+    label = f"{text} [{default}]: " if default is not None else f"{text}: "
+    value = _read_input(label)
+    return default if not value and default is not None else value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "tomlkit>=0.11.3",
     "pathvalidate>=2.5.2",
     "typing-extensions>=4.8.0",
-    "click>=7.1",
     "requirements-parser>=0.5.0",
     "setuptools>=65.6.0",
     "humanize>=4.4.0",
@@ -233,7 +232,6 @@ dlthub = "dlt._workspace.cli._dlt:_main_dlthub"
 # here you'll break everything
 dev = [
     "requests-mock>=1.10.0,<2",
-    "types-click>=7.1.8,<8",
     "sqlfluff>=2.3.2,<3",
     "types-deprecated>=1.2.9.2,<2",
     "pytest-console-scripts>=1.4.1,<2",

--- a/tests/workspace/cli/test_echo.py
+++ b/tests/workspace/cli/test_echo.py
@@ -1,0 +1,54 @@
+import io
+from unittest.mock import patch
+
+import pytest
+
+from dlt._workspace.cli import echo as fmt
+
+
+def test_style_and_echo_color_handling() -> None:
+    styled = fmt.style("message", fg="yellow", bold=True)
+    assert styled == "\033[33;1mmessage\033[0m"
+
+    plain_output = io.StringIO()
+    fmt.echo(styled, file=plain_output)
+    assert plain_output.getvalue() == "message\n"
+
+    color_output = io.StringIO()
+    fmt.echo(styled, file=color_output, color=True)
+    assert "\033[" in color_output.getvalue()
+    assert "message" in color_output.getvalue()
+
+
+def test_secho_can_write_to_stderr(capsys: pytest.CaptureFixture[str]) -> None:
+    fmt.secho("problem", fg="red", err=True)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "problem\n"
+
+
+@pytest.mark.parametrize(
+    ("answer", "default", "expected"),
+    [("y", False, True), ("NO", True, False), ("", True, True), ("", False, False)],
+)
+def test_confirm(answer: str, default: bool, expected: bool) -> None:
+    with patch("builtins.input", return_value=answer):
+        assert fmt.confirm("Continue?", default=default) is expected
+
+
+def test_confirm_retries_invalid_input(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("builtins.input", side_effect=["maybe", "yes"]):
+        assert fmt.confirm("Continue?") is True
+    assert capsys.readouterr().out == "Error: invalid input\n"
+
+
+def test_prompt_retries_until_choice(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch("builtins.input", side_effect=["x", "b"]):
+        assert fmt.prompt("Pick", ("a", "b"), default="a") == "b"
+    assert "invalid choice" in capsys.readouterr().out
+
+
+def test_prompt_and_text_input_use_defaults() -> None:
+    with patch("builtins.input", return_value=""):
+        assert fmt.prompt("Pick", ("a", "b"), default="a") == "a"
+        assert fmt.text_input("Name", default="Jane") == "Jane"

--- a/uv.lock
+++ b/uv.lock
@@ -2504,8 +2504,6 @@ name = "dlt"
 version = "1.29.0"
 source = { editable = "." }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "fsspec" },
     { name = "gitpython" },
     { name = "giturlparse" },
@@ -2749,7 +2747,6 @@ dev = [
     { name = "ruff" },
     { name = "sqlfluff" },
     { name = "types-cachetools" },
-    { name = "types-click" },
     { name = "types-croniter" },
     { name = "types-deprecated" },
     { name = "types-paramiko" },
@@ -2831,7 +2828,6 @@ requires-dist = [
     { name = "botocore", marker = "extra == 'athena'", specifier = ">=1.28" },
     { name = "botocore", marker = "extra == 'filesystem'", specifier = ">=1.28" },
     { name = "botocore", marker = "extra == 's3'", specifier = ">=1.28" },
-    { name = "click", specifier = ">=7.1" },
     { name = "clickhouse-connect", marker = "extra == 'clickhouse'", specifier = ">=0.7.7" },
     { name = "clickhouse-driver", marker = "extra == 'clickhouse'", specifier = ">=0.2.7" },
     { name = "cron-descriptor", marker = "extra == 'cli'", specifier = ">=1.2.32" },
@@ -2986,7 +2982,6 @@ dev = [
     { name = "ruff", specifier = ">=0.3.2,<0.4" },
     { name = "sqlfluff", specifier = ">=2.3.2,<3" },
     { name = "types-cachetools", specifier = ">=4.2.9" },
-    { name = "types-click", specifier = ">=7.1.8,<8" },
     { name = "types-croniter", specifier = ">=6.0.0" },
     { name = "types-deprecated", specifier = ">=1.2.9.2,<2" },
     { name = "types-paramiko", specifier = ">=3.5.0.20250708" },
@@ -10385,15 +10380,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/d0/55ff0eeda141436c1bd2142cd026906870c661b3f7755070d6da7ea7210f/types_cachetools-6.0.0.20250525.tar.gz", hash = "sha256:baf06f234cac3aeb44c07893447ba03ecdb6c0742ba2607e28a35d38e6821b02", size = 8925, upload-time = "2025-05-25T03:13:53.498Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8c/4ab0a17ece30fe608270b89cf066387051862899fff9f54ab12511fc7fdd/types_cachetools-6.0.0.20250525-py3-none-any.whl", hash = "sha256:1de8f0fe4bdcb187a48d2026c1e3672830f67943ad2bf3486abe031b632f1252", size = 8938, upload-time = "2025-05-25T03:13:52.406Z" },
-]
-
-[[package]]
-name = "types-click"
-version = "7.1.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/ff/0e6a56108d45c80c61cdd4743312d0304d8192482aea4cce96c554aaa90d/types-click-7.1.8.tar.gz", hash = "sha256:b6604968be6401dc516311ca50708a0a28baa7a0cb840efd7412f0dbbff4e092", size = 10015, upload-time = "2021-11-23T12:28:01.701Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ad/607454a5f991c5b3e14693a7113926758f889138371058a5f72f567fa131/types_click-7.1.8-py3-none-any.whl", hash = "sha256:8cb030a669e2e927461be9827375f83c16b8178c365852c060a34e24871e7e81", size = 12929, upload-time = "2021-11-23T12:27:59.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Removes the direct `click` dependency from the CLI helpers while keeping the existing output and prompting behavior.

The output helpers now use Rich for terminal-safe rendering, and the small interactive helpers use standard input for confirmations, choices, and text prompts. The related type dependency and lockfile entries are removed as well.

Closes #1658

### Tests

- Added coverage for styled output, stderr, confirmations, choices, retries, and defaults
- Ran the CLI echo and invocation tests (`74 passed`)
- Ran Black, isort, mypy, Flake8, and Ruff on the changed files
- Built the wheel and source distribution