### PR TITLE
fix: avoid collisions in compound SCD2 merge keys

### DIFF
--- a/dlt/destinations/impl/athena/athena.py
+++ b/dlt/destinations/impl/athena/athena.py
@@ -135,7 +135,7 @@ class AthenaMergeJob(SqlMergeFollowupJob):
     def gen_concat_sql(cls, columns: Sequence[str]) -> str:
         # Athena requires explicit casting
         columns = [f"CAST({c} AS VARCHAR)" for c in columns]
-        return f"CONCAT({', '.join(columns)})"
+        return "CONCAT(" + ", '\\x1f', ".join(columns) + ")"
 
     @classmethod
     def requires_temp_table_for_delete(cls) -> bool:

--- a/dlt/destinations/impl/sqlalchemy/merge_job.py
+++ b/dlt/destinations/impl/sqlalchemy/merge_job.py
@@ -345,6 +345,7 @@ class SqlalchemyMergeFollowupJob(SqlMergeFollowupJob):
         # Cast because CONCAT is only generated for string columns
         result = sa.cast(result, sa.String)
         for col in columns[1:]:
+            result = operator.add(result, sa.literal("\\x1f"))
             result = operator.add(result, sa.cast(col, sa.String))
         return result  # type: ignore[no-any-return]
 

--- a/dlt/destinations/sql_jobs.py
+++ b/dlt/destinations/sql_jobs.py
@@ -375,7 +375,9 @@ class SqlMergeFollowupJob(SqlFollowupJob):
 
     @classmethod
     def gen_concat_sql(cls, columns: Sequence[str]) -> str:
-        return f"CONCAT({', '.join(columns)})"
+        # Keep key components separate: CONCAT(a, b) makes ("ab", "c") and
+        # ("a", "bc") compare equal when scoping SCD2 record retirement.
+        return "CONCAT(" + ", '\\x1f', ".join(columns) + ")"
 
     @classmethod
     def _shorten_table_name(cls, ident: str, sql_client: SqlClientBase[Any]) -> str:

--- a/tests/load/pipeline/test_scd2.py
+++ b/tests/load/pipeline/test_scd2.py
@@ -962,6 +962,51 @@ def test_merge_key_compound_natural_key(
     destinations_configs(default_sql_configs=True, supports_merge=True),
     ids=lambda x: x.name,
 )
+def test_merge_key_compound_natural_key_does_not_collide(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    p = destination_config.setup_pipeline("abstract", dev_mode=True)
+
+    @dlt.resource(
+        merge_key=["document_number", "line_id"],
+        write_disposition={"disposition": "merge", "strategy": "scd2"},
+    )
+    def dim_test_compound(data):
+        yield data
+
+    # These compound keys both form "doc-712" when concatenated without a separator.
+    dim_snap = [
+        {"document_number": "doc-7", "line_id": "12", "status": "original-a"},
+        {"document_number": "doc-71", "line_id": "2", "status": "original-b"},
+    ]
+    info = p.run(dim_test_compound(dim_snap), **destination_config.run_kwargs)
+    assert_load_info(info)
+
+    # Only the first key changes. The second key must stay active.
+    info = p.run(
+        dim_test_compound([{"document_number": "doc-7", "line_id": "12", "status": "changed-a"}]),
+        **destination_config.run_kwargs,
+    )
+    assert_load_info(info)
+    ts = get_load_package_created_at(p, info)
+    actual = [
+        {k: v for k, v in row.items() if k in ("document_number", "line_id", "status", TO)}
+        for row in get_table(p, "dim_test_compound", ts_columns=[FROM, TO])
+    ]
+    expected = [
+        {"document_number": "doc-7", "line_id": "12", "status": "original-a", TO: ts},
+        {"document_number": "doc-7", "line_id": "12", "status": "changed-a", TO: None},
+        {"document_number": "doc-71", "line_id": "2", "status": "original-b", TO: None},
+    ]
+    assert_records_as_set(actual, expected)  # type: ignore[arg-type]
+
+
+@pytest.mark.essential
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, supports_merge=True),
+    ids=lambda x: x.name,
+)
 def test_merge_key_partition(
     destination_config: DestinationTestConfiguration,
 ) -> None:


### PR DESCRIPTION
### Description

Avoid ambiguous compound-key comparisons when SCD2 identifies records to retire. Without a separator, `("doc-7", "12")` and `("doc-71", "2")` both become `doc-712`, which can retire an unrelated active record.

This adds a separator between key components in the shared SQL implementation and its Athena and SQLAlchemy variants, with a regression test for the collision.

### Related Issues

Closes #4274

### Validation

- `uv run ruff check dlt/destinations/sql_jobs.py dlt/destinations/impl/athena/athena.py dlt/destinations/impl/sqlalchemy/merge_job.py tests/load/pipeline/test_scd2.py`
- 6 focused native-DuckDB SCD2 tests, including the new collision regression
