### PR TITLE
(feat) emit input/output lineage in traces

### DIFF
--- a/dlt/common/configuration/specs/connection_string_credentials.py
+++ b/dlt/common/configuration/specs/connection_string_credentials.py
@@ -46,6 +46,16 @@ class ConnectionStringCredentials(CredentialsConfiguration):
         except Exception:
             raise InvalidConnectionString(self.__class__, native_value, self.drivername)
 
+    def physical_location(self) -> str:
+        """Returns a human readable location of the data, ie. `postgresql://example.com:5432`."""
+        if self.host:
+            address = f"{self.host}:{self.port}" if self.port else self.host
+        else:
+            # file and memory backends have no server, the database locates them
+            address = self.database or ""
+        backend = self.drivername.split("+")[0] if self.drivername else ""
+        return f"{backend}://{address}" if backend else address
+
     def on_resolved(self) -> None:
         if self.password:
             self.password = self.password.strip()

--- a/dlt/common/destination/reference.py
+++ b/dlt/common/destination/reference.py
@@ -28,7 +28,12 @@ from dlt.common.destination.exceptions import (
     InvalidDestinationReference,
     UnknownDestinationModule,
 )
-from dlt.common.destination.client import DestinationClientConfiguration, JobClientBase
+from dlt.common.destination.client import (
+    DestinationClientConfiguration,
+    DestinationClientDwhConfiguration,
+    JobClientBase,
+)
+from dlt.common.metrics import TDatasetDataLocation, TSchemaReference, data_location_version
 from dlt.common.runtime.run_context import get_plugin_modules
 from dlt.common.schema.schema import Schema
 from dlt.common.typing import is_subclass
@@ -468,3 +473,56 @@ class DestinationReference:
             return refs
 
         return []
+
+
+def describe_dataset_location(
+    config: DestinationClientConfiguration,
+    caps: DestinationCapabilitiesContext,
+    schemas: Sequence[Schema],
+    resource_name: str,
+    tables: Sequence[str] = (),
+    physical_dataset_name: str = None,
+) -> TDatasetDataLocation:
+    """Describes the dataset bound to `config` as a data location recorded in the pipeline trace.
+
+    Both sides of the lineage graph are described here, so a dataset written by one run and read by
+    another compares field for field. Destinations without a dataset (ie. reverse ETL sinks) get no
+    dataset names. Table names are added by the caller, which knows what was touched.
+
+    Args:
+        config (DestinationClientConfiguration): Resolved configuration of the client in use.
+        caps (DestinationCapabilitiesContext): Runtime adjusted capabilities of the client in use.
+        schemas (Sequence[Schema]): Schemas holding the tables, the first one being the default.
+        resource_name (str): Resource that read from or wrote to the dataset.
+        tables (Sequence[str]): Tables the resource touched inside the dataset.
+        physical_dataset_name (str): Already normalized dataset name. Computed from `config` and the
+            default schema if not passed, which may emit the dataset normalization warning.
+
+    Returns:
+        TDatasetDataLocation: Destination identity, both dataset names, schemas and their version.
+    """
+    schema_refs: List[TSchemaReference] = [
+        {"name": schema.name, "version_hash": schema.version_hash} for schema in schemas
+    ]
+    location: TDatasetDataLocation = {
+        "kind": "dataset",
+        "resource_name": resource_name,
+        # a sink has no public location, its identity is carried only by the fingerprint
+        "location": config.physical_location(),
+        "version": data_location_version(schema_refs),
+        "schemas": schema_refs,
+        "tables": list(tables),
+        "destination_type": DestinationReference.normalize_type(config.destination_type),
+        "destination_name": config.destination_name or Destination.to_name(config.destination_type),
+        "destination_fingerprint": config.fingerprint(),
+        "casefold": getattr(caps.casefold_identifier, "__name__", "str"),
+        "case_sensitive": caps.has_case_sensitive_identifiers,
+    }
+    if isinstance(config, DestinationClientDwhConfiguration):
+        location["dataset_name"] = config._make_dataset_name(schemas[0].name)
+        location["physical_dataset_name"] = (
+            physical_dataset_name
+            if physical_dataset_name is not None
+            else config.normalize_dataset_name(schemas[0])
+        )
+    return without_none(location)  # type: ignore[return-value]

--- a/dlt/common/metrics.py
+++ b/dlt/common/metrics.py
@@ -11,7 +11,8 @@ from typing import (
     Tuple,
     TypeVar,
 )  # noqa: 251
-from dlt.common.typing import TypedDict
+from dlt.common.typing import NotRequired, TypedDict
+from dlt.common.utils import digest128
 
 TJobKey = TypeVar("TJobKey")
 
@@ -100,6 +101,58 @@ class ExtractDataInfo(TypedDict):
     data_type: str
 
 
+class TDataLocation(TypedDict):
+    """A logical data source or target: a dataset of tables, an API of endpoints, a bucket of files.
+
+    One entry per location. What a resource touched inside it is listed by the `kind`-specific
+    subclass. Only facts that some locations genuinely lack are not required, so a row keeps the
+    same shape whatever it describes.
+    """
+
+    kind: str
+    """Location type: `dataset`, `sql_database`, `filesystem`, `rest_api`, or a custom value."""
+    resource_name: str
+    """Resource that read from or wrote to this location, authoritative when metrics are collected."""
+    location: str
+    """Non-secret scope of the location, e.g. `postgresql://example.com:5432`, `s3://bucket`.
+
+    Empty when the location has no public address, ie. a reverse ETL sink.
+    """
+    version: NotRequired[str]
+    """Version of the location's contents as a whole."""
+
+
+class TSchemaReference(TypedDict):
+    name: str
+    version_hash: str
+
+
+class TDatasetDataLocation(TDataLocation):
+    """A dlt dataset: one or more schemas, holding tables, in a destination."""
+
+    schemas: List[TSchemaReference]
+    """Schemas grouping the tables, each carrying its own version hash."""
+    tables: List[str]
+    """Tables touched, as plain names - dlt qualifies tables by dataset, not by schema."""
+    destination_type: str
+    destination_name: str
+    destination_fingerprint: str
+    """Identifies destinations whose `location` is not public, ie. motherduck. May be empty."""
+    casefold: str
+    """Name of the casefolding function the destination applies: `upper`, `lower` or `str`."""
+    case_sensitive: bool
+    """Whether the destination generates case sensitive identifiers, as adjusted at runtime."""
+    dataset_name: NotRequired[str]
+    """Logical dataset name as configured by the user, e.g. `My_DataSet`. Absent for sinks."""
+    physical_dataset_name: NotRequired[str]
+    """Normalized name as it exists in the store, e.g. `my_data_set`. Absent for sinks."""
+
+
+def data_location_version(schemas: Sequence[TSchemaReference]) -> str:
+    """Hashes the version hashes of `schemas` into a single version of the location contents."""
+    return digest128("".join(sorted(schema.get("version_hash") or "" for schema in schemas)))
+
+
 class ExtractMetrics(StepMetrics):
     schema_name: str
     job_metrics: Dict[str, DataWriterMetrics]
@@ -112,6 +165,8 @@ class ExtractMetrics(StepMetrics):
     """A resource dag where elements of the list are graph edges"""
     hints: Dict[str, Dict[str, Any]]
     """Hints passed to the resources"""
+    inputs: List[TDataLocation]
+    """Locations read from, one entry per (resource, location)"""
 
 
 class NormalizeMetrics(StepMetrics):
@@ -136,3 +191,6 @@ class LoadJobMetrics(NamedTuple):
 class LoadMetrics(StepMetrics):
     job_metrics: Dict[str, LoadJobMetrics]
     dataset_name: Optional[str]
+    """Physical dataset name, normalized as it exists in the destination"""
+    outputs: List[TDatasetDataLocation]
+    """Locations written to, one entry per (resource, location)"""

--- a/dlt/common/pipeline.py
+++ b/dlt/common/pipeline.py
@@ -225,6 +225,7 @@ class ExtractInfo(StepInfo[ExtractMetrics], _ExtractInfo):
             "resource_metrics": [],
             "dag": [],
             "hints": [],
+            "inputs": [],
         }
         for load_id, metrics_list in self.metrics.items():
             for idx, metrics in enumerate(metrics_list):
@@ -245,6 +246,10 @@ class ExtractInfo(StepInfo[ExtractMetrics], _ExtractInfo):
                         {**extend, "resource_name": name, **hints}
                         for name, hints in metrics["hints"].items()
                     ]
+                )
+                # traces restored from an older dlt have no inputs
+                load_metrics["inputs"].extend(
+                    [{**extend, **location} for location in metrics.get("inputs", [])]
                 )
                 load_metrics["job_metrics"].extend(
                     self.writer_metrics_asdict(metrics["job_metrics"], extend=extend)
@@ -348,7 +353,7 @@ class LoadInfo(StepInfo[LoadMetrics], _LoadInfo):
         d = super().asdict()
         # transform metrics
         d.pop("metrics")
-        load_metrics: Dict[str, List[Any]] = {"job_metrics": []}
+        load_metrics: Dict[str, List[Any]] = {"job_metrics": [], "outputs": []}
         for load_id, metrics_list in self.metrics.items():
             # one set of metrics per package id
             assert len(metrics_list) == 1
@@ -361,6 +366,10 @@ class LoadInfo(StepInfo[LoadMetrics], _LoadInfo):
                         **job_metrics._asdict(),
                     }
                 )
+            # traces restored from an older dlt have no outputs
+            load_metrics["outputs"].extend(
+                [{"load_id": load_id, **location} for location in metrics.get("outputs", [])]
+            )
 
         d.update(load_metrics)
         return d

--- a/dlt/extract/exceptions.py
+++ b/dlt/extract/exceptions.py
@@ -123,6 +123,17 @@ class ResourceNameMissing(DltResourceException):
         )
 
 
+class DataLocationKindRequired(DltResourceException):
+    def __init__(self, resource_name: str) -> None:
+        super().__init__(
+            resource_name,
+            f"Resource `{resource_name}` does not belong to a source, so `kind` of a recorded data"
+            " location cannot default to the source name. Pass `kind` explicitly. Note that a"
+            " resource joins its source only after the source function returns, so the default is"
+            " not available to code recording inputs while the source is still being created.",
+        )
+
+
 class ResourceNotFoundError(DltResourceException, KeyError):
     def __init__(self, resource_name: str, context: str) -> None:
         self.resource_name = resource_name

