### PR TITLE
fix(workspace): do not follow symlinks when selecting deployment files

### DIFF
--- a/dlt/_workspace/deployment/file_selector.py
+++ b/dlt/_workspace/deployment/file_selector.py
@@ -83,7 +83,9 @@ class WorkspaceFileSelector(BaseFileSelector):
         from pathspec.util import iter_tree_files
 
         root_path = Path(self.root_path)
-        for file_path in iter_tree_files(self.root_path):
+        # do not follow symlinks: a symlink pointing at one of its own parents makes
+        # `iter_tree_files` recurse until it raises RecursionError
+        for file_path in iter_tree_files(self.root_path, follow_links=False):
             if not self.ignore_spec.match_file(file_path):
                 yield root_path / file_path, Path(file_path)
 

--- a/tests/workspace/deployment/test_file_selector.py
+++ b/tests/workspace/deployment/test_file_selector.py
@@ -110,6 +110,22 @@ def test_default_ignores_applied_without_ignore_file() -> None:
         assert "empty_file.py" in files
 
 
+def test_file_selector_does_not_follow_symlink_loops() -> None:
+    """A symlink pointing at one of its own parents must not make iteration recurse."""
+    with isolated_workspace("default") as ctx:
+        root = Path(ctx.run_dir)
+        looping_dir = root / "looping"
+        looping_dir.mkdir(exist_ok=True)
+        (looping_dir / "somefile.py").write_text("x")
+        os.symlink(looping_dir, looping_dir / "self")
+
+        selector = WorkspaceFileSelector(ctx, ignore_file=".ignorefile")
+        files = {rel.as_posix() for _, rel in selector}
+
+        assert "looping/somefile.py" in files
+        assert "ducklake_pipeline.py" in files
+
+
 def test_default_ignores_not_applied_with_ignore_file() -> None:
     """DEFAULT_IGNORES patterns are NOT applied when an ignore file exists."""
     with isolated_workspace("default") as ctx:


### PR DESCRIPTION
### Description

`WorkspaceFileSelector.__iter__` walked the workspace with pathspec's `iter_tree_files`, which follows symlinks by default. A symlink pointing at one of its own parent directories makes the walk recurse until it raises `RecursionError`, so `dlthub pipeline run` failed outright — and adding the directory to `.gitignore` did not help, because the tree is walked before the ignore patterns are applied.

Passing `follow_links=False` makes the walk yield the link itself without descending through it.

### Related Issues

- Fixes #4273

### Additional Context

Added `test_file_selector_does_not_follow_symlink_loops` next to the existing selector tests; it fails with `RecursionError` without the change and passes with it. `tests/workspace/deployment/test_file_selector.py` is green (8 passed).
