### PR TITLE
docs(sql): warn about cursor column mismatch after reflection

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/configuration.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/configuration.md
@@ -192,6 +192,21 @@ to split long incremental loading into many chunks by time and row count. [Look 
 If your cursor column name contains special characters (e.g., `$`) you need to escape it when passing it to the `incremental` function. For example, if your cursor column is `example_$column`, you should pass it as `"'example_$column'"` or `'"example_$column"'` to the `incremental` function: `incremental("'example_$column'", initial_value=...)`.
 :::
 
+:::warning Cursor column not found after reflection
+If `dlt` raises ``KeyError: 'Cursor column `...` does not exist in table `...`'``, your cursor name doesn't match the reflected schema. Dialects normalize identifiers differently: PostgreSQL lowercases, Oracle uppercases, MySQL/MSSQL/SQLite preserve case. Inspect the reflected columns first:
+
+```py
+import sqlalchemy as sa
+
+engine = sa.create_engine("postgresql://user:pass@host/db")
+meta = sa.MetaData()
+meta.reflect(bind=engine, only=["your_table"])
+print(list(meta.tables["your_table"].c.keys()))
+```
+
+Use the exact name shown as your cursor path.
+:::
+
 ### Configure timezone-aware and naive timestamp cursors
 If your cursor is on a timestamp/datetime column, make sure you set up your initial and end values correctly. This will help you avoid implicit type conversions, invalid datetime literals, or column comparisons in database queries. Note that implicit conversions may result in data loss, for example if a naive datetime has a different local timezone on the machine where Python is executing versus your DBMS.
 

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/configuration.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/configuration.md
@@ -192,19 +192,8 @@ to split long incremental loading into many chunks by time and row count. [Look 
 If your cursor column name contains special characters (e.g., `$`) you need to escape it when passing it to the `incremental` function. For example, if your cursor column is `example_$column`, you should pass it as `"'example_$column'"` or `'"example_$column"'` to the `incremental` function: `incremental("'example_$column'", initial_value=...)`.
 :::
 
-:::warning Cursor column not found after reflection
-If `dlt` raises ``KeyError: 'Cursor column `...` does not exist in table `...`'``, your cursor name doesn't match the reflected schema. Dialects normalize identifiers differently: PostgreSQL lowercases, Oracle uppercases, MySQL/MSSQL/SQLite preserve case. Inspect the reflected columns first:
-
-```py
-import sqlalchemy as sa
-
-engine = sa.create_engine("postgresql://user:pass@host/db")
-meta = sa.MetaData()
-meta.reflect(bind=engine, only=["your_table"])
-print(list(meta.tables["your_table"].c.keys()))
-```
-
-Use the exact name shown as your cursor path.
+:::info Cursor column not found?
+If you hit ``KeyError: 'Cursor column `...` does not exist in table `...`'``, your cursor name doesn't match the schema SQLAlchemy reflected. See [I get a KeyError saying the cursor column doesn't exist](troubleshooting.md#i-get-a-keyerror-saying-the-cursor-column-doesnt-exist) for how to inspect the reflected columns.
 :::
 
 ### Configure timezone-aware and naive timestamp cursors

--- a/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/troubleshooting.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/sql_database/troubleshooting.md
@@ -23,6 +23,24 @@ must match timezone-awareness of the cursor column](setup.md) because they will 
 In rare cases where the last value is already stored in the pipeline state and has incorrect timezone-awareness, you may not be able to recover your pipeline automatically. You can
 modify the local pipeline state (after syncing with destination) to add/remove timezone information.
 
+## Troubleshooting incremental loading
+
+### I get a KeyError saying the cursor column doesn't exist
+If `dlt` raises ``KeyError: 'Cursor column `...` does not exist in table `...`'``, the name you passed to `dlt.sources.incremental(...)` isn't present in the schema that SQLAlchemy reflected. Reflection returns whatever the database itself stores, and dialects normalize identifiers differently: PostgreSQL lowercases unquoted identifiers, Oracle uppercases them, MySQL, MSSQL, and SQLite preserve the case you declared.
+
+Inspect the reflected column names first:
+
+```py
+import sqlalchemy as sa
+
+engine = sa.create_engine("postgresql://user:pass@host/db")
+meta = sa.MetaData()
+meta.reflect(bind=engine, only=["your_table"])
+print(list(meta.tables["your_table"].c.keys()))
+```
+
+Copy the column name from that output, case included, and pass it to `dlt.sources.incremental(...)`.
+
 ## Troubleshooting connection
 
 ### Pipeline state grows extremely large or I get deduplication state warnings when using incremental


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Closes #4213.

Documents the `KeyError: 'Cursor column \`...\` does not exist in table \`...\`'` a user hits when the cursor column name they pass to `dlt.sources.incremental(...)` doesn't match the SQLAlchemy-reflected column name.

## Why
SQLAlchemy reflection returns whatever the source database stores, and dialects normalize identifiers differently:
- PostgreSQL lowercases unquoted identifiers
- Oracle uppercases them
- MySQL, MSSQL, and SQLite preserve the case you declared

The error message doesn't hint at this, so users burn time double-checking their SQL before figuring out it's a reflection issue.

## What changed
Split across two pages, since users hit this from two directions (writing incremental config vs. searching after seeing the error):

- **`sql_database/configuration.md#incremental-loading`** — short `:::info` pointer next to the incremental setup section, naming the error and linking to the troubleshooting entry.
- **`sql_database/troubleshooting.md`** — new "Troubleshooting incremental loading" H2 with a full entry (`I get a KeyError saying the cursor column doesn't exist`) that explains per-dialect normalization and provides a 5-line SQLAlchemy snippet to print reflected column names.

## Verification
Reproduced locally against SQLite: reflecting a table created with `UPDATED_AT` returns `['id', 'UPDATED_AT']`, and `dlt.sources.incremental("updated_at")` (lowercase) raises exactly the documented error.