### PR TITLE
fix(filesystem): normalize OneLake directory probes

### DIFF
--- a/dlt/destinations/impl/filesystem/factory.py
+++ b/dlt/destinations/impl/filesystem/factory.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional, Type, Union, Dict, TYPE_CHECKING, Sequence, Tuple
+from urllib.parse import urlparse
 
 from dlt.common.configuration import configspec
 from dlt.common.configuration.resolve import resolve_configuration
@@ -13,8 +14,23 @@ from dlt.destinations.impl.filesystem.configuration import (
     HfFilesystemDestinationClientConfiguration,
 )
 from dlt.destinations.impl.filesystem.filesystem import FilesystemClient, HfFilesystemClient
+from dlt.destinations.impl.filesystem.onelake import OneLakeFilesystemClient
 from dlt.destinations.impl.filesystem.typing import TCurrentDateTime, TExtraPlaceholders
 from dlt.common.normalizers.naming import NamingConvention
+
+_ONELAKE_HOSTS = {
+    "onelake.blob.fabric.microsoft.com",
+    "onelake.dfs.fabric.microsoft.com",
+}
+_AZURE_PROTOCOLS = {"az", "abfs", "adl", "abfss", "azure"}
+
+
+def _is_onelake_host(value: Optional[str]) -> bool:
+    if not value:
+        return False
+    parsed = urlparse(value if "://" in value else f"//{value}")
+    return (parsed.hostname or "").lower().rstrip(".") in _ONELAKE_HOSTS
+
 
 if TYPE_CHECKING:
     from dlt.common.libs.ibis import BaseBackend
