### PR TITLE
Add instance size, including disk and reference to optimize dlt.

### DIFF
--- a/docs/website/docs/hub/pipeline-operations/job-configuration.md
+++ b/docs/website/docs/hub/pipeline-operations/job-configuration.md
@@ -1,12 +1,12 @@
 ---
 title: Job configuration
-description: Per-job options on the dltHub platform — execution timeouts, dependency groups, and TOML configuration sections
-keywords: [dlthub platform, job configuration, timeout, dependency groups, static egress, execute, require, expose, section]
+description: Per-job options on the dltHub platform — execution timeouts, dependency groups, instance size, and TOML configuration sections
+keywords: [dlthub platform, job configuration, timeout, dependency groups, instance, size, require.instance, static egress, execute, require, expose, section]
 ---
 
 # Job configuration
 
-This page documents the per-job options that aren't about *when* a job runs (those live in [Triggers and scheduling](triggers.md)) but about *how* it runs — execution limits, the Python environment it gets, and the configuration values it reads at runtime.
+This page documents the per-job options that aren't about *when* a job runs (those live in [Triggers and scheduling](triggers.md)) but about *how* it runs — execution limits, runner resources, the Python environment it gets, and the configuration values it reads at runtime.
 
 All options below are arguments to the `@run.pipeline`, `@run.job`, and `@run.interactive` decorators.
 
@@ -43,6 +43,30 @@ def transform(run_context: TJobRunContext):
 ```
 
 The dltHub platform composes the execution environment from the workspace's base dependencies plus the job's declared groups.
+
+## Instance size
+
+Pick how much CPU and memory the job’s runner gets. Pass it under `require.instance`:
+
+```py
+@run.pipeline(
+    my_pipeline,
+    require={"instance": {"size": "medium"}},
+)
+def heavy_sync():
+    ...
+```
+
+| `size` | vCPU | Memory | Disk | Multiplier |
+|--------|------|--------|------|------------|
+| `small` | 2 | 4 GiB | 500 GB | 1× |
+| `medium` | 4 | 8 GiB | 500 GB | 2× |
+| `large` | 8 | 16 GiB | 500 GB | 4× |
+| `xlarge` | 16 | 32 GiB | 500 GB | 8× |
+
+If you omit `instance`, jobs default to `small`. Larger sizes use a higher `multiplier` against your organization's run time budget. For example, a one-hour `large` run consumes four hours of budget.
+
+Pipeline-level tuning (chunking, parallelism, memory settings) often lowers the size you need, see [Optimizing dlt](../../reference/performance.md).
 
 ## Static egress IPs
 


### PR DESCRIPTION
This PR adds docs for configuring instance size for a job for dlthub platform via job decorator.