### PR TITLE
(fix) uses case sensitive identifiers in sqlglot schema

### DIFF
--- a/dlt/dataset/lineage.py
+++ b/dlt/dataset/lineage.py
@@ -74,7 +74,12 @@ def create_sqlglot_schema(
 
         nested_schema[dataset_name] = sqlglot_tables
 
-    return ensure_schema(nested_schema, dialect=dialect, normalize=False)
+    # keep case-sensitive so star-expansion doesn't re-fold already-normalized identifiers
+    return ensure_schema(
+        nested_schema,
+        dialect=f"{dialect}, normalization_strategy=case_sensitive" if dialect else dialect,
+        normalize=False,
+    )
 
 
 # NOTE even if `infer_sqlglot_schema=True`, some queries can have undetermined final columns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,7 @@ dependencies = [
     "packaging>=21.1",
     "pluggy>=1.3.0",
     "win-precise-time>=1.4.2 ; os_name == 'nt' and python_version < '3.13'",
-    # TODO: remove upper bound once https://github.com/tobymao/sqlglot/pull/7921 is released
-    "sqlglot>=26.32.0,<30.13",
+    "sqlglot>=26.32.0",
     "pywin32>=306 ; sys_platform == 'win32'",
     "rich-argparse>=1.6.0",
 ]

--- a/tests/destinations/test_lineage.py
+++ b/tests/destinations/test_lineage.py
@@ -6,6 +6,7 @@ import pytest
 import sqlglot.expressions as sge
 from sqlglot.schema import Schema as SQLGlotSchema, ensure_schema
 
+from dlt import Schema
 from dlt.common.libs.sqlglot import TSqlGlotDialect
 from dlt.common.schema import TTableSchemaColumns
 from dlt.dataset import lineage
@@ -217,3 +218,35 @@ def test_compute_columns_schema(
                 **config,
             )[0]
         )
+
+
+@pytest.mark.parametrize(
+    "names_ref",
+    (
+        "tests.common.cases.normalizers.sql_upper",
+        "tests.common.cases.normalizers.title_case",
+    ),
+)
+def test_star_select_preserves_case_sensitive_identifiers(names_ref: str) -> None:
+    """`SELECT *` expansion must keep the case of already normalized dlt identifiers."""
+    schema = Schema("d1")
+    schema._normalizers_config["names"] = names_ref
+    schema.update_normalizers()
+    schema.update_table(
+        {
+            "name": "products",
+            "columns": {
+                "id": {"data_type": "bigint", "name": "id"},
+                "name": {"data_type": "text", "name": "name"},
+                "_dlt_load_id": {"data_type": "text", "name": "_dlt_load_id"},
+            },
+        }
+    )
+    normalized_table = schema.naming.normalize_tables_path("products")
+    expected = [schema.naming.normalize_identifier(c) for c in ("id", "name", "_dlt_load_id")]
+
+    sqlglot_schema = lineage.create_sqlglot_schema({"d1": [schema]}, DIALECT)
+    columns, _ = lineage.compute_columns_schema(
+        sqlglot.parse_one(f'SELECT * FROM "{normalized_table}"'), sqlglot_schema, DIALECT
+    )
+    assert list(columns.keys()) == expected

--- a/tests/normalize/test_model_item_normalizer.py
+++ b/tests/normalize/test_model_item_normalizer.py
@@ -216,12 +216,14 @@ def test_simple_model_normalizing(
             == normalized_select_query
         )
     elif dialect in ("tsql", "fabric"):  # mssql, synapse, fabric
-        assert (
+        # newer sqlglot lower-cases the generated inner derived-table alias for case-insensitive
+        # T-SQL (`[A_a] AS [A_a]` -> `[A_a] AS [a_a]`); both resolve identically, so accept either
+        assert normalized_select_query in [
             "SELECT _dlt_subquery.[A_a] AS [a_a], _dlt_subquery.[b] AS [b], NULL AS [d],"
             f" '{load_id}' AS [_dlt_load_id], NEWID() AS [_dlt_id] FROM (SELECT [b] AS [b], [A_a]"
-            " AS [A_a], [c] AS [c] FROM [my_table]) AS _dlt_subquery\n"
-            == normalized_select_query
-        )
+            f" AS [{inner}], [c] AS [c] FROM [my_table]) AS _dlt_subquery\n"
+            for inner in ("A_a", "a_a")
+        ]
     elif dialect == "postgres":
         assert (
             'SELECT _dlt_subquery."A_a" AS "a_a", _dlt_subquery."b" AS "b", NULL AS "d",'

--- a/uv.lock
+++ b/uv.lock
@@ -2925,7 +2925,7 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'pyiceberg'", specifier = ">=1.4" },
     { name = "sqlalchemy", marker = "extra == 'sql-database'", specifier = ">=1.4" },
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=1.4" },
-    { name = "sqlglot", specifier = ">=26.32.0,<30.13" },
+    { name = "sqlglot", specifier = ">=26.32.0" },
     { name = "tenacity", specifier = ">=8.0.2" },
     { name = "tomlkit", specifier = ">=0.11.3" },
     { name = "typing-extensions", specifier = ">=4.8.0" },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
`sqlglot` 30.13.0 started to normalize identifiers in a few more cases. here we prevent case folding explicitly when we create sqlglot schema. this was already made when computing column schemas.
