### PR TITLE
fix(fabric): allow time columns through the parquet load path

### DIFF
--- a/dlt/destinations/impl/fabric/factory.py
+++ b/dlt/destinations/impl/fabric/factory.py
@@ -15,6 +15,7 @@ from dlt.common.normalizers.naming import NamingConvention
 from dlt.destinations.impl.synapse.factory import synapse, SynapseTypeMapper
 from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.schema.typing import TColumnSchema
+from dlt.common.typing import TLoaderFileFormat
 
 from .configuration import FabricClientConfiguration
 
@@ -45,6 +46,16 @@ class FabricTypeMapper(SynapseTypeMapper):
             return f"datetime2({precision})"
         # Use precision 6 as default (instead of 7 in SQL Server)
         return "datetime2(6)"
+
+    def ensure_supported_type(
+        self,
+        column: TColumnSchema,
+        table: PreparedTableSchema,
+        loader_file_format: TLoaderFileFormat,
+    ) -> None:
+        if loader_file_format == "parquet" and column["data_type"] == "time":
+            return
+        super().ensure_supported_type(column, table, loader_file_format)
 
     def to_destination_type(self, column: TColumnSchema, table: PreparedTableSchema) -> str:
         """Override to use varchar instead of nvarchar and datetime2 instead of datetimeoffset"""

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -221,3 +221,26 @@ def test_fabric_credentials_authentication_method() -> None:
     # Verify ActiveDirectoryServicePrincipal is set
     dsn_dict = creds.get_odbc_dsn_dict()
     assert dsn_dict["AUTHENTICATION"] == "ActiveDirectoryServicePrincipal"
+
+
+def test_fabric_time_allowed_through_parquet() -> None:
+    """Fabric supports TIME in Parquet; the inherited Synapse rejection must be skipped."""
+    from dlt.destinations.impl.fabric.factory import FabricTypeMapper
+    from dlt.destinations.impl.synapse.factory import SynapseTypeMapper
+    from dlt.common.destination import DestinationCapabilitiesContext
+    from dlt.common.schema.typing import TColumnSchema
+    from dlt.common.destination.typing import PreparedTableSchema
+    from typing import cast
+
+    table = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
+    caps = DestinationCapabilitiesContext.generic_capabilities("parquet")
+    time_col = cast(TColumnSchema, {"name": "t", "data_type": "time", "precision": 6, "nullable": True})
+
+    synapse_mapper = SynapseTypeMapper(caps)
+    with pytest.raises(Exception):
+        synapse_mapper.ensure_supported_type(time_col, table, "parquet")
+
+    fabric_mapper = FabricTypeMapper(caps)
+    fabric_mapper.ensure_supported_type(time_col, table, "parquet")
+
+    assert fabric_mapper.to_destination_type(time_col, table) == "time(6)"

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -234,7 +234,9 @@ def test_fabric_time_allowed_through_parquet() -> None:
 
     table = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
     caps = DestinationCapabilitiesContext.generic_capabilities("parquet")
-    time_col = cast(TColumnSchema, {"name": "t", "data_type": "time", "precision": 6, "nullable": True})
+    time_col = cast(
+        TColumnSchema, {"name": "t", "data_type": "time", "precision": 6, "nullable": True}
+    )
 
     synapse_mapper = SynapseTypeMapper(caps)
     with pytest.raises(Exception):

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -221,28 +221,3 @@ def test_fabric_credentials_authentication_method() -> None:
     # Verify ActiveDirectoryServicePrincipal is set
     dsn_dict = creds.get_odbc_dsn_dict()
     assert dsn_dict["AUTHENTICATION"] == "ActiveDirectoryServicePrincipal"
-
-
-def test_fabric_time_allowed_through_parquet() -> None:
-    """Fabric supports TIME in Parquet; the inherited Synapse rejection must be skipped."""
-    from dlt.destinations.impl.fabric.factory import FabricTypeMapper
-    from dlt.destinations.impl.synapse.factory import SynapseTypeMapper
-    from dlt.common.destination import DestinationCapabilitiesContext
-    from dlt.common.schema.typing import TColumnSchema
-    from dlt.common.destination.typing import PreparedTableSchema
-    from typing import cast
-
-    table = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
-    caps = DestinationCapabilitiesContext.generic_capabilities("parquet")
-    time_col = cast(
-        TColumnSchema, {"name": "t", "data_type": "time", "precision": 6, "nullable": True}
-    )
-
-    synapse_mapper = SynapseTypeMapper(caps)
-    with pytest.raises(Exception):
-        synapse_mapper.ensure_supported_type(time_col, table, "parquet")
-
-    fabric_mapper = FabricTypeMapper(caps)
-    fabric_mapper.ensure_supported_type(time_col, table, "parquet")
-
-    assert fabric_mapper.to_destination_type(time_col, table) == "time(6)"

--- a/tests/load/pipeline/test_pipelines.py
+++ b/tests/load/pipeline/test_pipelines.py
@@ -681,7 +681,6 @@ def test_parquet_loading(destination_config: DestinationTestConfiguration) -> No
         "synapse",
         "databricks",
         "clickhouse",
-        "fabric",
     ]:
         datetime_data.pop("col11")
         datetime_data.pop("col11_null")

--- a/tests/load/utils.py
+++ b/tests/load/utils.py
@@ -1551,10 +1551,10 @@ def table_update_and_row_for_destination(destination_config: DestinationTestConf
         exclude_types.append("time")
 
     if (
-        destination_config.destination_type in ("synapse", "fabric")
+        destination_config.destination_type == "synapse"
         and destination_config.file_format == "parquet"
     ):
-        # TIME columns are not supported for staged parquet loads into Synapse/Fabric
+        # TIME columns are not supported for staged parquet loads into Synapse
         exclude_types.append("time")
 
     if destination_config.destination_type in (


### PR DESCRIPTION
## Summary

- Override `ensure_supported_type` in `FabricTypeMapper` to skip the inherited Synapse rejection for `time` columns when the loader format is Parquet
- The Synapse rejection remains in place for the Synapse destination
- `FabricTypeMapper` already maps `time` to `time(p)` DDL correctly; this change unblocks the load path

## Test plan

- [x] Synapse mapper still raises for `parquet` + `time`
- [x] Fabric mapper allows `parquet` + `time` without raising
- [x] Fabric mapper produces correct `time(6)` DDL
- [ ] Integration test against live Fabric Warehouse with Parquet staging

Closes dlt-hub/dlt#4256