### PR TITLE
fix(fabric): scale nvarchar precision for utf-8 varchar byte semantics

### DIFF
--- a/dlt/destinations/impl/fabric/fabric.py
+++ b/dlt/destinations/impl/fabric/fabric.py
@@ -188,20 +188,8 @@ class FabricClient(SynapseClient):
             self.active_hints.pop("unique", None)
 
     def _get_column_def_sql(self, c: TColumnSchema, table: PreparedTableSchema = None) -> str:
-        """Override to use varchar instead of nvarchar for unique text columns"""
-        sc_type = c["data_type"]
-        if sc_type == "text" and c.get("unique"):
-            # Fabric does not support nvarchar - use varchar with max length 900 for unique columns
-            db_type = "varchar(%i)" % (c.get("precision") or 900)
-        else:
-            db_type = self.type_mapper.to_destination_type(c, table)
-
-        # Don't add COLLATE clause here - let the database default handle it
-        # The warehouse-level collation will be applied automatically
-
-        hints_str = self._get_column_hints_sql(c)
-        column_name = self.sql_client.escape_column_name(c["name"])
-        return f"{column_name} {db_type} {hints_str} {self._gen_not_null(c.get('nullable', True))}"
+        """Override to skip the mssql 900 byte cap on unique text columns, Fabric has no index keys"""
+        return SqlJobClientBase._get_column_def_sql(self, c, table)
 
     def prepare_load_table(self, table_name: str) -> PreparedTableSchema:
         """Override to ensure proper table configuration for Fabric

--- a/dlt/destinations/impl/fabric/factory.py
+++ b/dlt/destinations/impl/fabric/factory.py
@@ -53,6 +53,16 @@ class FabricTypeMapper(SynapseTypeMapper):
             # Fabric doesn't have native JSON type, use varchar instead of nvarchar
             return "varchar(%s)" % column.get("precision", "max")
 
+        if sc_t == "text":
+            # varchar uses byte semantics; scale nvarchar char precision by 4 (worst-case utf-8)
+            precision = column.get("precision")
+            if precision is not None:
+                safe_length = precision * 4
+                if safe_length > 8000:
+                    return "varchar(max)"
+                return "varchar(%i)" % safe_length
+            return "varchar(max)"
+
         if sc_t == "time":
             # Fabric requires explicit precision for TIME (0-6)
             precision = min(column.get("precision", 6), 6)

--- a/dlt/destinations/impl/fabric/factory.py
+++ b/dlt/destinations/impl/fabric/factory.py
@@ -54,11 +54,7 @@ class FabricTypeMapper(SynapseTypeMapper):
     def to_destination_type(self, column: TColumnSchema, table: PreparedTableSchema) -> str:
         """Override to use varchar instead of nvarchar and datetime2 instead of datetimeoffset"""
         sc_t = column["data_type"]
-        if sc_t == "json":
-            # Fabric doesn't have native JSON type, use varchar instead of nvarchar
-            return "varchar(%s)" % column.get("precision", "max")
-
-        if sc_t == "text":
+        if sc_t in ("json", "text"):
             precision = column.get("precision")
             if precision is None:
                 return "varchar(max)"

--- a/dlt/destinations/impl/fabric/factory.py
+++ b/dlt/destinations/impl/fabric/factory.py
@@ -22,6 +22,11 @@ if TYPE_CHECKING:
     from .fabric import FabricClient
 
 
+UTF8_MAX_BYTES_PER_CODE_POINT = 4
+FABRIC_VARCHAR_MAX_N = 8000
+"""Largest explicit length for `varchar(n)`, anything longer must be `varchar(max)`"""
+
+
 class FabricTypeMapper(SynapseTypeMapper):
     """Custom type mapper for Fabric Warehouse - replaces nvarchar with varchar and datetimeoffset with datetime2"""
 
@@ -54,14 +59,14 @@ class FabricTypeMapper(SynapseTypeMapper):
             return "varchar(%s)" % column.get("precision", "max")
 
         if sc_t == "text":
-            # varchar uses byte semantics; scale nvarchar char precision by 4 (worst-case utf-8)
             precision = column.get("precision")
-            if precision is not None:
-                safe_length = precision * 4
-                if safe_length > 8000:
-                    return "varchar(max)"
-                return "varchar(%i)" % safe_length
-            return "varchar(max)"
+            if precision is None:
+                return "varchar(max)"
+            # precision counts characters, varchar counts bytes
+            length = precision * UTF8_MAX_BYTES_PER_CODE_POINT
+            if length > FABRIC_VARCHAR_MAX_N:
+                return "varchar(max)"
+            return "varchar(%i)" % length
 
         if sc_t == "time":
             # Fabric requires explicit precision for TIME (0-6)
@@ -70,10 +75,6 @@ class FabricTypeMapper(SynapseTypeMapper):
 
         # Get base type from parent
         db_type = super().to_destination_type(column, table)
-
-        # Replace any nvarchar with varchar (Fabric doesn't support nvarchar)
-        if "nvarchar" in db_type.lower():
-            db_type = db_type.replace("nvarchar", "varchar").replace("NVARCHAR", "varchar")
 
         # Replace any datetimeoffset with datetime2 (Fabric doesn't support datetimeoffset)
         # This should be handled by to_db_datetime_type but just in case

--- a/docs/website/docs/dlt-ecosystem/destinations/fabric.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/fabric.md
@@ -153,9 +153,11 @@ This destination fully supports [dlt state sync](../../general-usage/state#synci
 Fabric Warehouse differs from standard SQL Server in several important ways:
 
 ### VARCHAR vs NVARCHAR
-Fabric Warehouse uses `varchar` for text columns instead of `nvarchar`. This destination automatically maps:
+Fabric Warehouse uses `varchar` for text columns instead of `nvarchar`. Because `varchar` lengths are counted in
+bytes while `precision` counts characters, the precision is multiplied by 4 (the worst case for UTF-8):
 - `text` → `varchar(max)`
-- `text` (with unique hint) → `varchar(900)` (limited for index support)
+- `text` with `precision` → `varchar(precision * 4)`, for example `precision=25` → `varchar(100)`
+- `text` with `precision` above 2000 → `varchar(max)`, since 8000 is the longest length Fabric accepts
 
 ### DATETIME2 vs DATETIMEOFFSET
 Fabric uses `datetime2` for timestamps instead of `datetimeoffset`:

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -221,3 +221,29 @@ def test_fabric_credentials_authentication_method() -> None:
     # Verify ActiveDirectoryServicePrincipal is set
     dsn_dict = creds.get_odbc_dsn_dict()
     assert dsn_dict["AUTHENTICATION"] == "ActiveDirectoryServicePrincipal"
+
+
+def test_fabric_type_mapper_nvarchar_to_varchar_length() -> None:
+    """Fabric varchar uses UTF-8 byte semantics; nvarchar precision (characters) must be scaled"""
+    from dlt.destinations.impl.fabric.factory import FabricTypeMapper
+    from dlt.common.destination import DestinationCapabilitiesContext
+    from dlt.common.schema.typing import TColumnSchema
+    from dlt.common.destination.typing import PreparedTableSchema
+    from typing import cast
+
+    table = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
+    caps = DestinationCapabilitiesContext.generic_capabilities("parquet")
+    mapper = FabricTypeMapper(caps)
+
+    col = cast(TColumnSchema, {"name": "c", "data_type": "text", "precision": 100, "nullable": True})
+    assert mapper.to_destination_type(col, table) == "varchar(400)"
+
+    # 2001*4=8004 > 8000 → varchar(max)
+    col = cast(TColumnSchema, {"name": "c", "data_type": "text", "precision": 2001, "nullable": True})
+    assert mapper.to_destination_type(col, table) == "varchar(max)"
+
+    col = cast(TColumnSchema, {"name": "c", "data_type": "text", "nullable": True})
+    assert mapper.to_destination_type(col, table) == "varchar(max)"
+
+    col = cast(TColumnSchema, {"name": "c", "data_type": "text", "precision": 10, "nullable": True})
+    assert mapper.to_destination_type(col, table) == "varchar(40)"

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -1,14 +1,17 @@
 """Tests for Microsoft Fabric Warehouse destination configuration"""
 
 import os
-from typing import Optional
+from typing import Optional, cast
 
 import pytest
 
 from dlt.common.configuration import resolve_configuration
+from dlt.common.destination import DestinationCapabilitiesContext
+from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.schema import Schema
+from dlt.common.schema.typing import TColumnSchema
 from dlt.common.utils import digest128
-from dlt.destinations.impl.fabric.factory import fabric
+from dlt.destinations.impl.fabric.factory import fabric, FabricTypeMapper
 from dlt.destinations.impl.fabric.configuration import (
     FabricCredentials,
     FabricClientConfiguration,
@@ -117,12 +120,6 @@ def test_fabric_configuration_custom_collation() -> None:
 
 def test_fabric_type_mapper() -> None:
     """Test Fabric type mapper converts nvarchar to varchar and datetimeoffset to datetime2"""
-    from dlt.destinations.impl.fabric.factory import FabricTypeMapper
-    from dlt.common.destination import DestinationCapabilitiesContext
-    from dlt.common.schema.typing import TColumnSchema
-    from dlt.common.destination.typing import PreparedTableSchema
-    from typing import cast
-
     # Create a mock table for testing
     table = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
 
@@ -223,14 +220,8 @@ def test_fabric_credentials_authentication_method() -> None:
     assert dsn_dict["AUTHENTICATION"] == "ActiveDirectoryServicePrincipal"
 
 
-def test_fabric_type_mapper_nvarchar_to_varchar_length() -> None:
+def test_fabric_type_mapper_scales_text_precision() -> None:
     """Fabric varchar uses UTF-8 byte semantics; nvarchar precision (characters) must be scaled"""
-    from dlt.destinations.impl.fabric.factory import FabricTypeMapper
-    from dlt.common.destination import DestinationCapabilitiesContext
-    from dlt.common.schema.typing import TColumnSchema
-    from dlt.common.destination.typing import PreparedTableSchema
-    from typing import cast
-
     table = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
     caps = DestinationCapabilitiesContext.generic_capabilities("parquet")
     mapper = FabricTypeMapper(caps)
@@ -239,6 +230,12 @@ def test_fabric_type_mapper_nvarchar_to_varchar_length() -> None:
         TColumnSchema, {"name": "c", "data_type": "text", "precision": 100, "nullable": True}
     )
     assert mapper.to_destination_type(col, table) == "varchar(400)"
+
+    # 2000*4=8000 is the longest length Fabric accepts
+    col = cast(
+        TColumnSchema, {"name": "c", "data_type": "text", "precision": 2000, "nullable": True}
+    )
+    assert mapper.to_destination_type(col, table) == "varchar(8000)"
 
     # 2001*4=8004 > 8000 → varchar(max)
     col = cast(

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -9,7 +9,7 @@ from dlt.common.configuration import resolve_configuration
 from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.schema import Schema
-from dlt.common.schema.typing import TColumnSchema
+from dlt.common.schema.typing import TColumnSchema, TDataType
 from dlt.common.utils import digest128
 from dlt.destinations.impl.fabric.factory import fabric, FabricTypeMapper
 from dlt.destinations.impl.fabric.configuration import (
@@ -220,31 +220,36 @@ def test_fabric_credentials_authentication_method() -> None:
     assert dsn_dict["AUTHENTICATION"] == "ActiveDirectoryServicePrincipal"
 
 
-def test_fabric_type_mapper_scales_text_precision() -> None:
-    """Fabric varchar uses UTF-8 byte semantics; nvarchar precision (characters) must be scaled"""
+@pytest.mark.parametrize("data_type", ["text", "json"])
+def test_fabric_type_mapper_scales_varchar_precision(data_type: TDataType) -> None:
+    """Fabric varchar uses UTF-8 byte semantics; character precision must be scaled."""
     table = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
     caps = DestinationCapabilitiesContext.generic_capabilities("parquet")
     mapper = FabricTypeMapper(caps)
 
     col = cast(
-        TColumnSchema, {"name": "c", "data_type": "text", "precision": 100, "nullable": True}
+        TColumnSchema, {"name": "c", "data_type": data_type, "precision": 100, "nullable": True}
     )
     assert mapper.to_destination_type(col, table) == "varchar(400)"
 
     # 2000*4=8000 is the longest length Fabric accepts
     col = cast(
-        TColumnSchema, {"name": "c", "data_type": "text", "precision": 2000, "nullable": True}
+        TColumnSchema,
+        {"name": "c", "data_type": data_type, "precision": 2000, "nullable": True},
     )
     assert mapper.to_destination_type(col, table) == "varchar(8000)"
 
     # 2001*4=8004 > 8000 → varchar(max)
     col = cast(
-        TColumnSchema, {"name": "c", "data_type": "text", "precision": 2001, "nullable": True}
+        TColumnSchema,
+        {"name": "c", "data_type": data_type, "precision": 2001, "nullable": True},
     )
     assert mapper.to_destination_type(col, table) == "varchar(max)"
 
-    col = cast(TColumnSchema, {"name": "c", "data_type": "text", "nullable": True})
+    col = cast(TColumnSchema, {"name": "c", "data_type": data_type, "nullable": True})
     assert mapper.to_destination_type(col, table) == "varchar(max)"
 
-    col = cast(TColumnSchema, {"name": "c", "data_type": "text", "precision": 10, "nullable": True})
+    col = cast(
+        TColumnSchema, {"name": "c", "data_type": data_type, "precision": 10, "nullable": True}
+    )
     assert mapper.to_destination_type(col, table) == "varchar(40)"

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -235,11 +235,15 @@ def test_fabric_type_mapper_nvarchar_to_varchar_length() -> None:
     caps = DestinationCapabilitiesContext.generic_capabilities("parquet")
     mapper = FabricTypeMapper(caps)
 
-    col = cast(TColumnSchema, {"name": "c", "data_type": "text", "precision": 100, "nullable": True})
+    col = cast(
+        TColumnSchema, {"name": "c", "data_type": "text", "precision": 100, "nullable": True}
+    )
     assert mapper.to_destination_type(col, table) == "varchar(400)"
 
     # 2001*4=8004 > 8000 → varchar(max)
-    col = cast(TColumnSchema, {"name": "c", "data_type": "text", "precision": 2001, "nullable": True})
+    col = cast(
+        TColumnSchema, {"name": "c", "data_type": "text", "precision": 2001, "nullable": True}
+    )
     assert mapper.to_destination_type(col, table) == "varchar(max)"
 
     col = cast(TColumnSchema, {"name": "c", "data_type": "text", "nullable": True})

--- a/tests/load/fabric/test_fabric_table_builder.py
+++ b/tests/load/fabric/test_fabric_table_builder.py
@@ -73,8 +73,8 @@ def test_create_table_uses_varchar(client: FabricClient) -> None:
     # Fabric uses datetime2 with precision 0-6
     assert '"col4_precision" datetime2(3)  NOT NULL' in sql
 
-    # varchar instead of nvarchar
-    assert '"col5_precision" varchar(25)' in sql
+    # varchar instead of nvarchar, with the char precision scaled to utf-8 bytes
+    assert '"col5_precision" varchar(100)' in sql
 
     assert '"col6_precision" decimal(6,2)  NOT NULL' in sql
     assert '"col7_precision" varbinary(19)' in sql

--- a/tests/load/fabric/test_fabric_table_builder.py
+++ b/tests/load/fabric/test_fabric_table_builder.py
@@ -120,26 +120,25 @@ def test_create_dlt_version_table_uses_varchar(client: FabricClient) -> None:
 
 
 def test_unique_column_uses_varchar(client: FabricClient) -> None:
-    """Test that unique text columns use varchar with proper length"""
+    """Unique text columns are typed like any other text column, Fabric has no index key limit"""
     from dlt.common.schema.typing import TColumnSchema
 
-    # Create a table schema with a unique text column
     prepared_table = client.prepare_load_table("event_test_table")
 
-    # Add a unique text column to test
     unique_column: TColumnSchema = {
         "name": "unique_text_col",
         "data_type": "text",
         "nullable": False,
         "unique": True,
     }
-
-    # Get column definition SQL
     col_sql = client._get_column_def_sql(unique_column, prepared_table)
-
-    # Should use varchar (not nvarchar) with 900 byte limit for unique columns
-    assert "varchar(900)" in col_sql
+    assert "varchar(max)" in col_sql
     assert "nvarchar" not in col_sql
+
+    # precision is scaled the same way as for non unique columns
+    unique_column["precision"] = 25
+    col_sql = client._get_column_def_sql(unique_column, prepared_table)
+    assert "varchar(100)" in col_sql
 
 
 def test_fabric_capabilities() -> None:


### PR DESCRIPTION
## Summary

- Handle `text` type explicitly in `FabricTypeMapper.to_destination_type` before the parent `nvarchar` -> `varchar` string replacement
- Multiply character precision by 4 to safely cover UTF-8 encoding (worst-case 4 bytes per code point)
- Fall back to `varchar(max)` when the scaled length exceeds Fabric's 8000-byte limit or when no precision is set

## Test plan

- [x] `varchar(400)` for `nvarchar(100)` (4x scaling)
- [x] `varchar(max)` when scaled length > 8000
- [x] `varchar(max)` when no precision set
- [x] Small precision stays bounded (`varchar(40)` for precision 10)

Closes dlt-hub/dlt#4255