### PR TITLE
fix(dbt): default athena work group to primary

### DIFF
--- a/dlt/helpers/dbt/profiles.yml
+++ b/dlt/helpers/dbt/profiles.yml
@@ -140,7 +140,7 @@ athena:
       schema: "{{ var('destination_dataset_name', var('source_dataset_name')) }}"
       database: "{{ env_var('DLT__AWS_DATA_CATALOG') }}"
       # aws_profile_name: "{{ env_var('DLT__CREDENTIALS__PROFILE_NAME', '') }}"
-      work_group: "{{ env_var('DLT__ATHENA_WORK_GROUP', '') }}"
+      work_group: "{{ env_var('DLT__ATHENA_WORK_GROUP', 'primary') }}"
 
 
 mssql:


### PR DESCRIPTION
Default the athena `work_group` in dbt profiles.yml to `primary` instead of an empty string, looks lie newer dbt-athena passes the empty value through.