### PR TITLE
fix(incremental): do not close bounded arrow source on all-null cursor batch

### DIFF
--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -506,7 +506,11 @@ class ArrowIncremental(IncrementalTransform):
                 ) from ex
             # Is max row value higher than end value?
             # NOTE: pyarrow bool *always* evaluates to python True. `as_py()` is necessary
-            end_out_of_range = not self.end_compare(row_value_scalar, end_value_scalar).as_py()
+            # NOTE: an all-null cursor column aggregates to a null scalar, and comparing it
+            # yields null as well. That means "no comparable cursor value in this batch",
+            # not "out of range" - treating it as out of range closes an ordered source early.
+            end_compare_result = self.end_compare(row_value_scalar, end_value_scalar).as_py()
+            end_out_of_range = end_compare_result is not None and not end_compare_result
             if end_out_of_range:
                 tbl = tbl.filter(self.end_compare(tbl[cursor_path], end_value_scalar))
                 # NOTE: here we should recalculate row_value_scalar and row_value because it was out of range!

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -924,6 +924,32 @@ def test_cursor_path_none_excludes_records_and_updates_incremental_cursor(
     assert s["last_value"] == 2
 
 
+def test_arrow_all_null_cursor_batch_does_not_close_bounded_source() -> None:
+    """An all-null cursor batch must not be read as crossing end_value (issue #4284)."""
+    requested_pages = []
+
+    @dlt.resource
+    def pages(
+        ts=dlt.sources.incremental(
+            "ts",
+            initial_value=0,
+            end_value=10,
+            row_order="asc",
+            on_cursor_value_missing="exclude",
+        ),
+    ):
+        requested_pages.append(1)
+        yield pa.table({"id": [1, 2], "ts": pa.array([None, None], type=pa.int64())})
+
+        requested_pages.append(2)
+        yield pa.table({"id": [3, 4], "ts": [5, 6]})
+
+    result = list(pages())
+
+    assert requested_pages == [1, 2]
+    assert [row["ts"] for tbl in result for row in tbl.to_pylist()] == [5, 6]
+
+
 @pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
 def test_cursor_path_none_can_raise_on_none_1(item_type: TestDataItemFormat) -> None:
     data = [


### PR DESCRIPTION
### Description

`ArrowIncremental.__call__` aggregates the cursor column before null rows are removed. For an all-null cursor batch the aggregate is a null scalar, so `end_compare(...).as_py()` returns `None` and `not None` set `end_out_of_range = True`. With `row_order="asc"`, `Incremental.can_close()` reads that as a real upper-bound crossing and closes the source pipe, silently dropping every later batch.

A null comparison result now means "no comparable cursor value in this batch" instead of out of range.

### Related Issues

- Closes #4284

### Additional Context

New `test_arrow_all_null_cursor_batch_does_not_close_bounded_source` in `tests/extract/test_incremental.py` (next to the existing `on_cursor_value_missing` tests) fails on `devel` with `assert [1] == [1, 2]` and passes with the fix. `tests/extract/test_incremental.py -k "cursor_path_none or arrow or end_value"`: 214 passed; the one `test_warning_large_deduplication_state[id-arrow-table]` fixture error is identical on baseline.
