### PR TITLE
fix(config): remove nested none values before toml serialization

### DIFF
--- a/dlt/common/configuration/providers/doc.py
+++ b/dlt/common/configuration/providers/doc.py
@@ -9,6 +9,14 @@ from dlt.common.utils import clone_dict_nested, update_dict_nested
 from .provider import ConfigProvider, get_key_name
 
 
+def _remove_none_values(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _remove_none_values(v) for k, v in value.items() if v is not None}
+    if isinstance(value, (list, tuple)):
+        return type(value)(_remove_none_values(v) for v in value)
+    return value
+
+
 class BaseDocProvider(ConfigProvider):
     _config_doc: Dict[str, Any]
     """Holds a dict with config values"""
@@ -112,8 +120,7 @@ class BaseDocProvider(ConfigProvider):
             master.pop(key, None)
             return
         if isinstance(value, dict):
-            # remove none values, TODO: we need recursive None removal
-            value = {k: v for k, v in value.items() if v is not None}
+            value = _remove_none_values(value)
             # if target is also dict then merge recursively
             if isinstance(master.get(key), dict):
                 update_dict_nested(master[key], value)

--- a/dlt/common/configuration/providers/doc.py
+++ b/dlt/common/configuration/providers/doc.py
@@ -13,7 +13,7 @@ def _remove_none_values(value: Any) -> Any:
     if isinstance(value, dict):
         return {k: _remove_none_values(v) for k, v in value.items() if v is not None}
     if isinstance(value, (list, tuple)):
-        return type(value)(_remove_none_values(v) for v in value)
+        return [_remove_none_values(v) for v in value]
     return value
 
 

--- a/tests/common/configuration/test_toml_provider.py
+++ b/tests/common/configuration/test_toml_provider.py
@@ -414,8 +414,13 @@ def test_write_value_removes_nested_none(tmp_path: Path) -> None:
     value = {
         "nested": {"keep": "x", "optional": None},
         "items": [{"keep": 1, "optional": None}],
+        "tuple_items": ({"keep": 2, "optional": None},),
     }
-    expected = {"nested": {"keep": "x"}, "items": [{"keep": 1}]}
+    expected = {
+        "nested": {"keep": "x"},
+        "items": [{"keep": 1}],
+        "tuple_items": [{"keep": 2}],
+    }
 
     string_provider = StringTomlProvider("")
     string_provider.set_value("payload", value, None)

--- a/tests/common/configuration/test_toml_provider.py
+++ b/tests/common/configuration/test_toml_provider.py
@@ -410,6 +410,25 @@ def test_write_value(toml_providers: ConfigProvidersContainer) -> None:
         assert provider._config_doc["new_pipeline"]["runner_config"] == expected_pool
 
 
+def test_write_value_removes_nested_none(tmp_path: Path) -> None:
+    value = {
+        "nested": {"keep": "x", "optional": None},
+        "items": [{"keep": 1, "optional": None}],
+    }
+    expected = {"nested": {"keep": "x"}, "items": [{"keep": 1}]}
+
+    string_provider = StringTomlProvider("")
+    string_provider.set_value("payload", value, None)
+    assert StringTomlProvider.loads(string_provider.dumps()).unwrap() == {"payload": expected}
+
+    file_provider = ConfigTomlProvider(str(tmp_path), global_dir=None)
+    file_provider.set_value("payload", value, None)
+    assert file_provider._config_doc == file_provider._config_toml.unwrap() == {"payload": expected}
+    file_provider.write_toml()
+    reloaded_provider = ConfigTomlProvider(str(tmp_path), global_dir=None)
+    assert reloaded_provider.get_value("payload", dict, None)[0] == expected
+
+
 def test_set_value_none_deletes_key(toml_providers: ConfigProvidersContainer) -> None:
     """value=None deletes the key from BOTH the dict mirror and the tomlkit doc."""
     TAny: Type[Any] = Any


### PR DESCRIPTION
### Description

- recursively remove `None` values from nested mappings before TOML serialization
- sanitize mappings contained in lists through the shared provider path
- normalize tuple inputs to TOML arrays so file-backed `_config_doc` and `_config_toml` stay synchronized
- add regression coverage for string serialization and file write/reload behavior

### Related Issues

- Fixes #4248

### Additional Context

`BaseDocProvider._set_value` previously removed `None` only from the outer dictionary. Nested `None` values reached tomlkit, causing `StringTomlProvider.dumps()` to raise `_ConvertError`. `SettingsTomlProvider` caught that conversion error but still updated its plain dictionary, so the value appeared in memory while being omitted from persisted TOML.

The fix sanitizes values in the shared provider path before either representation is updated. Tuple inputs are normalized to lists because tomlkit represents TOML arrays as lists; this also avoids reconstructing tuple subclasses with incompatible constructors.

### Validation

- `make lint` — passed, including mypy, Ruff, Flake8, Bandit, lockfile, dependency, and API compatibility checks
- `python -m pytest tests/common/configuration/test_toml_provider.py -q` — 20 passed
- `python -m pytest tests/common/configuration -q` — 247 passed, 11 skipped
- parallel common phase — 7,056 passed, 57 skipped; the only failure was the live `load_github` example exhausting GitHub's 60-request unauthenticated API quota while fetching issue comments
- serial/forked common phase — 209 passed, 1 skipped before the macOS `pytest-forked` harness stalled; the isolated five-test tail then passed
- GitHub Actions — awaiting upstream maintainer approval for the fork workflow