--- a/dlt/extract/extract.py
+++ b/dlt/extract/extract.py
@@ -12,6 +12,7 @@ from dlt.common.data_writers.writers import TDataItemFormat
 from dlt.common.metrics import (
     EMPTY_DATA_WRITER_METRICS,
     DataWriterAndCustomMetrics,
+    TDataLocation,
     aggregate_job_metrics,
 )
 from dlt.common.pipeline import (
@@ -400,6 +401,12 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
                     continue
                 hints[name] = hint
 
+        inputs: List[TDataLocation] = []
+        for resource in {r._pipe.instance_id: r for r in source.resources.extracted}.values():
+            inputs.extend(
+                {**location, "resource_name": resource.name} for location in resource.inputs
+            )
+
         return {
             "started_at": None,
             "finished_at": None,
@@ -409,6 +416,7 @@ class Extract(WithStepInfo[ExtractMetrics, ExtractInfo]):
             "resource_metrics": resource_metrics,
             "dag": source.resources.selected_dag,
             "hints": clean_hints,
+            "inputs": inputs,
         }
 
     def _handle_empty_tables(

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -8,6 +8,7 @@ from typing import (
     Iterable,
     Iterator,
     Generator,
+    List,
     Type,
     Union,
     Any,
@@ -16,6 +17,8 @@ from typing import (
 )
 
 from dlt.common import logger
+from dlt.common.exceptions import TypeErrorWithKnownTypes
+from dlt.common.metrics import TDataLocation
 from dlt.common.configuration.inject import get_fun_spec, with_config
 from dlt.common.configuration.resolve import inject_section
 from dlt.common.configuration.specs import BaseConfiguration, known_sections
@@ -141,6 +144,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         self.source_name = None
         self._parent: DltResource = None
         self._custom_metrics: Dict[str, Any] = {}
+        self._inputs: List[TDataLocation] = []
         super().__init__(hints)
         self._update_wrapper()
 
@@ -226,6 +230,39 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
     def custom_metrics(self) -> Dict[str, Any]:
         """Customizable resource metrics"""
         return self._custom_metrics
+
+    @property
+    def inputs(self) -> List[TDataLocation]:
+        """Data locations this resource read from, recorded during extraction."""
+        return self._inputs
+
+    def add_input(self, location: TDataLocation) -> Self:
+        """Records a data location this resource reads from, to be emitted in the pipeline trace.
+
+        Call on the resource instance when it is created, or from inside a running resource via
+        `dlt.current.resource()` when the location is only known once config is resolved. One entry
+        per location, listing the tables, endpoints or files touched inside it - not one entry per
+        table. `kind` defaults to the name of the source this resource belongs to.
+
+        Args:
+            location (TDataLocation): Location that was read, or a `kind`-specific subclass of it.
+
+        Returns:
+            DltResource: returns self
+
+        Raises:
+            TypeErrorWithKnownTypes: If `location` is not a mapping.
+        """
+        if not isinstance(location, dict):
+            raise TypeErrorWithKnownTypes("location", location, ["TDataLocation"])
+        # a fact that could not be established is absent from the row, not null
+        described: DictStrAny = dict(without_none(location))
+        if not described.get("kind") and self.source_name:
+            described["kind"] = self.source_name
+        # a resource instance may be extracted more than once, a location is still listed once
+        if described not in self._inputs:
+            self._inputs.append(cast(TDataLocation, described))
+        return self
 
     @property
     def name(self) -> str:

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -77,6 +77,7 @@ from dlt.extract.pipe import Pipe
 from dlt.extract.hints import DltResourceHints, HintsMeta, TResourceHints
 from dlt.extract.incremental import Incremental, IncrementalResourceWrapper
 from dlt.extract.exceptions import (
+    DataLocationKindRequired,
     InvalidTransformerDataTypeGeneratorFunctionRequired,
     InvalidParentResourceDataType,
     InvalidParentResourceIsAFunction,
@@ -242,7 +243,8 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         Call on the resource instance when it is created, or from inside a running resource via
         `dlt.current.resource()` when the location is only known once config is resolved. One entry
         per location, listing the tables, endpoints or files touched inside it - not one entry per
-        table. `kind` defaults to the name of the source this resource belongs to.
+        table. `kind` defaults to the name of the source this resource belongs to, and must be
+        passed explicitly by a resource that has no source yet.
 
         Args:
             location (TDataLocation): Location that was read, or a `kind`-specific subclass of it.
@@ -254,18 +256,19 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
 
         Raises:
             TypeErrorWithKnownTypes: If `location` is not a mapping.
+            DataLocationKindRequired: If `kind` is absent and there is no source to default it from.
         """
         if not isinstance(location, dict):
             raise TypeErrorWithKnownTypes("location", location, ["TDataLocation"])
         # a fact that could not be established is absent from the row, not null
         described: DictStrAny = dict(without_none(location))
-        if not described.get("kind") and self.source_name:
+        if not described.get("kind"):
+            if not self.source_name:
+                raise DataLocationKindRequired(self.name)
             described["kind"] = self.source_name
         if replace:
             self._inputs.clear()
-        # a resource instance may be extracted more than once, a location is still listed once
-        if described not in self._inputs:
-            self._inputs.append(cast(TDataLocation, described))
+        self._inputs.append(cast(TDataLocation, described))
         return self
 
     @property

--- a/dlt/extract/resource.py
+++ b/dlt/extract/resource.py
@@ -236,7 +236,7 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         """Data locations this resource read from, recorded during extraction."""
         return self._inputs
 
-    def add_input(self, location: TDataLocation) -> Self:
+    def add_input(self, location: TDataLocation, replace: bool = False) -> Self:
         """Records a data location this resource reads from, to be emitted in the pipeline trace.
 
         Call on the resource instance when it is created, or from inside a running resource via
@@ -246,6 +246,8 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
 
         Args:
             location (TDataLocation): Location that was read, or a `kind`-specific subclass of it.
+            replace (bool): Drops the locations recorded so far and records `location` as the only
+                one.
 
         Returns:
             DltResource: returns self
@@ -259,6 +261,8 @@ class DltResource(Iterable[TDataItem], DltResourceHints):
         described: DictStrAny = dict(without_none(location))
         if not described.get("kind") and self.source_name:
             described["kind"] = self.source_name
+        if replace:
+            self._inputs.clear()
         # a resource instance may be extracted more than once, a location is still listed once
         if described not in self._inputs:
             self._inputs.append(cast(TDataLocation, described))

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -19,6 +19,7 @@ from dlt.common.storages.load_storage import (
 )
 from dlt.common.storages.load_package import (
     LoadPackageStateInjectableContext,
+    TLoadPackageStatus,
     commit_load_package_state,
     load_package_state as current_load_package,
 )
@@ -650,17 +651,24 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                     self._maybe_truncate_staging_dataset(schema, job_client)
 
         self.load_storage.complete_load_package(load_id, aborted)
-        self.gather_metrics(load_id, finished=True)
+        self.gather_metrics(load_id, schema, "aborted" if aborted else "loaded")
         # delete jobs only after metrics collected
         self.load_storage.maybe_remove_completed_jobs(load_id)
         logger.info(
             f"All jobs completed, archiving package {load_id} with aborted set to {aborted}"
         )
 
-    def gather_metrics(self, load_id: str, finished: bool) -> None:
+    def gather_metrics(self, load_id: str, schema: Schema, state: TLoadPackageStatus) -> None:
         # collect package info
-        self._loaded_packages.append(self.load_storage.get_load_package_info(load_id))
-        self._step_info_complete_load_id(load_id, finished=finished)
+        package_info = self.load_storage.get_load_package_info(load_id)
+        self._loaded_packages.append(package_info)
+        if state == "loaded":
+            metrics = self._step_info_metrics(load_id)[0]
+            # `dataset_name` was normalized when the metrics were first recorded
+            metrics["outputs"] = self._compute_outputs(
+                schema, *self._output_context(schema), metrics["dataset_name"]
+            )
+        self._step_info_complete_load_id(load_id, finished=state in ("aborted", "loaded"))
 
     def initialize_package(
         self, load_id: str, schema: Schema, new_jobs: List[ParsedLoadJobFileName]
@@ -749,7 +757,6 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         dataset_name: Optional[str] = None
         if isinstance(self.initial_client_config, DestinationClientDwhConfiguration):
             dataset_name = self.initial_client_config.normalize_dataset_name(schema)
-        caps, tables_by_resource = self._output_context(schema)
         # loop until all jobs are processed
         pending_exception: Optional[LoadClientJobException] = None
         while True:
@@ -778,14 +785,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                 running_jobs += self.start_new_jobs(load_id, schema, running_jobs)
 
             # update metrics on each run so they are available even in exception
-            metrics: LoadMetrics = {
-                "started_at": None,
-                "finished_at": None,
-                "job_metrics": self._job_metrics,
-                "dataset_name": dataset_name,
-                "outputs": self._compute_outputs(schema, caps, tables_by_resource, dataset_name),
-            }
-            self._step_info_update_metrics(load_id, metrics)
+            self._step_info_update_metrics(load_id, self._package_metrics(dataset_name))
 
             if len(running_jobs) > 0:
                 # wakes when managed job enters terminal state (in the pool)
@@ -808,10 +808,10 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
             elif isinstance(pending_exception, LoadClientJobTerminalRetry):
                 # created only with raise_on_failed_jobs set, package stays pending.
                 # gather package info so retried jobs and their exceptions reach the trace
-                self.gather_metrics(load_id, finished=False)
+                self.gather_metrics(load_id, schema, state="normalized")
                 raise pending_exception from pending_exception.client_exception
             else:
-                self.gather_metrics(load_id, finished=False)
+                self.gather_metrics(load_id, schema, state="normalized")
                 logger.warning(
                     f"Package {load_id} was not fully loaded. Load job pool is successfully drained"
                     f" but {len(remaining_jobs)} new jobs are left in the package."
@@ -823,7 +823,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         if not remaining_jobs:
             self.complete_package(load_id, schema, aborted=False)
         else:
-            self.gather_metrics(load_id, finished=False)
+            self.gather_metrics(load_id, schema, state="normalized")
             logger.warning(
                 f"Package {load_id} was not fully loaded. Load job pool is successfully drained but"
                 f" {len(remaining_jobs)} new jobs are left in the package."
@@ -864,14 +864,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         dataset_name: Optional[str] = None
         if isinstance(self.initial_client_config, DestinationClientDwhConfiguration):
             dataset_name = self.initial_client_config.normalize_dataset_name(schema)
-        metrics: LoadMetrics = {
-            "started_at": None,
-            "finished_at": None,
-            "job_metrics": self._job_metrics,
-            "dataset_name": dataset_name,
-            "outputs": self._compute_outputs(schema, *self._output_context(schema), dataset_name),
-        }
-        self._step_info_update_metrics(load_id, metrics)
+        self._step_info_update_metrics(load_id, self._package_metrics(dataset_name))
         self.complete_package(load_id, schema, aborted=True)
         logger.info(f"Package {load_id} aborted successfully")
         raise LoadPackageAborted(load_id, job_exception)
@@ -927,6 +920,17 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         except Exception as ex:
             logger.warning(f"Metrics could not be restored from state: {ex}")
 
+    def _package_metrics(
+        self, dataset_name: Optional[str], outputs: List[TDatasetDataLocation] = None
+    ) -> LoadMetrics:
+        return {
+            "started_at": None,
+            "finished_at": None,
+            "job_metrics": self._job_metrics,
+            "dataset_name": dataset_name,
+            "outputs": outputs or [],
+        }
+
     def _output_context(
         self, schema: Schema
     ) -> Tuple[DestinationCapabilitiesContext, Dict[str, Set[str]]]:
@@ -948,13 +952,15 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         tables_by_resource: Dict[str, Set[str]],
         physical_dataset_name: Optional[str],
     ) -> List[TDatasetDataLocation]:
-        """Describes the dataset per resource that owns tables written so far.
+        """Describes the dataset per resource that owns tables written by the package.
 
         `physical_dataset_name` is passed in already normalized so the normalization warning is not
         emitted again.
         """
-        # a table written in several files must be listed once
-        written_tables = {job.table_name for job in self._job_metrics.values()}
+        # a failed job wrote nothing, and a table written in several files is listed once
+        written_tables = {
+            job.table_name for job in self._job_metrics.values() if job.state == "completed"
+        }
         outputs: List[TDatasetDataLocation] = []
         for resource_name, tables in tables_by_resource.items():
             resource_tables = sorted(tables & written_tables)

--- a/dlt/load/load.py
+++ b/dlt/load/load.py
@@ -1,17 +1,17 @@
 import contextlib
 from functools import reduce
 from threading import BoundedSemaphore
-from typing import Dict, List, NoReturn, Optional, Tuple, Iterator, Sequence
+from typing import Dict, List, NoReturn, Optional, Set, Tuple, Iterator, Sequence
 from concurrent.futures import Executor
 
 from dlt.common import logger, pendulum
 from dlt.common.exceptions import TerminalException
-from dlt.common.metrics import LoadJobMetrics
+from dlt.common.metrics import LoadJobMetrics, TDatasetDataLocation
 from dlt.common.runtime.signals import sleep
 from dlt.common.configuration import with_config, known_sections
 from dlt.common.configuration.accessors import config
 from dlt.common.pipeline import LoadInfo, LoadMetrics, SupportsPipeline, WithStepInfo
-from dlt.common.schema.utils import get_root_table
+from dlt.common.schema.utils import get_root_table, group_tables_by_resource
 from dlt.common.storages.load_storage import (
     LoadJobInfo,
     LoadPackageInfo,
@@ -30,6 +30,8 @@ from dlt.common.schema import Schema
 from dlt.common.storages import LoadStorage
 from dlt.common.storages.file_storage import FileStorage
 from dlt.common.destination import DestinationReference, AnyDestination, Destination
+from dlt.common.destination.capabilities import DestinationCapabilitiesContext
+from dlt.common.destination.reference import describe_dataset_location
 from dlt.common.destination.client import (
     DestinationClientDwhConfiguration,
     HasFollowupJobs,
@@ -747,6 +749,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
         dataset_name: Optional[str] = None
         if isinstance(self.initial_client_config, DestinationClientDwhConfiguration):
             dataset_name = self.initial_client_config.normalize_dataset_name(schema)
+        caps, tables_by_resource = self._output_context(schema)
         # loop until all jobs are processed
         pending_exception: Optional[LoadClientJobException] = None
         while True:
@@ -780,6 +783,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                 "finished_at": None,
                 "job_metrics": self._job_metrics,
                 "dataset_name": dataset_name,
+                "outputs": self._compute_outputs(schema, caps, tables_by_resource, dataset_name),
             }
             self._step_info_update_metrics(load_id, metrics)
 
@@ -865,6 +869,7 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
             "finished_at": None,
             "job_metrics": self._job_metrics,
             "dataset_name": dataset_name,
+            "outputs": self._compute_outputs(schema, *self._output_context(schema), dataset_name),
         }
         self._step_info_update_metrics(load_id, metrics)
         self.complete_package(load_id, schema, aborted=True)
@@ -921,6 +926,50 @@ class Load(Runnable[Executor], WithStepInfo[LoadMetrics, LoadInfo]):
                 self._job_metrics[job_id] = LoadJobMetrics(**m)
         except Exception as ex:
             logger.warning(f"Metrics could not be restored from state: {ex}")
+
+    def _output_context(
+        self, schema: Schema
+    ) -> Tuple[DestinationCapabilitiesContext, Dict[str, Set[str]]]:
+        """Capabilities and table ownership of a package, constant while it loads."""
+        # nested tables are owned by the resource of their root table
+        tables_by_resource = {
+            resource_name: {table["name"] for table in tables}
+            for resource_name, tables in group_tables_by_resource(schema.tables).items()
+        }
+        return (
+            self.destination.capabilities(self.initial_client_config, schema.naming),
+            tables_by_resource,
+        )
+
+    def _compute_outputs(
+        self,
+        schema: Schema,
+        caps: DestinationCapabilitiesContext,
+        tables_by_resource: Dict[str, Set[str]],
+        physical_dataset_name: Optional[str],
+    ) -> List[TDatasetDataLocation]:
+        """Describes the dataset per resource that owns tables written so far.
+
+        `physical_dataset_name` is passed in already normalized so the normalization warning is not
+        emitted again.
+        """
+        # a table written in several files must be listed once
+        written_tables = {job.table_name for job in self._job_metrics.values()}
+        outputs: List[TDatasetDataLocation] = []
+        for resource_name, tables in tables_by_resource.items():
+            resource_tables = sorted(tables & written_tables)
+            if resource_tables:
+                outputs.append(
+                    describe_dataset_location(
+                        self.initial_client_config,
+                        caps,
+                        [schema],
+                        resource_name,
+                        resource_tables,
+                        physical_dataset_name,
+                    )
+                )
+        return outputs
 
     def _maybe_truncate_staging_dataset(self, schema: Schema, job_client: JobClientBase) -> None:
         """

--- a/dlt/pipeline/trace.py
+++ b/dlt/pipeline/trace.py
@@ -35,7 +35,7 @@ from dlt.pipeline.typing import TPipelineStep
 from dlt.pipeline.exceptions import PipelineStepFailed
 
 
-TRACE_ENGINE_VERSION = 1
+TRACE_ENGINE_VERSION = 2
 TRACE_FILE_NAME = "trace.pickle"
 
 

--- a/dlt/sources/filesystem/__init__.py
+++ b/dlt/sources/filesystem/__init__.py
@@ -15,6 +15,7 @@ from dlt.sources.credentials import FileSystemCredentials
 from dlt.sources.filesystem.helpers import (
     AbstractFileSystem,
     FilesystemConfigurationResource,
+    record_bucket_input,
 )
 from dlt.sources.filesystem.readers import (
     ReadersSource,
@@ -127,6 +128,8 @@ def filesystem(  # noqa DOC
         fs_client = fsspec_filesystem(
             bucket_url, credentials, kwargs=kwargs, client_kwargs=client_kwargs
         )[0]
+
+    record_bucket_input(bucket_url, file_glob)
 
     files_chunk: List[FileItem] = []
 

--- a/dlt/sources/filesystem/helpers.py
+++ b/dlt/sources/filesystem/helpers.py
@@ -3,12 +3,14 @@ from typing import Any, Dict, Iterable, List, Optional, Type, Union
 from fsspec import AbstractFileSystem
 
 import dlt
+from dlt.common import logger
 from dlt.common.configuration import resolve_type
 from dlt.common.configuration.specs import known_sections
 from dlt.common.configuration.specs.config_section_context import ConfigSectionContext
+from dlt.common.metrics import TDataLocation
 from dlt.common.storages.fsspec_filesystem import fsspec_from_config
 from dlt.common.storages import FilesystemConfigurationWithLocalFiles
-from dlt.common.typing import TDataItem
+from dlt.common.typing import NotRequired, TDataItem
 
 from dlt.sources import DltResource
 from dlt.sources.config import configspec, with_config
@@ -32,6 +34,33 @@ class FilesystemConfigurationResource(FilesystemConfigurationWithLocalFiles):
     def resolve_credentials_type(self) -> Type[CredentialsConfiguration]:
         # also allow AbstractFileSystem to be directly passed
         return Union[self.PROTOCOL_CREDENTIALS.get(self.protocol) or Optional[CredentialsConfiguration], AbstractFileSystem]  # type: ignore[return-value]
+
+
+class TFilesystemDataLocation(TDataLocation):
+    """A bucket or folder holding files matched by a glob."""
+
+    glob: NotRequired[str]
+
+
+def record_bucket_input(bucket_url: str, file_glob: str) -> None:
+    """Records the bucket and glob the currently running resource lists files from"""
+
+    try:
+        resource = dlt.current.resource()
+        resource.add_input(
+            TFilesystemDataLocation(
+                kind="filesystem",
+                resource_name=resource.name,
+                location=(
+                    FilesystemConfiguration.make_file_url(bucket_url)
+                    if FilesystemConfiguration.is_local_path(bucket_url)
+                    else bucket_url
+                ),
+                glob=file_glob,
+            )
+        )
+    except Exception as ex:
+        logger.debug(f"Could not record input location for bucket `{bucket_url}`: {ex}")
 
 
 def fsspec_from_resource(filesystem_instance: DltResource) -> AbstractFileSystem:

--- a/dlt/sources/filesystem/helpers.py
+++ b/dlt/sources/filesystem/helpers.py
@@ -57,7 +57,8 @@ def record_bucket_input(bucket_url: str, file_glob: str) -> None:
                     else bucket_url
                 ),
                 glob=file_glob,
-            )
+            ),
+            replace=True,
         )
     except Exception as ex:
         logger.debug(f"Could not record input location for bucket `{bucket_url}`: {ex}")

--- a/dlt/sources/rest_api/__init__.py
+++ b/dlt/sources/rest_api/__init__.py
@@ -46,6 +46,7 @@ from .config_setup import (
     build_resource_dependency_graph,
     paginate_dependent_resource,
     paginate_resource,
+    record_endpoint_input,
     process_parent_data_item,
     setup_incremental_object,
     create_response_hooks,
@@ -342,6 +343,8 @@ def create_resources(
             )
 
             resources[resource_name] = process(resources[resource_name], processing_steps)
+
+        record_endpoint_input(resources[resource_name], client, endpoint_config.get("path"))
 
     return resources
 

--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -1038,7 +1038,8 @@ def record_endpoint_input(resource: DltResource, client: RESTClient, path: str) 
                 location=sanitize_url(client.base_url),
                 # `path` is the endpoint template, not a resolved request url
                 endpoints=[path],
-            )
+            ),
+            replace=True,
         )
     except Exception as ex:
         logger.debug(f"Could not record input location for endpoint `{path}`: {ex}")

--- a/dlt/sources/rest_api/config_setup.py
+++ b/dlt/sources/rest_api/config_setup.py
@@ -22,9 +22,10 @@ from requests import Response
 from dlt.common import logger
 from dlt.common.configuration import resolve_configuration
 from dlt.common.exceptions import TypeErrorWithKnownTypes, ValueErrorWithKnownValues
+from dlt.common.metrics import TDataLocation
 from dlt.common.schema.utils import merge_columns
 from dlt.common.utils import update_dict_nested, exclude_keys
-from dlt.common.typing import add_value_to_literal
+from dlt.common.typing import NotRequired, add_value_to_literal
 from dlt.common import jsonpath
 
 from dlt.extract.incremental import Incremental
@@ -51,6 +52,7 @@ from dlt.sources.helpers.rest_client.auth import (
     OAuth2ClientCredentials,
 )
 from dlt.sources.helpers.rest_client.client import RESTClient, raise_for_status
+from dlt.sources.helpers.rest_client.redaction import sanitize_url
 
 from dlt.extract.resource import DltResource
 from dlt.sources.helpers.rest_client.typing import HTTPMethodBasic
@@ -1018,6 +1020,28 @@ def _set_incremental_params(
     if incremental_param.end:
         params[incremental_param.end] = transform(incremental_object.end_value)
     return params
+
+
+class TRestApiDataLocation(TDataLocation):
+    """A REST API base url holding endpoints."""
+
+    endpoints: NotRequired[List[str]]
+
+
+def record_endpoint_input(resource: DltResource, client: RESTClient, path: str) -> None:
+    """Records the API endpoint the currently running resource reads from."""
+    try:
+        resource.add_input(
+            TRestApiDataLocation(
+                kind="rest_api",
+                resource_name=resource.name,
+                location=sanitize_url(client.base_url),
+                # `path` is the endpoint template, not a resolved request url
+                endpoints=[path],
+            )
+        )
+    except Exception as ex:
+        logger.debug(f"Could not record input location for endpoint `{path}`: {ex}")
 
 
 def paginate_dependent_resource(

--- a/dlt/sources/sql_database/__init__.py
+++ b/dlt/sources/sql_database/__init__.py
@@ -13,6 +13,7 @@ from dlt.extract import DltResource, Incremental, decorators
 from .helpers import (
     _execute_table_adapter,
     default_engine_adapter_callback,
+    record_table_input,
     table_rows,
     engine_from_credentials,
     remove_nullability_adapter,
@@ -329,7 +330,7 @@ def sql_table(
         # may be from what is found in the reflection, so it is set explicitly
         hints["primary_key"] = [primary_key] if isinstance(primary_key, str) else list(primary_key)
 
-    return decorators.resource(
+    resource = decorators.resource(
         table_rows,
         name=str(table),
         write_disposition=write_disposition,
@@ -352,6 +353,8 @@ def sql_table(
         resolve_foreign_keys=resolve_foreign_keys,
         table_loader_class=table_loader_class,
     )
+    record_table_input(resource, credentials, schema, str(table))
+    return resource
 
 
 __all__ = [

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -27,15 +27,23 @@ from dlt.common.exceptions import (
     MissingDependencyException,
     ValueErrorWithKnownValues,
 )
+from dlt.common.metrics import TDataLocation
 from dlt.common.schema import TTableSchemaColumns
 from dlt.common.schema.typing import TWriteDispositionDict
 from dlt.common.schema.utils import merge_columns
-from dlt.common.typing import TColumnNames, TDataItem, TSortOrder, add_value_to_literal
+from dlt.common.typing import (
+    NotRequired,
+    TColumnNames,
+    TDataItem,
+    TSortOrder,
+    add_value_to_literal,
+)
 from dlt.common.jsonpath import extract_simple_field_name
 from dlt.common.utils import is_typeerror_due_to_wrong_call
 
 from dlt.extract import Incremental
 from dlt.extract.items_transform import LimitItem
+from dlt.extract.resource import DltResource
 
 from .arrow_helpers import row_tuples_to_arrow
 from .schema_types import (
@@ -435,6 +443,46 @@ def get_table_loader_class(backend_name: str) -> Type[BaseTableLoader]:
         return TABLE_LOADER_REGISTRY[backend_name]
     except KeyError:
         raise ValueErrorWithKnownValues("backend", backend_name, list(TABLE_LOADER_REGISTRY.keys()))
+
+
+class TSqlDatabaseDataLocation(TDataLocation):
+    """A SQL database server: databases and schemas holding tables."""
+
+    database: NotRequired[str]
+    db_schema: NotRequired[str]
+    tables: NotRequired[List[str]]
+
+
+def record_table_input(
+    resource: DltResource,
+    credentials: Union[ConnectionStringCredentials, Engine, str],
+    db_schema: Optional[str],
+    table_name: str,
+) -> None:
+    """Records the database table `resource` reads from, without credentials."""
+    if isinstance(credentials, Engine):
+        # an externally provided engine carries no credentials object to ask
+        url = credentials.url
+        credentials = ConnectionStringCredentials(
+            {
+                "drivername": url.drivername,
+                "host": url.host,
+                "port": url.port,
+                "database": url.database,
+            }
+        )
+    elif not isinstance(credentials, ConnectionStringCredentials):
+        credentials = ConnectionStringCredentials(credentials)
+    resource.add_input(
+        TSqlDatabaseDataLocation(
+            kind="sql_database",
+            resource_name=resource.name,
+            location=credentials.physical_location(),
+            database=credentials.database,
+            db_schema=db_schema,
+            tables=[table_name],
+        )
+    )
 
 
 def table_rows(

--- a/dlt/sources/sql_database/helpers.py
+++ b/dlt/sources/sql_database/helpers.py
@@ -460,29 +460,33 @@ def record_table_input(
     table_name: str,
 ) -> None:
     """Records the database table `resource` reads from, without credentials."""
-    if isinstance(credentials, Engine):
-        # an externally provided engine carries no credentials object to ask
-        url = credentials.url
-        credentials = ConnectionStringCredentials(
-            {
-                "drivername": url.drivername,
-                "host": url.host,
-                "port": url.port,
-                "database": url.database,
-            }
+    try:
+        if isinstance(credentials, Engine):
+            # an externally provided engine carries no credentials object to ask
+            url = credentials.url
+            credentials = ConnectionStringCredentials(
+                {
+                    "drivername": url.drivername,
+                    "host": url.host,
+                    "port": url.port,
+                    "database": url.database,
+                }
+            )
+        elif not isinstance(credentials, ConnectionStringCredentials):
+            credentials = ConnectionStringCredentials(credentials)
+        resource.add_input(
+            TSqlDatabaseDataLocation(
+                kind="sql_database",
+                resource_name=resource.name,
+                location=credentials.physical_location(),
+                database=credentials.database,
+                db_schema=db_schema,
+                tables=[table_name],
+            ),
+            replace=True,
         )
-    elif not isinstance(credentials, ConnectionStringCredentials):
-        credentials = ConnectionStringCredentials(credentials)
-    resource.add_input(
-        TSqlDatabaseDataLocation(
-            kind="sql_database",
-            resource_name=resource.name,
-            location=credentials.physical_location(),
-            database=credentials.database,
-            db_schema=db_schema,
-            tables=[table_name],
-        )
-    )
+    except Exception as ex:
+        logger.debug(f"Could not record input location for table `{table_name}`: {ex}")
 
 
 def table_rows(

--- a/tests/common/configuration/test_credentials.py
+++ b/tests/common/configuration/test_credentials.py
@@ -234,6 +234,49 @@ def test_connection_string_str_repr() -> None:
     assert str(c) == "postgres://loader:***@localhost:5432/dlt_data"
 
 
+@pytest.mark.parametrize(
+    "connection_string,expected",
+    [
+        ("postgresql://loader:pass@example.com:5432/dlt_data", "postgresql://example.com:5432"),
+        # the dbapi driver is not part of the identity, the backend is
+        ("postgresql+psycopg2://u:p@example.com:5432/db", "postgresql://example.com:5432"),
+        # a private or local address is reported as configured, a scope is not an identity
+        ("postgresql://example.com/dlt_data", "postgresql://example.com"),
+        ("postgresql://loader:pass@localhost:5432/dlt_data", "postgresql://localhost:5432"),
+        ("mssql+pyodbc://u:p@host:1433/db?driver=ODBC+Driver+18", "mssql://host:1433"),
+        # file based backends are identified by the database path
+        ("sqlite:////tmp/abs.db", "sqlite:///tmp/abs.db"),
+        ("sqlite:///rel.db", "sqlite://rel.db"),
+        # transient backends are reported as configured too, the backend alone is a valid scope
+        ("sqlite:///:memory:", "sqlite://:memory:"),
+        ("sqlite://", "sqlite://"),
+    ],
+    ids=[
+        "postgres",
+        "postgres-with-driver",
+        "postgres-no-port",
+        "postgres-localhost",
+        "mssql-with-query",
+        "sqlite-absolute",
+        "sqlite-relative",
+        "sqlite-memory",
+        "sqlite-no-database",
+    ],
+)
+def test_connection_string_physical_location(connection_string: str, expected: str) -> None:
+    """A scope names the engine and address, never credentials or connect options"""
+    location = ConnectionStringCredentials(connection_string).physical_location()
+    assert location == expected
+    assert "pass" not in location and "loader" not in location
+
+
+def test_connection_string_physical_location_ignores_credentials() -> None:
+    """The same database read by two users is reported with the same scope"""
+    loader = ConnectionStringCredentials("postgresql://loader:a@example.com:5432/dlt_data")
+    admin = ConnectionStringCredentials("postgresql://admin:b@example.com:5432/dlt_data")
+    assert loader.physical_location() == admin.physical_location()
+
+
 def test_gcp_service_credentials_native_representation(environment) -> None:
     with pytest.raises(InvalidGoogleNativeCredentialsType):
         GcpServiceAccountCredentials().parse_native_representation(1)

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -1,4 +1,11 @@
-from dlt.common.metrics import DataWriterMetrics, aggregate_job_metrics
+from typing import List
+
+from dlt.common.metrics import (
+    DataWriterMetrics,
+    TSchemaReference,
+    aggregate_job_metrics,
+    data_location_version,
+)
 from dlt.common.storages.load_package import ParsedLoadJobFileName
 
 
@@ -59,3 +66,16 @@ def test_aggregate_job_metrics_sums_interleaved_resources() -> None:
     )
     assert resource_metrics["res_a"].items_count == 8
     assert resource_metrics["res_b"].items_count == 4
+
+
+def test_data_location_version_is_order_independent() -> None:
+    schemas: List[TSchemaReference] = [
+        {"name": "a", "version_hash": "hash_a"},
+        {"name": "b", "version_hash": "hash_b"},
+    ]
+    assert data_location_version(schemas) == data_location_version(list(reversed(schemas)))
+    # a changed constituent hash changes the version
+    assert data_location_version(schemas) != data_location_version(
+        [schemas[0], {"name": "b", "version_hash": "hash_b2"}]
+    )
+    assert data_location_version([]) == data_location_version([])

--- a/tests/destinations/test_custom_destination.py
+++ b/tests/destinations/test_custom_destination.py
@@ -172,8 +172,20 @@ def test_instantiation() -> None:
     # test decorator
     calls = []
     p = dlt.pipeline("sink_test", destination=dlt.destination()(local_sink_func), dev_mode=True)
-    p.run([1, 2, 3], table_name="items")
+    info = p.run([1, 2, 3], table_name="items")
     assert len(calls) == 1
+    # a sink writes tables but has no dataset, so the trace records neither dataset name
+    location = next(
+        location
+        for metrics in info.metrics.values()
+        for location in metrics[0]["outputs"]
+        if location["resource_name"] == "items"
+    )
+    assert location["tables"] == ["items"]
+    assert "dataset_name" not in location and "physical_dataset_name" not in location
+    # nor a public location, it stays addressable by destination name
+    assert location["location"] == ""
+    assert location["destination_name"] == "local_sink_func"
     # local func does not create entry in destinations
     with pytest.raises(KeyError):
         DestinationReference.find("local_sink_func")

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -19,7 +19,11 @@ from dlt.common.typing import TTableNames, TDataItems
 from dlt.common.utils import uniq_id
 
 from dlt.extract import DltResource, DltSource
-from dlt.extract.exceptions import DataItemRequiredForDynamicTableHints, ResourceExtractionError
+from dlt.extract.exceptions import (
+    DataItemRequiredForDynamicTableHints,
+    DataLocationKindRequired,
+    ResourceExtractionError,
+)
 from dlt.extract.extract import ExtractStorage, Extract
 from dlt.extract.hints import TResourceNestedHints, make_hints, make_nested_hints
 from dlt.extract.items_transform import ValidateItem, MetricsItem
@@ -1964,6 +1968,13 @@ def test_resource_inputs_kind_defaults_to_source_name(extract_step: Extract) -> 
         {"location": "sftp://host/path", "kind": "my_sftp", "resource_name": "no_kind"}
     ]
 
+    # a resource that belongs to no source has no `kind` to default to
+    standalone = dlt.resource([{"id": 1}], name="orders")
+    with pytest.raises(DataLocationKindRequired) as kind_ex:
+        standalone.add_input({"resource_name": "orders", "location": "sftp://host/path"})  # type: ignore[typeddict-item]
+    assert kind_ex.value.resource_name == "orders"
+    assert standalone.inputs == []
+
 
 def test_resource_inputs_of_pipe_root(extract_step: Extract) -> None:
     """A pipe root feeding a transformer is extracted but not selected, its inputs still count"""
@@ -1977,7 +1988,10 @@ def test_resource_inputs_of_pipe_root(extract_step: Extract) -> None:
                 "resource_name": resource.name,
                 "location": "file:///bucket",
                 "glob": "*.csv",
-            }
+            },
+            # this instance is piped into a second transformer below, like the filesystem
+            # source it only reports the location of the run in progress
+            replace=True,
         )
         yield [{"id": 1}]
 
@@ -2036,7 +2050,9 @@ def test_resource_inputs_of_pipe_root(extract_step: Extract) -> None:
     assert ("files", "fetch_detail") in metrics["dag"]
 
 
-def test_resource_inputs_are_deduplicated(extract_step: Extract) -> None:
+def test_resource_inputs_are_recorded_as_added(extract_step: Extract) -> None:
+    """Recording is additive, a resource reading the same location on every page says so"""
+
     @dlt.resource
     def repeats():
         for page in range(3):
@@ -2049,27 +2065,10 @@ def test_resource_inputs_are_deduplicated(extract_step: Extract) -> None:
     source = DltSource(dlt.Schema("repeats"), "module", [repeats()])
     load_id = extract_step.extract(source, 20, 1)
     step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
-    assert step_info.metrics[load_id][0]["inputs"] == [
-        {"kind": "api", "location": "https://example.com", "resource_name": "repeats"}
-    ]
-
-
-def test_resource_inputs_not_duplicated_between_extracts(extract_step: Extract) -> None:
-    """A source instance may be extracted twice, a location must still be listed once"""
-
-    @dlt.resource
-    def with_input():
-        resource = dlt.current.resource()
-        resource.add_input(
-            {"kind": "api", "resource_name": resource.name, "location": "https://example.com"}
-        )
-        yield [{"id": 1}]
-
-    source = DltSource(dlt.Schema("reused"), "module", [with_input()])
-    extract_step.extract(source, 20, 1)
-    load_id = extract_step.extract(source, 20, 1)
-    step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
-    assert len(step_info.metrics[load_id][0]["inputs"]) == 1
+    assert (
+        step_info.metrics[load_id][0]["inputs"]
+        == [{"kind": "api", "location": "https://example.com", "resource_name": "repeats"}] * 3
+    )
 
 
 def test_resource_inputs_replace_drops_all_previous() -> None:

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -1,10 +1,12 @@
-from typing import Dict, List, NamedTuple, Optional, Any
+from typing import Dict, List, NamedTuple, Optional, Any, cast
 import pytest
 import os
 
 import dlt
 from dlt.common import json
 from dlt.common.data_types.typing import TDataType
+from dlt.common.exceptions import TypeErrorWithKnownTypes
+from dlt.common.metrics import TDataLocation
 from dlt.common.schema.utils import is_nested_table, may_be_nested
 from dlt.common.storages import (
     SchemaStorage,
@@ -1868,3 +1870,214 @@ def test_handle_empty_tables_pseudo_root_refreshed_then_truncated(extract_step: 
     metrics = _extract_resource(extract_step, schema, make_resource("replace", []))
     assert schema.tables[pseudo]["write_disposition"] == "replace"
     assert metrics[pseudo].items_count == 0
+
+
+def test_resource_inputs_not_recorded(extract_step: Extract) -> None:
+    @dlt.resource
+    def no_inputs():
+        yield [{"id": 1}]
+
+    resource = no_inputs()
+    assert resource.inputs == []
+
+    source = DltSource(dlt.Schema("no_inputs"), "module", [resource])
+    load_id = extract_step.extract(source, 20, 1)
+    step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
+    assert step_info.metrics[load_id][0]["inputs"] == []
+    assert step_info.asdict()["inputs"] == []
+
+
+def test_resource_inputs_recorded(extract_step: Extract) -> None:
+    # a resource may join several locations, each is recorded separately
+    @dlt.resource
+    def with_input():
+        resource = dlt.current.resource()
+        resource.add_input(
+            {
+                "kind": "rest_api",
+                "resource_name": resource.name,
+                "location": "https://api.example.com",
+                "version": "v1",
+            }
+        )
+        resource.add_input(
+            {
+                "kind": "dataset",
+                "resource_name": resource.name,
+                "location": "duckdb:///ref.duckdb",
+            }
+        )
+        yield [{"id": 1}]
+
+    # every item filtered out, locations must still be reported
+    @dlt.resource
+    def all_filtered():
+        resource = dlt.current.resource()
+        resource.add_input(
+            {"kind": "files", "resource_name": resource.name, "location": "s3://bucket"}
+        )
+        yield [{"id": 1}]
+
+    source = DltSource(
+        dlt.Schema("inputs"),
+        "module",
+        [with_input(), all_filtered().add_filter(lambda _: False)],
+    )
+    load_id = extract_step.extract(source, 20, 1)
+    step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
+
+    inputs = step_info.metrics[load_id][0]["inputs"]
+    assert inputs == [
+        {
+            "kind": "rest_api",
+            "location": "https://api.example.com",
+            "version": "v1",
+            "resource_name": "with_input",
+        },
+        {
+            "kind": "dataset",
+            "location": "duckdb:///ref.duckdb",
+            "resource_name": "with_input",
+        },
+        {"kind": "files", "location": "s3://bucket", "resource_name": "all_filtered"},
+    ]
+    # flattened rows carry the load id and the extract index
+    assert step_info.asdict()["inputs"] == [
+        {"load_id": load_id, "extract_idx": 0, **location} for location in inputs
+    ]
+
+
+def test_resource_inputs_kind_defaults_to_source_name(extract_step: Extract) -> None:
+    @dlt.resource
+    def no_kind():
+        # kind is required by the type, the runtime fallback serves dynamic callers
+        resource = dlt.current.resource()
+        resource.add_input(
+            {"resource_name": resource.name, "location": "sftp://host/path"}  # type: ignore[typeddict-item]
+        )
+        yield [{"id": 1}]
+
+    source = DltSource(dlt.Schema("my_sftp"), "module", [no_kind()])
+    load_id = extract_step.extract(source, 20, 1)
+    step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
+    assert step_info.metrics[load_id][0]["inputs"] == [
+        {"location": "sftp://host/path", "kind": "my_sftp", "resource_name": "no_kind"}
+    ]
+
+
+def test_resource_inputs_of_pipe_root(extract_step: Extract) -> None:
+    """A pipe root feeding a transformer is extracted but not selected, its inputs still count"""
+
+    @dlt.resource
+    def files():
+        resource = dlt.current.resource()
+        resource.add_input(
+            {  # type: ignore[typeddict-unknown-key]
+                "kind": "filesystem",
+                "resource_name": resource.name,
+                "location": "file:///bucket",
+                "glob": "*.csv",
+            }
+        )
+        yield [{"id": 1}]
+
+    @dlt.transformer
+    def read(item):
+        # a transformer records no inputs of its own, its upstream is an edge in the dag
+        yield item
+
+    source = DltSource(dlt.Schema("piped"), "module", [files | read])
+    assert list(source.selected_resources.keys()) == ["read"]
+
+    load_id = extract_step.extract(source, 20, 1)
+    step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
+    metrics = step_info.metrics[load_id][0]
+    assert metrics["inputs"] == [
+        {
+            "kind": "filesystem",
+            "location": "file:///bucket",
+            "glob": "*.csv",
+            "resource_name": "files",
+        }
+    ]
+    assert ("files", "read") in metrics["dag"]
+
+    # a transformer that does read a location of its own is recorded, like a dependent rest_api
+    # endpoint. being fed by `files` is still not an input, only the dag edge says so
+    @dlt.transformer
+    def fetch_detail(item):
+        resource = dlt.current.resource()
+        resource.add_input(
+            {
+                "kind": "rest_api",
+                "resource_name": resource.name,
+                "location": "https://api.example.com",
+            }
+        )
+        yield item
+
+    source = DltSource(dlt.Schema("piped_reader"), "module", [files | fetch_detail])
+    load_id = extract_step.extract(source, 20, 1)
+    step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
+    metrics = step_info.metrics[load_id][0]
+    assert metrics["inputs"] == [
+        {
+            "kind": "rest_api",
+            "location": "https://api.example.com",
+            "resource_name": "fetch_detail",
+        },
+        {
+            "kind": "filesystem",
+            "location": "file:///bucket",
+            "glob": "*.csv",
+            "resource_name": "files",
+        },
+    ]
+    assert ("files", "fetch_detail") in metrics["dag"]
+
+
+def test_resource_inputs_are_deduplicated(extract_step: Extract) -> None:
+    @dlt.resource
+    def repeats():
+        for page in range(3):
+            resource = dlt.current.resource()
+            resource.add_input(
+                {"kind": "api", "resource_name": resource.name, "location": "https://example.com"}
+            )
+            yield [{"id": page}]
+
+    source = DltSource(dlt.Schema("repeats"), "module", [repeats()])
+    load_id = extract_step.extract(source, 20, 1)
+    step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
+    assert step_info.metrics[load_id][0]["inputs"] == [
+        {"kind": "api", "location": "https://example.com", "resource_name": "repeats"}
+    ]
+
+
+def test_resource_inputs_not_duplicated_between_extracts(extract_step: Extract) -> None:
+    """A source instance may be extracted twice, a location must still be listed once"""
+
+    @dlt.resource
+    def with_input():
+        resource = dlt.current.resource()
+        resource.add_input(
+            {"kind": "api", "resource_name": resource.name, "location": "https://example.com"}
+        )
+        yield [{"id": 1}]
+
+    source = DltSource(dlt.Schema("reused"), "module", [with_input()])
+    extract_step.extract(source, 20, 1)
+    load_id = extract_step.extract(source, 20, 1)
+    step_info = extract_step.get_step_info(MockPipeline("buba", first_run=False))  # type: ignore[abstract]
+    assert len(step_info.metrics[load_id][0]["inputs"]) == 1
+
+
+def test_resource_inputs_reject_invalid_location() -> None:
+    """A location is recorded when the resource is built, so a bad one fails right there"""
+
+    @dlt.resource
+    def data():
+        yield [{"id": 1}]
+
+    with pytest.raises(TypeErrorWithKnownTypes):
+        data().add_input("not a location")  # type: ignore[arg-type]

--- a/tests/extract/test_extract.py
+++ b/tests/extract/test_extract.py
@@ -2072,6 +2072,21 @@ def test_resource_inputs_not_duplicated_between_extracts(extract_step: Extract) 
     assert len(step_info.metrics[load_id][0]["inputs"]) == 1
 
 
+def test_resource_inputs_replace_drops_all_previous() -> None:
+    resource = dlt.resource([{"id": 1}], name="data")
+    resource.add_input({"kind": "api", "resource_name": "data", "location": "https://a.example"})
+    resource.add_input({"kind": "files", "resource_name": "data", "location": "s3://bucket"})
+    assert len(resource.inputs) == 2
+
+    # locations of other kinds go too, replace is not a per kind update
+    resource.add_input(
+        {"kind": "api", "resource_name": "data", "location": "https://b.example"}, replace=True
+    )
+    assert resource.inputs == [
+        {"kind": "api", "resource_name": "data", "location": "https://b.example"}
+    ]
+
+
 def test_resource_inputs_reject_invalid_location() -> None:
     """A location is recorded when the resource is built, so a bad one fails right there"""
 
@@ -2081,3 +2096,10 @@ def test_resource_inputs_reject_invalid_location() -> None:
 
     with pytest.raises(TypeErrorWithKnownTypes):
         data().add_input("not a location")  # type: ignore[arg-type]
+
+    # a bad location does not disturb what was recorded, even when it asks to replace
+    resource = dlt.resource([{"id": 1}], name="data")
+    resource.add_input({"kind": "api", "resource_name": "data", "location": "https://a.example"})
+    with pytest.raises(TypeErrorWithKnownTypes):
+        resource.add_input("not a location", replace=True)  # type: ignore[arg-type]
+    assert len(resource.inputs) == 1

--- a/tests/load/pipeline/test_merge_disposition.py
+++ b/tests/load/pipeline/test_merge_disposition.py
@@ -6,6 +6,7 @@ from typing import List
 import yaml
 
 import dlt
+from dlt.common.metrics import TDataLocation
 
 from dlt.common import json, pendulum
 from dlt.common.configuration.container import Container
@@ -696,7 +697,16 @@ def github():
             for item in json.load(f):
                 yield item
 
-    return load_issues
+    issues = load_issues()
+    # a captured page of the github api, so the trace carries the read side of the run too
+    issues.add_input(
+        TDataLocation(
+            kind="rest_api",
+            resource_name=issues.name,
+            location="https://api.github.com",
+        )
+    )
+    return issues
 
 
 @pytest.mark.essential

--- a/tests/load/pipeline/test_stage_loading.py
+++ b/tests/load/pipeline/test_stage_loading.py
@@ -149,6 +149,28 @@ def test_staging_load(destination_config: DestinationTestConfiguration) -> None:
     initial_counts = load_table_counts(pipeline)
     assert initial_counts["issues"] == 100
 
+    # the source records the read side, the load the write side, on every destination tested here
+    extract_info = pipeline.last_trace.last_extract_info
+    inputs = extract_info.metrics[extract_info.loads_ids[0]][0]["inputs"]
+    assert [location["resource_name"] for location in inputs] == ["load_issues"]
+    assert inputs[0]["location"] == "https://api.github.com"
+
+    written = next(
+        location
+        for metrics in info.metrics.values()
+        for location in metrics[0]["outputs"]
+        if location["resource_name"] == "load_issues"
+    )
+    # the only data resource, so it accounts for every table the schema has seen data for
+    assert set(written["tables"]) == {
+        table["name"] for table in pipeline.default_schema.data_tables(seen_data_only=True)
+    }
+    assert written["destination_type"].endswith(destination_config.destination_type)
+    assert written["physical_dataset_name"] == info.dataset_name
+    # every fact a location must carry is filled in, whatever the destination is
+    assert written["casefold"] in ("str", "upper", "lower")
+    assert written["schemas"][0]["version_hash"] == pipeline.default_schema.version_hash
+
     # check item of first row in db
     with pipeline.sql_client() as sql_client:
         qual_name = sql_client.make_qualified_table_name

--- a/tests/load/sources/filesystem/test_filesystem_source.py
+++ b/tests/load/sources/filesystem/test_filesystem_source.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 
 from fsspec import AbstractFileSystem
 
@@ -10,6 +10,7 @@ from dlt.common import pendulum
 from dlt.common.storages import fsspec_filesystem
 from dlt.common.typing import TSortOrder
 from dlt.extract.resource import DltResource
+from dlt.sources.filesystem.helpers import TFilesystemDataLocation
 from dlt.sources.filesystem import filesystem, readers, FileItem, FileItemDict, read_csv
 from dlt.sources.filesystem.helpers import fsspec_from_resource
 
@@ -156,6 +157,15 @@ def test_csv_transformers(
     met_files.apply_hints(write_disposition="merge", merge_key="date")
     load_info = pipeline.run(met_files.with_name("met_csv"))
     assert_load_info(load_info)
+
+    # the bucket is listed by the pipe root, which is extracted but not selected
+    extract_info = pipeline.last_trace.last_extract_info
+    inputs = extract_info.metrics[extract_info.loads_ids[0]][0]["inputs"]
+    assert len(inputs) == 1
+    assert inputs[0]["kind"] == "filesystem"
+    assert cast(TFilesystemDataLocation, inputs[0])["glob"] == "met_csv/A801/*.csv"
+    assert inputs[0]["location"].endswith("standard_source/samples")
+    assert inputs[0]["resource_name"] != "met_csv"
 
     # print(pipeline.last_trace.last_normalize_info)
     # must contain 24 rows of A881

--- a/tests/load/sources/sql_database/test_sql_database_source_all_destinations.py
+++ b/tests/load/sources/sql_database/test_sql_database_source_all_destinations.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, List
+from typing import Any, List, cast
 
 import humanize
 import pytest
@@ -20,6 +20,7 @@ from tests.pipeline.utils import (
 
 try:
     from dlt.sources.sql_database import TableBackend, sql_database, sql_table
+    from dlt.sources.sql_database.helpers import TSqlDatabaseDataLocation
     from tests.load.sources.sql_database.test_helpers import mock_json_column, mock_array_column
     from tests.load.sources.sql_database.test_sql_database_source import (
         assert_row_counts,
@@ -209,6 +210,20 @@ def test_load_sql_table_names(
     assert_load_info(load_info)
 
     assert_row_counts(pipeline, postgres_db, tables)
+
+    # each table resource records the database it read, addressed without credentials
+    extract_info = pipeline.last_trace.last_extract_info
+    inputs = extract_info.metrics[extract_info.loads_ids[0]][0]["inputs"]
+    by_resource = {location["resource_name"]: location for location in inputs}
+    assert set(by_resource) == set(tables)
+    for table in tables:
+        location = cast(TSqlDatabaseDataLocation, by_resource[table])
+        assert location["kind"] == "sql_database"
+        assert location["tables"] == [table]
+        assert location["db_schema"] == postgres_db.schema
+        assert location["database"] == postgres_db.credentials.database
+        assert location["location"].startswith("postgresql://")
+        assert postgres_db.credentials.password not in location["location"]
 
 
 @pytest.mark.parametrize(

--- a/tests/load/sources/sql_database/test_sql_database_source_all_destinations.py
+++ b/tests/load/sources/sql_database/test_sql_database_source_all_destinations.py
@@ -82,6 +82,38 @@ def test_load_sql_schema_loads_all_tables(
 
     assert_row_counts(pipeline, postgres_db)
 
+    # every table of the source schema is read by its own resource, which records that one table
+    expected_tables = {
+        name for name, info in postgres_db.table_infos.items() if not info["is_view"]
+    }
+    extract_info = pipeline.last_trace.last_extract_info
+    inputs = extract_info.metrics[extract_info.loads_ids[0]][0]["inputs"]
+    assert {location["resource_name"] for location in inputs} == expected_tables
+    assert len(inputs) == len(expected_tables)
+    for location in inputs:
+        assert location["kind"] == "sql_database"
+        sql_location = cast(TSqlDatabaseDataLocation, location)
+        assert sql_location["tables"] == [location["resource_name"]]
+        assert sql_location["db_schema"] == postgres_db.schema
+
+    # and every one of them is written back, attributed to the resource that read it
+    outputs = [
+        location for metrics in load_info.metrics.values() for location in metrics[0]["outputs"]
+    ]
+    written_tables = {
+        table
+        for location in outputs
+        if not location["resource_name"].startswith("_dlt")
+        for table in location["tables"]
+    }
+    assert written_tables == {
+        table["name"] for table in pipeline.default_schema.data_tables(seen_data_only=True)
+    }
+    for location in outputs:
+        assert location["physical_dataset_name"] == load_info.dataset_name
+        if location["resource_name"] in expected_tables:
+            assert location["resource_name"] in location["tables"]
+
 
 @pytest.mark.parametrize(
     "destination_config",

--- a/tests/load/sources/sql_database/test_sql_database_source_all_destinations.py
+++ b/tests/load/sources/sql_database/test_sql_database_source_all_destinations.py
@@ -82,10 +82,12 @@ def test_load_sql_schema_loads_all_tables(
 
     assert_row_counts(pipeline, postgres_db)
 
-    # every table of the source schema is read by its own resource, which records that one table
+    # every table of the source schema is read by its own resource, which records that one table.
+    # `camelCaseTable` is reflected but kept out of `table_infos`, its name is not queryable
+    # in destinations that normalize identifiers
     expected_tables = {
         name for name, info in postgres_db.table_infos.items() if not info["is_view"]
-    }
+    } | {"camelCaseTable"}
     extract_info = pipeline.last_trace.last_extract_info
     inputs = extract_info.metrics[extract_info.loads_ids[0]][0]["inputs"]
     assert {location["resource_name"] for location in inputs} == expected_tables
@@ -109,10 +111,14 @@ def test_load_sql_schema_loads_all_tables(
     assert written_tables == {
         table["name"] for table in pipeline.default_schema.data_tables(seen_data_only=True)
     }
+    naming = pipeline.default_schema.naming
     for location in outputs:
         assert location["physical_dataset_name"] == load_info.dataset_name
+        # a resource is named after the source table, the written table after normalizing it
         if location["resource_name"] in expected_tables:
-            assert location["resource_name"] in location["tables"]
+            assert (
+                naming.normalize_table_identifier(location["resource_name"]) in location["tables"]
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/load/test_dummy_client.py
+++ b/tests/load/test_dummy_client.py
@@ -4,7 +4,7 @@ from time import sleep, monotonic
 from unittest import mock
 import pytest
 from unittest.mock import patch
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Type
 
 from dlt.common import pendulum
 from dlt.common.destination.exceptions import DestinationTerminalException
@@ -710,6 +710,80 @@ def test_abort_package_replays_started_jobs() -> None:
     assert "job interrupted by package abort" in failed_message
     assert len(jobs_by_state["started_jobs"]) == 0
     assert len(jobs_by_state["new_jobs"]) == 0
+
+
+def test_outputs_skip_failed_jobs_of_a_completed_package() -> None:
+    """Outputs describe data that landed, so a table whose job failed is not among them"""
+    load = setup_loader(
+        # fail_table_names completes every table it does not list
+        client_config=DummyClientConfiguration(fail_table_names=["event_loop_interrupted"]),
+        loader_config=LoaderConfiguration(
+            auto_abort_on_terminal_error=False, raise_on_failed_jobs=False
+        ),
+    )
+    load_id, _ = prepare_load_package(load.load_storage, NORMALIZED_FILES)
+    run_all(load)
+
+    assert load.load_storage.get_load_package_info(load_id).state == "loaded"
+    metrics = load.get_step_info(MockPipeline("pipe", True)).metrics[load_id][0]  # type: ignore[abstract]
+    # both jobs ran and are in the metrics, only the one that completed is an output
+    assert {job.table_name: job.state for job in metrics["job_metrics"].values()} == {
+        "event_user": "completed",
+        "event_loop_interrupted": "failed",
+    }
+    assert [location["tables"] for location in metrics["outputs"]] == [["event_user"]]
+
+
+@pytest.mark.parametrize(
+    "auto_abort,package_state,expected_exception",
+    [
+        (True, "aborted", LoadPackageAborted),
+        (False, "normalized", LoadClientJobTerminalRetry),
+    ],
+    ids=["aborted", "pending_retry"],
+)
+def test_outputs_not_recorded_until_package_is_loaded(
+    auto_abort: bool, package_state: str, expected_exception: Type[Exception]
+) -> None:
+    """Only a loaded package has outputs, whatever its jobs managed to complete first"""
+    load = setup_loader(
+        # fail_table_names completes every table it does not list
+        client_config=DummyClientConfiguration(fail_table_names=["event_loop_interrupted"]),
+        loader_config=LoaderConfiguration(
+            auto_abort_on_terminal_error=auto_abort, raise_on_failed_jobs=True
+        ),
+    )
+    load_id, _ = prepare_load_package(load.load_storage, NORMALIZED_FILES)
+    with pytest.raises(expected_exception):
+        run_all(load)
+
+    assert load.load_storage.get_load_package_info(load_id).state == package_state
+    metrics = load._step_info_metrics(load_id)[0]
+    # a job did complete first, so an unguarded output would have been recorded
+    assert "completed" in {job.state for job in metrics["job_metrics"].values()}
+    assert metrics["outputs"] == []
+
+
+def test_outputs_survive_a_restart_like_job_metrics() -> None:
+    """Outputs are derived from job metrics, so they cover jobs completed by an earlier process"""
+    load = setup_loader(client_config=DummyClientConfiguration(completed_prob=1.0))
+    load_id, _ = prepare_load_package(load.load_storage, NORMALIZED_FILES)
+    # the jobs complete and persist their metrics, the package does not complete
+    with patch.object(load, "complete_package", side_effect=RuntimeError("crash")):
+        with pytest.raises(RuntimeError):
+            load.run(None)
+    assert load.load_storage.get_load_package_info(load_id).state == "normalized"
+
+    resumed = setup_loader(client_config=DummyClientConfiguration(completed_prob=1.0))
+    assert resumed._job_metrics == {}
+    run_all(resumed)
+
+    assert resumed.load_storage.get_load_package_info(load_id).state == "loaded"
+    metrics = resumed.get_step_info(MockPipeline("pipe", True)).metrics[load_id][0]  # type: ignore[abstract]
+    assert sorted(table for location in metrics["outputs"] for table in location["tables"]) == [
+        "event_loop_interrupted",
+        "event_user",
+    ]
 
 
 def test_auto_abort_crash_resumes_via_flag() -> None:

--- a/tests/pipeline/cases/contracts/trace.schema.yaml
+++ b/tests/pipeline/cases/contracts/trace.schema.yaml
@@ -1,5 +1,5 @@
-version: 19
-version_hash: cmZ/fKGtDKNuPqgqgbNV5tl5FQg8vlj2+d5RyrgB22I=
+version: 29
+version_hash: Zm55WoM0094+vOhqUdgyrUwwStk8qpxGTUCu/eT9rwY=
 engine_version: 11
 name: trace
 tables:
@@ -529,7 +529,8 @@ tables:
         data_type: text
         nullable: true
       has_pending_transitions:
-        description: True when jobs committed to the destination but were not yet moved
+        description: True when jobs committed to the destination but were not yet
+          moved
         data_type: bool
         nullable: true
     parent: trace__steps
@@ -895,6 +896,9 @@ tables:
       incremental:
         data_type: bool
         nullable: true
+      x_row_version:
+        data_type: bool
+        nullable: true
     parent: trace__steps__step_info__load_packages__tables
   trace__resolved_config_values:
     description: Config and secret values resolved during the pipeline run (key, provider,
@@ -1076,6 +1080,201 @@ tables:
         unique: true
         row_key: true
     parent: trace__steps__step_info__load_packages
+  trace__steps__extract_info__inputs:
+    columns:
+      load_id:
+        data_type: text
+        nullable: true
+      extract_idx:
+        data_type: bigint
+        nullable: true
+      kind:
+        data_type: text
+        nullable: true
+      location:
+        data_type: text
+        nullable: true
+      version:
+        data_type: text
+        nullable: true
+      resource_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+      dataset_name:
+        data_type: text
+        nullable: true
+      physical_dataset_name:
+        data_type: text
+        nullable: true
+      destination_type:
+        data_type: text
+        nullable: true
+      destination_name:
+        data_type: text
+        nullable: true
+      destination_fingerprint:
+        data_type: text
+        nullable: true
+      casefold:
+        data_type: text
+        nullable: true
+      case_sensitive:
+        data_type: bool
+        nullable: true
+    parent: trace__steps
+  trace__steps__extract_info__inputs__endpoints:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+    parent: trace__steps__extract_info__inputs
+  trace__steps__extract_info__inputs__schemas:
+    columns:
+      name:
+        data_type: text
+        nullable: true
+      version_hash:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+    parent: trace__steps__extract_info__inputs
+  trace__steps__extract_info__inputs__tables:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+    parent: trace__steps__extract_info__inputs
+  trace__steps__load_info__outputs:
+    columns:
+      load_id:
+        data_type: text
+        nullable: true
+      kind:
+        data_type: text
+        nullable: true
+      version:
+        data_type: text
+        nullable: true
+      destination_type:
+        data_type: text
+        nullable: true
+      destination_name:
+        data_type: text
+        nullable: true
+      case_sensitive:
+        data_type: bool
+        nullable: true
+      resource_name:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+      destination_fingerprint:
+        data_type: text
+        nullable: true
+      casefold:
+        data_type: text
+        nullable: true
+      location:
+        data_type: text
+        nullable: true
+    parent: trace__steps
+  trace__steps__load_info__outputs__schemas:
+    columns:
+      name:
+        data_type: text
+        nullable: true
+      version_hash:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+    parent: trace__steps__load_info__outputs
+  trace__steps__load_info__outputs__tables:
+    columns:
+      value:
+        data_type: text
+        nullable: true
+      _dlt_parent_id:
+        data_type: text
+        nullable: false
+        parent_key: true
+      _dlt_list_idx:
+        data_type: bigint
+        nullable: false
+      _dlt_id:
+        data_type: text
+        nullable: false
+        unique: true
+        row_key: true
+    parent: trace__steps__load_info__outputs
 settings:
   detections:
   - iso_timestamp
@@ -1100,13 +1299,13 @@ normalizers:
     module: dlt.common.normalizers.json.relational
   use_break_path_on_normalize: false
 previous_hashes:
-- ZBDNfQ43NvZDWWRpeQA8vPNqNNbfVOdYjsGvLCgb0DY=
-- znMcyqfPi4E8ciWxLoi31Hx25ymRtH5D2duFbHKwov8=
-- qROrh2phDRgzwXnNcnkhZZx1pVWYJhrONl37h7deVyk=
-- 1nBoY4D8QT4BCa++yYhyysyCXAanAGBr+W1j1xPq9mM=
-- eDaULREi928XF66TW4zt8u6f76m+JVyhny6cYIqATTc=
-- JPyWY81x+lB6dVBEvUD5A67wl16qwvd2QQIoDhevaBw=
-- QRhfna2wTZv+INSEUUmkKiH+Upb6yGg1cDBBbR8kEMo=
-- txv310BO0KgmKJ/8I/spuLPaMMOt+TarI8ytKq19cjo=
-- 7I1eufBNCdmIem6hEiD0CjKgFQNlg0MCHkJgCTtghxk=
-- P8E7cjYovKZVIFpXOcuizgzCVXmUriPYEZ1FxBt63Tc=
+- IjmTlJET8k8+C6tXvNj8AbbnJuozgus7IpMHyHajFUw=
+- ZLr3XFtMA/YYbGutCI92/cwwh5xbxwZfh7QEzT541RQ=
+- q4KacWuGaYN74mKfU4XUk7+12XdnuWtTdWtbfUArYHU=
+- XmCnGxqMtPEuQgzNNVVqhf0aUzcwzPi0Gk71p9CBP8w=
+- 9/I5yQZMOhWEdPc+Cal0MeULamc3DykS4vZqkRcsrAM=
+- XRwlTg3masjK7YvoEOt11D/ILQe6cB4FSZ5+cH3xfdc=
+- 5snV4y/ucV79nzDg/Kz96XQU99Tr/rJh7ZcnjfIHwqs=
+- PH8+XylY1qJ+IGXbQbRgJorv/xJwYuirdJW3zJMfhZM=
+- 1kxexbqKswtAzBSget26Tu/XrLSA4Limk+sRJeql5aY=
+- cmZ/fKGtDKNuPqgqgbNV5tl5FQg8vlj2+d5RyrgB22I=

--- a/tests/pipeline/test_data_locations.py
+++ b/tests/pipeline/test_data_locations.py
@@ -1,0 +1,179 @@
+import os
+from typing import Any, Dict, List, cast
+
+import dlt
+from dlt.common.metrics import TDatasetDataLocation, data_location_version
+from dlt.common.utils import uniq_id
+
+from tests.pipeline.utils import assert_load_info
+
+
+def _outputs(info: Any) -> List[TDatasetDataLocation]:
+    """All output locations of a load info, across load packages"""
+    return [location for metrics in info.metrics.values() for location in metrics[0]["outputs"]]
+
+
+def _by_resource(locations: List[TDatasetDataLocation]) -> Dict[str, TDatasetDataLocation]:
+    return {location["resource_name"]: location for location in locations}
+
+
+@dlt.resource(primary_key="id", name="orders")
+def orders_with_nested() -> Any:
+    yield [
+        {"id": 1, "items": [{"sku": "a"}, {"sku": "b"}]},
+        {"id": 2, "items": [{"sku": "c"}]},
+    ]
+
+
+@dlt.source(name="sales")
+def sales_source() -> Any:
+    return dlt.resource([{"id": 1}], name="orders")
+
+
+@dlt.source(name="crm")
+def crm_source() -> Any:
+    return dlt.resource([{"id": 1}], name="contacts")
+
+
+def test_output_locations_identify_the_dataset() -> None:
+    """One entry per resource, naming the dataset the way the input side of another run will"""
+    # rotate the writer so a table really is spread over several load jobs
+    os.environ["DATA_WRITER__FILE_MAX_ITEMS"] = "1"
+
+    pipeline = dlt.pipeline(
+        pipeline_name="out_" + uniq_id(),
+        destination="duckdb",
+        dataset_name="My_DataSet",
+        dev_mode=True,
+    )
+    info = pipeline.run([orders_with_nested(), dlt.resource([{"id": 1}], name="customers")])
+    assert_load_info(info)
+
+    locations = _by_resource(_outputs(info))
+    # nested tables belong to the resource owning their root table, each listed once even though
+    # the writer split them over several jobs
+    assert locations["orders"]["tables"] == ["orders", "orders__items"]
+    assert locations["customers"]["tables"] == ["customers"]
+    orders_jobs = [
+        job
+        for metrics in info.metrics.values()
+        for job in metrics[0]["job_metrics"].values()
+        if job.table_name == "orders"
+    ]
+    assert len(orders_jobs) > 1
+
+    location = locations["orders"]
+    assert location["kind"] == "dataset"
+    assert location["destination_type"] == "dlt.destinations.duckdb"
+    assert location["destination_name"] == "duckdb"
+    assert location["case_sensitive"] is False
+    # duckdb does not casefold, the identity function is still recorded
+    assert location["casefold"] == "str"
+    # duckdb has no fingerprint, the column is present and empty
+    assert location["destination_fingerprint"] == ""
+    # the logical name is kept for display, the normalized one is the join key between sides
+    assert location["dataset_name"] == pipeline.dataset_name
+    assert location["physical_dataset_name"].startswith("my_data_set")
+    assert location["physical_dataset_name"] == info.dataset_name
+    assert location["version"] == data_location_version(location["schemas"])
+
+    # a new column changes the schema hash and with it the version of the location
+    info = pipeline.run(dlt.resource([{"id": 2, "extra": "x"}], name="customers"))
+    assert _by_resource(_outputs(info))["customers"]["version"] != location["version"]
+
+
+def test_output_locations_of_multiple_datasets() -> None:
+    """A single load step writes several datasets when each schema resolves to its own"""
+    pipeline = dlt.pipeline(
+        pipeline_name="out_multi_" + uniq_id(),
+        destination="duckdb",
+        dataset_name="marts",
+        dev_mode=True,
+    )
+    pipeline.config.use_single_dataset = False
+
+    info = pipeline.run([sales_source(), crm_source()])
+    assert_load_info(info, expected_load_packages=2)
+    other_schema = next(s for s in pipeline.schema_names if s != pipeline.default_schema_name)
+
+    # a location carries only the schema of its own package, versioned by that schema alone
+    locations = _outputs(info)
+    by_schema = {
+        location["schemas"][0]["name"]: location
+        for location in locations
+        if location["resource_name"] in ("orders", "contacts")
+    }
+    assert set(by_schema) == {"sales", "crm"}
+    assert by_schema["sales"]["version"] != by_schema["crm"]["version"]
+
+    # the default schema keeps the configured dataset, the other is suffixed with its schema name
+    physical_of = {name: location["physical_dataset_name"] for name, location in by_schema.items()}
+    assert physical_of[pipeline.default_schema_name] == pipeline.dataset_name
+    assert physical_of[other_schema] == f"{pipeline.dataset_name}_{other_schema}"
+
+    # `LoadInfo.dataset_name` can only name one of them, the output locations record both
+    assert len(set(physical_of.values())) == 2
+    assert info.dataset_name in set(physical_of.values())
+
+    # pipeline state is written into every dataset, so a resource name alone does not identify a
+    # location - each row is self contained and carries the dataset it was written to
+    state_datasets = {
+        location["physical_dataset_name"]
+        for location in locations
+        if location["resource_name"] == "_dlt_pipeline_state"
+    }
+    assert state_datasets == set(physical_of.values())
+
+    # flattened rows stay attributable to their package
+    rows = info.asdict()["outputs"]
+    assert len({row["load_id"] for row in rows}) == 2
+    assert {row["physical_dataset_name"] for row in rows} == set(physical_of.values())
+
+    # a schema loaded by a later run resolves to its own dataset, leaving the first ones alone
+    info = pipeline.run(dlt.resource([{"id": 1}], name="c_table"), schema=dlt.Schema("other"))
+    later = _by_resource(_outputs(info))["c_table"]
+    assert later["physical_dataset_name"] == f"{pipeline.dataset_name}_other"
+    assert [s["name"] for s in later["schemas"]] == ["other"]
+
+
+def test_input_and_output_locations_join_on_physical_dataset_name() -> None:
+    """The read side of a run and the write side of the run before it compare field for field"""
+    source_pipeline = dlt.pipeline(
+        pipeline_name="lineage_src_" + uniq_id(),
+        destination="duckdb",
+        dataset_name="Raw_Data",
+        dev_mode=True,
+    )
+    load_info = source_pipeline.run(orders_with_nested())
+    assert_load_info(load_info)
+    written = _by_resource(_outputs(load_info))["orders"]
+
+    dataset = source_pipeline.dataset()
+
+    @dlt.resource(name="orders_copy")
+    def copy_orders() -> Any:
+        yield list(dataset.table("orders").fetchall())
+
+    resource = copy_orders()
+    resource.add_input(
+        TDatasetDataLocation(  # type: ignore[typeddict-item]
+            kind="dataset",
+            resource_name="orders_copy",
+            location=written["location"],
+            dataset_name=dataset.dataset_name,
+            physical_dataset_name=written["physical_dataset_name"],
+            tables=["orders"],
+        )
+    )
+
+    target_pipeline = dlt.pipeline(
+        pipeline_name="lineage_tgt_" + uniq_id(), destination="duckdb", dev_mode=True
+    )
+    extract_info = target_pipeline.extract(resource)
+
+    read = cast(
+        TDatasetDataLocation, extract_info.metrics[extract_info.loads_ids[0]][0]["inputs"][0]
+    )
+    assert read["physical_dataset_name"] == written["physical_dataset_name"]
+    assert read["location"] == written["location"]
+    assert read["resource_name"] == "orders_copy"

--- a/tests/pipeline/test_data_locations.py
+++ b/tests/pipeline/test_data_locations.py
@@ -17,6 +17,11 @@ def _by_resource(locations: List[TDatasetDataLocation]) -> Dict[str, TDatasetDat
     return {location["resource_name"]: location for location in locations}
 
 
+def _inputs(info: Any) -> List[Any]:
+    """All input locations of an extract info"""
+    return info.metrics[info.loads_ids[0]][0]["inputs"]
+
+
 @dlt.resource(primary_key="id", name="orders")
 def orders_with_nested() -> Any:
     yield [
@@ -134,6 +139,33 @@ def test_output_locations_of_multiple_datasets() -> None:
     later = _by_resource(_outputs(info))["c_table"]
     assert later["physical_dataset_name"] == f"{pipeline.dataset_name}_other"
     assert [s["name"] for s in later["schemas"]] == ["other"]
+
+
+def test_input_locations_replaced_on_each_run() -> None:
+    """A reused resource instance re-reads its location every run, `replace` drops the stale one"""
+    bucket = {"url": "file:///first"}
+
+    @dlt.resource(name="files")
+    def files() -> Any:
+        resource = dlt.current.resource()
+        resource.add_input(
+            {"kind": "filesystem", "resource_name": resource.name, "location": bucket["url"]},
+            replace=True,
+        )
+        yield [{"id": 1}]
+
+    resource = files()
+    pipeline = dlt.pipeline(
+        pipeline_name="inputs_replaced_" + uniq_id(), destination="duckdb", dev_mode=True
+    )
+    assert [location["location"] for location in _inputs(pipeline.extract(resource))] == [
+        "file:///first"
+    ]
+
+    bucket["url"] = "file:///second"
+    assert [location["location"] for location in _inputs(pipeline.extract(resource))] == [
+        "file:///second"
+    ]
 
 
 def test_input_and_output_locations_join_on_physical_dataset_name() -> None:

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -2703,6 +2703,12 @@ def test_dispatch_rows_to_tables(github_resource: DltResource):
             assert table["write_disposition"] == "merge"
             assert table["columns"]["id"]["primary_key"] is True
 
+    # dispatched tables are not knowable before items flow, they still land in one output location
+    outputs = [location for metrics in info.metrics.values() for location in metrics[0]["outputs"]]
+    dispatched = [o for o in outputs if o["resource_name"] == "github_repo_events"]
+    assert len(dispatched) == 1
+    assert set(dispatched[0]["tables"]) == {t["name"] for t in p.default_schema.data_tables()}
+
 
 def test_resource_name_in_schema() -> None:
     @dlt.resource(table_name="some_table")

--- a/tests/pipeline/test_pipeline_trace.py
+++ b/tests/pipeline/test_pipeline_trace.py
@@ -3,7 +3,7 @@ import io
 import os
 import asyncio
 import datetime  # noqa: 251
-from typing import Any, List, Set
+from typing import Any, List, Set, cast
 from unittest.mock import patch
 import pytest
 import requests_mock
@@ -15,6 +15,7 @@ from dlt.common import json, pendulum
 from dlt.common.configuration.specs import CredentialsConfiguration, RuntimeConfiguration
 from dlt.common.configuration.specs.config_providers_context import ConfigProvidersContainer
 from dlt.common.configuration.utils import get_resolved_traces
+from dlt.common.metrics import TDataLocation, TDatasetDataLocation
 from dlt.common.pipeline import ExtractInfo, NormalizeInfo, LoadInfo
 from dlt.common.schema import Schema
 from dlt.common.runtime.telemetry import stop_telemetry
@@ -69,7 +70,7 @@ def test_create_trace(toml_providers: ConfigProvidersContainer, environment: Any
     extract_info = pipeline.extract(inject_tomls())
     trace = pipeline.last_trace
     assert trace is not None
-    assert trace.engine_version == TRACE_ENGINE_VERSION == 1
+    assert trace.engine_version == TRACE_ENGINE_VERSION == 2
     # assert p._trace is None
     assert len(trace.steps) == 1
     step = trace.steps[0]
@@ -298,6 +299,25 @@ def test_trace_schema() -> None:
             ],
         )
         def data(id_=dlt.sources.incremental("id")):
+            # a dataset read location, so the contract covers every field of the location type
+            # and its nested schemas / tables tables
+            dlt.current.resource().add_input(
+                TDatasetDataLocation(
+                    kind="dataset",
+                    resource_name="data",
+                    location="duckdb:///upstream.duckdb",
+                    version="Nz1p6EJnRUFLKgVMPBTDgw",
+                    schemas=[{"name": "upstream", "version_hash": "e8Yg4KzYbG1eYQzT5xkFAA"}],
+                    tables=["orders", "customers"],
+                    dataset_name="Upstream_DataSet",
+                    physical_dataset_name="upstream_data_set",
+                    destination_type="dlt.destinations.duckdb",
+                    destination_name="duckdb",
+                    destination_fingerprint="0Xtq0OYSuqDcRTxWTLZY",
+                    casefold="lower",
+                    case_sensitive=False,
+                )
+            )
             yield [{"id": 1, "multi": "1.2"}, {"id": 2}, {"id": 3}]
 
         # dict-shaped write_disposition (merge) and schema_contract, so the trace contract
@@ -329,6 +349,18 @@ def test_trace_schema() -> None:
             # Add a custom metric
             custom_metrics = dlt.current.resource_metrics()
             custom_metrics["good_old_github"] = True
+            # record a read location so the contract covers inputs and their nested tables
+            dlt.current.resource().add_input(
+                cast(
+                    TDataLocation,
+                    {
+                        "kind": "rest_api",
+                        "location": "https://api.github.com",
+                        "version": "2022-11-28",
+                        "endpoints": ["/events"],
+                    },
+                )
+            )
             for _ in range(1):
                 with open(
                     "tests/normalize/cases/github.events.load_page_1_duck.json",
@@ -482,6 +514,16 @@ def test_trace_refresh_and_table_drops(
     assert extract_package.refresh == refresh
     assert set(extract_package.dropped_tables or []) == expected_dropped
     assert set(extract_package.truncated_tables or []) == expected_truncated
+
+    # a table dropped or truncated by refresh is written again, so it is still an output
+    outputs = {
+        location["resource_name"]: location
+        for metrics in info.metrics.values()
+        for location in metrics[0]["outputs"]
+    }
+    assert outputs["items"]["tables"] == ["items"]
+    assert outputs["other"]["tables"] == ["other"]
+    assert outputs["items"]["physical_dataset_name"] == info.dataset_name
 
     assert_trace_serializable(pipeline.last_trace)
 

--- a/tests/sources/filesystem/test_filesystem_source.py
+++ b/tests/sources/filesystem/test_filesystem_source.py
@@ -1,7 +1,9 @@
+from typing import cast
 import pytest
 
 import dlt
 
+from dlt.sources.filesystem.helpers import TFilesystemDataLocation
 from dlt.sources.filesystem import filesystem
 
 from tests.load.utils import HTTP_BUCKET
@@ -26,3 +28,12 @@ def test_http_filesystem(public_http_server, bucket_url: str):
     )
     assert_load_info(load_info)
     assert pipeline.last_trace.last_normalize_info.row_counts["http_parquet_example"] == 1
+
+    # the bucket and glob it listed are recorded as the input of the run
+    extract_info = pipeline.last_trace.last_extract_info
+    inputs = extract_info.metrics[extract_info.loads_ids[0]][0]["inputs"]
+    assert len(inputs) == 1
+    assert inputs[0]["kind"] == "filesystem"
+    assert inputs[0]["location"] == bucket_url
+    assert cast(TFilesystemDataLocation, inputs[0])["glob"] == "parquet/mlb_players.parquet"
+    assert inputs[0]["resource_name"] == "http_parquet_example"

--- a/tests/sources/rest_api/integration/test_offline.py
+++ b/tests/sources/rest_api/integration/test_offline.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, List, Optional
+from typing import Any, List, Optional, cast
 from unittest import mock
 from urllib.parse import parse_qs, urlsplit
 
@@ -10,6 +10,7 @@ import dlt
 from dlt.common import pendulum
 from dlt.pipeline.exceptions import PipelineStepFailed
 from dlt.sources.helpers.rest_client.paginators import BaseReferencePaginator
+from dlt.sources.rest_api.config_setup import TRestApiDataLocation
 from dlt.sources.rest_api import (
     ClientConfig,
     Endpoint,
@@ -200,6 +201,28 @@ def test_load_mock_api(mock_api_server, config):
     assert table_counts["posts"] == DEFAULT_PAGE_SIZE * DEFAULT_TOTAL_PAGES
     assert table_counts["post_details"] == DEFAULT_PAGE_SIZE * DEFAULT_TOTAL_PAGES
     assert table_counts["post_comments"] == 50 * DEFAULT_PAGE_SIZE * DEFAULT_TOTAL_PAGES
+
+    # every resource records the endpoint it read, the dependent ones (transformers) included,
+    # once each however many pages they paginated
+    extract_info = pipeline.last_trace.last_extract_info
+    inputs = extract_info.metrics[extract_info.loads_ids[0]][0]["inputs"]
+    by_resource = {location["resource_name"]: location for location in inputs}
+    assert set(by_resource) == {"posts", "post_comments", "post_details"}
+    for location in inputs:
+        assert location["kind"] == "rest_api"
+        assert location["location"] == "https://api.example.com"
+    # the configured endpoint is recorded as is, never a resolved request url
+    expected_paths = {}
+    for resource in config["resources"]:
+        if isinstance(resource, str):
+            expected_paths[resource] = resource
+        else:
+            endpoint = resource["endpoint"]
+            expected_paths[resource["name"]] = (
+                endpoint if isinstance(endpoint, str) else endpoint["path"]
+            )
+    for name, location in by_resource.items():
+        assert cast(TRestApiDataLocation, location)["endpoints"] == [expected_paths[name]]
 
     with pipeline.sql_client() as client:
         posts_table = client.make_qualified_table_name("posts")
@@ -2081,3 +2104,17 @@ def test_dependent_resource_parallelized_with_incremental(mock_api_server):
         f"SELECT MIN(id) FROM {post_comments_table}",
         [45],
     )
+
+
+def test_rest_api_endpoint_location_is_sanitized() -> None:
+    """A location is never allowed to carry credentials"""
+    from dlt.sources.helpers.rest_client.client import RESTClient
+    from dlt.sources.rest_api.config_setup import record_endpoint_input
+
+    resource = dlt.resource([{"id": 1}], name="posts")
+    record_endpoint_input(
+        resource, RESTClient(base_url="https://api.example.com?api_key=top_secret"), "posts"
+    )
+    location = cast(TRestApiDataLocation, resource.inputs[0])
+    assert "top_secret" not in str(location)
+    assert location["location"] == "https://api.example.com?api_key=***"

--- a/tests/sources/sql_database/test_data_locations.py
+++ b/tests/sources/sql_database/test_data_locations.py
@@ -1,0 +1,33 @@
+from typing import Any, cast
+
+import pytest
+import sqlalchemy as sa
+
+import dlt
+from dlt.common.configuration.specs import ConnectionStringCredentials
+from dlt.sources.sql_database.helpers import (
+    TSqlDatabaseDataLocation,
+    record_table_input,
+)
+
+
+@pytest.mark.parametrize("as_engine", [False, True], ids=["credentials", "engine"])
+def test_sql_database_location_hides_password(as_engine: bool) -> None:
+    """A location is never allowed to carry credentials, whichever form they came in"""
+    connection_string = "postgresql+psycopg2://loader:top_secret@example.com:5432/dlt_data"
+    credentials: Any = (
+        sa.create_engine(connection_string)
+        if as_engine
+        else ConnectionStringCredentials(connection_string)
+    )
+
+    resource = dlt.resource([{"id": 1}], name="orders")
+    record_table_input(resource, credentials, "public", "orders")
+
+    location = cast(TSqlDatabaseDataLocation, resource.inputs[0])
+    # the dbapi driver is not part of the identity, the backend is
+    assert location["location"] == "postgresql://example.com:5432"
+    assert location["database"] == "dlt_data"
+    assert location["db_schema"] == "public"
+    assert "top_secret" not in str(location)
+    assert "loader" not in str(location)

--- a/tests/sources/sql_database/test_data_locations.py
+++ b/tests/sources/sql_database/test_data_locations.py
@@ -11,14 +11,11 @@ from dlt.sources.sql_database.helpers import (
 )
 
 
-@pytest.mark.parametrize("as_engine", [False, True], ids=["credentials", "engine"])
-def test_sql_database_location_hides_password(as_engine: bool) -> None:
-    """A location is never allowed to carry credentials, whichever form they came in"""
-    connection_string = "postgresql+psycopg2://loader:top_secret@example.com:5432/dlt_data"
-    credentials: Any = (
-        sa.create_engine(connection_string)
-        if as_engine
-        else ConnectionStringCredentials(connection_string)
+def test_sql_database_location_hides_password() -> None:
+    """A location is never allowed to carry credentials"""
+    # parsing a connection string does not import the dbapi driver, creating an engine would
+    credentials = ConnectionStringCredentials(
+        "postgresql+psycopg2://loader:top_secret@example.com:5432/dlt_data"
     )
 
     resource = dlt.resource([{"id": 1}], name="orders")
@@ -31,3 +28,18 @@ def test_sql_database_location_hides_password(as_engine: bool) -> None:
     assert location["db_schema"] == "public"
     assert "top_secret" not in str(location)
     assert "loader" not in str(location)
+
+
+def test_sql_database_location_from_engine() -> None:
+    """An externally provided engine carries no credentials object, its url is read instead"""
+    # sqlite needs no driver beyond the standard library, so any ci job can build this engine
+    engine = sa.create_engine("sqlite://")
+
+    resource = dlt.resource([{"id": 1}], name="orders")
+    record_table_input(resource, engine, None, "orders")
+    engine.dispose()
+
+    location = cast(TSqlDatabaseDataLocation, resource.inputs[0])
+    assert location["location"] == "sqlite://"
+    assert location["tables"] == ["orders"]
+    assert "db_schema" not in location


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Lineage info is emitted in traces with data more or less similar to open lineage but in relational form that can be ingested with dlt (like the rest of traces).

A set of inputs (per resource + data location) is added to "extract" step trace. from that inputs dlt computes outputs (resource + data location) added to load step trace.

data location is similar to open lineage namespace and corresponds to ie. a dlt dataset, rest API or database with tables etc.

here's base for all inputs and outputs. `kind`, `resource_name` and `location` are required: without them a row adds nothing to what the trace already says. `location` is a **human readable scope**, not an identity - `localhost`, a private address or an in-memory database are reported as configured and must not be compared for joinability (a fingerprint may be added later for that).

```py
class TDataLocation(TypedDict):
    kind: str
    """Location type: `dataset`, `sql_database`, `filesystem`, `rest_api`, or a custom value."""
    resource_name: str
    """Resource that read from or wrote to this location."""
    location: str
    """Non-secret scope of the location, e.g. `postgresql://example.com:5432`, `s3://bucket`.
    Empty when the location has no public address, ie. a reverse ETL sink."""
    version: NotRequired[str]
    """Version of the location's contents as a whole."""
```

here's definition of dataset input / output. everything except the two dataset names is required, so a row keeps the same shape whatever destination it describes. `physical_dataset_name` is the name after normalization (`My_DataSet` -> `my_data_set`) and is what both sides agree on; `dataset_name` keeps what was configured, for display. `casefold` and `case_sensitive` come from the **runtime adjusted** capabilities (naming convention and destination config both change them), so a consumer can derive the destination-bound form of any identifier without dlt.

```py
class TSchemaReference(TypedDict):
    name: str
    version_hash: str


class TDatasetDataLocation(TDataLocation):
    schemas: List[TSchemaReference]
    """Schemas grouping the tables, each carrying its own version hash."""
    tables: List[str]
    """Tables touched, as plain names - dlt qualifies tables by dataset, not by schema."""
    destination_type: str
    destination_name: str
    destination_fingerprint: str
    """Identifies destinations whose `location` is not public, ie. motherduck. May be empty."""
    casefold: str
    """Name of the casefolding function the destination applies: `upper`, `lower` or `str`."""
    case_sensitive: bool
    """Whether the destination generates case sensitive identifiers, as adjusted at runtime."""
    dataset_name: NotRequired[str]
    """Logical dataset name as configured by the user, e.g. `My_DataSet`. Absent for sinks."""
    physical_dataset_name: NotRequired[str]
    """Normalized name as it exists in the store, e.g. `my_data_set`. Absent for sinks."""
```

`version` is a hash over the `version_hash` of all the schemas in the location, computed order independently, so a single scalar answers "did anything I read change".

for transformations inputs (per resource) are of "dataset" kind and several of them will be present if resource takes many datasets as arguments.

core sources were also instrumented:

- **sql_database** / **sql_table** - `kind="sql_database"`, the server scope (`postgresql://example.com:5432`), `database`, `db_schema` and the one table the resource reads. recorded when the resource is created, from the credentials that were passed in. the scope comes from a new `ConnectionStringCredentials.physical_location()` so credentials, dbapi driver and connect options are never part of it.
- **filesystem** - `kind="filesystem"`, the bucket scope and the `glob`. one entry for the glob, not per file: per file entries are unbounded and per file detail already lands in the loaded data as `FileItem.file_url`. recorded while the resource runs, because `bucket_url` may only be known after config resolution.
- **rest_api** - `kind="rest_api"`, `client.base_url` sanitized with `sanitize_url`, plus the endpoint **template** of the resource (never a resolved request url: unbounded cardinality and a secret leak surface). dependent resources are transformers and record their own endpoint, so they appear as well.

each of those subclasses `TDataLocation` with its own fields, ie.

```py
class TRestApiDataLocation(TDataLocation):
    endpoints: NotRequired[List[str]]
```

on top of that users can define their own inputs on resource. call it on the resource instance when you create one, or from inside a running resource via `dlt.current.resource()` when the location is only known once config is resolved. `kind` defaults to the name of the source the resource belongs to.

```py
class TOrdersApiLocation(TDataLocation):
    endpoints: NotRequired[List[str]]

@dlt.resource
def get_orders():
    yield [{"id": 1}, {"id": 2}]

@dlt.source
def orders_api():
    orders = get_orders()
    orders.add_input(TOrdersApiLocation(
        kind="rest_api",
        resource_name=orders.name,
        location="https://api.example.com",
        endpoints=["/orders"],
    ))
    return orders
```

recording is additive: no input means no entry, so traces of existing pipelines are unchanged. a transformer has no input of its own unless it reads one - being fed by another resource is not an input, that edge is already in `ExtractMetrics.dag`.

here's how inputs and outputs look in trace, for `sql_database` (sqlite) loaded into duckdb with `dataset_name="Marts"`:

```json
// trace__steps__extract_info__inputs
{
  "load_id": "1785098343.0313416",
  "extract_idx": 0,
  "kind": "sql_database",
  "resource_name": "customers",
  "location": "sqlite:///tmp/crm.db",
  "database": "/tmp/crm.db",
  "tables": ["customers"]
}

// trace__steps__load_info__outputs
{
  "load_id": "1785098343.0313416",
  "kind": "dataset",
  "resource_name": "customers",
  "location": "/tmp/marts.duckdb",
  "version": "W7OX1I+Eylroebrh6id4",
  "schemas": [{"name": "sql_database", "version_hash": "547e65vd7poMKv1Q9e5uk2Ul9dD1MBb0/XN01E0Ywi0="}],
  "tables": ["customers"],
  "destination_type": "dlt.destinations.duckdb",
  "destination_name": "duckdb",
  "destination_fingerprint": "",
  "casefold": "str",
  "case_sensitive": false,
  "dataset_name": "Marts_20260726083902",
  "physical_dataset_name": "marts_20260726083902"
}
```

loaded as `trace__steps__extract_info__inputs` and `trace__steps__load_info__outputs`, each with `__tables` / `__schemas` (and ie. `__endpoints`) child tables. the dataflow graph of your pipelines is then a SQL query:

```sql
select i.kind, i.location as read_from, o.physical_dataset_name as written_to, t.value as table_name
from trace__steps__load_info__outputs o
join trace__steps__load_info__outputs__tables t on t._dlt_parent_id = o._dlt_id
join trace__steps__extract_info__inputs i on i.resource_name = o.resource_name
```

a run writes one entry per (resource, location): a table spread over many load jobs is listed once, nested tables are attributed to the resource owning their root table, tables created by a dynamic `table_name` callable are picked up, and with `use_single_dataset=False` a single load step reports several datasets (`LoadInfo.dataset_name` can only name one of them).

`TRACE_ENGINE_VERSION` is bumped to `2` and the frozen trace contract in `tests/pipeline/cases/contracts/trace.schema.yaml` was regenerated - purely additive.

## todo
1. allow to define custom outputs for custom destinations (at least locations and any free data)
2. a big overhaul of how traces are generated

right now traces are generated in a relational form that is to store and query in the database. we plan upgrade trace emitters with other forms:

* oTel with a custom semantic convention for dlt pipelines (but mapping as many things into standard otel objects)
* open lineage both standalone or as a part of oTel traces
