### PR TITLE
fix(docs): replace dead playground link in README with marimo notebook demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ def players():
 dlt.pipeline(destination="duckdb", dataset_name="chess").run(players())
 ```
 
-Try it out in our **[Colab Demo](https://colab.research.google.com/drive/1NfSB1DpwbbHX9_t5vlalBTf13utwpMGx?usp=sharing)** or directly on our wasm-based [playground](https://dlthub.com/docs/tutorial/playground) in our docs.
+Check out a super simple demo in **[Colab](https://colab.research.google.com/drive/1NfSB1DpwbbHX9_t5vlalBTf13utwpMGx?usp=sharing)** or a more advanced [Hugging Face demo with Marimo notebooks](https://molab.marimo.io/github/marimo-team/gallery-examples/blob/main/notebooks/external/dlthub-huggingface.py).
 
 ## Why dlt
 


### PR DESCRIPTION
The README's "Try it out" line pointed to the wasm-based playground page (`dlthub.com/docs/tutorial/playground`), which is a dead link. This replaces it with a link to the dlt + Hugging Face marimo notebook on molab, alongside the existing Colab demo.

### Changes
- `README.md`: reword the demo line — keep the Colab link, drop the dead playground link, and point to the [marimo notebook demo](https://molab.marimo.io/github/marimo-team/gallery-examples/blob/main/notebooks/external/dlthub-huggingface.py) for a more advanced example.