### PR TITLE
fix(incremental): do not close bounded source on all-null arrow cursor batch

### DIFF
--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -506,7 +506,11 @@ class ArrowIncremental(IncrementalTransform):
                 ) from ex
             # Is max row value higher than end value?
             # NOTE: pyarrow bool *always* evaluates to python True. `as_py()` is necessary
-            end_out_of_range = not self.end_compare(row_value_scalar, end_value_scalar).as_py()
+            end_compare_result = self.end_compare(row_value_scalar, end_value_scalar).as_py()
+            # NOTE: a null result means the batch has no comparable cursor value (ie. the
+            # cursor column is all nulls). That is not evidence that end_value was crossed,
+            # so we must not close a `row_order` bounded source because of it.
+            end_out_of_range = end_compare_result is False
             if end_out_of_range:
                 tbl = tbl.filter(self.end_compare(tbl[cursor_path], end_value_scalar))
                 # NOTE: here we should recalculate row_value_scalar and row_value because it was out of range!

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -924,6 +924,32 @@ def test_cursor_path_none_excludes_records_and_updates_incremental_cursor(
     assert s["last_value"] == 2
 
 
+def test_all_null_arrow_batch_does_not_close_bounded_ascending_source() -> None:
+    """A null-only cursor batch must not be read as crossing `end_value` (issue #4284)."""
+    requested_pages = []
+
+    @dlt.resource
+    def pages(
+        ts=dlt.sources.incremental(
+            "ts",
+            initial_value=0,
+            end_value=10,
+            row_order="asc",
+            on_cursor_value_missing="exclude",
+        ),
+    ):
+        requested_pages.append(1)
+        yield pa.table({"id": [1, 2], "ts": pa.array([None, None], type=pa.int64())})
+
+        requested_pages.append(2)
+        yield pa.table({"id": [3, 4], "ts": [5, 6]})
+
+    result = list(pages())
+
+    assert requested_pages == [1, 2]
+    assert [row["ts"] for tbl in result for row in tbl.to_pylist()] == [5, 6]
+
+
 @pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
 def test_cursor_path_none_can_raise_on_none_1(item_type: TestDataItemFormat) -> None:
     data = [


### PR DESCRIPTION
### Description

`ArrowIncremental.__call__` computed `end_out_of_range` as `not self.end_compare(...).as_py()`. When an Arrow batch's cursor column is entirely null, both the aggregate and the comparison are null, so `.as_py()` returns `None` and the flag became `True`. With `row_order="asc"`, `Incremental.can_close()` reads that as the upper bound being crossed and closes the source pipe, silently dropping every later batch.

The flag is now only set when the comparison is explicitly `False`, so a null result means "no comparable cursor value in this batch" rather than out-of-range.

### Related Issues

- Fixes #4284

### Additional Context

New test `test_all_null_arrow_batch_does_not_close_bounded_ascending_source` fails on `devel` (only page 1 requested, no rows) and passes with the fix. `tests/extract/test_incremental.py -k "end_value or cursor_path_none or row_order"` is baseline-identical here (same pre-existing env failures with and without the change).
