### PR TITLE
feat(providers): add azure key vault configuration provider

### DIFF
--- a/dlt/common/configuration/providers/__init__.py
+++ b/dlt/common/configuration/providers/__init__.py
@@ -13,6 +13,7 @@ from .doc import CustomLoaderDocProvider
 from .vault import SECRETS_TOML_KEY, VaultDocProvider
 from .google_secrets import GoogleSecretsProvider
 from .aws_secrets import AwsSecretsManagerProvider
+from .azure_key_vault import AzureKeyVaultProvider
 from .context import ContextProvider
 
 __all__ = [
@@ -31,5 +32,6 @@ __all__ = [
     "VaultDocProvider",
     "GoogleSecretsProvider",
     "AwsSecretsManagerProvider",
+    "AzureKeyVaultProvider",
     "EXPLICIT_VALUES_PROVIDER_NAME",
 ]

--- a/dlt/common/configuration/providers/azure_key_vault.py
+++ b/dlt/common/configuration/providers/azure_key_vault.py
@@ -1,0 +1,148 @@
+import threading
+from typing import Any, Optional, Sequence, Set
+
+from dlt.common import logger
+from dlt.common.configuration.exceptions import ConfigProviderException
+from dlt.common.exceptions import MissingDependencyException
+from dlt import version
+
+from .vault import VaultDocProvider, normalize_key
+from .provider import get_key_name
+
+SECRET_NAME_SEPARATOR = "-"
+_AZURE_KEY_VAULT_EXTRA = f"{version.DLT_PKG_NAME}[azure_key_vault]"
+
+
+class AzureKeyVaultProvider(VaultDocProvider):
+    def __init__(
+        self,
+        vault_url: str,
+        credential: Any = None,
+        only_secrets: bool = True,
+        only_toml_fragments: bool = True,
+        list_secrets: bool = False,
+    ) -> None:
+        """Access secrets stored in Azure Key Vault.
+
+        Args:
+            vault_url (str): The URL of the Azure Key Vault, e.g. `https://myvault.vault.azure.net/`.
+            credential (Any): An `azure-identity` credential instance. When `None`,
+                `DefaultAzureCredential` is created automatically.
+            only_secrets (bool): When True, only keys with secret hint types will be looked up.
+            only_toml_fragments (bool): When True, only load known TOML fragments and ignore other lookups.
+            list_secrets (bool): When True, list all secrets upfront to optimize vault access by
+                avoiding lookups for non-existent secrets.
+        """
+        self.vault_url = vault_url
+        self._credential = credential
+        self._client: Any = None
+        self._client_lock = threading.Lock()
+        super().__init__(only_secrets, only_toml_fragments, list_secrets)
+
+    @staticmethod
+    def get_key_name(key: str, *sections: str) -> str:
+        """Joins normalized key components with `-`.
+
+        Azure Key Vault secret names allow alphanumerics and hyphens (1-127 chars).
+        """
+        normalized_sections = [normalize_key(section).replace("_", "-") for section in sections if section]
+        return get_key_name(normalize_key(key).replace("_", "-"), SECRET_NAME_SEPARATOR, *normalized_sections)
+
+    @property
+    def name(self) -> str:
+        return "Azure Key Vault"
+
+    @property
+    def locations(self) -> Sequence[str]:
+        return [self.vault_url]
+
+    def _get_credential(self) -> Any:
+        if self._credential is not None:
+            return self._credential
+        try:
+            from azure.identity import DefaultAzureCredential
+        except ModuleNotFoundError:
+            raise MissingDependencyException(
+                "AzureKeyVaultProvider",
+                [_AZURE_KEY_VAULT_EXTRA],
+                "We need azure-identity for authentication with Azure Key Vault",
+            )
+        self._credential = DefaultAzureCredential()
+        return self._credential
+
+    def _get_client(self) -> Any:
+        with self._client_lock:
+            if self._client is None:
+                try:
+                    from azure.keyvault.secrets import SecretClient  # type: ignore[import-untyped]
+                except ModuleNotFoundError:
+                    raise MissingDependencyException(
+                        "AzureKeyVaultProvider",
+                        [_AZURE_KEY_VAULT_EXTRA],
+                        "We need azure-keyvault-secrets to access Azure Key Vault",
+                    )
+                self._client = SecretClient(
+                    vault_url=self.vault_url, credential=self._get_credential()
+                )
+            return self._client
+
+    def _look_vault(self, full_key: str, hint: type) -> Optional[str]:
+        client = self._get_client()
+
+        from azure.core.exceptions import (
+            HttpResponseError,
+            ResourceNotFoundError,
+            ServiceRequestError,
+        )
+
+        try:
+            secret = client.get_secret(full_key)
+            return secret.value  # type: ignore[no-any-return]
+        except ResourceNotFoundError:
+            return None
+        except HttpResponseError as error:
+            if error.status_code == 403:
+                logger.warning(
+                    f"Access denied when reading secret {full_key} from Azure Key Vault"
+                    f" ({self.vault_url}): {error.message}"
+                )
+                return None
+            raise
+        except ServiceRequestError as error:
+            logger.warning(
+                f"Unable to connect to Azure Key Vault ({self.vault_url}): {error.message}"
+            )
+            raise
+
+    def _list_vault(self) -> Set[str]:
+        client = self._get_client()
+
+        from azure.core.exceptions import HttpResponseError, ServiceRequestError
+
+        available_keys: Set[str] = set()
+        try:
+            for secret_properties in client.list_properties_of_secrets():
+                if secret_properties.name and secret_properties.enabled:
+                    available_keys.add(secret_properties.name)
+        except HttpResponseError as error:
+            if error.status_code == 403:
+                raise ConfigProviderException(
+                    self.name,
+                    f"Cannot list secrets: access denied for Azure Key Vault ({self.vault_url})."
+                    " Secret listing is required when list_secrets=True to optimize vault"
+                    " access by skipping lookups for non-existent secrets."
+                    f" Error: {error.message}",
+                )
+            raise ConfigProviderException(
+                self.name,
+                f"Failed to list secrets in Azure Key Vault ({self.vault_url})."
+                " Secret listing is required when list_secrets=True to optimize vault"
+                f" access by skipping lookups for non-existent secrets. Error: {error.message}",
+            )
+        except ServiceRequestError as error:
+            logger.warning(
+                f"Unable to connect to Azure Key Vault ({self.vault_url}): {error.message}"
+            )
+            raise
+        logger.info(f"Listed {len(available_keys)} secrets from Azure Key Vault ({self.vault_url})")
+        return available_keys

--- a/dlt/common/configuration/providers/azure_key_vault.py
+++ b/dlt/common/configuration/providers/azure_key_vault.py
@@ -9,7 +9,7 @@ from dlt import version
 from .vault import VaultDocProvider, normalize_key
 from .provider import get_key_name
 
-SECRET_NAME_SEPARATOR = "-"
+SECRET_NAME_SEPARATOR = "--"
 _AZURE_KEY_VAULT_EXTRA = f"{version.DLT_PKG_NAME}[azure_key_vault]"
 
 
@@ -41,9 +41,10 @@ class AzureKeyVaultProvider(VaultDocProvider):
 
     @staticmethod
     def get_key_name(key: str, *sections: str) -> str:
-        """Joins normalized key components with `-`.
+        """Joins normalized key components with `--`.
 
         Azure Key Vault secret names allow alphanumerics and hyphens (1-127 chars).
+        Uses `--` as separator since `-` appears in key names after underscore replacement.
         """
         normalized_sections = [normalize_key(section).replace("_", "-") for section in sections if section]
         return get_key_name(normalize_key(key).replace("_", "-"), SECRET_NAME_SEPARATOR, *normalized_sections)
@@ -85,6 +86,13 @@ class AzureKeyVaultProvider(VaultDocProvider):
                     vault_url=self.vault_url, credential=self._get_credential()
                 )
             return self._client
+
+    def _update_from_vault(
+        self, full_key: str, key: str, hint: type, pipeline_name: str, sections: tuple
+    ) -> None:
+        # base class passes raw SECRETS_TOML_KEY which contains underscores
+        full_key = full_key.replace("_", "-")
+        super()._update_from_vault(full_key, key, hint, pipeline_name, sections)
 
     def _look_vault(self, full_key: str, hint: type) -> Optional[str]:
         client = self._get_client()

--- a/dlt/common/configuration/providers/azure_key_vault.py
+++ b/dlt/common/configuration/providers/azure_key_vault.py
@@ -4,6 +4,10 @@ from typing import Any, Optional, Sequence, Set
 from dlt.common import logger
 from dlt.common.configuration.exceptions import ConfigProviderException
 from dlt.common.exceptions import MissingDependencyException
+from dlt.common.runtime.fab_notebookutils import (
+    FabNotebookUtilsCredential,
+    is_fab_notebookutils_available,
+)
 from dlt import version
 
 from .vault import VaultDocProvider, normalize_key
@@ -26,8 +30,9 @@ class AzureKeyVaultProvider(VaultDocProvider):
 
         Args:
             vault_url (str): The URL of the Azure Key Vault, e.g. `https://myvault.vault.azure.net/`.
-            credential (Any): An `azure-identity` credential instance. When `None`,
-                `DefaultAzureCredential` is created automatically.
+            credential (Any): An `azure-identity` credential instance. When `None`, a credential
+                is created automatically: NotebookUtils inside the Microsoft Fabric runtime,
+                `DefaultAzureCredential` everywhere else.
             only_secrets (bool): When True, only keys with secret hint types will be looked up.
             only_toml_fragments (bool): When True, only load known TOML fragments and ignore other lookups.
             list_secrets (bool): When True, list all secrets upfront to optimize vault access by
@@ -46,8 +51,12 @@ class AzureKeyVaultProvider(VaultDocProvider):
         Azure Key Vault secret names allow alphanumerics and hyphens (1-127 chars).
         Uses `--` as separator since `-` appears in key names after underscore replacement.
         """
-        normalized_sections = [normalize_key(section).replace("_", "-") for section in sections if section]
-        return get_key_name(normalize_key(key).replace("_", "-"), SECRET_NAME_SEPARATOR, *normalized_sections)
+        normalized_sections = [
+            normalize_key(section).replace("_", "-") for section in sections if section
+        ]
+        return get_key_name(
+            normalize_key(key).replace("_", "-"), SECRET_NAME_SEPARATOR, *normalized_sections
+        )
 
     @property
     def name(self) -> str:
@@ -59,6 +68,16 @@ class AzureKeyVaultProvider(VaultDocProvider):
 
     def _get_credential(self) -> Any:
         if self._credential is not None:
+            return self._credential
+        # DefaultAzureCredential cannot sign in inside a Fabric notebook: there are no environment
+        # variables, managed identity or CLI login to fall back on. NotebookUtils exposes the
+        # notebook owner's identity instead.
+        if is_fab_notebookutils_available():
+            logger.info(
+                "Authenticating with Azure Key Vault through the Microsoft Fabric NotebookUtils"
+                " credential API"
+            )
+            self._credential = FabNotebookUtilsCredential("keyvault")
             return self._credential
         try:
             from azure.identity import DefaultAzureCredential

--- a/dlt/common/configuration/providers/azure_key_vault.py
+++ b/dlt/common/configuration/providers/azure_key_vault.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Any, Optional, Sequence, Set
+from typing import Any, Optional, Sequence, Set, Tuple
 
 from dlt.common import logger
 from dlt.common.configuration.exceptions import ConfigProviderException
@@ -94,7 +94,10 @@ class AzureKeyVaultProvider(VaultDocProvider):
         with self._client_lock:
             if self._client is None:
                 try:
-                    from azure.keyvault.secrets import SecretClient  # type: ignore[import-untyped]
+                    # the package ships type hints, so the ignore is unused when it is installed
+                    from azure.keyvault.secrets import (  # type: ignore[import-untyped,unused-ignore]
+                        SecretClient,
+                    )
                 except ModuleNotFoundError:
                     raise MissingDependencyException(
                         "AzureKeyVaultProvider",
@@ -107,7 +110,7 @@ class AzureKeyVaultProvider(VaultDocProvider):
             return self._client
 
     def _update_from_vault(
-        self, full_key: str, key: str, hint: type, pipeline_name: str, sections: tuple
+        self, full_key: str, key: str, hint: type, pipeline_name: str, sections: Tuple[str, ...]
     ) -> None:
         # base class passes raw SECRETS_TOML_KEY which contains underscores
         full_key = full_key.replace("_", "-")

--- a/dlt/common/configuration/providers/vault.py
+++ b/dlt/common/configuration/providers/vault.py
@@ -15,7 +15,7 @@ from .doc import BaseDocProvider
 SECRETS_TOML_KEY = "dlt_secrets_toml"
 
 # translation table that removes punctuation from secret name components
-# "-" and "_" are allowed in secret names by all supported vaults so we keep them
+# "-" and "_" are allowed in secret names by most vaults so we keep them here
 PUNCTUATION_TRANSLATOR = str.maketrans("", "", "".join(set(string.punctuation) - {"-", "_"}))
 WHITESPACE_RE = re.compile(r"\s+")
 

--- a/dlt/common/configuration/specs/azure_credentials.py
+++ b/dlt/common/configuration/specs/azure_credentials.py
@@ -2,8 +2,13 @@ import os
 from copy import copy
 from typing import Optional, Dict, Any, Union
 
+from dlt.common import logger
 from dlt.common.pendulum import pendulum
 from dlt.common.exceptions import MissingDependencyException
+from dlt.common.runtime.fab_notebookutils import (
+    FabNotebookUtilsCredential,
+    is_fab_notebookutils_available,
+)
 from dlt.common.typing import TSecretStrValue, Self
 from dlt.common.configuration.specs import (
     CredentialsConfiguration,
@@ -20,6 +25,31 @@ from dlt.common.utils import without_none
 
 _AZURE_STORAGE_EXTRA = f"{version.DLT_PKG_NAME}[az]"
 _AZURE_STORAGE_SCOPE = "https://storage.azure.com/.default"
+
+
+def _default_storage_credential(spec_name: str) -> Any:
+    """Credential used for blob storage when no account key, SAS token or principal is configured.
+
+    Returns:
+        Any: A NotebookUtils credential inside the Microsoft Fabric runtime,
+            `DefaultAzureCredential` everywhere else.
+
+    Raises:
+        MissingDependencyException: When azure-identity is needed but not installed.
+    """
+    # DefaultAzureCredential cannot sign in inside a Fabric notebook: there are no environment
+    # variables, managed identity or CLI login to fall back on
+    if is_fab_notebookutils_available():
+        logger.info(
+            "Authenticating with Azure blob storage through the Microsoft Fabric NotebookUtils"
+            " credential API"
+        )
+        return FabNotebookUtilsCredential("storage")
+    try:
+        from azure.identity import DefaultAzureCredential
+    except ModuleNotFoundError:
+        raise MissingDependencyException(spec_name, [_AZURE_STORAGE_EXTRA])
+    return DefaultAzureCredential()
 
 
 def _object_store_will_refresh_default() -> bool:
@@ -225,13 +255,12 @@ class AzureCredentials(
     _AzureExternalSession, AzureCredentialsWithoutDefaults, CredentialsWithDefault
 ):
     def on_partial(self) -> None:
-        try:
-            from azure.identity import DefaultAzureCredential
-        except ModuleNotFoundError:
-            raise MissingDependencyException(self.__class__.__name__, [_AZURE_STORAGE_EXTRA])
-
         if not self.azure_storage_account_key and not self.azure_storage_sas_token:
-            self._set_default_credentials(DefaultAzureCredential())
+            credential = _default_storage_credential(self.__class__.__name__)
+            self._set_default_credentials(credential)
+            # adlfs cannot reach the Fabric identity through its own credential chain, so the
+            # credential object itself has to be handed over
+            self._external_session = isinstance(credential, FabNotebookUtilsCredential)
             if self.azure_storage_account_name:
                 self.resolve()
         else:

--- a/dlt/common/configuration/specs/config_providers_context.py
+++ b/dlt/common/configuration/specs/config_providers_context.py
@@ -1,9 +1,12 @@
 import contextlib
 import dataclasses
 import io
-from typing import ClassVar, List
+from typing import ClassVar, List, Optional
 
-from dlt.common.configuration.exceptions import DuplicateConfigProviderException
+from dlt.common.configuration.exceptions import (
+    ConfigProviderException,
+    DuplicateConfigProviderException,
+)
 from dlt.common.configuration.providers import (
     ConfigProvider,
     ContextProvider,
@@ -34,11 +37,18 @@ class AwsSecretsProviderConfiguration(VaultProviderConfiguration):
 
 
 @configspec
+class AzureKeyVaultProviderConfiguration(VaultProviderConfiguration):
+    vault_url: Optional[str] = None
+    """Azure Key Vault URL, e.g. `https://myvault.vault.azure.net/`"""
+
+
+@configspec
 class ConfigProvidersConfiguration(BaseConfiguration):
     # TODO: set to False in 2.0
     enable_airflow_secrets: bool = True
     enable_google_secrets: bool = False
     enable_aws_secrets: bool = False
+    enable_azure_key_vault: bool = False
 
     airflow_secrets: VaultProviderConfiguration = VaultProviderConfiguration(
         only_secrets=False, only_toml_fragments=False, list_secrets=False
@@ -48,6 +58,9 @@ class ConfigProvidersConfiguration(BaseConfiguration):
     )  # None  # dataclasses.field(default_factory=lambda: dict(only_secrets=True, only_toml_fragments=True, list_secrets=False))
     # VaultProviderConfiguration(only_secrets=True, only_toml_fragments=True, list_secrets=False)
     aws_secrets: AwsSecretsProviderConfiguration = AwsSecretsProviderConfiguration(
+        only_secrets=True, only_toml_fragments=True, list_secrets=False
+    )
+    azure_key_vault: AzureKeyVaultProviderConfiguration = AzureKeyVaultProviderConfiguration(
         only_secrets=True, only_toml_fragments=True, list_secrets=False
     )
     # always look in providers
@@ -110,6 +123,8 @@ def _extra_providers() -> List[ConfigProvider]:
         extra_providers.append(_google_secrets_provider(providers_config.google_secrets))
     if providers_config.enable_aws_secrets:
         extra_providers.append(_aws_secrets_provider(providers_config.aws_secrets))
+    if providers_config.enable_azure_key_vault:
+        extra_providers.append(_azure_key_vault_provider(providers_config.azure_key_vault))
     return extra_providers
 
 
@@ -129,6 +144,18 @@ def _aws_secrets_provider(settings: AwsSecretsProviderConfiguration) -> ConfigPr
 
     c = resolve_configuration(AwsCredentials(), sections=(known_sections.PROVIDERS, "aws_secrets"))
     return AwsSecretsManagerProvider(c, **dict(settings))
+
+
+def _azure_key_vault_provider(settings: AzureKeyVaultProviderConfiguration) -> ConfigProvider:
+    from dlt.common.configuration.providers.azure_key_vault import AzureKeyVaultProvider
+
+    if not settings.vault_url:
+        raise ConfigProviderException(
+            "Azure Key Vault",
+            "vault_url is required. Set it via PROVIDERS__AZURE_KEY_VAULT__VAULT_URL"
+            " or in config.toml under [providers.azure_key_vault].",
+        )
+    return AzureKeyVaultProvider(**dict(settings))
 
 
 def _airflow_providers(settings: VaultProviderConfiguration) -> List[ConfigProvider]:

--- a/dlt/common/runtime/fab_notebookutils.py
+++ b/dlt/common/runtime/fab_notebookutils.py
@@ -1,0 +1,134 @@
+"""Azure SDK TokenCredential backed by Microsoft Fabric NotebookUtils."""
+
+import base64
+import threading
+import time
+from typing import Any, Dict, NamedTuple, Optional
+
+from dlt.common import logger
+from dlt.common.configuration.exceptions import ConfigurationException
+from dlt.common.json import json
+
+_REFRESH_BUFFER_SECONDS = 300
+_FALLBACK_LIFETIME_SECONDS = 3600
+
+_AUDIENCE_ALIASES: Dict[str, str] = {
+    "sql": "https://database.windows.net/",
+}
+
+
+class _AccessToken(NamedTuple):
+    token: str
+    expires_on: int
+
+
+def _decode_jwt_expiry(token: str) -> Optional[int]:
+    """Extract the `exp` claim from a JWT payload without signature verification."""
+    try:
+        payload = token.split(".")[1]
+        remainder = len(payload) % 4
+        if remainder:
+            payload += "=" * (4 - remainder)
+        claims = json.loadb(base64.urlsafe_b64decode(payload))
+        return int(claims["exp"])
+    except (IndexError, KeyError, ValueError, TypeError):
+        return None
+
+
+def resolve_fab_notebookutils_get_token() -> Any:
+    """Return the Fabric NotebookUtils `getToken` callable, trying the modern API first.
+
+    Raises:
+        ConfigurationException: When not running in a Microsoft Fabric runtime, or when the
+            runtime exposes no known credential API.
+    """
+    try:
+        import notebookutils  # type: ignore[import-not-found]
+    except ImportError:
+        raise ConfigurationException(
+            "NotebookUtils credential API is not available."
+            " It requires the Microsoft Fabric runtime."
+        )
+
+    for path in ("credentials.getToken", "mssparkutils.credentials.getToken"):
+        obj: Any = notebookutils
+        try:
+            for attr in path.split("."):
+                obj = getattr(obj, attr)
+            if callable(obj):
+                return obj
+        except AttributeError:
+            continue
+
+    raise ConfigurationException(
+        "NotebookUtils credential API is not available. It requires the Microsoft Fabric runtime."
+    )
+
+
+def is_fab_notebookutils_available() -> bool:
+    """True when the NotebookUtils credential API can be reached (Microsoft Fabric runtime)."""
+    try:
+        resolve_fab_notebookutils_get_token()
+        return True
+    except ConfigurationException:
+        return False
+
+
+class FabNotebookUtilsCredential:
+    """Azure SDK `TokenCredential` backed by Microsoft Fabric NotebookUtils.
+
+    Authenticates as the identity the Fabric notebook runs under. Only usable inside the
+    Fabric runtime; `notebookutils` is imported lazily, never at module load time.
+
+    Args:
+        audience (str): Token audience. Accepts NotebookUtils resource keys (`storage`,
+            `keyvault`, `pbi`, `kusto`) or a full resource URI. The alias `sql` expands to
+            `https://database.windows.net/`.
+
+    Example:
+        >>> sql_cred = FabNotebookUtilsCredential("sql")
+        >>> vault_cred = FabNotebookUtilsCredential("keyvault")
+    """
+
+    def __init__(self, audience: str) -> None:
+        self._audience = _AUDIENCE_ALIASES.get(audience, audience)
+        self._lock = threading.Lock()
+        self._cached: Optional[_AccessToken] = None
+        self._get_token_fn: Optional[Any] = None
+
+    def get_token(self, *scopes: str, **kwargs: Any) -> _AccessToken:
+        """Acquire a token for the configured audience.
+
+        Implements the Azure SDK `TokenCredential` protocol. `scopes` is accepted for protocol
+        compatibility but ignored: the token is always acquired for the audience bound at
+        construction.
+        """
+        with self._lock:
+            now = int(time.time())
+            if self._cached is not None and self._cached.expires_on - now > _REFRESH_BUFFER_SECONDS:
+                return self._cached
+
+            if self._get_token_fn is None:
+                self._get_token_fn = resolve_fab_notebookutils_get_token()
+
+            token_str: str = self._get_token_fn(self._audience)
+            expires_on = _decode_jwt_expiry(token_str)
+            if expires_on is None:
+                expires_on = now + _FALLBACK_LIFETIME_SECONDS
+
+            self._cached = _AccessToken(token=token_str, expires_on=expires_on)
+            logger.info(
+                "Acquired Fabric NotebookUtils token for audience %s (expires in %d s)",
+                self._audience,
+                max(0, expires_on - now),
+            )
+            return self._cached
+
+    def close(self) -> None:
+        """Part of the Azure SDK credential protocol. No-op: no session is held between tokens."""
+
+    def __enter__(self) -> "FabNotebookUtilsCredential":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()

--- a/dlt/common/runtime/fab_notebookutils.py
+++ b/dlt/common/runtime/fab_notebookutils.py
@@ -118,9 +118,8 @@ class FabNotebookUtilsCredential:
 
             self._cached = _AccessToken(token=token_str, expires_on=expires_on)
             logger.info(
-                "Acquired Fabric NotebookUtils token for audience %s (expires in %d s)",
-                self._audience,
-                max(0, expires_on - now),
+                f"Acquired NotebookUtils token for audience {self._audience}, expires in"
+                f" {max(0, expires_on - now)}s"
             )
             return self._cached
 

--- a/dlt/destinations/impl/fabric/configuration.py
+++ b/dlt/destinations/impl/fabric/configuration.py
@@ -5,20 +5,37 @@ from dlt.common.configuration import configspec
 from dlt.common.configuration.exceptions import ConfigurationValueError
 from dlt.common.configuration.specs import AzureServicePrincipalCredentials
 from dlt.common.destination.client import DestinationClientDwhWithStagingConfiguration
-from dlt.common.exceptions import MissingDependencyException
+from dlt.common.typing import TSecretStrValue
 from dlt.common.utils import digest128
-from dlt import version
+from dlt.destinations.impl.mssql.configuration import (
+    apply_authentication_to_dsn,
+    build_token_attrs_before,
+    setup_token_credential,
+    validate_authentication,
+)
 
-_AZURE_STORAGE_EXTRA = f"{version.DLT_PKG_NAME}[az]"
+# Fabric Warehouse only supports Entra ID authentication, so it defaults to Service Principal
+# (the shared MsSql auth machinery additionally enables azure-identity token methods).
+_DEFAULT_AUTHENTICATION = "ActiveDirectoryServicePrincipal"
 
 
 @configspec(init=False)
 class FabricCredentials(AzureServicePrincipalCredentials):
-    """Credentials for Microsoft Fabric Warehouse with Service Principal authentication.
+    """Credentials for Microsoft Fabric Warehouse.
 
-    Fabric Warehouse requires Azure AD Service Principal authentication.
-    Inherits from AzureServicePrincipalCredentials for Service Principal fields and
-    automatic fallback to DefaultAzureCredential.
+    Supports several Entra ID authentication methods, selected through `authentication`:
+
+    * **Driver-native** (the ODBC driver authenticates): `ActiveDirectoryServicePrincipal`
+      (default), `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`,
+      `ActiveDirectoryInteractive`.
+    * **azure-identity** (dlt acquires an access token and injects it, works cross-platform):
+      `auto`/`default` (DefaultAzureCredential), `cli`, `environment`, `interactive`,
+      `devicecode`, `msi`/`managedidentity`.
+
+    When `authentication` is left at its default but no Service Principal secret is configured,
+    dlt falls back to `DefaultAzureCredential` and injects its token.
+
+    Inherits from AzureServicePrincipalCredentials for the Service Principal fields.
     """
 
     drivername: str = "mssql+pyodbc"
@@ -36,42 +53,54 @@ class FabricCredentials(AzureServicePrincipalCredentials):
     connect_timeout: int = 15
     """Connection timeout in seconds (default: 15)"""
 
+    authentication: str = _DEFAULT_AUTHENTICATION
+    """Authentication method. Driver-native: `ActiveDirectoryServicePrincipal` (default),
+    `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`.
+    azure-identity (token injected by dlt): `auto`/`default`, `cli`, `environment`,
+    `interactive`, `devicecode`, `msi`/`managedidentity`."""
+
+    username: str | None = None
+    """User principal name, used with `ActiveDirectoryPassword` authentication."""
+
+    password: TSecretStrValue | None = None
+    """Password, used with `ActiveDirectoryPassword` authentication."""
+
     # Override to make optional - not needed for Fabric Warehouse credentials (only for staging)
     azure_storage_account_name: Optional[str] = None
     """Not used for Fabric Warehouse credentials (only staging credentials need this)"""
 
     def on_partial(self) -> None:
-        """Enable fallback to DefaultAzureCredential if explicit credentials not provided."""
-        try:
-            from azure.identity import DefaultAzureCredential
-        except ModuleNotFoundError:
-            raise MissingDependencyException(self.__class__.__name__, [_AZURE_STORAGE_EXTRA])
+        """Set up token-based credentials and resolve once host and database are known.
 
-        # If no explicit Service Principal credentials, use default credentials
-        if not self.azure_client_id or not self.azure_client_secret or not self.azure_tenant_id:
-            self._set_default_credentials(DefaultAzureCredential())
-            # Resolve if we have warehouse connection details (not storage account name)
-            if self.host and self.database:
-                self.resolve()
+        Token-based methods (and the default Service Principal method without a secret) get an
+        azure-identity credential whose token is injected into the connection. Driver-native
+        methods need no token and resolve as-is. Auth logic is shared with `MsSqlCredentials`.
+        """
+        setup_token_credential(self)
+        # Resolve if we have the warehouse connection details (not the storage account name)
+        if self.host and self.database:
+            self.resolve()
+
+    def on_resolved(self) -> None:
+        """Validate the configured authentication method."""
+        validate_authentication(self)
 
     def get_odbc_dsn_dict(self) -> Dict[str, Any]:
         """Build ODBC DSN dictionary with Fabric-specific settings."""
-        params = {
+        params: dict[str, Any] = {
             "DRIVER": "{ODBC Driver 18 for SQL Server}",
             "SERVER": f"{self.host},{self.port}",
             "DATABASE": self.database,
-            "AUTHENTICATION": "ActiveDirectoryServicePrincipal",
             "LongAsMax": "yes",  # Required for UTF-8 collation support
             "Encrypt": "yes",
             "TrustServerCertificate": "no",
         }
-
-        # Add Service Principal credentials if provided
-        if self.azure_client_id and self.azure_tenant_id and self.azure_client_secret:
-            params["UID"] = f"{self.azure_client_id}@{self.azure_tenant_id}"
-            params["PWD"] = str(self.azure_client_secret)
-
+        apply_authentication_to_dsn(self, params)
         return params
+
+    def to_odbc_attrs_before(self) -> dict[int, bytes] | None:
+        """Return pyodbc `attrs_before` with an Entra ID access token, or None for driver-native auth."""
+        return build_token_attrs_before(self)
 
     def to_odbc_dsn(self) -> str:
         """Build ODBC connection string for pyodbc."""

--- a/dlt/destinations/impl/fabric/configuration.py
+++ b/dlt/destinations/impl/fabric/configuration.py
@@ -72,14 +72,10 @@ class FabricCredentials(AzureServicePrincipalCredentials):
     """Password, used with `ActiveDirectoryPassword` authentication."""
 
     access_token: Optional[TSecretStrValue] = None
-    """Pre-acquired Entra ID access token. When set, dlt injects it directly via `attrs_before`
-    without acquiring anything. Takes precedence over `azure_credential` and `authentication`."""
+    """Pre-acquired Entra ID access token, injected as-is. Takes precedence over `azure_credential` and `authentication`"""
 
     azure_credential: Annotated[Optional[Any], NotResolved()] = None
-    """An externally constructed `azure.core.credentials.TokenCredential` (e.g.
-    `DefaultAzureCredential()`) injected at runtime, not resolved from config providers. dlt
-    calls its `get_token()` to acquire an access token. Takes precedence over `authentication`,
-    but `access_token` takes precedence over this."""
+    """A `TokenCredential` injected at runtime, e.g. `DefaultAzureCredential()`. Takes precedence over `authentication` but not over `access_token`"""
 
     # Override to make optional - not needed for Fabric Warehouse credentials (only for staging)
     azure_storage_account_name: Optional[str] = None

--- a/dlt/destinations/impl/fabric/configuration.py
+++ b/dlt/destinations/impl/fabric/configuration.py
@@ -1,11 +1,11 @@
 """Configuration for Fabric Warehouse destination - extends Synapse configuration with COPY INTO support"""
 
 from typing import Optional, Final, ClassVar, Dict, Any, List
-from dlt.common.configuration import configspec
+from dlt.common.configuration import configspec, NotResolved
 from dlt.common.configuration.exceptions import ConfigurationValueError
 from dlt.common.configuration.specs import AzureServicePrincipalCredentials
 from dlt.common.destination.client import DestinationClientDwhWithStagingConfiguration
-from dlt.common.typing import TSecretStrValue
+from dlt.common.typing import TSecretStrValue, Annotated
 from dlt.common.utils import digest128
 from dlt.destinations.impl.mssql.configuration import (
     apply_authentication_to_dsn,
@@ -34,6 +34,9 @@ class FabricCredentials(AzureServicePrincipalCredentials):
 
     When `authentication` is left at its default but no Service Principal secret is configured,
     dlt falls back to `ActiveDirectoryDefault` and injects its token.
+
+    Alternatively, `access_token` or `azure_credential` can be injected directly, bypassing
+    `authentication` entirely (see their docstrings for precedence).
 
     Inherits from AzureServicePrincipalCredentials for the Service Principal fields.
     """
@@ -64,6 +67,16 @@ class FabricCredentials(AzureServicePrincipalCredentials):
 
     password: TSecretStrValue | None = None
     """Password, used with `ActiveDirectoryPassword` authentication."""
+
+    access_token: Optional[TSecretStrValue] = None
+    """Pre-acquired Entra ID access token. When set, dlt injects it directly via `attrs_before`
+    without acquiring anything. Takes precedence over `azure_credential` and `authentication`."""
+
+    azure_credential: Annotated[Optional[Any], NotResolved()] = None
+    """An externally constructed `azure.core.credentials.TokenCredential` (e.g.
+    `DefaultAzureCredential()`) injected at runtime, not resolved from config providers. dlt
+    calls its `get_token()` to acquire an access token. Takes precedence over `authentication`,
+    but `access_token` takes precedence over this."""
 
     # Override to make optional - not needed for Fabric Warehouse credentials (only for staging)
     azure_storage_account_name: Optional[str] = None

--- a/dlt/destinations/impl/fabric/configuration.py
+++ b/dlt/destinations/impl/fabric/configuration.py
@@ -5,6 +5,7 @@ from dlt.common.configuration import configspec, NotResolved
 from dlt.common.configuration.exceptions import ConfigurationValueError
 from dlt.common.configuration.specs import AzureServicePrincipalCredentials
 from dlt.common.destination.client import DestinationClientDwhWithStagingConfiguration
+from dlt.common.runtime.fab_notebookutils import FabNotebookUtilsCredential
 from dlt.common.typing import TSecretStrValue, Annotated
 from dlt.common.utils import digest128
 from dlt.destinations.impl.mssql.configuration import (
@@ -31,6 +32,8 @@ class FabricCredentials(AzureServicePrincipalCredentials):
     * **azure-identity** (dlt acquires an access token and injects it, works cross-platform):
       `ActiveDirectoryDefault` (alias `default`, uses `DefaultAzureCredential`),
       `ActiveDirectoryDeviceCode` (uses `DeviceCodeCredential`).
+    * **fab_notebookutils** (Fabric runtime only): lazily acquires a token via the
+      NotebookUtils credential API.
 
     When `authentication` is left at its default but no Service Principal secret is configured,
     dlt falls back to `ActiveDirectoryDefault` and injects its token.
@@ -60,7 +63,7 @@ class FabricCredentials(AzureServicePrincipalCredentials):
     """Authentication method. Driver-native: `ActiveDirectoryServicePrincipal` (default),
     `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`,
     `ActiveDirectoryMsi`. azure-identity (token injected by dlt): `ActiveDirectoryDefault`
-    (alias `default`), `ActiveDirectoryDeviceCode`."""
+    (alias `default`), `ActiveDirectoryDeviceCode`. Fabric runtime: `fab_notebookutils`."""
 
     username: str | None = None
     """User principal name, used with `ActiveDirectoryPassword` authentication."""
@@ -89,8 +92,9 @@ class FabricCredentials(AzureServicePrincipalCredentials):
         azure-identity credential whose token is injected into the connection. Driver-native
         methods need no token and resolve as-is. Auth logic is shared with `MsSqlCredentials`.
         """
+        if self.authentication == "fab_notebookutils" and self.azure_credential is None:
+            self.azure_credential = FabNotebookUtilsCredential(audience="sql")
         setup_token_credential(self)
-        # Resolve if we have the warehouse connection details (not the storage account name)
         if self.host and self.database:
             self.resolve()
 

--- a/dlt/destinations/impl/fabric/configuration.py
+++ b/dlt/destinations/impl/fabric/configuration.py
@@ -27,13 +27,13 @@ class FabricCredentials(AzureServicePrincipalCredentials):
 
     * **Driver-native** (the ODBC driver authenticates): `ActiveDirectoryServicePrincipal`
       (default), `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`,
-      `ActiveDirectoryInteractive`.
+      `ActiveDirectoryInteractive`, `ActiveDirectoryMsi`.
     * **azure-identity** (dlt acquires an access token and injects it, works cross-platform):
-      `auto`/`default` (DefaultAzureCredential), `cli`, `environment`, `interactive`,
-      `devicecode`, `msi`/`managedidentity`.
+      `ActiveDirectoryDefault` (alias `default`, uses `DefaultAzureCredential`),
+      `ActiveDirectoryDeviceCode` (uses `DeviceCodeCredential`).
 
     When `authentication` is left at its default but no Service Principal secret is configured,
-    dlt falls back to `DefaultAzureCredential` and injects its token.
+    dlt falls back to `ActiveDirectoryDefault` and injects its token.
 
     Inherits from AzureServicePrincipalCredentials for the Service Principal fields.
     """
@@ -55,9 +55,9 @@ class FabricCredentials(AzureServicePrincipalCredentials):
 
     authentication: str = _DEFAULT_AUTHENTICATION
     """Authentication method. Driver-native: `ActiveDirectoryServicePrincipal` (default),
-    `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`.
-    azure-identity (token injected by dlt): `auto`/`default`, `cli`, `environment`,
-    `interactive`, `devicecode`, `msi`/`managedidentity`."""
+    `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`,
+    `ActiveDirectoryMsi`. azure-identity (token injected by dlt): `ActiveDirectoryDefault`
+    (alias `default`), `ActiveDirectoryDeviceCode`."""
 
     username: str | None = None
     """User principal name, used with `ActiveDirectoryPassword` authentication."""

--- a/dlt/destinations/impl/fabric/fabric.py
+++ b/dlt/destinations/impl/fabric/fabric.py
@@ -107,6 +107,12 @@ class FabricCopyFileLoadJob(SynapseCopyFileLoadJob):
         if cache_key in self._token_initialized_cache:
             return
 
+        if not credentials.azure_client_secret:
+            # No Service Principal secret configured: ClientSecretCredential would raise before
+            # any data moves. Skip the proactive Fabric token initialization rather than fail the
+            # whole load; COPY INTO still works as long as the staging credential is otherwise valid.
+            return
+
         try:
             import requests
             from azure.identity import ClientSecretCredential

--- a/dlt/destinations/impl/fabric/sql_client.py
+++ b/dlt/destinations/impl/fabric/sql_client.py
@@ -13,6 +13,8 @@ class FabricSqlClient(SynapseSqlClient):
     """SQL client for Microsoft Fabric Warehouse
 
     Inherits all behavior from Synapse since Fabric Warehouse is built on Synapse technology.
+    Azure AD token injection (for token-based authentication) is handled by the shared
+    `PyOdbcMsSqlClient.open_connection`.
     """
 
     def __init__(

--- a/dlt/destinations/impl/mssql/configuration.py
+++ b/dlt/destinations/impl/mssql/configuration.py
@@ -1,13 +1,186 @@
 import dataclasses
-from typing import ClassVar, Any, Final, List, Dict, Optional
+import struct
+from typing import ClassVar, Any, Final, List, Dict, Optional, TYPE_CHECKING
 
+from dlt import version
 from dlt.common.configuration import configspec
-from dlt.common.configuration.specs import ConnectionStringCredentials
+from dlt.common.configuration.exceptions import ConfigurationException
+from dlt.common.configuration.specs import ConnectionStringCredentials, CredentialsWithDefault
 from dlt.common.typing import TSecretStrValue
-from dlt.common.exceptions import SystemConfigurationException
+from dlt.common.exceptions import MissingDependencyException, SystemConfigurationException
 
 from dlt.common.destination.client import DestinationClientDwhWithStagingConfiguration
 from dlt.common.utils import digest128
+
+if TYPE_CHECKING:
+    from azure.core.credentials import TokenCredential
+
+_AZURE_AUTH_EXTRA = f"{version.DLT_PKG_NAME}[az]"
+
+# pyodbc connection attribute used to inject a pre-acquired Entra ID access token.
+# https://learn.microsoft.com/sql/connect/odbc/using-azure-active-directory#authenticating-with-an-access-token
+SQL_COPT_SS_ACCESS_TOKEN = 1256
+SQL_TOKEN_SCOPE = "https://database.windows.net/.default"
+
+# Authentication methods handled by the ODBC driver itself (passed as `Authentication=` in the DSN).
+DRIVER_NATIVE_AUTHENTICATION = frozenset(
+    {
+        "ActiveDirectoryServicePrincipal",
+        "ActiveDirectoryPassword",
+        "ActiveDirectoryIntegrated",
+        "ActiveDirectoryInteractive",
+    }
+)
+
+# Authentication methods backed by azure-identity. dlt acquires the access token and injects it
+# into the connection, so these work cross-platform without relying on ODBC driver support.
+AZURE_IDENTITY_AUTHENTICATION = frozenset(
+    {
+        "auto",
+        "default",
+        "cli",
+        "environment",
+        "interactive",
+        "devicecode",
+        "msi",
+        "managedidentity",
+    }
+)
+
+
+def create_token_credential(authentication: str) -> "TokenCredential":
+    """Create an azure-identity credential for a token-based authentication method."""
+    try:
+        from azure.identity import (
+            AzureCliCredential,
+            DefaultAzureCredential,
+            DeviceCodeCredential,
+            EnvironmentCredential,
+            InteractiveBrowserCredential,
+            ManagedIdentityCredential,
+        )
+    except ModuleNotFoundError:
+        raise MissingDependencyException("MsSqlCredentials", [_AZURE_AUTH_EXTRA])
+
+    credential_factories = {
+        "auto": DefaultAzureCredential,
+        "default": DefaultAzureCredential,
+        "cli": AzureCliCredential,
+        "environment": EnvironmentCredential,
+        "interactive": InteractiveBrowserCredential,
+        "devicecode": DeviceCodeCredential,
+        "msi": ManagedIdentityCredential,
+        "managedidentity": ManagedIdentityCredential,
+    }
+    return credential_factories[authentication.lower()]()  # type: ignore[no-any-return]
+
+
+def uses_token_authentication(credentials: Any) -> bool:
+    """True when dlt must acquire an access token and inject it into the connection.
+
+    Derived from the configured method, not from `has_default_credentials`: cooperative
+    `on_partial` calls up the MRO may set a default credential even for driver-native methods.
+    """
+    authentication = credentials.authentication
+    if not authentication:
+        return False
+    if authentication.lower() in AZURE_IDENTITY_AUTHENTICATION:
+        return True
+    # ActiveDirectoryServicePrincipal without a secret cannot authenticate through the ODBC
+    # driver, so dlt falls back to a DefaultAzureCredential token.
+    return authentication == "ActiveDirectoryServicePrincipal" and not (
+        credentials.azure_client_id
+        and credentials.azure_client_secret
+        and credentials.azure_tenant_id
+    )
+
+
+def setup_token_credential(credentials: Any) -> None:
+    """Create and store the azure-identity credential for token-based authentication."""
+    authentication = credentials.authentication or ""
+    if authentication.lower() in AZURE_IDENTITY_AUTHENTICATION:
+        credentials._set_default_credentials(create_token_credential(authentication))
+    elif authentication == "ActiveDirectoryServicePrincipal" and not (
+        credentials.azure_client_id
+        and credentials.azure_client_secret
+        and credentials.azure_tenant_id
+    ):
+        credentials._set_default_credentials(create_token_credential("default"))
+
+
+def get_token_credential(credentials: Any) -> "TokenCredential":
+    """Return the azure-identity credential used for token authentication.
+
+    Reuses the credential created during resolution (so azure-identity can cache tokens
+    across connections) and creates one on demand otherwise.
+    """
+    if credentials.has_default_credentials():
+        return credentials.default_credentials()  # type: ignore[no-any-return]
+    authentication = credentials.authentication or ""
+    if authentication.lower() not in AZURE_IDENTITY_AUTHENTICATION:
+        authentication = "default"
+    return create_token_credential(authentication)
+
+
+def build_token_attrs_before(credentials: Any) -> dict[int, bytes] | None:
+    """Return pyodbc `attrs_before` with an Entra ID access token, or None for driver-native auth."""
+    if not uses_token_authentication(credentials):
+        return None
+    token = get_token_credential(credentials).get_token(SQL_TOKEN_SCOPE).token
+    encoded_token = token.encode("utf-16-le")
+    token_struct = struct.pack(f"<I{len(encoded_token)}s", len(encoded_token), encoded_token)
+    return {SQL_COPT_SS_ACCESS_TOKEN: token_struct}
+
+
+def validate_authentication(credentials: Any) -> None:
+    """Validate the configured authentication method."""
+    authentication = credentials.authentication
+    if not authentication:
+        return  # plain SQL login (username/password)
+    if (
+        authentication not in DRIVER_NATIVE_AUTHENTICATION
+        and authentication.lower() not in AZURE_IDENTITY_AUTHENTICATION
+    ):
+        supported = sorted(DRIVER_NATIVE_AUTHENTICATION) + sorted(AZURE_IDENTITY_AUTHENTICATION)
+        raise ConfigurationException(
+            f"Unsupported `authentication` method `{authentication}`."
+            f" Supported methods: {', '.join(supported)}."
+        )
+    if authentication == "ActiveDirectoryPassword" and not (
+        credentials.username and credentials.password
+    ):
+        raise ConfigurationException(
+            "`authentication = ActiveDirectoryPassword` requires `username` and `password`."
+        )
+
+
+def apply_authentication_to_dsn(credentials: Any, params: dict[str, Any]) -> None:
+    """Add UID/PWD/Authentication keys to an ODBC DSN dict based on the authentication method."""
+    if uses_token_authentication(credentials):
+        # The access token is injected via attrs_before, so the DSN carries no credentials.
+        return
+    authentication = credentials.authentication
+    if not authentication:
+        # Plain SQL login.
+        params["UID"] = credentials.username
+        params["PWD"] = credentials.password
+        return
+    params["AUTHENTICATION"] = authentication
+    if (
+        authentication == "ActiveDirectoryServicePrincipal"
+        and credentials.azure_client_id
+        and credentials.azure_tenant_id
+        and credentials.azure_client_secret
+    ):
+        params["UID"] = f"{credentials.azure_client_id}@{credentials.azure_tenant_id}"
+        params["PWD"] = str(credentials.azure_client_secret)
+    elif (
+        authentication == "ActiveDirectoryPassword"
+        and credentials.username
+        and credentials.password
+    ):
+        params["UID"] = credentials.username
+        params["PWD"] = credentials.password
 
 
 def escape_mssql_odbc_value(value: Optional[str]) -> str:
@@ -50,7 +223,7 @@ def build_odbc_dsn(params: Dict[str, Any]) -> str:
 
 
 @configspec(init=False)
-class MsSqlCredentials(ConnectionStringCredentials):
+class MsSqlCredentials(ConnectionStringCredentials, CredentialsWithDefault):
     drivername: Final[str] = dataclasses.field(default="mssql", init=False, repr=False, compare=False)  # type: ignore[misc]
     database: str = None
     username: str = None
@@ -59,6 +232,22 @@ class MsSqlCredentials(ConnectionStringCredentials):
     port: int = 1433
     connect_timeout: int = 30
     driver: str = None
+
+    authentication: str | None = None
+    """Authentication method. Empty (default) uses plain SQL login (`username`/`password`).
+    Driver-native: `ActiveDirectoryServicePrincipal`, `ActiveDirectoryPassword`,
+    `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`. azure-identity (token injected by
+    dlt): `auto`/`default`, `cli`, `environment`, `interactive`, `devicecode`,
+    `msi`/`managedidentity`."""
+
+    azure_tenant_id: str | None = None
+    """Entra ID tenant id, used with `ActiveDirectoryServicePrincipal` authentication."""
+
+    azure_client_id: str | None = None
+    """Service Principal client id, used with `ActiveDirectoryServicePrincipal` authentication."""
+
+    azure_client_secret: TSecretStrValue | None = None
+    """Service Principal client secret, used with `ActiveDirectoryServicePrincipal` authentication."""
 
     __config_gen_annotations__: ClassVar[List[str]] = ["port", "connect_timeout"]
 
@@ -76,6 +265,7 @@ class MsSqlCredentials(ConnectionStringCredentials):
         self.connect_timeout = int(self.query.get("connect_timeout", self.connect_timeout))
 
     def on_resolved(self) -> None:
+        validate_authentication(self)
         if self.driver not in self.SUPPORTED_DRIVERS:
             raise SystemConfigurationException(
                 f"The specified driver `{self.driver}` is not supported."
@@ -90,7 +280,14 @@ class MsSqlCredentials(ConnectionStringCredentials):
 
     def on_partial(self) -> None:
         self.driver = self._get_driver()
-        if not self.is_partial():
+        setup_token_credential(self)
+        if self.authentication:
+            # Entra ID methods (token or driver-native) supply their own credentials and do not
+            # rely on username/password; resolve once we have a target. `on_resolved` validates.
+            if self.host and self.database:
+                self.resolve()
+        elif not self.is_partial():
+            # Plain SQL login needs username/password.
             self.resolve()
 
     def _get_driver(self) -> str:
@@ -111,13 +308,12 @@ class MsSqlCredentials(ConnectionStringCredentials):
         )
 
     def get_odbc_dsn_dict(self) -> Dict[str, Any]:
-        params = {
+        params: dict[str, Any] = {
             "DRIVER": self.driver,
             "SERVER": f"{self.host},{self.port}",
             "DATABASE": self.database,
-            "UID": self.username,
-            "PWD": self.password,
         }
+        apply_authentication_to_dsn(self, params)
         if self.query is not None:
             params.update({k.upper(): v for k, v in self.query.items()})
         return params
@@ -125,6 +321,10 @@ class MsSqlCredentials(ConnectionStringCredentials):
     def to_odbc_dsn(self) -> str:
         params = self.get_odbc_dsn_dict()
         return build_odbc_dsn(params)
+
+    def to_odbc_attrs_before(self) -> dict[int, bytes] | None:
+        """Return pyodbc `attrs_before` with an Entra ID access token, or None for driver-native auth."""
+        return build_token_attrs_before(self)
 
 
 @configspec

--- a/dlt/destinations/impl/mssql/configuration.py
+++ b/dlt/destinations/impl/mssql/configuration.py
@@ -22,57 +22,56 @@ _AZURE_AUTH_EXTRA = f"{version.DLT_PKG_NAME}[az]"
 SQL_COPT_SS_ACCESS_TOKEN = 1256
 SQL_TOKEN_SCOPE = "https://database.windows.net/.default"
 
-# Authentication methods handled by the ODBC driver itself (passed as `Authentication=` in the DSN).
+# Authentication methods the ODBC driver performs natively (passed as `Authentication=` in the
+# DSN). Poolable: the driver signs in itself, so no token needs to be reacquired and injected
+# per connection.
 DRIVER_NATIVE_AUTHENTICATION = frozenset(
     {
         "ActiveDirectoryServicePrincipal",
         "ActiveDirectoryPassword",
         "ActiveDirectoryIntegrated",
         "ActiveDirectoryInteractive",
+        "ActiveDirectoryMsi",
     }
 )
 
-# Authentication methods backed by azure-identity. dlt acquires the access token and injects it
-# into the connection, so these work cross-platform without relying on ODBC driver support.
-AZURE_IDENTITY_AUTHENTICATION = frozenset(
+# Authentication methods pyodbc/msodbcsql does not support natively. dlt acquires the access
+# token itself with azure-identity and injects it into the connection (`attrs_before`), so these
+# work cross-platform but are not poolable.
+AZURE_IDENTITY_INJECTION_AUTHENTICATION = frozenset(
     {
-        "auto",
-        "default",
-        "cli",
-        "environment",
-        "interactive",
-        "devicecode",
-        "msi",
-        "managedidentity",
+        "ActiveDirectoryDefault",
+        "ActiveDirectoryDeviceCode",
     }
 )
+
+# Thin alias for `ActiveDirectoryDefault`, resolved by `_normalize_authentication`.
+_AUTHENTICATION_ALIASES = {
+    "default": "ActiveDirectoryDefault",
+}
+
+
+def _normalize_authentication(authentication: str) -> str:
+    """Resolve the thin `default` alias to the canonical `ActiveDirectoryDefault` name."""
+    return _AUTHENTICATION_ALIASES.get(authentication.lower(), authentication)
 
 
 def create_token_credential(authentication: str) -> "TokenCredential":
-    """Create an azure-identity credential for a token-based authentication method."""
+    """Create an azure-identity credential for a token-injection authentication method.
+
+    Expects the canonical name (`ActiveDirectoryDefault` or `ActiveDirectoryDeviceCode`), as
+    already resolved by `_normalize_authentication`.
+    """
     try:
-        from azure.identity import (
-            AzureCliCredential,
-            DefaultAzureCredential,
-            DeviceCodeCredential,
-            EnvironmentCredential,
-            InteractiveBrowserCredential,
-            ManagedIdentityCredential,
-        )
+        from azure.identity import DefaultAzureCredential, DeviceCodeCredential
     except ModuleNotFoundError:
         raise MissingDependencyException("MsSqlCredentials", [_AZURE_AUTH_EXTRA])
 
     credential_factories = {
-        "auto": DefaultAzureCredential,
-        "default": DefaultAzureCredential,
-        "cli": AzureCliCredential,
-        "environment": EnvironmentCredential,
-        "interactive": InteractiveBrowserCredential,
-        "devicecode": DeviceCodeCredential,
-        "msi": ManagedIdentityCredential,
-        "managedidentity": ManagedIdentityCredential,
+        "ActiveDirectoryDefault": DefaultAzureCredential,
+        "ActiveDirectoryDeviceCode": DeviceCodeCredential,
     }
-    return credential_factories[authentication.lower()]()  # type: ignore[no-any-return]
+    return credential_factories[authentication]()  # type: ignore[no-any-return]
 
 
 def uses_token_authentication(credentials: Any) -> bool:
@@ -84,7 +83,7 @@ def uses_token_authentication(credentials: Any) -> bool:
     authentication = credentials.authentication
     if not authentication:
         return False
-    if authentication.lower() in AZURE_IDENTITY_AUTHENTICATION:
+    if _normalize_authentication(authentication) in AZURE_IDENTITY_INJECTION_AUTHENTICATION:
         return True
     # ActiveDirectoryServicePrincipal without a secret cannot authenticate through the ODBC
     # driver, so dlt falls back to a DefaultAzureCredential token.
@@ -96,16 +95,17 @@ def uses_token_authentication(credentials: Any) -> bool:
 
 
 def setup_token_credential(credentials: Any) -> None:
-    """Create and store the azure-identity credential for token-based authentication."""
+    """Create and store the azure-identity credential for token-injection authentication."""
     authentication = credentials.authentication or ""
-    if authentication.lower() in AZURE_IDENTITY_AUTHENTICATION:
-        credentials._set_default_credentials(create_token_credential(authentication))
+    normalized = _normalize_authentication(authentication)
+    if normalized in AZURE_IDENTITY_INJECTION_AUTHENTICATION:
+        credentials._set_default_credentials(create_token_credential(normalized))
     elif authentication == "ActiveDirectoryServicePrincipal" and not (
         credentials.azure_client_id
         and credentials.azure_client_secret
         and credentials.azure_tenant_id
     ):
-        credentials._set_default_credentials(create_token_credential("default"))
+        credentials._set_default_credentials(create_token_credential("ActiveDirectoryDefault"))
 
 
 def get_token_credential(credentials: Any) -> "TokenCredential":
@@ -116,9 +116,9 @@ def get_token_credential(credentials: Any) -> "TokenCredential":
     """
     if credentials.has_default_credentials():
         return credentials.default_credentials()  # type: ignore[no-any-return]
-    authentication = credentials.authentication or ""
-    if authentication.lower() not in AZURE_IDENTITY_AUTHENTICATION:
-        authentication = "default"
+    authentication = _normalize_authentication(credentials.authentication or "")
+    if authentication not in AZURE_IDENTITY_INJECTION_AUTHENTICATION:
+        authentication = "ActiveDirectoryDefault"
     return create_token_credential(authentication)
 
 
@@ -137,11 +137,14 @@ def validate_authentication(credentials: Any) -> None:
     authentication = credentials.authentication
     if not authentication:
         return  # plain SQL login (username/password)
+    normalized = _normalize_authentication(authentication)
     if (
-        authentication not in DRIVER_NATIVE_AUTHENTICATION
-        and authentication.lower() not in AZURE_IDENTITY_AUTHENTICATION
+        normalized not in DRIVER_NATIVE_AUTHENTICATION
+        and normalized not in AZURE_IDENTITY_INJECTION_AUTHENTICATION
     ):
-        supported = sorted(DRIVER_NATIVE_AUTHENTICATION) + sorted(AZURE_IDENTITY_AUTHENTICATION)
+        supported = sorted(DRIVER_NATIVE_AUTHENTICATION) + sorted(
+            AZURE_IDENTITY_INJECTION_AUTHENTICATION
+        )
         raise ConfigurationException(
             f"Unsupported `authentication` method `{authentication}`."
             f" Supported methods: {', '.join(supported)}."
@@ -235,10 +238,11 @@ class MsSqlCredentials(ConnectionStringCredentials, CredentialsWithDefault):
 
     authentication: str | None = None
     """Authentication method. Empty (default) uses plain SQL login (`username`/`password`).
-    Driver-native: `ActiveDirectoryServicePrincipal`, `ActiveDirectoryPassword`,
-    `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive`. azure-identity (token injected by
-    dlt): `auto`/`default`, `cli`, `environment`, `interactive`, `devicecode`,
-    `msi`/`managedidentity`."""
+    Driver-native (passed as `Authentication=` in the DSN, poolable):
+    `ActiveDirectoryServicePrincipal`, `ActiveDirectoryPassword`, `ActiveDirectoryIntegrated`,
+    `ActiveDirectoryInteractive`, `ActiveDirectoryMsi`. azure-identity (token acquired and
+    injected by dlt, not poolable): `ActiveDirectoryDefault` (alias `default`),
+    `ActiveDirectoryDeviceCode`."""
 
     azure_tenant_id: str | None = None
     """Entra ID tenant id, used with `ActiveDirectoryServicePrincipal` authentication."""

--- a/dlt/destinations/impl/mssql/configuration.py
+++ b/dlt/destinations/impl/mssql/configuration.py
@@ -3,10 +3,10 @@ import struct
 from typing import ClassVar, Any, Final, List, Dict, Optional, TYPE_CHECKING
 
 from dlt import version
-from dlt.common.configuration import configspec
+from dlt.common.configuration import configspec, NotResolved
 from dlt.common.configuration.exceptions import ConfigurationException
 from dlt.common.configuration.specs import ConnectionStringCredentials, CredentialsWithDefault
-from dlt.common.typing import TSecretStrValue
+from dlt.common.typing import TSecretStrValue, Annotated
 from dlt.common.exceptions import MissingDependencyException, SystemConfigurationException
 
 from dlt.common.destination.client import DestinationClientDwhWithStagingConfiguration
@@ -77,9 +77,13 @@ def create_token_credential(authentication: str) -> "TokenCredential":
 def uses_token_authentication(credentials: Any) -> bool:
     """True when dlt must acquire an access token and inject it into the connection.
 
-    Derived from the configured method, not from `has_default_credentials`: cooperative
-    `on_partial` calls up the MRO may set a default credential even for driver-native methods.
+    `access_token`/`azure_credential` take precedence over `authentication`: when either is
+    set, dlt injects that token directly regardless of the configured method. Otherwise derived
+    from the configured method, not from `has_default_credentials`: cooperative `on_partial`
+    calls up the MRO may set a default credential even for driver-native methods.
     """
+    if credentials.access_token or credentials.azure_credential:
+        return True
     authentication = credentials.authentication
     if not authentication:
         return False
@@ -96,6 +100,10 @@ def uses_token_authentication(credentials: Any) -> bool:
 
 def setup_token_credential(credentials: Any) -> None:
     """Create and store the azure-identity credential for token-injection authentication."""
+    if credentials.access_token or credentials.azure_credential:
+        # The token (or a credential able to fetch one) was injected directly: no
+        # DefaultAzureCredential fallback is needed.
+        return
     authentication = credentials.authentication or ""
     normalized = _normalize_authentication(authentication)
     if normalized in AZURE_IDENTITY_INJECTION_AUTHENTICATION:
@@ -122,11 +130,27 @@ def get_token_credential(credentials: Any) -> "TokenCredential":
     return create_token_credential(authentication)
 
 
+def get_access_token(credentials: Any) -> Optional[str]:
+    """Return a directly usable Entra ID access token, bypassing `authentication` resolution.
+
+    Prefers a pre-fetched `access_token`, then a token fetched from an injected
+    `azure_credential`. Returns None when neither is set, so callers fall back to the
+    `authentication` named-method resolution.
+    """
+    if credentials.access_token:
+        return str(credentials.access_token)
+    if credentials.azure_credential:
+        return credentials.azure_credential.get_token(SQL_TOKEN_SCOPE).token  # type: ignore[no-any-return]
+    return None
+
+
 def build_token_attrs_before(credentials: Any) -> dict[int, bytes] | None:
     """Return pyodbc `attrs_before` with an Entra ID access token, or None for driver-native auth."""
-    if not uses_token_authentication(credentials):
-        return None
-    token = get_token_credential(credentials).get_token(SQL_TOKEN_SCOPE).token
+    token = get_access_token(credentials)
+    if token is None:
+        if not uses_token_authentication(credentials):
+            return None
+        token = get_token_credential(credentials).get_token(SQL_TOKEN_SCOPE).token
     encoded_token = token.encode("utf-16-le")
     token_struct = struct.pack(f"<I{len(encoded_token)}s", len(encoded_token), encoded_token)
     return {SQL_COPT_SS_ACCESS_TOKEN: token_struct}
@@ -134,6 +158,10 @@ def build_token_attrs_before(credentials: Any) -> dict[int, bytes] | None:
 
 def validate_authentication(credentials: Any) -> None:
     """Validate the configured authentication method."""
+    if credentials.access_token or credentials.azure_credential:
+        # A token (or a credential able to fetch one) was injected directly: it takes
+        # precedence over `authentication`, whose value does not need to be validated.
+        return
     authentication = credentials.authentication
     if not authentication:
         return  # plain SQL login (username/password)
@@ -253,6 +281,16 @@ class MsSqlCredentials(ConnectionStringCredentials, CredentialsWithDefault):
     azure_client_secret: TSecretStrValue | None = None
     """Service Principal client secret, used with `ActiveDirectoryServicePrincipal` authentication."""
 
+    access_token: Optional[TSecretStrValue] = None
+    """Pre-acquired Entra ID access token. When set, dlt injects it directly via `attrs_before`
+    without acquiring anything. Takes precedence over `azure_credential` and `authentication`."""
+
+    azure_credential: Annotated[Optional[Any], NotResolved()] = None
+    """An externally constructed `azure.core.credentials.TokenCredential` (e.g.
+    `DefaultAzureCredential()`) injected at runtime, not resolved from config providers. dlt
+    calls its `get_token()` to acquire an access token. Takes precedence over `authentication`,
+    but `access_token` takes precedence over this."""
+
     __config_gen_annotations__: ClassVar[List[str]] = ["port", "connect_timeout"]
 
     SUPPORTED_DRIVERS: ClassVar[List[str]] = [
@@ -285,7 +323,7 @@ class MsSqlCredentials(ConnectionStringCredentials, CredentialsWithDefault):
     def on_partial(self) -> None:
         self.driver = self._get_driver()
         setup_token_credential(self)
-        if self.authentication:
+        if self.authentication or self.access_token or self.azure_credential:
             # Entra ID methods (token or driver-native) supply their own credentials and do not
             # rely on username/password; resolve once we have a target. `on_resolved` validates.
             if self.host and self.database:

--- a/dlt/destinations/impl/mssql/configuration.py
+++ b/dlt/destinations/impl/mssql/configuration.py
@@ -282,14 +282,10 @@ class MsSqlCredentials(ConnectionStringCredentials, CredentialsWithDefault):
     """Service Principal client secret, used with `ActiveDirectoryServicePrincipal` authentication."""
 
     access_token: Optional[TSecretStrValue] = None
-    """Pre-acquired Entra ID access token. When set, dlt injects it directly via `attrs_before`
-    without acquiring anything. Takes precedence over `azure_credential` and `authentication`."""
+    """Pre-acquired Entra ID access token, injected as-is. Takes precedence over `azure_credential` and `authentication`"""
 
     azure_credential: Annotated[Optional[Any], NotResolved()] = None
-    """An externally constructed `azure.core.credentials.TokenCredential` (e.g.
-    `DefaultAzureCredential()`) injected at runtime, not resolved from config providers. dlt
-    calls its `get_token()` to acquire an access token. Takes precedence over `authentication`,
-    but `access_token` takes precedence over this."""
+    """A `TokenCredential` injected at runtime, e.g. `DefaultAzureCredential()`. Takes precedence over `authentication` but not over `access_token`"""
 
     __config_gen_annotations__: ClassVar[List[str]] = ["port", "connect_timeout"]
 

--- a/dlt/destinations/impl/mssql/sql_client.py
+++ b/dlt/destinations/impl/mssql/sql_client.py
@@ -55,10 +55,19 @@ class PyOdbcMsSqlClient(SqlClientBase[pyodbc.Connection], DBTransaction):
         self.credentials = credentials
 
     def open_connection(self) -> pyodbc.Connection:
-        self._conn = pyodbc.connect(
-            self.credentials.to_odbc_dsn(),
-            timeout=self.credentials.connect_timeout,
-        )
+        # For Entra ID token authentication, inject a fresh access token via attrs_before.
+        attrs_before = self.credentials.to_odbc_attrs_before()
+        if attrs_before:
+            self._conn = pyodbc.connect(
+                self.credentials.to_odbc_dsn(),
+                timeout=self.credentials.connect_timeout,
+                attrs_before=attrs_before,
+            )
+        else:
+            self._conn = pyodbc.connect(
+                self.credentials.to_odbc_dsn(),
+                timeout=self.credentials.connect_timeout,
+            )
         # https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function
         self._conn.add_output_converter(-155, handle_datetimeoffset)
         self._conn.autocommit = True

--- a/docs/website/docs/dlt-ecosystem/destinations/fabric.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/fabric.md
@@ -49,6 +49,7 @@ With the **driver-native** methods, the ODBC driver performs the Entra ID sign-i
 | `ActiveDirectoryPassword` | Entra ID username/password | `username`, `password` |
 | `ActiveDirectoryIntegrated` | Integrated Windows authentication | None |
 | `ActiveDirectoryInteractive` | Interactive browser prompt (driver) | None |
+| `ActiveDirectoryMsi` | Managed identity (driver) | None |
 
 With the **azure-identity** methods, `dlt` acquires an access token with
 [azure-identity](https://learn.microsoft.com/python/api/overview/azure/identity-readme) and injects
@@ -57,15 +58,11 @@ Entra ID modes are unreliable) and need no secret in `secrets.toml`:
 
 | `authentication` | azure-identity credential |
 |---|---|
-| `auto` / `default` | `DefaultAzureCredential` |
-| `cli` | `AzureCliCredential` (uses `az login`) |
-| `environment` | `EnvironmentCredential` |
-| `interactive` | `InteractiveBrowserCredential` |
-| `devicecode` | `DeviceCodeCredential` |
-| `msi` / `managedidentity` | `ManagedIdentityCredential` |
+| `ActiveDirectoryDefault` (alias `default`) | `DefaultAzureCredential` (managed identity, environment, Azure CLI, …) |
+| `ActiveDirectoryDeviceCode` | `DeviceCodeCredential` |
 
 When `authentication` is left at its default but no Service Principal secret is configured, `dlt`
-falls back to `DefaultAzureCredential`.
+falls back to `ActiveDirectoryDefault` (`DefaultAzureCredential`).
 
 ### Create a pipeline
 
@@ -98,13 +95,13 @@ port = 1433
 connect_timeout = 30
 ```
 
-azure-identity, e.g. the Azure CLI (`az login`), which needs no secret:
+azure-identity, e.g. `DefaultAzureCredential` after `az login`, which needs no secret:
 
 ```toml
 [destination.fabric.credentials]
 host = "<your-warehouse-guid>.datawarehouse.fabric.microsoft.com"
 database = "mydb"
-authentication = "cli"
+authentication = "default"
 ```
 
 ## Write disposition

--- a/docs/website/docs/dlt-ecosystem/destinations/fabric.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/fabric.md
@@ -38,39 +38,18 @@ Fabric Warehouse authenticates with Microsoft Entra ID. Whichever method you cho
 - Select **SQL endpoint**
 - Copy the **SQL connection string** - it should be in the format: `<guid>.datawarehouse.fabric.microsoft.com`
 
-The authentication method is selected with the `authentication` credential option. `dlt` supports
-two families of methods.
+The method is selected with the `authentication` credential option. Fabric Warehouse accepts these
+authentication types:
 
-With the **driver-native** methods, the ODBC driver performs the Entra ID sign-in:
+- Service Principal, and the other methods the ODBC driver signs in with itself
+- [azure-identity](https://learn.microsoft.com/python/api/overview/azure/identity-readme) methods, where `dlt` acquires the token
+- [NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials), for pipelines running inside a Fabric notebook
 
-| `authentication` | Description | Required fields |
-|---|---|---|
-| `ActiveDirectoryServicePrincipal` (default) | Service Principal | `azure_tenant_id`, `azure_client_id`, `azure_client_secret` |
-| `ActiveDirectoryPassword` | Entra ID username/password | `username`, `password` |
-| `ActiveDirectoryIntegrated` | Integrated Windows authentication | None |
-| `ActiveDirectoryInteractive` | Interactive browser prompt (driver) | None |
-| `ActiveDirectoryMsi` | Managed identity (driver) | None |
+With the **driver-native** methods the ODBC driver performs the Entra ID sign-in. `ActiveDirectoryServicePrincipal` is the default and needs `azure_tenant_id`, `azure_client_id` and `azure_client_secret`; `ActiveDirectoryPassword` needs `username` and `password`. `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive` and `ActiveDirectoryMsi` need no further fields.
 
-With the **azure-identity** methods, `dlt` acquires an access token with
-[azure-identity](https://learn.microsoft.com/python/api/overview/azure/identity-readme) and injects
-it into the connection. These work cross-platform (including macOS, where the ODBC driver's built-in
-Entra ID modes are unreliable) and need no secret in `secrets.toml`:
+With the **azure-identity** methods `dlt` acquires an access token and injects it into the connection, so no secret is needed in `secrets.toml`. These work cross-platform, including macOS, where the ODBC driver's built-in Entra ID modes are unreliable. Use `ActiveDirectoryDefault` (alias `default`) for `DefaultAzureCredential`, or `ActiveDirectoryDeviceCode` for `DeviceCodeCredential`. When `authentication` is left at its default but no Service Principal secret is configured, `dlt` falls back to `ActiveDirectoryDefault`.
 
-| `authentication` | azure-identity credential |
-|---|---|
-| `ActiveDirectoryDefault` (alias `default`) | `DefaultAzureCredential` (managed identity, environment, Azure CLI, …) |
-| `ActiveDirectoryDeviceCode` | `DeviceCodeCredential` |
-
-When `authentication` is left at its default but no Service Principal secret is configured, `dlt`
-falls back to `ActiveDirectoryDefault` (`DefaultAzureCredential`).
-
-#### Running inside a Fabric notebook
-
-A Fabric notebook has no environment variables, managed identity or Azure CLI login, so
-`DefaultAzureCredential` cannot sign in there. Fabric instead exposes the identity the notebook runs
-under through
-[NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials).
-Select it with `authentication = "fab_notebookutils"`:
+The **NotebookUtils** method authenticates as whoever runs the notebook, so that identity needs write access to the warehouse. A Fabric notebook has no environment variables, managed identity or Azure CLI login, so `DefaultAzureCredential` cannot sign in there:
 
 ```toml
 [destination.fabric.credentials]
@@ -79,17 +58,7 @@ database = "mydb"
 authentication = "fab_notebookutils"
 ```
 
-No secret is needed: the pipeline authenticates as whoever runs the notebook, so that identity needs
-write access to the warehouse. `dlt` acquires the token lazily, caches it, and refreshes it before
-the JWT expires.
-
-The `notebookutils` module ships with the Fabric runtime and is not installed by `dlt`. It is
-imported only when this method is used, so pipelines that never run in Fabric are unaffected. Using
-`authentication = "fab_notebookutils"` outside the Fabric runtime raises a configuration error rather
-than falling back silently.
-
-Staging through OneLake or Azure Blob Storage picks the same identity up automatically — see
-[OneLake staging from a Fabric notebook](#onelake-staging-from-a-fabric-notebook).
+The `notebookutils` module ships with the Fabric runtime and is not installed by `dlt`, so it is imported only when this method is used. Using it outside the Fabric runtime raises a configuration error rather than falling back silently. Staging through OneLake or Azure Blob Storage picks the same identity up automatically — see [OneLake staging from a Fabric notebook](#onelake-staging-from-a-fabric-notebook).
 
 ### Create a pipeline
 

--- a/docs/website/docs/dlt-ecosystem/destinations/fabric.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/fabric.md
@@ -29,20 +29,43 @@ Supported driver versions:
 
 You can also [configure the driver name](#additional-destination-options) explicitly.
 
-### Service Principal Authentication
+### Authentication
 
-Fabric Warehouse requires Azure Active Directory Service Principal authentication. You'll need:
-
-1. **Tenant ID**: Your Azure AD tenant ID (GUID)
-2. **Client ID**: Application (service principal) client ID (GUID)
-3. **Client Secret**: Application client secret
-4. **Host**: Your Fabric warehouse SQL endpoint
-5. **Database**: The database name within your warehouse
+Fabric Warehouse authenticates with Microsoft Entra ID. Whichever method you choose, you always set the warehouse SQL endpoint as the `host` (`<guid>.datawarehouse.fabric.microsoft.com`) and the warehouse name as the `database`.
 
 **Finding your SQL endpoint:**
 - In the Fabric portal, go to your warehouse **Settings**
 - Select **SQL endpoint**
 - Copy the **SQL connection string** - it should be in the format: `<guid>.datawarehouse.fabric.microsoft.com`
+
+The authentication method is selected with the `authentication` credential option. `dlt` supports
+two families of methods.
+
+With the **driver-native** methods, the ODBC driver performs the Entra ID sign-in:
+
+| `authentication` | Description | Required fields |
+|---|---|---|
+| `ActiveDirectoryServicePrincipal` (default) | Service Principal | `azure_tenant_id`, `azure_client_id`, `azure_client_secret` |
+| `ActiveDirectoryPassword` | Entra ID username/password | `username`, `password` |
+| `ActiveDirectoryIntegrated` | Integrated Windows authentication | None |
+| `ActiveDirectoryInteractive` | Interactive browser prompt (driver) | None |
+
+With the **azure-identity** methods, `dlt` acquires an access token with
+[azure-identity](https://learn.microsoft.com/python/api/overview/azure/identity-readme) and injects
+it into the connection. These work cross-platform (including macOS, where the ODBC driver's built-in
+Entra ID modes are unreliable) and need no secret in `secrets.toml`:
+
+| `authentication` | azure-identity credential |
+|---|---|
+| `auto` / `default` | `DefaultAzureCredential` |
+| `cli` | `AzureCliCredential` (uses `az login`) |
+| `environment` | `EnvironmentCredential` |
+| `interactive` | `InteractiveBrowserCredential` |
+| `devicecode` | `DeviceCodeCredential` |
+| `msi` / `managedidentity` | `ManagedIdentityCredential` |
+
+When `authentication` is left at its default but no Service Principal secret is configured, `dlt`
+falls back to `DefaultAzureCredential`.
 
 ### Create a pipeline
 
@@ -62,6 +85,8 @@ pip install "dlt[fabric]"
 
 **3. Enter your credentials into `.dlt/secrets.toml`.**
 
+Service Principal (default):
+
 ```toml
 [destination.fabric.credentials]
 host = "<your-warehouse-guid>.datawarehouse.fabric.microsoft.com"
@@ -71,6 +96,15 @@ azure_client_id = "your-client-id"
 azure_client_secret = "your-client-secret"
 port = 1433
 connect_timeout = 30
+```
+
+azure-identity, e.g. the Azure CLI (`az login`), which needs no secret:
+
+```toml
+[destination.fabric.credentials]
+host = "<your-warehouse-guid>.datawarehouse.fabric.microsoft.com"
+database = "mydb"
+authentication = "cli"
 ```
 
 ## Write disposition
@@ -207,7 +241,7 @@ driver="ODBC Driver 18 for SQL Server"
 
 While Fabric Warehouse is based on SQL Server, there are key differences:
 
-1. **Authentication**: Fabric requires Service Principal; username/password auth is not supported
+1. **Authentication**: Fabric uses Entra ID; in addition to Service Principal, `dlt` supports several azure-identity methods (see [Authentication](#authentication))
 2. **Type System**: Uses `varchar` and `datetime2` instead of `nvarchar` and `datetimeoffset`
 3. **Collation**: Optimized for UTF-8 collations with automatic `LongAsMax` configuration
 4. **SQL Dialect**: Uses `fabric` SQLglot dialect for proper SQL generation
@@ -234,7 +268,7 @@ sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
 Ensure your Service Principal has:
 - Proper permissions on the Fabric workspace
 - Access to the target database/warehouse  
-- Correct tenant ID (your Azure AD tenant, not the workspace/capacity ID)
+- Correct tenant ID (your Entra ID tenant, not the workspace/capacity ID)
 
 ### UTF-8 Character Issues
 

--- a/docs/website/docs/dlt-ecosystem/destinations/fabric.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/fabric.md
@@ -43,13 +43,13 @@ authentication types:
 
 - Service Principal, and the other methods the ODBC driver signs in with itself
 - [azure-identity](https://learn.microsoft.com/python/api/overview/azure/identity-readme) methods, where `dlt` acquires the token
-- [NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials), for pipelines running inside a Fabric notebook
+- `fab_notebookutils`, for pipelines running inside a Fabric notebook
 
 With the **driver-native** methods the ODBC driver performs the Entra ID sign-in. `ActiveDirectoryServicePrincipal` is the default and needs `azure_tenant_id`, `azure_client_id` and `azure_client_secret`; `ActiveDirectoryPassword` needs `username` and `password`. `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive` and `ActiveDirectoryMsi` need no further fields.
 
 With the **azure-identity** methods `dlt` acquires an access token and injects it into the connection, so no secret is needed in `secrets.toml`. These work cross-platform, including macOS, where the ODBC driver's built-in Entra ID modes are unreliable. Use `ActiveDirectoryDefault` (alias `default`) for `DefaultAzureCredential`, or `ActiveDirectoryDeviceCode` for `DeviceCodeCredential`. When `authentication` is left at its default but no Service Principal secret is configured, `dlt` falls back to `ActiveDirectoryDefault`.
 
-The **NotebookUtils** method authenticates as whoever runs the notebook, so that identity needs write access to the warehouse. A Fabric notebook has no environment variables, managed identity or Azure CLI login, so `DefaultAzureCredential` cannot sign in there:
+**`fab_notebookutils`** authenticates as whoever runs the notebook through [NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials), so that identity needs write access to the warehouse. A Fabric notebook has no environment variables, managed identity or Azure CLI login, so `DefaultAzureCredential` cannot sign in there:
 
 ```toml
 [destination.fabric.credentials]

--- a/docs/website/docs/dlt-ecosystem/destinations/fabric.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/fabric.md
@@ -64,6 +64,33 @@ Entra ID modes are unreliable) and need no secret in `secrets.toml`:
 When `authentication` is left at its default but no Service Principal secret is configured, `dlt`
 falls back to `ActiveDirectoryDefault` (`DefaultAzureCredential`).
 
+#### Running inside a Fabric notebook
+
+A Fabric notebook has no environment variables, managed identity or Azure CLI login, so
+`DefaultAzureCredential` cannot sign in there. Fabric instead exposes the identity the notebook runs
+under through
+[NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials).
+Select it with `authentication = "fab_notebookutils"`:
+
+```toml
+[destination.fabric.credentials]
+host = "<your-warehouse-guid>.datawarehouse.fabric.microsoft.com"
+database = "mydb"
+authentication = "fab_notebookutils"
+```
+
+No secret is needed: the pipeline authenticates as whoever runs the notebook, so that identity needs
+write access to the warehouse. `dlt` acquires the token lazily, caches it, and refreshes it before
+the JWT expires.
+
+The `notebookutils` module ships with the Fabric runtime and is not installed by `dlt`. It is
+imported only when this method is used, so pipelines that never run in Fabric are unaffected. Using
+`authentication = "fab_notebookutils"` outside the Fabric runtime raises a configuration error rather
+than falling back silently.
+
+Staging through OneLake or Azure Blob Storage picks the same identity up automatically — see
+[OneLake staging from a Fabric notebook](#onelake-staging-from-a-fabric-notebook).
+
 ### Create a pipeline
 
 **1. Initialize a project with a pipeline that loads to Fabric by running:**
@@ -149,6 +176,30 @@ azure_client_secret = "your-client-secret"
 2. The workspace GUID is in the URL: `https://fabric.microsoft.com/groups/<workspace_guid>/...`
 3. Open your Lakehouse
 4. The lakehouse GUID is in the URL: `https://fabric.microsoft.com/.../lakehouses/<lakehouse_guid>`
+
+#### OneLake staging from a Fabric notebook
+
+Inside a Fabric notebook you can drop the Service Principal from the staging credentials entirely.
+Leave out `azure_storage_account_key`, `azure_storage_sas_token` and the principal fields, and `dlt`
+authenticates to blob storage with the notebook identity through NotebookUtils, the same way the
+warehouse connection does:
+
+```toml
+[destination.fabric.credentials]
+host = "<your-warehouse-guid>.datawarehouse.fabric.microsoft.com"
+database = "mydb"
+authentication = "fab_notebookutils"
+
+[destination.filesystem]
+bucket_url = "abfss://<your-workspace-guid>@onelake.dfs.fabric.microsoft.com/<your-lakehouse-guid>/Files"
+
+[destination.filesystem.credentials]
+azure_storage_account_name = "onelake"
+azure_account_host = "onelake.blob.fabric.microsoft.com"
+```
+
+Outside the Fabric runtime the same configuration keeps using `DefaultAzureCredential`, so a static
+secret or an explicitly passed credential always takes precedence over NotebookUtils.
 
 #### `.dlt/secrets.toml` when using Azure Blob / Data Lake Storage:
 

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -239,6 +239,16 @@ If you have the correct Azure credentials set up on your machine (e.g., via Azur
 you can omit both `azure_storage_account_key` and `azure_storage_sas_token` and `dlt` will fall back to the available default.
 Note that `azure_storage_account_name` is still required as it can't be inferred from the environment.
 
+:::tip Fabric notebooks
+A Fabric notebook has no environment variables, managed identity or Azure CLI login for
+`DefaultAzureCredential` to use. When `dlt` detects the Fabric runtime it falls back to the identity
+the notebook runs under, via
+[NotebookUtils](https://learn.microsoft.com/fabric/data-engineering/notebookutils/notebookutils-credentials),
+so the credentials above work unchanged inside a notebook. A configured account key, SAS token or
+service principal still takes precedence, and so does a credential you pass yourself with
+`AzureCredentials.from_credential(...)`.
+:::
+
 #### Service principal credentials
 
 Supply a client ID, client secret, and a tenant ID for a service principal authorized to access your container.

--- a/docs/website/docs/dlt-ecosystem/destinations/mssql.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/mssql.md
@@ -109,23 +109,20 @@ They require the `azure-identity` package (installed with `pip install "dlt[az]"
 | `authentication` | How it authenticates |
 |---|---|
 | _(empty, default)_ | SQL login with `username`/`password` |
-| `cli` | `AzureCliCredential` (uses `az login`) |
-| `auto` / `default` | `DefaultAzureCredential` (managed identity, env, CLI, …) |
-| `environment` | `EnvironmentCredential` |
-| `interactive` | `InteractiveBrowserCredential` |
-| `devicecode` | `DeviceCodeCredential` |
-| `msi` / `managedidentity` | `ManagedIdentityCredential` |
-| `ActiveDirectoryServicePrincipal` | Service Principal (`azure_tenant_id`, `azure_client_id`, `azure_client_secret`) |
+| `ActiveDirectoryServicePrincipal` | Service Principal (`azure_tenant_id`, `azure_client_id`, `azure_client_secret`), handled by the ODBC driver |
 | `ActiveDirectoryPassword` | Entra ID `username`/`password` (handled by the ODBC driver) |
 | `ActiveDirectoryIntegrated` | Integrated Windows authentication (handled by the ODBC driver) |
 | `ActiveDirectoryInteractive` | Interactive prompt (handled by the ODBC driver) |
+| `ActiveDirectoryMsi` | Managed identity (handled by the ODBC driver) |
+| `ActiveDirectoryDefault` (alias `default`) | `DefaultAzureCredential` (managed identity, environment, Azure CLI, …), token injected by dlt |
+| `ActiveDirectoryDeviceCode` | `DeviceCodeCredential`, token injected by dlt |
 
-Passwordless example using the Azure CLI:
+Passwordless example using `DefaultAzureCredential` (e.g. after `az login`):
 ```toml
 [destination.mssql.credentials]
 database = "dlt_data"
 host = "loader.database.windows.net"
-authentication = "cli"
+authentication = "default"
 ```
 
 Service Principal example:

--- a/docs/website/docs/dlt-ecosystem/destinations/mssql.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/mssql.md
@@ -97,6 +97,51 @@ destination.mssql.credentials="mssql://loader:loader@localhost/dlt_data?TrustSer
 destination.mssql.credentials="mssql://loader:loader@localhost/dlt_data?LongAsMax=yes"
 ```
 
+### Microsoft Entra ID authentication
+
+For Azure-hosted SQL Server (Azure SQL Database, Managed Instance) you can authenticate with
+Entra ID instead of a SQL login. Set the `authentication` credential option.
+
+With the **azure-identity** methods, `dlt` acquires an access token and injects it into the
+connection, so they work cross-platform (including macOS) and need no password in `secrets.toml`.
+They require the `azure-identity` package (installed with `pip install "dlt[az]"`).
+
+| `authentication` | How it authenticates |
+|---|---|
+| _(empty, default)_ | SQL login with `username`/`password` |
+| `cli` | `AzureCliCredential` (uses `az login`) |
+| `auto` / `default` | `DefaultAzureCredential` (managed identity, env, CLI, …) |
+| `environment` | `EnvironmentCredential` |
+| `interactive` | `InteractiveBrowserCredential` |
+| `devicecode` | `DeviceCodeCredential` |
+| `msi` / `managedidentity` | `ManagedIdentityCredential` |
+| `ActiveDirectoryServicePrincipal` | Service Principal (`azure_tenant_id`, `azure_client_id`, `azure_client_secret`) |
+| `ActiveDirectoryPassword` | Entra ID `username`/`password` (handled by the ODBC driver) |
+| `ActiveDirectoryIntegrated` | Integrated Windows authentication (handled by the ODBC driver) |
+| `ActiveDirectoryInteractive` | Interactive prompt (handled by the ODBC driver) |
+
+Passwordless example using the Azure CLI:
+```toml
+[destination.mssql.credentials]
+database = "dlt_data"
+host = "loader.database.windows.net"
+authentication = "cli"
+```
+
+Service Principal example:
+```toml
+[destination.mssql.credentials]
+database = "dlt_data"
+host = "loader.database.windows.net"
+authentication = "ActiveDirectoryServicePrincipal"
+azure_tenant_id = "your-tenant-id"
+azure_client_id = "your-client-id"
+azure_client_secret = "your-client-secret"
+```
+
+When `authentication` is left empty but no `password` is set, `dlt` falls back to
+`DefaultAzureCredential`.
+
 **To pass credentials directly**, use the [explicit instance of the destination](../../general-usage/destination.md#pass-explicit-credentials)
 ```py
 pipeline = dlt.pipeline(

--- a/docs/website/docs/dlt-ecosystem/destinations/mssql.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/mssql.md
@@ -106,16 +106,7 @@ With the **azure-identity** methods, `dlt` acquires an access token and injects 
 connection, so they work cross-platform (including macOS) and need no password in `secrets.toml`.
 They require the `azure-identity` package (installed with `pip install "dlt[az]"`).
 
-| `authentication` | How it authenticates |
-|---|---|
-| _(empty, default)_ | SQL login with `username`/`password` |
-| `ActiveDirectoryServicePrincipal` | Service Principal (`azure_tenant_id`, `azure_client_id`, `azure_client_secret`), handled by the ODBC driver |
-| `ActiveDirectoryPassword` | Entra ID `username`/`password` (handled by the ODBC driver) |
-| `ActiveDirectoryIntegrated` | Integrated Windows authentication (handled by the ODBC driver) |
-| `ActiveDirectoryInteractive` | Interactive prompt (handled by the ODBC driver) |
-| `ActiveDirectoryMsi` | Managed identity (handled by the ODBC driver) |
-| `ActiveDirectoryDefault` (alias `default`) | `DefaultAzureCredential` (managed identity, environment, Azure CLI, …), token injected by dlt |
-| `ActiveDirectoryDeviceCode` | `DeviceCodeCredential`, token injected by dlt |
+Leaving `authentication` empty keeps the plain SQL login with `username` and `password`. The ODBC driver signs in itself for `ActiveDirectoryServicePrincipal` (`azure_tenant_id`, `azure_client_id`, `azure_client_secret`), `ActiveDirectoryPassword` (`username`, `password`), `ActiveDirectoryIntegrated`, `ActiveDirectoryInteractive` and `ActiveDirectoryMsi`. `dlt` injects the token itself for `ActiveDirectoryDefault` (alias `default`, uses `DefaultAzureCredential`) and `ActiveDirectoryDeviceCode`.
 
 Passwordless example using `DefaultAzureCredential` (e.g. after `az login`):
 ```toml

--- a/docs/website/docs/dlt-ecosystem/destinations/synapse.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/synapse.md
@@ -97,6 +97,10 @@ pipeline = dlt.pipeline(
     dataset_name='chess_data'
 )
 ```
+**Microsoft Entra ID authentication** is supported through the same `authentication` credential
+option as the [mssql destination](./mssql.md#microsoft-entra-id-authentication), including the
+passwordless azure-identity methods (`cli`, `default`, `msi`, …) that inject an access token.
+
 To use **Active Directory Principal**, you can use the `sqlalchemy.engine.URL.create` method to create the connection URL using your Active Directory Service Principal credentials. First, create the connection string as:
 ```py
 conn_str = (

--- a/docs/website/docs/dlt-ecosystem/destinations/synapse.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/synapse.md
@@ -99,7 +99,8 @@ pipeline = dlt.pipeline(
 ```
 **Microsoft Entra ID authentication** is supported through the same `authentication` credential
 option as the [mssql destination](./mssql.md#microsoft-entra-id-authentication), including the
-passwordless azure-identity methods (`cli`, `default`, `msi`, …) that inject an access token.
+passwordless azure-identity methods (`ActiveDirectoryDefault`, `ActiveDirectoryDeviceCode`) that
+inject an access token.
 
 To use **Active Directory Principal**, you can use the `sqlalchemy.engine.URL.create` method to create the connection URL using your Active Directory Service Principal credentials. First, create the connection string as:
 ```py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,10 @@ gs = [
 az = [
     "adlfs>=2024.7.0"
 ]
+azure_key_vault = [
+    "azure-keyvault-secrets>=4.7.0",
+    "azure-identity>=1.12.0",
+]
 hf = [
     "huggingface-hub>=1.4.1",
     "pyarrow>=21.0.0",  # minimum version that supports CDC (https://huggingface.co/blog/parquet-cdc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ az = [
 azure_key_vault = [
     "azure-keyvault-secrets>=4.7.0",
     "azure-identity>=1.12.0",
+    "azure-core>=1.31.0",
 ]
 hf = [
     "huggingface-hub>=1.4.1",

--- a/tests/helpers/providers/test_azure_key_vault_provider.py
+++ b/tests/helpers/providers/test_azure_key_vault_provider.py
@@ -1,0 +1,118 @@
+"""Integration tests for AzureKeyVaultProvider against a real Azure Key Vault.
+
+Requires a vault reachable with the ambient Azure credentials (`az login` is enough) and the
+secrets listed in `REQUIRED_SECRETS` below. Set `DLT_TEST_AZURE_KEY_VAULT_URL` to point at your
+own vault. Tests skip when the vault is unset or unreachable, so they are safe to run anywhere.
+
+Create the fixtures with:
+
+    az keyvault secret set --vault-name <vault> --name dlt-pr-test--api-key --value sekret-value-42
+    az keyvault secret set --vault-name <vault> --name dlt-pr-test--nested--token --value nested-token-99
+"""
+
+import os
+from typing import Any, Iterator
+
+import pytest
+
+from dlt.common.configuration.providers.azure_key_vault import AzureKeyVaultProvider
+from dlt.common.typing import TSecretValue
+
+VAULT_URL = os.environ.get("DLT_TEST_AZURE_KEY_VAULT_URL")
+
+REQUIRED_SECRETS = {
+    "dlt-pr-test--api-key": "sekret-value-42",
+    "dlt-pr-test--nested--token": "nested-token-99",
+}
+
+pytestmark = pytest.mark.skipif(not VAULT_URL, reason="DLT_TEST_AZURE_KEY_VAULT_URL is not set")
+
+
+def _provider_or_skip(**settings: Any) -> AzureKeyVaultProvider:
+    """Provider for a vault that holds the fixture secrets, skipping when it does not."""
+    p = AzureKeyVaultProvider(vault_url=VAULT_URL, **settings)
+    try:
+        p._get_client().get_secret("dlt-pr-test--api-key")
+    except Exception as ex:  # noqa: BLE001
+        pytest.skip(f"Key Vault {VAULT_URL} has no test fixtures or is not reachable: {ex}")
+    return p
+
+
+@pytest.fixture(scope="module")
+def provider() -> Iterator[AzureKeyVaultProvider]:
+    yield _provider_or_skip()
+
+
+@pytest.fixture(scope="module")
+def listing_provider() -> Iterator[AzureKeyVaultProvider]:
+    yield _provider_or_skip(list_secrets=True)
+
+
+def test_look_vault_reads_real_secret(provider: AzureKeyVaultProvider) -> None:
+    assert provider._look_vault("dlt-pr-test--api-key", TSecretValue) == "sekret-value-42"
+
+
+def test_look_vault_reads_sectioned_secret(provider: AzureKeyVaultProvider) -> None:
+    assert provider._look_vault("dlt-pr-test--nested--token", TSecretValue) == "nested-token-99"
+
+
+def test_look_vault_returns_none_for_missing_secret(provider: AzureKeyVaultProvider) -> None:
+    assert provider._look_vault("dlt-pr-test--does-not-exist", TSecretValue) is None
+
+
+def test_list_vault_includes_test_secrets(listing_provider: AzureKeyVaultProvider) -> None:
+    try:
+        names = listing_provider._list_vault()
+    except Exception as ex:  # noqa: BLE001
+        pytest.skip(f"listing not permitted on {VAULT_URL}: {ex}")
+    assert REQUIRED_SECRETS.keys() <= names
+
+
+@pytest.fixture(scope="module")
+def exact_key_provider() -> Iterator[AzureKeyVaultProvider]:
+    """Provider that also looks up exact keys, not just the known toml fragments."""
+    yield _provider_or_skip(only_toml_fragments=False)
+
+
+def test_get_value_normalizes_underscores(exact_key_provider: AzureKeyVaultProvider) -> None:
+    """`api_key` under section `dlt_pr_test` resolves to the `dlt-pr-test--api-key` secret."""
+    value, key = exact_key_provider.get_value("api_key", TSecretValue, None, "dlt_pr_test")
+    assert key == "dlt-pr-test--api-key"
+    assert value == "sekret-value-42"
+
+
+def test_get_value_walks_sections(exact_key_provider: AzureKeyVaultProvider) -> None:
+    value, key = exact_key_provider.get_value("token", TSecretValue, None, "dlt_pr_test", "nested")
+    assert key == "dlt-pr-test--nested--token"
+    assert value == "nested-token-99"
+
+
+def test_only_toml_fragments_skips_exact_key(provider: AzureKeyVaultProvider) -> None:
+    """With the default `only_toml_fragments`, an exact key is not fetched from the vault."""
+    value, key = provider.get_value("api_key", TSecretValue, None, "dlt_pr_test")
+    assert key == "dlt-pr-test--api-key"
+    assert value is None
+
+
+def test_only_secrets_skips_non_secret_hint() -> None:
+    """With the default `only_secrets`, a non-secret hint is not fetched from the vault.
+
+    Uses a fresh provider: a shared one would serve the value from its cached toml document,
+    which is populated by any earlier lookup of the same key.
+    """
+    fresh = _provider_or_skip(only_toml_fragments=False)
+    value, _ = fresh.get_value("api_key", str, None, "dlt_pr_test")
+    assert value is None
+
+
+def test_client_is_cached(provider: AzureKeyVaultProvider) -> None:
+    assert provider._get_client() is provider._get_client()
+
+
+def test_default_azure_credential_authenticates() -> None:
+    """Outside the Fabric runtime the provider signs in with DefaultAzureCredential."""
+    p = AzureKeyVaultProvider(vault_url=VAULT_URL)
+    credential = p._get_credential()
+    assert type(credential).__name__ == "DefaultAzureCredential"
+    token = credential.get_token("https://vault.azure.net/.default")
+    assert token.token.count(".") == 2

--- a/tests/helpers/providers/test_azure_key_vault_provider_stub.py
+++ b/tests/helpers/providers/test_azure_key_vault_provider_stub.py
@@ -115,10 +115,10 @@ def test_list_vault_raises_config_provider_exception_on_other_error() -> None:
 @pytest.mark.parametrize(
     "key,sections,expected",
     (
-        ("credentials", ("sources", "my_source"), "sources-my-source-credentials"),
-        ("dlt_secrets_toml", ("pipeline x !!",), "pipelinex-dlt-secrets-toml"),
+        ("credentials", ("sources", "my_source"), "sources--my-source--credentials"),
+        ("dlt_secrets_toml", ("pipeline x !!",), "pipelinex--dlt-secrets-toml"),
         ("api-key", (), "api-key"),
-        ("secret", ("destination", None, "bigquery"), "destination-bigquery-secret"),
+        ("secret", ("destination", None, "bigquery"), "destination--bigquery--secret"),
     ),
     ids=["sections_joined", "punctuation_stripped", "no_sections", "empty_sections_filtered"],
 )

--- a/tests/helpers/providers/test_azure_key_vault_provider_stub.py
+++ b/tests/helpers/providers/test_azure_key_vault_provider_stub.py
@@ -1,0 +1,192 @@
+"""Tests for AzureKeyVaultProvider using a mocked SecretClient."""
+
+from typing import Any, Optional, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dlt.common.configuration.exceptions import ConfigProviderException
+from dlt.common.configuration.providers.azure_key_vault import AzureKeyVaultProvider
+from dlt.common.configuration.resolve import resolve_configuration
+from dlt.common.configuration.specs.config_providers_context import (
+    AzureKeyVaultProviderConfiguration,
+    ConfigProvidersConfiguration,
+    _azure_key_vault_provider,
+)
+from dlt.common.typing import TSecretValue
+
+from tests.utils import preserve_environ
+from tests.common.configuration.utils import environment
+
+
+VAULT_URL = "https://test-vault.vault.azure.net/"
+
+
+def _make_provider(**settings: Any) -> Tuple[AzureKeyVaultProvider, MagicMock]:
+    mock_credential = MagicMock()
+    provider = AzureKeyVaultProvider(
+        vault_url=VAULT_URL, credential=mock_credential, **settings
+    )
+    mock_client = MagicMock()
+    provider._client = mock_client
+    return provider, mock_client
+
+
+def _resource_not_found_error() -> Exception:
+    from azure.core.exceptions import ResourceNotFoundError
+
+    return ResourceNotFoundError("Secret not found")
+
+
+def _http_response_error(status_code: int, message: str = "error") -> Exception:
+    from azure.core.exceptions import HttpResponseError
+
+    error = HttpResponseError(message=message)
+    error.status_code = status_code
+    return error
+
+
+def _make_secret_mock(value: str) -> MagicMock:
+    secret = MagicMock()
+    secret.value = value
+    return secret
+
+
+def _make_secret_properties(name: str, enabled: bool = True) -> MagicMock:
+    props = MagicMock()
+    props.name = name
+    props.enabled = enabled
+    return props
+
+
+def test_look_vault_returns_secret_value() -> None:
+    provider, client = _make_provider()
+    client.get_secret.return_value = _make_secret_mock("my-secret-value")
+    assert provider._look_vault("sources-my_source", TSecretValue) == "my-secret-value"
+    client.get_secret.assert_called_once_with("sources-my_source")
+
+
+def test_look_vault_returns_none_on_not_found() -> None:
+    provider, client = _make_provider()
+    client.get_secret.side_effect = _resource_not_found_error()
+    assert provider._look_vault("sources-my_source", TSecretValue) is None
+
+
+def test_look_vault_returns_none_on_403() -> None:
+    provider, client = _make_provider()
+    client.get_secret.side_effect = _http_response_error(403, "Forbidden")
+    assert provider._look_vault("sources-my_source", TSecretValue) is None
+
+
+def test_look_vault_raises_on_other_http_error() -> None:
+    from azure.core.exceptions import HttpResponseError
+
+    provider, client = _make_provider()
+    client.get_secret.side_effect = _http_response_error(500, "Internal Server Error")
+    with pytest.raises(HttpResponseError):
+        provider._look_vault("sources-my_source", TSecretValue)
+
+
+def test_list_vault_lists_enabled_secrets() -> None:
+    provider, client = _make_provider(list_secrets=True)
+    client.list_properties_of_secrets.return_value = [
+        _make_secret_properties("sources-a"),
+        _make_secret_properties("sources-b"),
+        _make_secret_properties("disabled-secret", enabled=False),
+    ]
+    assert provider._list_vault() == {"sources-a", "sources-b"}
+
+
+def test_list_vault_raises_config_provider_exception_on_403() -> None:
+    provider, client = _make_provider(list_secrets=True)
+    client.list_properties_of_secrets.side_effect = _http_response_error(403, "Forbidden")
+    with pytest.raises(ConfigProviderException) as exc_info:
+        provider._list_vault()
+    assert "access denied" in str(exc_info.value).lower()
+
+
+def test_list_vault_raises_config_provider_exception_on_other_error() -> None:
+    provider, client = _make_provider(list_secrets=True)
+    client.list_properties_of_secrets.side_effect = _http_response_error(500, "Server Error")
+    with pytest.raises(ConfigProviderException):
+        provider._list_vault()
+
+
+@pytest.mark.parametrize(
+    "key,sections,expected",
+    (
+        ("credentials", ("sources", "my_source"), "sources-my-source-credentials"),
+        ("dlt_secrets_toml", ("pipeline x !!",), "pipelinex-dlt-secrets-toml"),
+        ("api-key", (), "api-key"),
+        ("secret", ("destination", None, "bigquery"), "destination-bigquery-secret"),
+    ),
+    ids=["sections_joined", "punctuation_stripped", "no_sections", "empty_sections_filtered"],
+)
+def test_get_key_name(key: str, sections: Tuple[str, ...], expected: str) -> None:
+    assert AzureKeyVaultProvider.get_key_name(key, *sections) == expected
+
+
+def test_provider_name() -> None:
+    provider, _ = _make_provider()
+    assert provider.name == "Azure Key Vault"
+
+
+def test_provider_locations() -> None:
+    provider, _ = _make_provider()
+    assert provider.locations == [VAULT_URL]
+
+
+def test_provider_supports_secrets() -> None:
+    provider, _ = _make_provider()
+    assert provider.supports_secrets is True
+
+
+def test_provider_client_created_once() -> None:
+    mock_credential = MagicMock()
+    provider = AzureKeyVaultProvider(vault_url=VAULT_URL, credential=mock_credential)
+    mock_secret_client_cls = MagicMock()
+    mock_module = MagicMock()
+    mock_module.SecretClient = mock_secret_client_cls
+    with patch.dict("sys.modules", {"azure.keyvault.secrets": mock_module}):
+        client1 = provider._get_client()
+        client2 = provider._get_client()
+        assert client1 is client2
+        mock_secret_client_cls.assert_called_once()
+
+
+def test_factory_creates_provider(environment: Any) -> None:
+    environment["PROVIDERS__ENABLE_AZURE_KEY_VAULT"] = "true"
+    environment["PROVIDERS__AZURE_KEY_VAULT__VAULT_URL"] = VAULT_URL
+    environment["PROVIDERS__AZURE_KEY_VAULT__LIST_SECRETS"] = "true"
+
+    providers_config = resolve_configuration(ConfigProvidersConfiguration())
+    assert providers_config.enable_azure_key_vault is True
+
+    with patch(
+        "dlt.common.configuration.providers.azure_key_vault.AzureKeyVaultProvider._get_client"
+    ):
+        provider = _azure_key_vault_provider(providers_config.azure_key_vault)
+        assert isinstance(provider, AzureKeyVaultProvider)
+        assert provider.vault_url == VAULT_URL
+        assert provider.list_secrets is True
+        assert provider.only_secrets is True
+        assert provider.only_toml_fragments is True
+        assert provider.locations == [VAULT_URL]
+
+
+def test_factory_raises_without_vault_url(environment: Any) -> None:
+    environment["PROVIDERS__ENABLE_AZURE_KEY_VAULT"] = "true"
+
+    providers_config = resolve_configuration(ConfigProvidersConfiguration())
+    with pytest.raises(ConfigProviderException) as exc_info:
+        _azure_key_vault_provider(providers_config.azure_key_vault)
+    assert "vault_url" in str(exc_info.value)
+
+
+def test_default_azure_credential_fallback() -> None:
+    with patch("azure.identity.DefaultAzureCredential") as mock_dac:
+        mock_dac.return_value = MagicMock()
+        provider = AzureKeyVaultProvider(vault_url=VAULT_URL)
+        cred = provider._get_credential()
+        mock_dac.assert_called_once()
+        assert cred is mock_dac.return_value

--- a/tests/helpers/providers/test_azure_key_vault_provider_stub.py
+++ b/tests/helpers/providers/test_azure_key_vault_provider_stub.py
@@ -1,12 +1,16 @@
 """Tests for AzureKeyVaultProvider using a mocked SecretClient."""
 
-from typing import Any, Optional, Tuple
+import sys
+from typing import Any, Iterator, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from dlt.common.configuration.exceptions import ConfigProviderException
 from dlt.common.configuration.providers.azure_key_vault import AzureKeyVaultProvider
+from dlt.common.runtime.fab_notebookutils import (
+    FabNotebookUtilsCredential,
+)
 from dlt.common.configuration.resolve import resolve_configuration
 from dlt.common.configuration.specs.config_providers_context import (
     AzureKeyVaultProviderConfiguration,
@@ -24,9 +28,7 @@ VAULT_URL = "https://test-vault.vault.azure.net/"
 
 def _make_provider(**settings: Any) -> Tuple[AzureKeyVaultProvider, MagicMock]:
     mock_credential = MagicMock()
-    provider = AzureKeyVaultProvider(
-        vault_url=VAULT_URL, credential=mock_credential, **settings
-    )
+    provider = AzureKeyVaultProvider(vault_url=VAULT_URL, credential=mock_credential, **settings)
     mock_client = MagicMock()
     provider._client = mock_client
     return provider, mock_client
@@ -183,10 +185,42 @@ def test_factory_raises_without_vault_url(environment: Any) -> None:
     assert "vault_url" in str(exc_info.value)
 
 
-def test_default_azure_credential_fallback() -> None:
+def test_default_azure_credential_fallback(no_notebookutils: None) -> None:
     with patch("azure.identity.DefaultAzureCredential") as mock_dac:
         mock_dac.return_value = MagicMock()
         provider = AzureKeyVaultProvider(vault_url=VAULT_URL)
         cred = provider._get_credential()
         mock_dac.assert_called_once()
         assert cred is mock_dac.return_value
+
+
+@pytest.fixture()
+def mock_notebookutils() -> Iterator[MagicMock]:
+    mod = MagicMock()
+    mod.credentials.getToken = MagicMock(return_value="token")
+    sys.modules["notebookutils"] = mod
+    yield mod
+    sys.modules.pop("notebookutils", None)
+
+
+@pytest.fixture()
+def no_notebookutils() -> Iterator[None]:
+    saved = sys.modules.pop("notebookutils", None)
+    yield
+    if saved is not None:
+        sys.modules["notebookutils"] = saved
+
+
+def test_notebookutils_credential_in_fabric(mock_notebookutils: MagicMock) -> None:
+    provider = AzureKeyVaultProvider(vault_url=VAULT_URL)
+    cred = provider._get_credential()
+    assert isinstance(cred, FabNotebookUtilsCredential)
+    assert cred.get_token().token == "token"
+    mock_notebookutils.credentials.getToken.assert_called_once_with("keyvault")
+
+
+def test_explicit_credential_wins_over_notebookutils(mock_notebookutils: MagicMock) -> None:
+    explicit = MagicMock()
+    provider = AzureKeyVaultProvider(vault_url=VAULT_URL, credential=explicit)
+    assert provider._get_credential() is explicit
+    mock_notebookutils.credentials.getToken.assert_not_called()

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -18,7 +18,7 @@ from dlt.destinations.impl.fabric.configuration import (
     FabricCredentials,
     FabricClientConfiguration,
 )
-from dlt.destinations.impl.mssql.configuration import uses_token_authentication
+from dlt.destinations.impl.mssql.configuration import get_access_token, uses_token_authentication
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
@@ -414,4 +414,82 @@ def test_fabric_resolve_configuration_token_authentication() -> None:
     assert resolved.is_resolved()
     assert uses_token_authentication(resolved) is True
     assert type(resolved.default_credentials()).__name__ == "DeviceCodeCredential"
+    assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()
+
+
+# ---------------------------------------------------------------------------
+# Injectable access_token / azure_credential (precedence over `authentication`)
+# ---------------------------------------------------------------------------
+
+
+class _RaisingTokenCredential:
+    """A TokenCredential whose `get_token` must never be called (used to prove precedence)."""
+
+    def get_token(self, *scopes: str, **kwargs: object) -> _FakeAccessToken:
+        raise AssertionError("azure_credential.get_token() should not have been called")
+
+
+def test_fabric_access_token_and_azure_credential_default_to_none() -> None:
+    creds = FabricCredentials()
+    assert creds.access_token is None
+    assert creds.azure_credential is None
+
+
+def test_fabric_get_access_token_uses_azure_credential() -> None:
+    creds = _warehouse_credentials(azure_credential=_FakeTokenCredential())
+    assert get_access_token(creds) == "fake-access-token"
+
+
+def test_fabric_get_access_token_prefers_access_token_over_azure_credential() -> None:
+    creds = _warehouse_credentials(
+        access_token="explicit-token", azure_credential=_RaisingTokenCredential()
+    )
+    assert get_access_token(creds) == "explicit-token"
+
+
+def test_fabric_access_token_takes_precedence_over_default_service_principal() -> None:
+    """access_token bypasses the default ActiveDirectoryServicePrincipal authentication entirely,
+    even though that method is on by default for Fabric and no Service Principal secret is set."""
+    creds = _warehouse_credentials(access_token="explicit-token")
+    creds.on_partial()
+
+    assert uses_token_authentication(creds) is True
+    dsn = creds.get_odbc_dsn_dict()
+    assert "AUTHENTICATION" not in dsn
+    assert "UID" not in dsn
+    assert "PWD" not in dsn
+
+    attrs = creds.to_odbc_attrs_before()
+    assert attrs is not None
+    assert attrs[1256][4:].decode("utf-16-le") == "explicit-token"
+
+
+def test_fabric_azure_credential_takes_precedence_over_authentication() -> None:
+    creds = _warehouse_credentials(
+        "ActiveDirectoryDeviceCode", azure_credential=_FakeTokenCredential()
+    )
+    creds.on_partial()
+
+    # setup_token_credential must skip the azure-identity DefaultAzureCredential machinery
+    assert creds.has_default_credentials() is False
+    assert uses_token_authentication(creds) is True
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert "AUTHENTICATION" not in dsn
+
+    attrs = creds.to_odbc_attrs_before()
+    assert attrs is not None
+    assert attrs[1256][4:].decode("utf-16-le") == "fake-access-token"
+
+
+def test_fabric_resolve_configuration_access_token_without_service_principal() -> None:
+    creds = FabricCredentials()
+    creds.host = "abc.datawarehouse.fabric.microsoft.com"
+    creds.database = "mydb"
+    creds.access_token = "explicit-token"
+
+    resolved = resolve_configuration(creds)
+
+    assert resolved.is_resolved()
+    assert uses_token_authentication(resolved) is True
     assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -1,11 +1,13 @@
 """Tests for Microsoft Fabric Warehouse destination configuration"""
 
 import os
+import struct
 from typing import Optional, cast
 
 import pytest
 
 from dlt.common.configuration import resolve_configuration
+from dlt.common.configuration.exceptions import ConfigurationException
 from dlt.common.destination import DestinationCapabilitiesContext
 from dlt.common.destination.typing import PreparedTableSchema
 from dlt.common.schema import Schema
@@ -16,6 +18,7 @@ from dlt.destinations.impl.fabric.configuration import (
     FabricCredentials,
     FabricClientConfiguration,
 )
+from dlt.destinations.impl.mssql.configuration import uses_token_authentication
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
@@ -253,3 +256,155 @@ def test_fabric_type_mapper_scales_varchar_precision(data_type: TDataType) -> No
         TColumnSchema, {"name": "c", "data_type": data_type, "precision": 10, "nullable": True}
     )
     assert mapper.to_destination_type(col, table) == "varchar(40)"
+
+
+# ---------------------------------------------------------------------------
+# Authentication methods
+# ---------------------------------------------------------------------------
+
+
+class _FakeAccessToken:
+    token = "fake-access-token"
+
+
+class _FakeTokenCredential:
+    """Minimal azure-identity-like credential, avoids hitting Azure in unit tests."""
+
+    def get_token(self, *scopes: str, **kwargs: object) -> _FakeAccessToken:
+        return _FakeAccessToken()
+
+
+def _warehouse_credentials(
+    authentication: str | None = None, **kwargs: object
+) -> FabricCredentials:
+    creds = FabricCredentials()
+    creds.host = "test.datawarehouse.fabric.microsoft.com"
+    creds.database = "testdb"
+    if authentication is not None:
+        creds.authentication = authentication
+    for key, value in kwargs.items():
+        setattr(creds, key, value)
+    return creds
+
+
+def test_fabric_authentication_default_is_service_principal() -> None:
+    assert FabricCredentials().authentication == "ActiveDirectoryServicePrincipal"
+
+
+@pytest.mark.parametrize(
+    "authentication,expected",
+    [
+        ("auto", "DefaultAzureCredential"),
+        ("default", "DefaultAzureCredential"),
+        ("cli", "AzureCliCredential"),
+        ("environment", "EnvironmentCredential"),
+        ("interactive", "InteractiveBrowserCredential"),
+        ("devicecode", "DeviceCodeCredential"),
+        ("msi", "ManagedIdentityCredential"),
+        ("managedidentity", "ManagedIdentityCredential"),
+    ],
+)
+def test_fabric_azure_identity_credential_mapping(authentication: str, expected: str) -> None:
+    """Each azure-identity method maps to the right credential and skips the DSN AUTHENTICATION."""
+    creds = _warehouse_credentials(authentication)
+    creds.on_partial()
+
+    assert type(creds.default_credentials()).__name__ == expected
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert "AUTHENTICATION" not in dsn
+    assert "UID" not in dsn
+    assert "PWD" not in dsn
+    assert dsn["LongAsMax"] == "yes"
+
+
+def test_fabric_service_principal_without_secret_falls_back_to_token() -> None:
+    """Default method without a Service Principal secret injects a DefaultAzureCredential token."""
+    creds = _warehouse_credentials()
+    creds.on_partial()
+
+    assert uses_token_authentication(creds) is True
+    assert type(creds.default_credentials()).__name__ == "DefaultAzureCredential"
+    assert "AUTHENTICATION" not in creds.get_odbc_dsn_dict()
+
+
+def test_fabric_service_principal_with_secret_is_driver_native() -> None:
+    """Default method with a Service Principal secret authenticates through the ODBC driver."""
+    creds = _warehouse_credentials(
+        azure_tenant_id="t", azure_client_id="c", azure_client_secret="s"
+    )
+    creds.on_partial()
+
+    assert uses_token_authentication(creds) is False
+    dsn = creds.get_odbc_dsn_dict()
+    assert dsn["AUTHENTICATION"] == "ActiveDirectoryServicePrincipal"
+    assert dsn["UID"] == "c@t"
+    assert dsn["PWD"] == "s"
+    assert creds.to_odbc_attrs_before() is None
+
+
+@pytest.mark.parametrize(
+    "authentication", ["ActiveDirectoryIntegrated", "ActiveDirectoryInteractive"]
+)
+def test_fabric_driver_native_passthrough(authentication: str) -> None:
+    creds = _warehouse_credentials(authentication)
+    creds.on_partial()
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert dsn["AUTHENTICATION"] == authentication
+    assert "UID" not in dsn
+    assert "PWD" not in dsn
+    assert creds.to_odbc_attrs_before() is None
+
+
+def test_fabric_active_directory_password() -> None:
+    creds = _warehouse_credentials(
+        "ActiveDirectoryPassword", username="user@contoso.com", password="pwd"
+    )
+    creds.on_partial()
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert dsn["AUTHENTICATION"] == "ActiveDirectoryPassword"
+    assert dsn["UID"] == "user@contoso.com"
+    assert dsn["PWD"] == "pwd"
+    assert creds.to_odbc_attrs_before() is None
+
+
+def test_fabric_active_directory_password_requires_username_password() -> None:
+    creds = _warehouse_credentials("ActiveDirectoryPassword")
+    with pytest.raises(ConfigurationException):
+        creds.on_partial()  # on_partial -> resolve() -> on_resolved validates
+
+
+def test_fabric_unsupported_authentication_raises() -> None:
+    creds = _warehouse_credentials("SqlPassword")
+    with pytest.raises(ConfigurationException):
+        creds.on_partial()
+
+
+def test_fabric_to_odbc_attrs_before_token_struct() -> None:
+    """The injected token follows the SQL_COPT_SS_ACCESS_TOKEN struct layout."""
+    creds = _warehouse_credentials("cli")
+    creds._set_default_credentials(_FakeTokenCredential())
+
+    attrs = creds.to_odbc_attrs_before()
+    assert attrs is not None
+    token_struct = attrs[1256]  # SQL_COPT_SS_ACCESS_TOKEN
+    length = struct.unpack("<I", token_struct[:4])[0]
+    assert length == len(token_struct) - 4
+    assert token_struct[4:].decode("utf-16-le") == "fake-access-token"
+
+
+def test_fabric_resolve_configuration_token_authentication() -> None:
+    """Resolution succeeds without a Service Principal secret for token authentication."""
+    creds = FabricCredentials()
+    creds.host = "abc.datawarehouse.fabric.microsoft.com"
+    creds.database = "mydb"
+    creds.authentication = "cli"
+
+    resolved = resolve_configuration(creds)
+
+    assert resolved.is_resolved()
+    assert uses_token_authentication(resolved) is True
+    assert type(resolved.default_credentials()).__name__ == "AzureCliCredential"
+    assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -294,14 +294,9 @@ def test_fabric_authentication_default_is_service_principal() -> None:
 @pytest.mark.parametrize(
     "authentication,expected",
     [
-        ("auto", "DefaultAzureCredential"),
         ("default", "DefaultAzureCredential"),
-        ("cli", "AzureCliCredential"),
-        ("environment", "EnvironmentCredential"),
-        ("interactive", "InteractiveBrowserCredential"),
-        ("devicecode", "DeviceCodeCredential"),
-        ("msi", "ManagedIdentityCredential"),
-        ("managedidentity", "ManagedIdentityCredential"),
+        ("ActiveDirectoryDefault", "DefaultAzureCredential"),
+        ("ActiveDirectoryDeviceCode", "DeviceCodeCredential"),
     ],
 )
 def test_fabric_azure_identity_credential_mapping(authentication: str, expected: str) -> None:
@@ -316,6 +311,17 @@ def test_fabric_azure_identity_credential_mapping(authentication: str, expected:
     assert "UID" not in dsn
     assert "PWD" not in dsn
     assert dsn["LongAsMax"] == "yes"
+
+
+@pytest.mark.parametrize(
+    "authentication",
+    ["auto", "cli", "environment", "interactive", "devicecode", "msi", "managedidentity"],
+)
+def test_fabric_removed_dlt_custom_alias_raises(authentication: str) -> None:
+    """The old dlt-custom lowercase aliases were replaced by native ODBC/azure-identity names."""
+    creds = _warehouse_credentials(authentication)
+    with pytest.raises(ConfigurationException):
+        creds.on_partial()  # resolves (host+database present) -> on_resolved -> validate raises
 
 
 def test_fabric_service_principal_without_secret_falls_back_to_token() -> None:
@@ -344,7 +350,8 @@ def test_fabric_service_principal_with_secret_is_driver_native() -> None:
 
 
 @pytest.mark.parametrize(
-    "authentication", ["ActiveDirectoryIntegrated", "ActiveDirectoryInteractive"]
+    "authentication",
+    ["ActiveDirectoryIntegrated", "ActiveDirectoryInteractive", "ActiveDirectoryMsi"],
 )
 def test_fabric_driver_native_passthrough(authentication: str) -> None:
     creds = _warehouse_credentials(authentication)
@@ -384,7 +391,7 @@ def test_fabric_unsupported_authentication_raises() -> None:
 
 def test_fabric_to_odbc_attrs_before_token_struct() -> None:
     """The injected token follows the SQL_COPT_SS_ACCESS_TOKEN struct layout."""
-    creds = _warehouse_credentials("cli")
+    creds = _warehouse_credentials("default")
     creds._set_default_credentials(_FakeTokenCredential())
 
     attrs = creds.to_odbc_attrs_before()
@@ -400,11 +407,11 @@ def test_fabric_resolve_configuration_token_authentication() -> None:
     creds = FabricCredentials()
     creds.host = "abc.datawarehouse.fabric.microsoft.com"
     creds.database = "mydb"
-    creds.authentication = "cli"
+    creds.authentication = "ActiveDirectoryDeviceCode"
 
     resolved = resolve_configuration(creds)
 
     assert resolved.is_resolved()
     assert uses_token_authentication(resolved) is True
-    assert type(resolved.default_credentials()).__name__ == "AzureCliCredential"
+    assert type(resolved.default_credentials()).__name__ == "DeviceCodeCredential"
     assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -1,8 +1,13 @@
 """Tests for Microsoft Fabric Warehouse destination configuration"""
 
+import base64
+import json
 import os
 import struct
+import sys
+import time
 from typing import Optional, cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,6 +22,11 @@ from dlt.destinations.impl.fabric.factory import fabric, FabricTypeMapper
 from dlt.destinations.impl.fabric.configuration import (
     FabricCredentials,
     FabricClientConfiguration,
+)
+from dlt.common.runtime.fab_notebookutils import (
+    FabNotebookUtilsCredential,
+    is_fab_notebookutils_available,
+    _decode_jwt_expiry,
 )
 from dlt.destinations.impl.mssql.configuration import get_access_token, uses_token_authentication
 
@@ -493,3 +503,163 @@ def test_fabric_resolve_configuration_access_token_without_service_principal() -
     assert resolved.is_resolved()
     assert uses_token_authentication(resolved) is True
     assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()
+
+
+# ---------------------------------------------------------------------------
+# NotebookUtils credential
+# ---------------------------------------------------------------------------
+
+
+def _make_jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
+    return f"{header}.{payload}.sig"
+
+
+@pytest.fixture()
+def mock_notebookutils():
+    mod = MagicMock()
+    mod.credentials.getToken = MagicMock(return_value=_make_jwt(int(time.time()) + 3600))
+    sys.modules["notebookutils"] = mod
+    yield mod
+    sys.modules.pop("notebookutils", None)
+
+
+@pytest.fixture()
+def no_notebookutils():
+    saved = sys.modules.pop("notebookutils", None)
+    yield
+    if saved is not None:
+        sys.modules["notebookutils"] = saved
+
+
+def test_decode_jwt_expiry_valid() -> None:
+    exp = int(time.time()) + 7200
+    assert _decode_jwt_expiry(_make_jwt(exp)) == exp
+
+
+def test_decode_jwt_expiry_garbage() -> None:
+    assert _decode_jwt_expiry("not-a-jwt") is None
+
+
+def test_notebookutils_get_token(mock_notebookutils: MagicMock) -> None:
+    cred = FabNotebookUtilsCredential("https://database.windows.net/")
+    token = cred.get_token()
+    assert token.token == mock_notebookutils.credentials.getToken.return_value
+    mock_notebookutils.credentials.getToken.assert_called_once_with("https://database.windows.net/")
+
+
+def test_notebookutils_sql_alias(mock_notebookutils: MagicMock) -> None:
+    cred = FabNotebookUtilsCredential("sql")
+    cred.get_token()
+    mock_notebookutils.credentials.getToken.assert_called_once_with("https://database.windows.net/")
+
+
+def test_notebookutils_caches_token(mock_notebookutils: MagicMock) -> None:
+    cred = FabNotebookUtilsCredential("storage")
+    t1 = cred.get_token()
+    t2 = cred.get_token()
+    assert t1 is t2
+    assert mock_notebookutils.credentials.getToken.call_count == 1
+
+
+def test_notebookutils_refreshes_near_expiry(mock_notebookutils: MagicMock) -> None:
+    near_expiry_jwt = _make_jwt(int(time.time()) + 100)
+    fresh_jwt = _make_jwt(int(time.time()) + 3600)
+    mock_notebookutils.credentials.getToken.side_effect = [near_expiry_jwt, fresh_jwt]
+
+    cred = FabNotebookUtilsCredential("storage")
+    t1 = cred.get_token()
+    assert t1.token == near_expiry_jwt
+    t2 = cred.get_token()
+    assert t2.token == fresh_jwt
+    assert mock_notebookutils.credentials.getToken.call_count == 2
+
+
+def test_notebookutils_mssparkutils_fallback(mock_notebookutils: MagicMock) -> None:
+    del mock_notebookutils.credentials.getToken
+    mock_notebookutils.mssparkutils.credentials.getToken = MagicMock(
+        return_value=_make_jwt(int(time.time()) + 3600)
+    )
+
+    cred = FabNotebookUtilsCredential("storage")
+    cred.get_token()
+    mock_notebookutils.mssparkutils.credentials.getToken.assert_called_once()
+
+
+def test_notebookutils_unavailable_raises(no_notebookutils: None) -> None:
+    cred = FabNotebookUtilsCredential("storage")
+    with pytest.raises(ConfigurationException, match="NotebookUtils"):
+        cred.get_token()
+
+
+def test_notebookutils_available_in_fabric(mock_notebookutils: MagicMock) -> None:
+    assert is_fab_notebookutils_available() is True
+
+
+def test_notebookutils_available_outside_fabric(no_notebookutils: None) -> None:
+    assert is_fab_notebookutils_available() is False
+
+
+def test_notebookutils_available_without_credential_api(mock_notebookutils: MagicMock) -> None:
+    del mock_notebookutils.credentials
+    del mock_notebookutils.mssparkutils
+    assert is_fab_notebookutils_available() is False
+
+
+def test_notebookutils_closeable(mock_notebookutils: MagicMock) -> None:
+    """adlfs and the Azure SDK clients close the credential they were handed."""
+    with FabNotebookUtilsCredential("storage") as cred:
+        assert cred.get_token().token
+    cred.close()
+    assert cred.get_token().token
+
+
+def test_notebookutils_importable_from_runtime() -> None:
+    from dlt.common.runtime.fab_notebookutils import FabNotebookUtilsCredential as Cls
+
+    assert Cls is FabNotebookUtilsCredential
+
+
+def test_fabric_notebookutils_creates_credential(mock_notebookutils: MagicMock) -> None:
+    creds = _warehouse_credentials("fab_notebookutils")
+    creds.on_partial()
+    assert isinstance(creds.azure_credential, FabNotebookUtilsCredential)
+
+
+def test_fabric_notebookutils_dsn_has_no_authentication_key(
+    mock_notebookutils: MagicMock,
+) -> None:
+    creds = _warehouse_credentials("fab_notebookutils")
+    creds.on_partial()
+    dsn = creds.get_odbc_dsn_dict()
+    assert "AUTHENTICATION" not in dsn
+    assert "UID" not in dsn
+    assert "PWD" not in dsn
+
+
+def test_fabric_notebookutils_attrs_before(mock_notebookutils: MagicMock) -> None:
+    creds = _warehouse_credentials("fab_notebookutils")
+    creds.on_partial()
+    attrs = creds.to_odbc_attrs_before()
+    assert attrs is not None
+    token_struct = attrs[1256]
+    length = struct.unpack("<I", token_struct[:4])[0]
+    assert length == len(token_struct) - 4
+
+
+def test_fabric_notebookutils_does_not_replace_explicit_azure_credential(
+    mock_notebookutils: MagicMock,
+) -> None:
+    explicit = _FakeTokenCredential()
+    creds = _warehouse_credentials("fab_notebookutils", azure_credential=explicit)
+    creds.on_partial()
+    assert creds.azure_credential is explicit
+
+
+def test_fabric_access_token_precedence_over_notebookutils(
+    mock_notebookutils: MagicMock,
+) -> None:
+    creds = _warehouse_credentials("fab_notebookutils", access_token="explicit-token")
+    creds.on_partial()
+    assert get_access_token(creds) == "explicit-token"

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -268,11 +268,6 @@ def test_fabric_type_mapper_scales_varchar_precision(data_type: TDataType) -> No
     assert mapper.to_destination_type(col, table) == "varchar(40)"
 
 
-# ---------------------------------------------------------------------------
-# Authentication methods
-# ---------------------------------------------------------------------------
-
-
 class _FakeAccessToken:
     token = "fake-access-token"
 
@@ -427,11 +422,6 @@ def test_fabric_resolve_configuration_token_authentication() -> None:
     assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()
 
 
-# ---------------------------------------------------------------------------
-# Injectable access_token / azure_credential (precedence over `authentication`)
-# ---------------------------------------------------------------------------
-
-
 class _RaisingTokenCredential:
     """A TokenCredential whose `get_token` must never be called (used to prove precedence)."""
 
@@ -503,11 +493,6 @@ def test_fabric_resolve_configuration_access_token_without_service_principal() -
     assert resolved.is_resolved()
     assert uses_token_authentication(resolved) is True
     assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()
-
-
-# ---------------------------------------------------------------------------
-# NotebookUtils credential
-# ---------------------------------------------------------------------------
 
 
 def _make_jwt(exp: int) -> str:

--- a/tests/load/filesystem/test_azure_credentials.py
+++ b/tests/load/filesystem/test_azure_credentials.py
@@ -1,4 +1,9 @@
-from typing import Any, Dict, Optional
+import base64
+import json
+import sys
+import time
+from typing import Any, Dict, Iterator, Optional
+from unittest.mock import MagicMock
 from urllib.parse import parse_qs
 from uuid import uuid4
 
@@ -16,6 +21,7 @@ from dlt.common.configuration.specs import (
     AzureCredentialsWithoutDefaults,
 )
 from dlt.common.configuration.specs.exceptions import UnsupportedAuthenticationMethodException
+from dlt.common.runtime.fab_notebookutils import FabNotebookUtilsCredential
 from dlt.common.storages.configuration import FilesystemConfiguration
 from dlt.common.storages.fsspec_filesystem import fsspec_from_config
 
@@ -186,6 +192,97 @@ def test_azure_external_session_always_frozen(creds_cls: Any) -> None:
     # pyiceberg ADLS cannot express a bearer token / live credential
     with pytest.raises(UnsupportedAuthenticationMethodException):
         creds.to_pyiceberg_fileio_config()
+
+
+def _make_jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
+    return f"{header}.{payload}.sig"
+
+
+@pytest.fixture()
+def mock_notebookutils() -> Iterator[MagicMock]:
+    mod = MagicMock()
+    mod.credentials.getToken = MagicMock(return_value=_make_jwt(int(time.time()) + 3600))
+    sys.modules["notebookutils"] = mod
+    yield mod
+    sys.modules.pop("notebookutils", None)
+
+
+@pytest.fixture()
+def no_notebookutils() -> Iterator[None]:
+    saved = sys.modules.pop("notebookutils", None)
+    yield
+    if saved is not None:
+        sys.modules["notebookutils"] = saved
+
+
+def test_azure_notebookutils_credential_in_fabric(
+    environment: Dict[str, str], mock_notebookutils: MagicMock
+) -> None:
+    """Inside Fabric, storage falls back to NotebookUtils instead of DefaultAzureCredential."""
+    environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"] = "onelake"
+
+    config = resolve_configuration(AzureCredentials())
+
+    assert isinstance(config.default_credentials(), FabNotebookUtilsCredential)
+    assert config.is_external_session()
+
+    # adlfs gets the live credential, not `anon`, since it cannot resolve a Fabric identity itself
+    adlfs_creds = config.to_adlfs_credentials()
+    assert adlfs_creds["credential"] is config.default_credentials()
+    assert "anon" not in adlfs_creds
+
+    assert (
+        config.default_credentials().get_token().token
+        == mock_notebookutils.credentials.getToken("storage")
+    )
+    mock_notebookutils.credentials.getToken.assert_called_with("storage")
+
+
+def test_azure_default_credential_outside_fabric(
+    environment: Dict[str, str], no_notebookutils: None
+) -> None:
+    environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"] = "fake_account_name"
+
+    config = resolve_configuration(AzureCredentials())
+
+    assert type(config.default_credentials()).__name__ == "DefaultAzureCredential"
+    assert not config.is_external_session()
+
+
+def test_azure_notebookutils_object_store_freezes_token(
+    environment: Dict[str, str], mock_notebookutils: MagicMock
+) -> None:
+    """object_store cannot call a Python credential, so the NotebookUtils token is frozen."""
+    environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"] = "onelake"
+
+    os_creds = resolve_configuration(AzureCredentials()).to_object_store_rs_credentials()
+
+    assert os_creds["account_name"] == "onelake"
+    assert os_creds["azure_storage_token"].count(".") == 2
+    assert "credential" not in os_creds
+
+
+def test_azure_static_secret_wins_over_notebookutils(
+    environment: Dict[str, str], mock_notebookutils: MagicMock
+) -> None:
+    environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"] = "fake_account_name"
+    environment["CREDENTIALS__AZURE_STORAGE_SAS_TOKEN"] = "sp=rwdl&sig=1234567890"
+
+    config = resolve_configuration(AzureCredentials())
+
+    assert not config.has_default_credentials()
+    mock_notebookutils.credentials.getToken.assert_not_called()
+
+
+def test_azure_explicit_credential_wins_over_notebookutils(mock_notebookutils: MagicMock) -> None:
+    explicit = _fake_token_credential()
+    creds = AzureCredentials.from_credential(explicit)
+    creds.azure_storage_account_name = "fake_account_name"
+
+    assert creds.default_credentials() is explicit
+    mock_notebookutils.credentials.getToken.assert_not_called()
 
 
 def test_azure_service_principal_credentials(environment: Dict[str, str]) -> None:

--- a/tests/load/mssql/docker-compose.yml
+++ b/tests/load/mssql/docker-compose.yml
@@ -1,0 +1,18 @@
+# Local SQL Server for mssql destination integration tests.
+# Start with `docker compose up`; tests skip automatically when the server is unreachable.
+#
+# Uses SQL Server 2025, which is required because the destination maps the dlt `json` type to
+# the native `json` column type that older SQL Server versions do not support.
+# On Apple Silicon, enable Rosetta in Docker Desktop so the amd64 image runs under emulation.
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2025-latest
+    container_name: dlt_test_mssql
+    restart: on-failure
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Strong!Passw0rd"
+      MSSQL_PID: "Developer"
+    ports:
+      - 1433:1433
+    # (this is just an example, not intended to be a production configuration)

--- a/tests/load/mssql/test_mssql_configuration.py
+++ b/tests/load/mssql/test_mssql_configuration.py
@@ -263,14 +263,9 @@ def test_mssql_sql_login_dsn_uses_uid_pwd() -> None:
 @pytest.mark.parametrize(
     "authentication,expected",
     [
-        ("auto", "DefaultAzureCredential"),
         ("default", "DefaultAzureCredential"),
-        ("cli", "AzureCliCredential"),
-        ("environment", "EnvironmentCredential"),
-        ("interactive", "InteractiveBrowserCredential"),
-        ("devicecode", "DeviceCodeCredential"),
-        ("msi", "ManagedIdentityCredential"),
-        ("managedidentity", "ManagedIdentityCredential"),
+        ("ActiveDirectoryDefault", "DefaultAzureCredential"),
+        ("ActiveDirectoryDeviceCode", "DeviceCodeCredential"),
     ],
 )
 def test_mssql_azure_identity_credential_mapping(authentication: str, expected: str) -> None:
@@ -283,6 +278,17 @@ def test_mssql_azure_identity_credential_mapping(authentication: str, expected: 
     assert "AUTHENTICATION" not in dsn
     assert "UID" not in dsn
     assert "PWD" not in dsn
+
+
+@pytest.mark.parametrize(
+    "authentication",
+    ["auto", "cli", "environment", "interactive", "devicecode", "msi", "managedidentity"],
+)
+def test_mssql_removed_dlt_custom_alias_raises(authentication: str) -> None:
+    """The old dlt-custom lowercase aliases were replaced by native ODBC/azure-identity names."""
+    creds = _mssql_credentials(authentication)
+    with pytest.raises(ConfigurationException):
+        validate_authentication(creds)
 
 
 def test_mssql_service_principal_driver_native() -> None:
@@ -312,7 +318,8 @@ def test_mssql_service_principal_without_secret_falls_back_to_token() -> None:
 
 
 @pytest.mark.parametrize(
-    "authentication", ["ActiveDirectoryIntegrated", "ActiveDirectoryInteractive"]
+    "authentication",
+    ["ActiveDirectoryIntegrated", "ActiveDirectoryInteractive", "ActiveDirectoryMsi"],
 )
 def test_mssql_driver_native_passthrough(authentication: str) -> None:
     creds = _mssql_credentials(authentication)
@@ -350,7 +357,7 @@ def test_mssql_unsupported_authentication_raises() -> None:
 
 
 def test_mssql_to_odbc_attrs_before_token_struct() -> None:
-    creds = _mssql_credentials("cli")
+    creds = _mssql_credentials("default")
     creds._set_default_credentials(_FakeTokenCredential())
 
     attrs = creds.to_odbc_attrs_before()
@@ -366,11 +373,11 @@ def test_mssql_resolve_configuration_token_authentication() -> None:
     creds.host = "sql.example.com"
     creds.database = "test_db"
     creds.driver = "ODBC Driver 18 for SQL Server"
-    creds.authentication = "cli"
+    creds.authentication = "ActiveDirectoryDeviceCode"
 
     resolved = resolve_configuration(creds)
 
     assert resolved.is_resolved()
     assert uses_token_authentication(resolved) is True
-    assert type(resolved.default_credentials()).__name__ == "AzureCliCredential"
+    assert type(resolved.default_credentials()).__name__ == "DeviceCodeCredential"
     assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()

--- a/tests/load/mssql/test_mssql_configuration.py
+++ b/tests/load/mssql/test_mssql_configuration.py
@@ -1,14 +1,21 @@
 import os
+import struct
 
 import pyodbc
 import pytest
 
 from dlt.common.configuration import ConfigFieldMissingException, resolve_configuration
+from dlt.common.configuration.exceptions import ConfigurationException
 from dlt.common.exceptions import SystemConfigurationException
 from dlt.common.schema import Schema
 from dlt.common.utils import digest128
 from dlt.destinations import mssql
-from dlt.destinations.impl.mssql.configuration import MsSqlClientConfiguration, MsSqlCredentials
+from dlt.destinations.impl.mssql.configuration import (
+    MsSqlClientConfiguration,
+    MsSqlCredentials,
+    uses_token_authentication,
+    validate_authentication,
+)
 
 # mark all tests as essential, do not remove
 pytestmark = pytest.mark.essential
@@ -208,3 +215,162 @@ def test_to_odbc_dsn_driver_not_specified() -> None:
         }
         for d in MsSqlCredentials.SUPPORTED_DRIVERS
     ]
+
+
+# ---------------------------------------------------------------------------
+# Authentication methods
+# ---------------------------------------------------------------------------
+
+
+class _FakeAccessToken:
+    token = "fake-access-token"
+
+
+class _FakeTokenCredential:
+    """Minimal azure-identity-like credential, avoids hitting Azure in unit tests."""
+
+    def get_token(self, *scopes: str, **kwargs: object) -> _FakeAccessToken:
+        return _FakeAccessToken()
+
+
+def _mssql_credentials(authentication: object = None, **kwargs: object) -> MsSqlCredentials:
+    creds = MsSqlCredentials()
+    creds.host = "sql.example.com"
+    creds.database = "test_db"
+    creds.driver = "ODBC Driver 18 for SQL Server"  # avoid probing for an installed driver
+    if authentication is not None:
+        creds.authentication = authentication  # type: ignore[assignment]
+    for key, value in kwargs.items():
+        setattr(creds, key, value)
+    return creds
+
+
+def test_mssql_authentication_defaults_to_sql_login() -> None:
+    assert MsSqlCredentials().authentication is None
+
+
+def test_mssql_sql_login_dsn_uses_uid_pwd() -> None:
+    creds = _mssql_credentials(username="loader", password="secret")
+    creds.on_partial()
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert "AUTHENTICATION" not in dsn
+    assert dsn["UID"] == "loader"
+    assert dsn["PWD"] == "secret"
+    assert creds.to_odbc_attrs_before() is None
+
+
+@pytest.mark.parametrize(
+    "authentication,expected",
+    [
+        ("auto", "DefaultAzureCredential"),
+        ("default", "DefaultAzureCredential"),
+        ("cli", "AzureCliCredential"),
+        ("environment", "EnvironmentCredential"),
+        ("interactive", "InteractiveBrowserCredential"),
+        ("devicecode", "DeviceCodeCredential"),
+        ("msi", "ManagedIdentityCredential"),
+        ("managedidentity", "ManagedIdentityCredential"),
+    ],
+)
+def test_mssql_azure_identity_credential_mapping(authentication: str, expected: str) -> None:
+    creds = _mssql_credentials(authentication)
+    creds.on_partial()
+
+    assert type(creds.default_credentials()).__name__ == expected
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert "AUTHENTICATION" not in dsn
+    assert "UID" not in dsn
+    assert "PWD" not in dsn
+
+
+def test_mssql_service_principal_driver_native() -> None:
+    creds = _mssql_credentials(
+        "ActiveDirectoryServicePrincipal",
+        azure_tenant_id="t",
+        azure_client_id="c",
+        azure_client_secret="s",
+    )
+    creds.on_partial()
+
+    assert uses_token_authentication(creds) is False
+    dsn = creds.get_odbc_dsn_dict()
+    assert dsn["AUTHENTICATION"] == "ActiveDirectoryServicePrincipal"
+    assert dsn["UID"] == "c@t"
+    assert dsn["PWD"] == "s"
+    assert creds.to_odbc_attrs_before() is None
+
+
+def test_mssql_service_principal_without_secret_falls_back_to_token() -> None:
+    creds = _mssql_credentials("ActiveDirectoryServicePrincipal")
+    creds.on_partial()
+
+    assert uses_token_authentication(creds) is True
+    assert type(creds.default_credentials()).__name__ == "DefaultAzureCredential"
+    assert "AUTHENTICATION" not in creds.get_odbc_dsn_dict()
+
+
+@pytest.mark.parametrize(
+    "authentication", ["ActiveDirectoryIntegrated", "ActiveDirectoryInteractive"]
+)
+def test_mssql_driver_native_passthrough(authentication: str) -> None:
+    creds = _mssql_credentials(authentication)
+    creds.on_partial()
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert dsn["AUTHENTICATION"] == authentication
+    assert "UID" not in dsn
+    assert "PWD" not in dsn
+    assert creds.to_odbc_attrs_before() is None
+
+
+def test_mssql_active_directory_password() -> None:
+    creds = _mssql_credentials(
+        "ActiveDirectoryPassword", username="user@contoso.com", password="pwd"
+    )
+    creds.on_partial()
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert dsn["AUTHENTICATION"] == "ActiveDirectoryPassword"
+    assert dsn["UID"] == "user@contoso.com"
+    assert dsn["PWD"] == "pwd"
+
+
+def test_mssql_active_directory_password_requires_username_password() -> None:
+    creds = _mssql_credentials("ActiveDirectoryPassword")
+    with pytest.raises(ConfigurationException):
+        validate_authentication(creds)
+
+
+def test_mssql_unsupported_authentication_raises() -> None:
+    creds = _mssql_credentials("SqlPassword", username="u", password="p")
+    with pytest.raises(ConfigurationException):
+        creds.on_partial()  # resolves (all present) -> on_resolved -> validate raises
+
+
+def test_mssql_to_odbc_attrs_before_token_struct() -> None:
+    creds = _mssql_credentials("cli")
+    creds._set_default_credentials(_FakeTokenCredential())
+
+    attrs = creds.to_odbc_attrs_before()
+    assert attrs is not None
+    token_struct = attrs[1256]  # SQL_COPT_SS_ACCESS_TOKEN
+    length = struct.unpack("<I", token_struct[:4])[0]
+    assert length == len(token_struct) - 4
+    assert token_struct[4:].decode("utf-16-le") == "fake-access-token"
+
+
+def test_mssql_resolve_configuration_token_authentication() -> None:
+    creds = MsSqlCredentials()
+    creds.host = "sql.example.com"
+    creds.database = "test_db"
+    creds.driver = "ODBC Driver 18 for SQL Server"
+    creds.authentication = "cli"
+
+    resolved = resolve_configuration(creds)
+
+    assert resolved.is_resolved()
+    assert uses_token_authentication(resolved) is True
+    assert type(resolved.default_credentials()).__name__ == "AzureCliCredential"
+    assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()

--- a/tests/load/mssql/test_mssql_configuration.py
+++ b/tests/load/mssql/test_mssql_configuration.py
@@ -13,6 +13,7 @@ from dlt.destinations import mssql
 from dlt.destinations.impl.mssql.configuration import (
     MsSqlClientConfiguration,
     MsSqlCredentials,
+    get_access_token,
     uses_token_authentication,
     validate_authentication,
 )
@@ -380,4 +381,105 @@ def test_mssql_resolve_configuration_token_authentication() -> None:
     assert resolved.is_resolved()
     assert uses_token_authentication(resolved) is True
     assert type(resolved.default_credentials()).__name__ == "DeviceCodeCredential"
+    assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()
+
+
+# ---------------------------------------------------------------------------
+# Injectable access_token / azure_credential (precedence over `authentication`)
+# ---------------------------------------------------------------------------
+
+
+class _RaisingTokenCredential:
+    """A TokenCredential whose `get_token` must never be called (used to prove precedence)."""
+
+    def get_token(self, *scopes: str, **kwargs: object) -> _FakeAccessToken:
+        raise AssertionError("azure_credential.get_token() should not have been called")
+
+
+def test_mssql_access_token_and_azure_credential_default_to_none() -> None:
+    creds = MsSqlCredentials()
+    assert creds.access_token is None
+    assert creds.azure_credential is None
+
+
+def test_mssql_get_access_token_returns_none_without_token_or_credential() -> None:
+    creds = _mssql_credentials("ActiveDirectoryDeviceCode")
+    assert get_access_token(creds) is None
+
+
+def test_mssql_get_access_token_uses_azure_credential() -> None:
+    creds = _mssql_credentials(azure_credential=_FakeTokenCredential())
+    assert get_access_token(creds) == "fake-access-token"
+
+
+def test_mssql_get_access_token_prefers_access_token_over_azure_credential() -> None:
+    creds = _mssql_credentials(
+        access_token="explicit-token", azure_credential=_RaisingTokenCredential()
+    )
+    assert get_access_token(creds) == "explicit-token"
+
+
+def test_mssql_access_token_takes_precedence_over_authentication() -> None:
+    creds = _mssql_credentials(
+        "ActiveDirectoryServicePrincipal",
+        azure_tenant_id="t",
+        azure_client_id="c",
+        azure_client_secret="s",
+        access_token="explicit-token",
+    )
+    creds.on_partial()
+
+    assert uses_token_authentication(creds) is True
+    dsn = creds.get_odbc_dsn_dict()
+    assert "AUTHENTICATION" not in dsn
+    assert "UID" not in dsn
+    assert "PWD" not in dsn
+
+    attrs = creds.to_odbc_attrs_before()
+    assert attrs is not None
+    assert attrs[1256][4:].decode("utf-16-le") == "explicit-token"
+
+
+def test_mssql_azure_credential_takes_precedence_over_authentication() -> None:
+    creds = _mssql_credentials("ActiveDirectoryDeviceCode", azure_credential=_FakeTokenCredential())
+    creds.on_partial()
+
+    # setup_token_credential must skip the azure-identity DefaultAzureCredential machinery
+    assert creds.has_default_credentials() is False
+    assert uses_token_authentication(creds) is True
+
+    dsn = creds.get_odbc_dsn_dict()
+    assert "AUTHENTICATION" not in dsn
+
+    attrs = creds.to_odbc_attrs_before()
+    assert attrs is not None
+    assert attrs[1256][4:].decode("utf-16-le") == "fake-access-token"
+
+
+def test_mssql_resolve_configuration_access_token_without_username_password() -> None:
+    creds = MsSqlCredentials()
+    creds.host = "sql.example.com"
+    creds.database = "test_db"
+    creds.driver = "ODBC Driver 18 for SQL Server"
+    creds.access_token = "explicit-token"
+
+    resolved = resolve_configuration(creds)
+
+    assert resolved.is_resolved()
+    assert uses_token_authentication(resolved) is True
+    assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()
+    assert resolved.to_odbc_attrs_before()[1256][4:].decode("utf-16-le") == "explicit-token"
+
+
+def test_mssql_resolve_configuration_azure_credential_without_username_password() -> None:
+    creds = MsSqlCredentials()
+    creds.host = "sql.example.com"
+    creds.database = "test_db"
+    creds.driver = "ODBC Driver 18 for SQL Server"
+    creds.azure_credential = _FakeTokenCredential()
+
+    resolved = resolve_configuration(creds)
+
+    assert resolved.is_resolved()
+    assert uses_token_authentication(resolved) is True
     assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()

--- a/tests/load/mssql/test_mssql_configuration.py
+++ b/tests/load/mssql/test_mssql_configuration.py
@@ -218,11 +218,6 @@ def test_to_odbc_dsn_driver_not_specified() -> None:
     ]
 
 
-# ---------------------------------------------------------------------------
-# Authentication methods
-# ---------------------------------------------------------------------------
-
-
 class _FakeAccessToken:
     token = "fake-access-token"
 
@@ -382,11 +377,6 @@ def test_mssql_resolve_configuration_token_authentication() -> None:
     assert uses_token_authentication(resolved) is True
     assert type(resolved.default_credentials()).__name__ == "DeviceCodeCredential"
     assert "AUTHENTICATION" not in resolved.get_odbc_dsn_dict()
-
-
-# ---------------------------------------------------------------------------
-# Injectable access_token / azure_credential (precedence over `authentication`)
-# ---------------------------------------------------------------------------
 
 
 class _RaisingTokenCredential:

--- a/tests/load/mssql/test_mssql_docker_auth.py
+++ b/tests/load/mssql/test_mssql_docker_auth.py
@@ -1,0 +1,61 @@
+"""Integration tests for the mssql destination against a local SQL Server.
+
+Start the server with `docker compose up` in this directory (see docker-compose.yml).
+Tests skip automatically when the server is unreachable, so they are safe to run anywhere.
+
+These exercise the real `PyOdbcMsSqlClient.open_connection` code path. SQL Server in Docker
+only supports SQL login (no Entra ID), so token/Azure AD authentication is validated against a
+real Azure SQL / Fabric instance instead, via the parametrized `tests/load` suite.
+"""
+
+import pytest
+
+from dlt.common.configuration import resolve_configuration
+from dlt.common.schema import Schema
+from dlt.destinations.impl.mssql.configuration import MsSqlClientConfiguration, MsSqlCredentials
+
+# mark all tests as essential, do not remove
+pytestmark = pytest.mark.essential
+
+DOCKER_HOST = "localhost"
+DOCKER_DATABASE = "master"
+DOCKER_USERNAME = "sa"
+DOCKER_PASSWORD = "Strong!Passw0rd"
+
+
+def _docker_credentials() -> MsSqlCredentials:
+    creds = MsSqlCredentials()
+    creds.host = DOCKER_HOST
+    creds.database = DOCKER_DATABASE
+    creds.username = DOCKER_USERNAME
+    creds.password = DOCKER_PASSWORD
+    creds.connect_timeout = 5
+    # local container uses a self-signed certificate
+    creds.query = {"trustservercertificate": "yes", "encrypt": "no"}
+    return resolve_configuration(creds)
+
+
+def _sql_client(creds: MsSqlCredentials):
+    from dlt.destinations import mssql
+
+    config = MsSqlClientConfiguration(credentials=creds)._bind_dataset_name("dataset")
+    client = mssql().client(Schema("schema"), config)
+    return client.sql_client
+
+
+def test_mssql_docker_sql_login_opens_connection() -> None:
+    """SQL login (no Azure AD) opens a real connection - attrs_before is skipped."""
+    creds = _docker_credentials()
+    assert creds.to_odbc_attrs_before() is None
+
+    sql_client = _sql_client(creds)
+    try:
+        sql_client.open_connection()
+    except Exception as ex:  # noqa: BLE001
+        pytest.skip(f"Local SQL Server not reachable (run `docker compose up`): {ex}")
+
+    try:
+        rows = sql_client.execute_sql("SELECT 1")
+        assert rows[0][0] == 1
+    finally:
+        sql_client.close_connection()

--- a/uv.lock
+++ b/uv.lock
@@ -859,6 +859,20 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-keyvault-secrets"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b8/03c7b4edd1e3355ad5fffb70e68af70cd09542963f45cf3a2aa9fb3930b5/azure_keyvault_secrets-4.11.0.tar.gz", hash = "sha256:ac14727b9159cca353173ec5a454d8d7b192a6f2f5e7eb540f9fbcf914fa0ca0", size = 112291, upload-time = "2026-04-17T00:52:12.422Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/76/41c513917c0e8dc68de0c33578c6a0668b4a09eb4dc3e2782d382dc2947f/azure_keyvault_secrets-4.11.0-py3-none-any.whl", hash = "sha256:d8543b710423569bd00ada2a2533fe83d52d8e1fe026e1c47f41a3bc0fc73ef5", size = 103148, upload-time = "2026-04-17T00:52:13.796Z" },
+]
+
+[[package]]
 name = "azure-storage-blob"
 version = "12.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2543,6 +2557,10 @@ athena = [
 az = [
     { name = "adlfs" },
 ]
+azure-key-vault = [
+    { name = "azure-identity" },
+    { name = "azure-keyvault-secrets" },
+]
 bigquery = [
     { name = "db-dtypes" },
     { name = "gcsfs" },
@@ -2828,6 +2846,8 @@ requires-dist = [
     { name = "adlfs", marker = "extra == 'synapse'", specifier = ">=2024.7.0" },
     { name = "aiohttp", marker = "extra == 'http'", specifier = ">3.9.0" },
     { name = "alembic", marker = "extra == 'sqlalchemy'", specifier = ">1.10.0" },
+    { name = "azure-identity", marker = "extra == 'azure-key-vault'", specifier = ">=1.12.0" },
+    { name = "azure-keyvault-secrets", marker = "extra == 'azure-key-vault'", specifier = ">=4.7.0" },
     { name = "botocore", marker = "extra == 'athena'", specifier = ">=1.28" },
     { name = "botocore", marker = "extra == 'filesystem'", specifier = ">=1.28" },
     { name = "botocore", marker = "extra == 's3'", specifier = ">=1.28" },
@@ -2933,7 +2953,7 @@ requires-dist = [
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = ">=4.0.0,<5.0.0" },
     { name = "win-precise-time", marker = "python_full_version < '3.13' and os_name == 'nt'", specifier = ">=1.4.2" },
 ]
-provides-extras = ["hub", "gcp", "bigquery", "postgres", "redshift", "parquet", "polars", "duckdb", "ducklake", "filesystem", "s3", "gs", "az", "hf", "sftp", "http", "snowflake", "motherduck", "cli", "athena", "weaviate", "mssql", "synapse", "fabric", "oracle", "qdrant", "databricks", "clickhouse", "dremio", "lancedb", "lance", "deltalake", "sql-database", "sqlalchemy", "pyiceberg", "postgis", "dbml"]
+provides-extras = ["hub", "gcp", "bigquery", "postgres", "redshift", "parquet", "polars", "duckdb", "ducklake", "filesystem", "s3", "gs", "az", "azure-key-vault", "hf", "sftp", "http", "snowflake", "motherduck", "cli", "athena", "weaviate", "mssql", "synapse", "fabric", "oracle", "qdrant", "databricks", "clickhouse", "dremio", "lancedb", "lance", "deltalake", "sql-database", "sqlalchemy", "pyiceberg", "postgis", "dbml"]
 
 [package.metadata.requires-dev]
 adbc = [

--- a/uv.lock
+++ b/uv.lock
@@ -2558,6 +2558,7 @@ az = [
     { name = "adlfs" },
 ]
 azure-key-vault = [
+    { name = "azure-core" },
     { name = "azure-identity" },
     { name = "azure-keyvault-secrets" },
 ]
@@ -2846,6 +2847,7 @@ requires-dist = [
     { name = "adlfs", marker = "extra == 'synapse'", specifier = ">=2024.7.0" },
     { name = "aiohttp", marker = "extra == 'http'", specifier = ">3.9.0" },
     { name = "alembic", marker = "extra == 'sqlalchemy'", specifier = ">1.10.0" },
+    { name = "azure-core", marker = "extra == 'azure-key-vault'", specifier = ">=1.31.0" },
     { name = "azure-identity", marker = "extra == 'azure-key-vault'", specifier = ">=1.12.0" },
     { name = "azure-keyvault-secrets", marker = "extra == 'azure-key-vault'", specifier = ">=4.7.0" },
     { name = "botocore", marker = "extra == 'athena'", specifier = ">=1.28" },


### PR DESCRIPTION
## Summary

Adds `AzureKeyVaultProvider` as a new `VaultDocProvider`, allowing users to load dlt configuration and secrets from Azure Key Vault. Follows the same architecture as the existing Google Secrets and AWS Secrets Manager providers.

- New `AzureKeyVaultProvider` class with thread-safe lazy client initialization
- Credential resolution: an explicitly passed credential wins; inside the Microsoft Fabric runtime the provider authenticates through NotebookUtils; everywhere else it falls back to `DefaultAzureCredential`
- Secret name normalization replaces underscores with hyphens to comply with Azure Key Vault naming constraints (alphanumeric + hyphens only)
- Uses `--` (double hyphen) as section separator to avoid ambiguity with hyphens in key names
- Overrides `_update_from_vault` to normalize `SECRETS_TOML_KEY` (which contains underscores) before vault lookup
- Configuration via `enable_azure_key_vault` flag and `PROVIDERS__AZURE_KEY_VAULT__VAULT_URL`
- Optional dependencies via `dlt[azure_key_vault]` extra (`azure-keyvault-secrets`, `azure-identity`, `azure-core>=1.31.0`)
- Consistent error handling for `HttpResponseError`, `ResourceNotFoundError`, and `ServiceRequestError`

Closes #4076

## Dependency on #4147

This branch is stacked on #4147, which adds `FabNotebookUtilsCredential` and `is_fab_notebookutils_available()` in `dlt/common/runtime/fab_notebookutils.py`. **Please review and merge #4147 first**; the diff shown here includes its commits until it lands.

The dependency exists because `DefaultAzureCredential` cannot sign in inside a Fabric notebook: there are no environment variables, managed identity or CLI login to fall back on. NotebookUtils exposes the notebook owner's identity instead, which is what makes Key Vault usable from a Fabric notebook at all. The provider requests the documented `keyvault` audience.

GitHub cannot express this as a real stacked PR: both branches live in a fork, and a cross-fork PR must have its base in the upstream repository.

## Test plan

- 20 unit tests with a mocked `SecretClient` covering lookup, listing, key normalization, error handling, client caching, credential resolution (NotebookUtils, explicit, `DefaultAzureCredential`) and factory creation.
- 10 integration tests in `tests/helpers/providers/test_azure_key_vault_provider.py`, run against a real Azure Key Vault. They skip unless `DLT_TEST_AZURE_KEY_VAULT_URL` is set, so they are safe in CI. Verified green against a live vault, covering exact and sectioned lookups, missing keys, listing, underscore-to-hyphen normalization through `get_value`, and client caching.
- Two of those tests pin behaviour that is easy to regress: with the default `only_toml_fragments` an exact key is deliberately **not** fetched, and with the default `only_secrets` a non-secret hint is **not** fetched.
- The `FabNotebookUtilsCredential` was verified to satisfy `azure-keyvault-secrets`: a real `SecretClient` authenticates with it and reads a secret, and the provider resolves secrets end to end through it.
- Inside a real Fabric notebook the provider selects `FabNotebookUtilsCredential(audience="keyvault")`, and an explicitly supplied credential still takes precedence.
- The integration tests skip cleanly when the vault is reachable but the fixture secrets are absent, so a partially set up vault does not produce failures.
- Re-verified after rebasing onto the current `devel`: 30/30 green against a freshly created Azure Key Vault (20 mocked, 10 integration), including the exact-key, sectioned, listing and `only_toml_fragments`/`only_secrets` default-behaviour cases.

The `azure-core>=1.31.0` floor comes out of that Fabric run: `azure-keyvault-secrets` imports `AccessTokenInfo`, which azure-core only gained in 1.31.0, so runtimes shipping an older azure-core (Fabric notebooks among them) failed at import time until the extra pinned it.
