### PR TITLE
fix(extract): preserve nested hint path separators

### DIFF
--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -338,14 +338,12 @@ class DltResourceHints:
         )
         for sub_path, hints in sorted_items:
             # both str and sequence is supported
+            if isinstance(sub_path, str):
+                sub_path = naming.break_path(sub_path)
             full_path = list(
                 map(
                     naming.normalize_table_identifier,
-                    (
-                        (root_table_name, sub_path)
-                        if isinstance(sub_path, str)
-                        else (root_table_name, *sub_path)
-                    ),
+                    (root_table_name, *sub_path),
                 )
             )
             yield (

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -467,8 +467,7 @@ def test_nested_hints_subpath_with_separator() -> None:
         name="items",
         nested_hints={
             "sub__MoreItems": make_nested_hints(columns=[{"name": "x", "data_type": "bigint"}]),
-            # a deeper nested hint (subchild) declared under the same non-normalized sub_path
-            ("sub__MoreItems", "TheChild"): make_nested_hints(
+            ("sub", "MoreItems", "TheChild"): make_nested_hints(
                 columns=[{"name": "y", "data_type": "bigint"}]
             ),
         },
@@ -476,21 +475,19 @@ def test_nested_hints_subpath_with_separator() -> None:
     def items() -> Any:
         yield {}
 
-    # each nested-hint path fragment is normalized immediately in the resource, so a sub_path that
-    # contains the `__` separator / camel case yields a normalized table name AND a normalized parent
+    # String paths may use the naming convention separator to identify nested tables.
     nested = {t["name"]: t for t in items().compute_nested_table_schemas("items", schema.naming)}
 
-    # the direct child is a single level under the root
-    child = nested["items__sub_more_items"]
-    assert child["parent"] == "items"
-    assert len(schema.naming.break_path(child["name"])) == 2
+    child = nested["items__sub__more_items"]
+    assert child["parent"] == "items__sub"
+    assert child["columns"]["x"]["data_type"] == "bigint"
+    assert len(schema.naming.break_path(child["name"])) == 3
 
-    # the subchild's parent is the normalized name of the direct child (not the raw
-    # `items__sub__MoreItems`), proving the parent path is normalized right away
-    subchild = nested["items__sub_more_items__the_child"]
-    assert subchild["parent"] == "items__sub_more_items"
+    subchild = nested["items__sub__more_items__the_child"]
+    assert subchild["parent"] == "items__sub__more_items"
     assert subchild["parent"] == child["name"]
-    assert len(schema.naming.break_path(subchild["name"])) == 3
+    assert subchild["columns"]["y"]["data_type"] == "bigint"
+    assert len(schema.naming.break_path(subchild["name"])) == 4
 
 
 def test_nested_hints_dynamic_table_names(extract_step: Extract) -> None:


### PR DESCRIPTION
## Summary

Restore support for pre-joined string paths in `nested_hints`.

## Root cause

`get_nested_hints` treated a string path containing the naming separator as one identifier. Under snake case, normalizing `cat__rows` as one identifier collapses it to `cat_rows`, so the hint is attached to a table that is never produced.

## Changes

- Split string nested-hint paths with the active naming convention before normalizing their individual segments.
- Keep tuple paths as explicit path segments.
- Add regression coverage for a pre-joined path and its documented tuple-path child.

## Validation

- `uv run pytest tests/extract/test_extract.py -q`
- `uv run black --check dlt/extract/hints.py tests/extract/test_extract.py`
- `uv run ruff check dlt/extract/hints.py tests/extract/test_extract.py`
- `uv run mypy dlt/extract/hints.py`

Fixes #4247