@@ -71,7 +87,11 @@ class filesystem(Destination[FilesystemDestinationClientConfiguration, Filesyste
 
     @property
     def client_class(self) -> Type[FilesystemClient]:
-        return HfFilesystemClient if self.is_hf else FilesystemClient
+        if self.is_hf:
+            return HfFilesystemClient
+        if self.is_onelake:
+            return OneLakeFilesystemClient
+        return FilesystemClient
 
     def create_ibis_backend(
         self, client: "FilesystemClient", read_only: bool = False, schemas: "Sequence[Schema]" = ()
@@ -153,6 +173,19 @@ class filesystem(Destination[FilesystemDestinationClientConfiguration, Filesyste
         resolved = resolve_configuration(_BucketUrlConfig(), sections=sections)
         return resolved.bucket_url
 
+    def _resolve_azure_account_host(self, destination_name: Optional[str]) -> Optional[str]:
+        @configspec
+        class _AzureAccountHostConfig(BaseConfiguration):
+            azure_account_host: Optional[str] = None
+
+        sections = (
+            *FilesystemDestinationClientConfiguration.__recommended_sections__,
+            self.resolve_destination_name(destination_name),
+            "credentials",
+        )
+        resolved = resolve_configuration(_AzureAccountHostConfig(), sections=sections)
+        return resolved.azure_account_host
+
     def __init__(
         self,
         bucket_url: str = None,
@@ -203,6 +236,14 @@ class filesystem(Destination[FilesystemDestinationClientConfiguration, Filesyste
             resolved_url = self._resolve_bucket_url(destination_name)
         protocol = FilesystemConfiguration.parse_protocol(resolved_url) if resolved_url else None
         self.is_hf = protocol == "hf"
+        account_host = (
+            credentials.get("azure_account_host")
+            if isinstance(credentials, dict)
+            else getattr(credentials, "azure_account_host", None)
+        )
+        if not account_host and protocol in _AZURE_PROTOCOLS:
+            account_host = self._resolve_azure_account_host(destination_name)
+        self.is_onelake = _is_onelake_host(resolved_url) or _is_onelake_host(account_host)
         super().__init__(
             bucket_url=bucket_url,
             credentials=credentials,

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -4,6 +4,7 @@ import time as _time
 import base64
 from contextlib import contextmanager
 from types import TracebackType
+from urllib.parse import urlparse
 from typing import (
     ClassVar,
     List,
@@ -104,6 +105,18 @@ SUPPORTED_VERSIONS: set[int] = {1, CURRENT_VERSION}
 
 INIT_FILE_NAME = "init"
 FILENAME_SEPARATOR = "__"
+
+_ONELAKE_HOSTS = {
+    "onelake.blob.fabric.microsoft.com",
+    "onelake.dfs.fabric.microsoft.com",
+}
+
+
+def _is_onelake_host(value: Optional[str]) -> bool:
+    if not value:
+        return False
+    parsed = urlparse(value if "://" in value else f"//{value}")
+    return (parsed.hostname or "").lower().rstrip(".") in _ONELAKE_HOSTS
 
 
 class FilesystemLoadJob(RunnableLoadJob):
@@ -523,6 +536,9 @@ class FilesystemClient(
         self.pathlib = os.path if self.is_local_filesystem else posixpath
 
         self.config: FilesystemDestinationClientConfiguration = config
+        self._normalize_probe_paths = _is_onelake_host(config.bucket_url) or _is_onelake_host(
+            getattr(config.credentials, "azure_account_host", None)
+        )
         # verify files layout. we need {table_name} and only allow {schema_name} before it, otherwise tables
         # cannot be replaced and we cannot initialize folders consistently
         self.table_prefix_layout = path_utils.get_table_prefix_layout(
@@ -595,6 +611,18 @@ class FilesystemClient(
         """
         return self.pathlib.join(self.bucket_path, self.dataset_name, "")  # type: ignore[no-any-return]
 
+    def _probe_path(self, path: str) -> str:
+        if self._normalize_probe_paths:
+            # OneLake rejects directory HEAD probes with a trailing slash.
+            return path.rstrip(self.pathlib.sep) or path
+        return path
+
+    def _exists(self, path: str) -> bool:
+        return self.fs_client.exists(self._probe_path(path))  # type: ignore[no-any-return]
+
+    def _isdir(self, path: str) -> bool:
+        return self.fs_client.isdir(self._probe_path(path))  # type: ignore[no-any-return]
+
     @contextmanager
     def with_staging_dataset(self) -> Iterator["FilesystemClient"]:
         current_dataset_name = self.dataset_name
@@ -607,7 +635,7 @@ class FilesystemClient(
 
     def initialize_storage(self, truncate_tables: Iterable[str] = None) -> None:
         # clean up existing files for tables selected for truncating
-        if truncate_tables and self.fs_client.isdir(self.dataset_path):
+        if truncate_tables and self._isdir(self.dataset_path):
             # get all dirs with table data to delete. the table data are guaranteed to be files in those folders
             # TODO: when we do partitioning it is no longer the case and we may remove folders below instead
             truncate_names = [
@@ -618,7 +646,7 @@ class FilesystemClient(
                 self.truncate_tables(truncate_names)
 
         # check if init file already exists
-        if self.fs_client.exists(self.init_file_path):
+        if self._exists(self.init_file_path):
             current_version = self.get_storage_versions()[0]
 
             # check if migration is needed
@@ -715,7 +743,7 @@ class FilesystemClient(
         else:
             # dropped tables may be gone from the schema, detect iceberg via the metadata dir
             metadata_dir = self.pathlib.join(self.get_table_dir(table_name), "metadata")
-            if not self.fs_client.exists(metadata_dir):
+            if not self._exists(metadata_dir):
                 return False
         try:
             from dlt.common.libs.pyiceberg import is_ephemeral_catalog, drop_iceberg_table
@@ -742,7 +770,7 @@ class FilesystemClient(
             if (
                 # TODO: isdir is sufficient if table_dir == table prefix
                 #   since this method is used currently only for tests we do not need to improve it
-                self.fs_client.isdir(table_dir)
+                self._isdir(table_dir)
                 and len(self.list_table_files(table_name)) > 0
             ):
                 if table_name in self.schema.tables:
@@ -813,7 +841,7 @@ class FilesystemClient(
         table_dirs = set(self.get_table_dirs(table_names))
         table_prefixes = [self.get_table_prefix(t) for t in table_names]
         for table_dir in table_dirs:
-            if self.fs_client.exists(table_dir):
+            if self._exists(table_dir):
                 for table_file in self.list_files_with_prefixes(table_dir, table_prefixes):
                     # NOTE: deleting in chunks on s3 does not raise on access denied, file non existing and probably other errors
                     # print(f"DEL {table_file}")
@@ -837,7 +865,7 @@ class FilesystemClient(
             # Azure SDK treats this as an error, but the delete actually succeeded
             if "Operation returned an invalid status 'OK'" in str(e):
                 # Verify deletion succeeded by checking if file still exists
-                if not self.fs_client.exists(file_path):
+                if not self._exists(file_path):
                     return  # Delete succeeded despite the error
             # If it's NotImplementedError, try the fallback rm() method
             if isinstance(e, NotImplementedError):
@@ -851,10 +879,10 @@ class FilesystemClient(
                     # Azure SDK treats this as an error, but the delete actually succeeded
                     if "Operation returned an invalid status 'OK'" in str(rm_e):
                         # Verify deletion succeeded by checking if file still exists
-                        if not self.fs_client.exists(file_path):
+                        if not self._exists(file_path):
                             return  # Delete succeeded despite the error
                     raise
-                if self.fs_client.exists(file_path):
+                if self._exists(file_path):
                     raise FileExistsError(file_path)
             else:
                 raise
@@ -1047,7 +1075,7 @@ class FilesystemClient(
         return result
 
     def is_storage_initialized(self) -> bool:
-        return self.fs_client.exists(self.init_file_path)  # type: ignore[no-any-return]
+        return self._exists(self.init_file_path)
 
     @staticmethod
     def get_reference_followup_job_class(

--- a/dlt/destinations/impl/filesystem/filesystem.py
+++ b/dlt/destinations/impl/filesystem/filesystem.py
@@ -4,7 +4,6 @@ import time as _time
 import base64
 from contextlib import contextmanager
 from types import TracebackType
-from urllib.parse import urlparse
 from typing import (
     ClassVar,
     List,
@@ -105,18 +104,6 @@ SUPPORTED_VERSIONS: set[int] = {1, CURRENT_VERSION}
 
 INIT_FILE_NAME = "init"
 FILENAME_SEPARATOR = "__"
-
-_ONELAKE_HOSTS = {
-    "onelake.blob.fabric.microsoft.com",
-    "onelake.dfs.fabric.microsoft.com",
-}
-
-
-def _is_onelake_host(value: Optional[str]) -> bool:
-    if not value:
-        return False
-    parsed = urlparse(value if "://" in value else f"//{value}")
-    return (parsed.hostname or "").lower().rstrip(".") in _ONELAKE_HOSTS
 
 
 class FilesystemLoadJob(RunnableLoadJob):
@@ -536,9 +523,6 @@ class FilesystemClient(
         self.pathlib = os.path if self.is_local_filesystem else posixpath
 
         self.config: FilesystemDestinationClientConfiguration = config
-        self._normalize_probe_paths = _is_onelake_host(config.bucket_url) or _is_onelake_host(
-            getattr(config.credentials, "azure_account_host", None)
-        )
         # verify files layout. we need {table_name} and only allow {schema_name} before it, otherwise tables
         # cannot be replaced and we cannot initialize folders consistently
         self.table_prefix_layout = path_utils.get_table_prefix_layout(
@@ -611,17 +595,11 @@ class FilesystemClient(
         """
         return self.pathlib.join(self.bucket_path, self.dataset_name, "")  # type: ignore[no-any-return]
 
-    def _probe_path(self, path: str) -> str:
-        if self._normalize_probe_paths:
-            # OneLake rejects directory HEAD probes with a trailing slash.
-            return path.rstrip(self.pathlib.sep) or path
-        return path
-
     def _exists(self, path: str) -> bool:
-        return self.fs_client.exists(self._probe_path(path))  # type: ignore[no-any-return]
+        return self.fs_client.exists(path)  # type: ignore[no-any-return]
 
     def _isdir(self, path: str) -> bool:
-        return self.fs_client.isdir(self._probe_path(path))  # type: ignore[no-any-return]
+        return self.fs_client.isdir(path)  # type: ignore[no-any-return]
 
     @contextmanager
     def with_staging_dataset(self) -> Iterator["FilesystemClient"]:

--- a/dlt/destinations/impl/filesystem/onelake.py
+++ b/dlt/destinations/impl/filesystem/onelake.py
@@ -1,0 +1,13 @@
+from dlt.destinations.impl.filesystem.filesystem import FilesystemClient
+
+
+class OneLakeFilesystemClient(FilesystemClient):
+    def _probe_path(self, path: str) -> str:
+        # OneLake rejects directory HEAD probes with a trailing slash.
+        return path.rstrip(self.pathlib.sep) or path
+
+    def _exists(self, path: str) -> bool:
+        return self.fs_client.exists(self._probe_path(path))  # type: ignore[no-any-return]
+
+    def _isdir(self, path: str) -> bool:
+        return self.fs_client.isdir(self._probe_path(path))  # type: ignore[no-any-return]

--- a/tests/load/filesystem/test_filesystem_client.py
+++ b/tests/load/filesystem/test_filesystem_client.py
@@ -39,6 +39,7 @@ from dlt.destinations.impl.filesystem.filesystem import (
     CURRENT_VERSION,
     SUPPORTED_VERSIONS,
 )
+from dlt.destinations.impl.filesystem.onelake import OneLakeFilesystemClient
 
 from dlt.destinations.path_utils import create_path, prepare_datetime_params
 from tests.load.filesystem.utils import perform_load, setup_loader
@@ -197,6 +198,7 @@ def test_onelake_directory_probes_strip_trailing_separator(
     bucket_url: str, azure_account_host: Optional[str]
 ) -> None:
     client, fs_client = _mock_filesystem_client(bucket_url, azure_account_host)
+    assert isinstance(client, OneLakeFilesystemClient)
     fs_client.isdir.return_value = False
     fs_client.exists.return_value = False
 
@@ -216,6 +218,7 @@ def test_regular_azure_directory_probes_keep_trailing_separator() -> None:
     client, fs_client = _mock_filesystem_client(
         "abfss://container@account.dfs.core.windows.net/bucket"
     )
+    assert type(client) is FilesystemClient
     fs_client.isdir.return_value = False
     fs_client.exists.return_value = False
 

--- a/tests/load/filesystem/test_filesystem_client.py
+++ b/tests/load/filesystem/test_filesystem_client.py
@@ -9,6 +9,10 @@ from urllib.parse import urlparse
 
 import pytest
 
+from dlt.common.configuration.specs.azure_credentials import (
+    AzureCredentials,
+    AzureCredentialsWithoutDefaults,
+)
 from dlt.common.configuration.specs.base_configuration import (
     CredentialsConfiguration,
     extract_inner_hint,
@@ -76,6 +80,23 @@ def _client_factory(fs: filesystem) -> FilesystemClient:
         initial_config=config_class()._bind_dataset_name("test"),
     )
     return client
+
+
+def _mock_filesystem_client(
+    bucket_url: str, azure_account_host: Optional[str] = None
+) -> tuple[FilesystemClient, mock.Mock]:
+    fs_client = mock.Mock()
+    credentials = AzureCredentialsWithoutDefaults(
+        azure_storage_account_name="onelake",
+        azure_storage_sas_token="token",
+        azure_account_host=azure_account_host,
+    )
+    with patch(
+        "dlt.destinations.impl.filesystem.filesystem.fsspec_from_config",
+        return_value=(fs_client, "lakehouse/Files/bucket"),
+    ):
+        client = _client_factory(filesystem(bucket_url=bucket_url, credentials=credentials))
+    return client, fs_client
 
 
 @pytest.mark.parametrize(
@@ -160,6 +181,48 @@ def test_trailing_separators(layout: str, with_gdrive_buckets_env: str) -> None:
         assert client.get_table_prefix("letters").endswith("_data/letters/")
     else:
         assert client.get_table_prefix("letters").endswith("_data/letters.")
+
+
+@pytest.mark.parametrize(
+    "bucket_url,azure_account_host",
+    [
+        (
+            "abfss://workspace@onelake.dfs.fabric.microsoft.com/lakehouse/Files/bucket",
+            None,
+        ),
+        ("az://container/bucket", "onelake.blob.fabric.microsoft.com"),
+    ],
+)
+def test_onelake_directory_probes_strip_trailing_separator(
+    bucket_url: str, azure_account_host: Optional[str]
+) -> None:
+    client, fs_client = _mock_filesystem_client(bucket_url, azure_account_host)
+    fs_client.isdir.return_value = False
+    fs_client.exists.return_value = False
+
+    client.initialize_storage(["items"])
+    fs_client.isdir.assert_called_once_with(client.dataset_path.rstrip("/"))
+
+    fs_client.exists.reset_mock()
+    client._delete_table_files(["items"])
+    fs_client.exists.assert_called_once_with(client.get_table_dir("items").rstrip("/"))
+
+    fs_client.exists.reset_mock()
+    client._exists("/")
+    fs_client.exists.assert_called_once_with("/")
+
+
+def test_regular_azure_directory_probes_keep_trailing_separator() -> None:
+    client, fs_client = _mock_filesystem_client(
+        "abfss://container@account.dfs.core.windows.net/bucket"
+    )
+    fs_client.isdir.return_value = False
+    fs_client.exists.return_value = False
+
+    client.initialize_storage(["items"])
+
+    fs_client.isdir.assert_called_once_with(client.dataset_path)
+    assert client.dataset_path.endswith("/")
 
 
 def test_table_prefix_resolves_standard_extra_placeholders() -> None:

--- a/tests/load/filesystem/test_filesystem_factory.py
+++ b/tests/load/filesystem/test_filesystem_factory.py
@@ -2,12 +2,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from dlt.common.utils import custom_environ
+from dlt.common.configuration.specs.azure_credentials import AzureCredentialsWithoutDefaults
 from dlt.destinations import filesystem
 from dlt.destinations.impl.filesystem.configuration import (
     FilesystemDestinationClientConfiguration,
     HfFilesystemDestinationClientConfiguration,
 )
 from dlt.destinations.impl.filesystem.filesystem import FilesystemClient, HfFilesystemClient
+from dlt.destinations.impl.filesystem.onelake import OneLakeFilesystemClient
 from tests.load.utils import AWS_BUCKET, FILE_BUCKET, HF_BUCKET, MEMORY_BUCKET
 
 
@@ -62,6 +64,36 @@ def test_filesystem_factory_is_hf():
     assert non_hf_filesystem.client_class == FilesystemClient
     assert non_hf_filesystem.capabilities().preferred_loader_file_format == "jsonl"
     assert non_hf_filesystem.capabilities().parquet_format is None
+
+
+def test_filesystem_factory_is_onelake() -> None:
+    onelake_url = "abfss://workspace@onelake.dfs.fabric.microsoft.com/lakehouse/Files/bucket"
+    onelake_filesystem = filesystem(onelake_url)
+    assert onelake_filesystem.is_onelake
+    assert onelake_filesystem.client_class == OneLakeFilesystemClient
+
+    regular_azure_filesystem = filesystem("abfss://container@account.dfs.core.windows.net/bucket")
+    assert not regular_azure_filesystem.is_onelake
+    assert regular_azure_filesystem.client_class == FilesystemClient
+
+    onelake_credentials = AzureCredentialsWithoutDefaults(
+        azure_account_host="onelake.blob.fabric.microsoft.com"
+    )
+    onelake_filesystem = filesystem("az://container/bucket", credentials=onelake_credentials)
+    assert onelake_filesystem.is_onelake
+    assert onelake_filesystem.client_class == OneLakeFilesystemClient
+
+    with custom_environ(
+        {
+            "DESTINATION__FILESYSTEM__BUCKET_URL": "az://container/bucket",
+            "DESTINATION__FILESYSTEM__CREDENTIALS__AZURE_ACCOUNT_HOST": (
+                "onelake.blob.fabric.microsoft.com"
+            ),
+        }
+    ):
+        onelake_filesystem = filesystem()
+        assert onelake_filesystem.is_onelake
+        assert onelake_filesystem.client_class == OneLakeFilesystemClient
 
 
 def test_resolve_bucket_url_ignores_foreign_credentials():


### PR DESCRIPTION
## Summary

- Route OneLake filesystem configurations to a dedicated `OneLakeFilesystemClient` subclass
- Keep the generic `FilesystemClient` provider-agnostic with neutral `exists` and `isdir` hooks
- Strip trailing separators only in the OneLake subclass before directory probes
- Preserve existing paths for listing, writing, deletion, and prefix calculation

## Root cause

OneLake's Blob endpoint returns `403 AuthenticationFailed` when an existing directory is probed with a trailing slash. The same path succeeds without that separator, so valid Fabric identities could fail during filesystem storage initialization and table truncation.

This affects both direct filesystem destinations and Fabric Warehouse loads using OneLake through `staging=filesystem(...)`, because staging uses the same filesystem client probes before `COPY INTO` runs.

## Test plan

- Added factory coverage for OneLake selection through DFS bucket URLs and Blob account hosts, including environment configuration
- Added regression coverage for storage initialization and table-truncation probes
- Verified regular Azure filesystem configurations still use the generic client and retain existing trailing separators
- Local filesystem client and factory suites: 90 passed, 2 skipped
- Ruff, mypy, Black, and diff checks passed

Closes #4301