### PR TITLE
feat(filesystem): tag s3fs user agent with dlt version

### DIFF
--- a/dlt/common/configuration/specs/aws_credentials.py
+++ b/dlt/common/configuration/specs/aws_credentials.py
@@ -44,13 +44,14 @@ class AwsCredentialsWithoutDefaults(
         )
         if self.region_name:
             credentials["client_kwargs"] = {"region_name": self.region_name}
+        # identify dlt in the botocore user agent for Amazon S3 and any S3-compatible endpoint
+        config_kwargs: DictStrAny = {"user_agent_extra": f"dlt/{version.__version__}"}
         if self.endpoint_url:
             # NOTE: we need to make checksum validation optional for boto to work with s3 compat mode
             # https://www.beginswithdata.com/2025/05/14/aws-s3-tools-with-gcs/
-            credentials["config_kwargs"] = {
-                "response_checksum_validation": "when_required",
-                "request_checksum_calculation": "when_required",
-            }
+            config_kwargs["response_checksum_validation"] = "when_required"
+            config_kwargs["request_checksum_calculation"] = "when_required"
+        credentials["config_kwargs"] = config_kwargs
         return credentials
 
     def to_native_representation(self) -> Dict[str, Optional[str]]:

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -127,6 +127,8 @@ endpoint_url = "https://<account_id>.r2.cloudflarestorage.com" # copy your endpo
 
 For Tigris, set `endpoint_url = "https://t3.storage.dev"` and use your Tigris access key ID (prefixed `tid_`) and secret access key (prefixed `tsec_`). Tigris uses a single global endpoint and doesn't charge egress fees, which matters when warehouses in different regions load from the same staging bucket.
 
+Because the destination reaches these stores through the Amazon S3 API, `endpoint_url` is usually the only setting that differs between providers such as Backblaze B2, Cloudflare R2, and MinIO. Keep `bucket_url` on the `s3://` scheme, keep the same access key settings, and point `endpoint_url` at your provider's S3 endpoint, for example `https://your-s3-endpoint.example.com`.
+
 #### Adding additional configuration
 
 To pass any additional arguments to `fsspec`, you may supply `kwargs` and `client_kwargs` in `toml` config.

--- a/tests/load/filesystem/test_aws_credentials.py
+++ b/tests/load/filesystem/test_aws_credentials.py
@@ -9,6 +9,7 @@ from dlt.common.configuration.specs.aws_credentials import (
     AwsCredentialsWithoutDefaults,
 )
 from dlt.common.configuration.specs.exceptions import InvalidBoto3Session
+from dlt.version import __version__
 
 from tests.common.configuration.utils import environment
 from tests.load.filesystem.utils import can_connect_pyiceberg_fileio_config, fs_creds
@@ -78,6 +79,7 @@ def test_aws_credentials_from_botocore(environment: Dict[str, str]) -> None:
         "profile": None,
         "endpoint_url": None,
         "client_kwargs": {"region_name": region_name},
+        "config_kwargs": {"user_agent_extra": f"dlt/{__version__}"},
     }
 
     # to_session_credentials still freezes (used by the STS / object_store fallback paths)
@@ -163,6 +165,8 @@ def test_aws_credentials_with_endpoint_url(environment: Dict[str, str]) -> None:
     assert s3fs_creds["endpoint_url"] == "https://123.r2.cloudflarestorage.com"
     assert s3fs_creds["client_kwargs"] == {"region_name": "eu-central-1"}
     assert "config_kwargs" in s3fs_creds
+    # user agent is tagged for any S3-compatible endpoint, alongside the checksum settings
+    assert s3fs_creds["config_kwargs"]["user_agent_extra"] == f"dlt/{__version__}"
 
 
 def _refreshable_credentials(deferred: bool = False) -> Any:


### PR DESCRIPTION
### Description

`AwsCredentialsWithoutDefaults.to_s3fs_credentials()` now always sets `config_kwargs["user_agent_extra"] = f"dlt/{version.__version__}"`, so requests the filesystem destination makes through `s3fs`/`botocore` identify dlt and its version in the HTTP `User-Agent` header. botocore appends this to its own product tokens, so the usual `Boto3/... botocore/...` prefix is preserved. It makes dlt traffic recognizable in server-side access logs when debugging a bucket that several clients write to.

The existing S3-compatibility settings are unchanged in behavior: `response_checksum_validation` and `request_checksum_calculation` are still set to `when_required` only when `endpoint_url` is configured. They are now written into the same `config_kwargs` dict rather than replacing it, so they coexist with the user agent instead of dropping it.

The second commit is docs only. It notes in the filesystem destination page that because the destination talks to these stores through the Amazon S3 API, `endpoint_url` is usually the only setting that differs between providers, and that `bucket_url` stays on the `s3://` scheme. Placeholder endpoint, no new provider sections.

### Related Issues

I could not find an existing issue for this. Happy to open one and link it here if you would rather track it that way, or to drop the change if you do not want the extra token on the wire.

### Additional Context

Two commits: code plus tests, then docs.

`tests/load/filesystem/test_aws_credentials.py` covers both paths: `test_aws_credentials_from_botocore` asserts the full expected `to_s3fs_credentials()` dict with no `endpoint_url` set, and `test_aws_credentials_with_endpoint_url` asserts `user_agent_extra` survives alongside the two checksum keys.

Only the `s3fs` path is touched. `to_session_credentials()`, `to_native_representation()`, and the `object_store_rs`/pyiceberg mixins are untouched, so nothing that consumes those sees a new key.

Opened as a draft while I finish the full local lint and test run; I will mark it ready once that is green.
