### PR TITLE
(feat) add profile and location of resolved config value to trace

### DIFF
--- a/.claude/skills/create-worktree/SKILL.md
+++ b/.claude/skills/create-worktree/SKILL.md
@@ -47,6 +47,7 @@ git worktree list
   - If no conflict, create the worktree:
     - If `--branch` was given: `git worktree add .worktrees/<name> <ref>`
     - Otherwise: `git worktree add .worktrees/<name> --detach`
+    - Callers needing a new branch check it out afterwards: `git checkout --no-track -b <new-branch>`
     - If `--pr` was given, then also: `cd <worktree-path> && gh pr checkout <number>`
 - `gh pr checkout` handles fetching, fork tracking, and branch setup automatically.
 

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -94,14 +94,17 @@ Use the category from step 2 and the issue number:
 
 Example: `fix/3529-dedup-sort-escape`
 
+If `ISSUE` was already a branch name rather than a number (no ticket exists), use it as given.
+
 #### 4b. Create worktree and dev environment
 
-Invoke the `/worktree-issue` skill with the branch name:
+Invoke the `/worktree-from-issue` skill with the branch name:
 ```
-/worktree-issue {branch-name}
+/worktree-from-issue {branch-name}
 ```
 
 This creates the worktree, checks out a new branch from `origin/devel`, and runs `/worktree-make-dev`.
+Use it also when there is no issue number.
 
 Note the worktree path — referred to as `WORKTREE` below.
 

--- a/.claude/skills/worktree-from-issue/SKILL.md
+++ b/.claude/skills/worktree-from-issue/SKILL.md
@@ -65,8 +65,10 @@ Use `/create-worktree` skill:
 Then create the feature branch inside the worktree:
 
 ```
-git -C <worktree-path> checkout -b <branch_name>
+git -C <worktree-path> checkout --no-track -b <branch_name>
 ```
+
+`--no-track` leaves the branch without an upstream, so the user's `git push` works.
 
 ### 5. Set up dev environment
 

--- a/dlt/common/configuration/accessors.py
+++ b/dlt/common/configuration/accessors.py
@@ -99,7 +99,10 @@ class _Accessor(abc.ABC):
             if provider.is_empty:
                 continue
             value, effective_field = provider.get_value(key, type_hint, None, *sections)
-            trace = LookupTrace(provider.name, sections, effective_field, value)
+            location = (
+                provider.get_value_location(key, None, *sections) if value is not None else ""
+            )
+            trace = LookupTrace(provider.name, sections, effective_field, value, location)
             traces.append(trace)
             if value is not None:
                 # log trace

--- a/dlt/common/configuration/exceptions.py
+++ b/dlt/common/configuration/exceptions.py
@@ -11,6 +11,8 @@ class LookupTrace(NamedTuple):
     sections: Sequence[str]
     key: str
     value: Any
+    provider_location: str = ""
+    """Human readable location of the value"""
 
 
 class LookupTraces(NamedTuple):

--- a/dlt/common/configuration/providers/doc.py
+++ b/dlt/common/configuration/providers/doc.py
@@ -20,12 +20,18 @@ class BaseDocProvider(ConfigProvider):
     def get_key_name(key: str, *sections: str) -> str:
         return get_key_name(key, ".", *sections)
 
-    def get_value(
-        self, key: str, hint: Type[Any], pipeline_name: str, *sections: str
-    ) -> Tuple[Optional[Any], str]:
+    @staticmethod
+    def get_key_path(key: str, pipeline_name: Optional[str], *sections: str) -> Tuple[str, ...]:
+        """Returns a path to `key` in the config document"""
         full_path = sections + (key,)
         if pipeline_name:
             full_path = (pipeline_name,) + full_path
+        return full_path
+
+    def get_value(
+        self, key: str, hint: Type[Any], pipeline_name: str, *sections: str
+    ) -> Tuple[Optional[Any], str]:
+        full_path = self.get_key_path(key, pipeline_name, *sections)
         full_key = self.get_key_name(key, pipeline_name, *sections)
         node = self._config_doc
         try:

--- a/dlt/common/configuration/providers/provider.py
+++ b/dlt/common/configuration/providers/provider.py
@@ -17,6 +17,12 @@ class ConfigProvider(abc.ABC):
         `pipeline_name` was specified.
         """
 
+    def get_value_location(self, key: str, pipeline_name: Optional[str], *sections: str) -> str:
+        """Returns exact location (ie. a file name) of a value obtained with `get_value`, empty if
+        not known.
+        """
+        return self.present_locations[0] if self.present_locations else ""
+
     def set_value(self, key: str, value: Any, pipeline_name: Optional[str], *sections: str) -> None:
         raise NotImplementedError()
 

--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -1,11 +1,12 @@
 import os
 import tomlkit
-import tomlkit.container
 import tomlkit.exceptions
 import tomlkit.items
 from contextlib import contextmanager
-from typing import Any, Iterator, Optional, List
+from pathlib import PurePath
+from typing import Any, Dict, Iterator, Mapping, Optional, List, Sequence, Tuple
 
+from dlt.common.configuration.utils import auto_config_fragment
 from dlt.common.utils import update_dict_nested
 from dlt.common.configuration.exceptions import ConfigProviderException
 
@@ -13,7 +14,22 @@ from .doc import BaseDocProvider, CustomLoaderDocProvider
 
 CONFIG_TOML = "config.toml"
 SECRETS_TOML = "secrets.toml"
-VALUE_ORIGIN_ATTR = "_origin"
+GOOGLE_COLAB_ORIGIN = "google_colab"
+STREAMLIT_ORIGIN = "streamlit"
+GLOBAL_ORIGIN_PREFIX = "global:"
+
+
+class TValueOrigins(Dict[str, Any]):
+    """Mirrors a config doc shape: leaf values are origin names, tables carry their own origin."""
+
+    origin: str = ""
+
+    def clone(self) -> "TValueOrigins":
+        cloned = TValueOrigins(
+            {k: v.clone() if isinstance(v, TValueOrigins) else v for k, v in self.items()}
+        )
+        cloned.origin = self.origin
+        return cloned
 
 
 class StringTomlProvider(BaseDocProvider):
@@ -49,6 +65,7 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
         supports_secrets: bool,
         file_name: str,
         resolvable_dirs: List[str],
+        global_dir: str = None,
     ) -> None:
         """Creates config provider from a `toml` file
 
@@ -66,7 +83,9 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             name(str): name of the provider when registering in context
             supports_secrets(bool): allows to store secret values in this provider
             file_name (str): The name of `toml` file to load
-            resolvable_dirs (List[str]): A list of directories to resolve the file from, files will be merged into each other in the order the directories are specified. Provider is writeable if only one dir specified.
+            resolvable_dirs (List[str]): A list of directories to resolve the file from.
+                              Files will be merged into each other in the order the directories are specified. Provider is writeable if only one dir specified.
+            global_dir (str, optional): Which of the `resolvable_dirs` is the `dlt` global dir. Values from it are located with a `global:` prefix so that files sharing a name are told apart.
 
         Raises:
             TomlProviderReadException: File could not be read, most probably `toml` parsing error
@@ -79,6 +98,8 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
         )
         # read toml files and set present locations
         self._present_locations: List[str] = []
+        self._global_dir = global_dir
+        self._value_origins = TValueOrigins()
         self._config_toml = self._read_toml_files(name, file_name, self._toml_paths)
 
         super().__init__(
@@ -92,11 +113,11 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
         return [os.path.join(d, file_name) for d in resolvable_dirs]
 
     def get_value_location(self, key: str, pipeline_name: Optional[str], *sections: str) -> str:
-        """Get location (file name) via origin tags on toml Items created when file was loaded."""
-        origin: str = getattr(
-            self._find_toml_item(key, pipeline_name, *sections), VALUE_ORIGIN_ATTR, None
-        )
-        return origin or os.path.basename(super().get_value_location(key, pipeline_name, *sections))
+        """Get location (file name) of a value from the origins doc built when files were loaded."""
+        node = self._origins_node(self.get_key_path(key, pipeline_name, *sections))
+        if node is None:
+            return ""
+        return node.origin if isinstance(node, TValueOrigins) else node
 
     def write_toml(self) -> None:
         assert (
@@ -120,17 +141,20 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             pass
         if hasattr(value, "unwrap"):
             value = value.unwrap()
+        self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
         super().set_value(key, value, pipeline_name, *sections)
 
     @contextmanager
     def preserve(self) -> Iterator[None]:
         # set_value writes the tomlkit document in sync with the dict, so restore it too
         saved_toml = tomlkit.parse(tomlkit.dumps(self._config_toml))
+        saved_origins = self._value_origins.clone()
         with super().preserve():
             try:
                 yield
             finally:
                 self._config_toml = saved_toml
+                self._value_origins = saved_origins
 
     @property
     def is_empty(self) -> bool:
@@ -155,6 +179,14 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             )
         except ConvertError:
             pass
+        # re-parse to learn what _set_fragment actually wrote: a whole doc, a root merge or a value
+        if (fragment := auto_config_fragment(value_or_fragment)) is not None:
+            if key is None:
+                self._value_origins = TValueOrigins()
+            else:
+                self._drop_origins(fragment)
+        else:
+            self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
         super().set_fragment(key, value_or_fragment, pipeline_name, *sections)
 
     def to_toml(self) -> str:
@@ -210,34 +242,58 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             # Not in a Streamlit context
             return None
 
-    @staticmethod
-    def _tag_origins(container: tomlkit.container.Container, origin: str) -> None:
-        """Tags each item in `container` with `origin` name of a file it was parsed from."""
-        for key, item in container.body:
-            if key is None:
-                continue
-            setattr(item, VALUE_ORIGIN_ATTR, origin)
-            if isinstance(item, (tomlkit.items.Table, tomlkit.items.InlineTable)):
-                SettingsTomlProvider._tag_origins(item.value, origin)
-            elif isinstance(item, tomlkit.items.AoT):
-                for table in item.body:
-                    SettingsTomlProvider._tag_origins(table.value, origin)
+    def _is_in_global_dir(self, path: str) -> bool:
+        """Tells if `path` sits in the global dir. On Windows paths compare case insensitively."""
+        if not self._global_dir:
+            return False
+        # PurePath folds case and separators on Windows but keeps ".." verbatim, abspath resolves it
+        return PurePath(os.path.abspath(path)).is_relative_to(os.path.abspath(self._global_dir))
 
-    def _find_toml_item(
-        self, key: str, pipeline_name: Optional[str], *sections: str
-    ) -> Optional[tomlkit.items.Item]:
-        full_path = self.get_key_path(key, pipeline_name, *sections)
-        container: tomlkit.container.Container = self._config_toml
-        try:
-            for k in full_path[:-1]:
-                node = container.item(k)
-                # out of order tables are proxied and do not expose items
-                if not isinstance(node, (tomlkit.items.Table, tomlkit.items.InlineTable)):
-                    return None
-                container = node.value
-            return container.item(full_path[-1])
-        except KeyError:
-            return None
+    def _path_origin(self, path: str) -> str:
+        """Names the file `path`, marking the global dir so files sharing a name are told apart."""
+        if self._is_in_global_dir(path):
+            return GLOBAL_ORIGIN_PREFIX + os.path.basename(path)
+        return os.path.basename(path)
+
+    @staticmethod
+    def _doc_origins(doc: Mapping[str, Any], origin: str) -> TValueOrigins:
+        """Mirrors `doc` shape replacing each value with `origin`, tables carry `origin` as well."""
+        origins = TValueOrigins()
+        origins.origin = origin
+        for k, v in doc.items():
+            origins[k] = (
+                SettingsTomlProvider._doc_origins(v, origin) if isinstance(v, dict) else origin
+            )
+        return origins
+
+    def _origins_node(self, full_path: Sequence[str]) -> Any:
+        """Returns origins doc node under `full_path` or None if not known."""
+        node: Any = self._value_origins
+        for k in full_path:
+            if not isinstance(node, dict) or k not in node:
+                return None
+            node = node[k]
+        return node
+
+    def _drop_origin(self, full_path: Sequence[str]) -> None:
+        """Forgets origin of a value under `full_path`, dropping whole subtree for tables."""
+        if not full_path:
+            return
+        parent = self._origins_node(full_path[:-1])
+        if isinstance(parent, dict):
+            parent.pop(full_path[-1], None)
+
+    def _drop_origins(self, doc: Mapping[str, Any], path: Tuple[str, ...] = ()) -> None:
+        """Forgets origins of all values present in `doc`, a fragment merged from the root."""
+        if not isinstance(doc, dict):
+            return
+        for k, v in doc.items():
+            sub_path = path + (k,)
+            # a fragment table merges key by key, but it replaces a value that was not a table
+            if isinstance(v, dict) and isinstance(self._origins_node(sub_path), dict):
+                self._drop_origins(v, sub_path)
+            else:
+                self._drop_origin(sub_path)
 
     def _read_toml_file(self, toml_path: str) -> tomlkit.TOMLDocument:
         if os.path.isfile(toml_path):
@@ -257,22 +313,27 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             result_toml: Optional[tomlkit.TOMLDocument] = None
             for path in toml_paths:
                 if (loaded_toml := self._read_toml_file(path)) is not None:
-                    self._tag_origins(loaded_toml, os.path.basename(path))
+                    origins = self._doc_origins(loaded_toml.unwrap(), self._path_origin(path))
                     if result_toml is None:
-                        result_toml = loaded_toml
+                        result_toml, self._value_origins = loaded_toml, origins
                     else:
+                        # files are merged highest precedence first, so accumulated values win
                         result_toml = update_dict_nested(loaded_toml, result_toml)
+                        self._value_origins = update_dict_nested(origins, self._value_origins)
                     # store as present location
                     self._present_locations.append(path)
 
             # if nothing was found, try to load from google colab or streamlit
             if result_toml is None:
+                origin = None
                 if (result_toml := self._read_google_colab_secrets(name, file_name)) is not None:
-                    pass
+                    origin = GOOGLE_COLAB_ORIGIN
                 elif (result_toml := self._read_streamlit_secrets(name, file_name)) is not None:
-                    pass
+                    origin = STREAMLIT_ORIGIN
                 else:
                     result_toml = tomlkit.document()
+                if origin:
+                    self._value_origins = self._doc_origins(result_toml.unwrap(), origin)
 
             return result_toml
         except Exception as ex:
@@ -281,7 +342,7 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
 
 class ConfigTomlProvider(SettingsTomlProvider):
     def __init__(self, settings_dir: str, global_dir: str = None) -> None:
-        super().__init__(CONFIG_TOML, False, CONFIG_TOML, [settings_dir, global_dir])
+        super().__init__(CONFIG_TOML, False, CONFIG_TOML, [settings_dir, global_dir], global_dir)
 
     @property
     def is_writable(self) -> bool:
@@ -290,7 +351,7 @@ class ConfigTomlProvider(SettingsTomlProvider):
 
 class SecretsTomlProvider(SettingsTomlProvider):
     def __init__(self, settings_dir: str, global_dir: str = None) -> None:
-        super().__init__(SECRETS_TOML, True, SECRETS_TOML, [settings_dir, global_dir])
+        super().__init__(SECRETS_TOML, True, SECRETS_TOML, [settings_dir, global_dir], global_dir)
 
     @property
     def is_writable(self) -> bool:

--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -85,7 +85,7 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             file_name (str): The name of `toml` file to load
             resolvable_dirs (List[str]): A list of directories to resolve the file from.
                               Files will be merged into each other in the order the directories are specified. Provider is writeable if only one dir specified.
-            global_dir (str, optional): Which of the `resolvable_dirs` is the `dlt` global dir. Values from it are located with a `global:` prefix so that files sharing a name are told apart.
+            global_dir (str, optional): Which of the `resolvable_dirs` is the `dlt` global dir.
 
         Raises:
             TomlProviderReadException: File could not be read, most probably `toml` parsing error
@@ -113,7 +113,9 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
         return [os.path.join(d, file_name) for d in resolvable_dirs]
 
     def get_value_location(self, key: str, pipeline_name: Optional[str], *sections: str) -> str:
-        """Get location (file name) of a value from the origins doc built when files were loaded."""
+        """Get location (file name) of a value from the origins doc built when files were loaded.
+        Values from it are located with a `global:` prefix so that files sharing a name are told apart.
+        """
         node = self._origins_node(self.get_key_path(key, pipeline_name, *sections))
         if node is None:
             return ""

--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -1,5 +1,6 @@
 import os
 import tomlkit
+import tomlkit.container
 import tomlkit.exceptions
 import tomlkit.items
 from contextlib import contextmanager
@@ -12,6 +13,7 @@ from .doc import BaseDocProvider, CustomLoaderDocProvider
 
 CONFIG_TOML = "config.toml"
 SECRETS_TOML = "secrets.toml"
+VALUE_ORIGIN_ATTR = "_origin"
 
 
 class StringTomlProvider(BaseDocProvider):
@@ -88,6 +90,13 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
 
     def _resolve_toml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
         return [os.path.join(d, file_name) for d in resolvable_dirs]
+
+    def get_value_location(self, key: str, pipeline_name: Optional[str], *sections: str) -> str:
+        """Get location (file name) via origin tags on toml Items created when file was loaded."""
+        origin: str = getattr(
+            self._find_toml_item(key, pipeline_name, *sections), VALUE_ORIGIN_ATTR, None
+        )
+        return origin or os.path.basename(super().get_value_location(key, pipeline_name, *sections))
 
     def write_toml(self) -> None:
         assert (
@@ -201,6 +210,35 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             # Not in a Streamlit context
             return None
 
+    @staticmethod
+    def _tag_origins(container: tomlkit.container.Container, origin: str) -> None:
+        """Tags each item in `container` with `origin` name of a file it was parsed from."""
+        for key, item in container.body:
+            if key is None:
+                continue
+            setattr(item, VALUE_ORIGIN_ATTR, origin)
+            if isinstance(item, (tomlkit.items.Table, tomlkit.items.InlineTable)):
+                SettingsTomlProvider._tag_origins(item.value, origin)
+            elif isinstance(item, tomlkit.items.AoT):
+                for table in item.body:
+                    SettingsTomlProvider._tag_origins(table.value, origin)
+
+    def _find_toml_item(
+        self, key: str, pipeline_name: Optional[str], *sections: str
+    ) -> Optional[tomlkit.items.Item]:
+        full_path = self.get_key_path(key, pipeline_name, *sections)
+        container: tomlkit.container.Container = self._config_toml
+        try:
+            for k in full_path[:-1]:
+                node = container.item(k)
+                # out of order tables are proxied and do not expose items
+                if not isinstance(node, (tomlkit.items.Table, tomlkit.items.InlineTable)):
+                    return None
+                container = node.value
+            return container.item(full_path[-1])
+        except KeyError:
+            return None
+
     def _read_toml_file(self, toml_path: str) -> tomlkit.TOMLDocument:
         if os.path.isfile(toml_path):
             with open(toml_path, "r", encoding="utf-8") as f:
@@ -219,6 +257,7 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             result_toml: Optional[tomlkit.TOMLDocument] = None
             for path in toml_paths:
                 if (loaded_toml := self._read_toml_file(path)) is not None:
+                    self._tag_origins(loaded_toml, os.path.basename(path))
                     if result_toml is None:
                         result_toml = loaded_toml
                     else:

--- a/dlt/common/configuration/resolve.py
+++ b/dlt/common/configuration/resolve.py
@@ -647,7 +647,10 @@ def resolve_single_provider_value(
 
         # create trace, ignore providers that cant_hold_it
         if not cant_hold_it:
-            traces.append(LookupTrace(provider.name, list(path), ns_key, value))
+            location = (
+                provider.get_value_location(key, pipeline_name, *path) if value is not None else ""
+            )
+            traces.append(LookupTrace(provider.name, list(path), ns_key, value, location))
 
         if value is not None:
             break

--- a/dlt/common/configuration/utils.py
+++ b/dlt/common/configuration/utils.py
@@ -40,6 +40,8 @@ class ResolvedValueTrace(NamedTuple):
     sections: Sequence[str]
     provider_name: str
     config: BaseConfiguration
+    provider_location: str = ""
+    """Exact location (ie. a file path) of the value within the provider"""
 
     def is_resolved(self) -> bool:
         # explicit values if present are always resolved
@@ -218,6 +220,7 @@ def log_traces(
                 trace.sections,
                 trace.provider,
                 config,
+                trace.provider_location,
             )
         )
 

--- a/dlt/common/runtime/anon_tracker.py
+++ b/dlt/common/runtime/anon_tracker.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 from dlt.common import logger
 from dlt.common.managed_thread_pool import ManagedThreadPool
 from dlt.common.configuration.specs import RuntimeConfiguration
-from dlt.common.runtime.exec_info import get_execution_context, TExecutionContext, run_context_name
+from dlt.common.runtime.exec_info import get_execution_context, TExecutionContext, run_context_info
 from dlt.common.runtime import run_context
 from dlt.common.typing import DictStrAny, StrAny
 from dlt.common.utils import uniq_id
@@ -90,8 +90,8 @@ def track(event_category: TEventCategory, event_name: str, properties: DictStrAn
 
     try:
         context = _default_context_fields()
-        # always refresh run context name, it may change at runtime
-        context["run_context"] = run_context_name()
+        # always refresh run context info, name and profile may change at runtime
+        context["run_context"] = run_context_info()
         _send_event(f"{event_category}_{event_name}", properties, context)
     except Exception as e:
         logger.debug(f"Skipping telemetry reporting: {e}")

--- a/dlt/common/runtime/exec_info.py
+++ b/dlt/common/runtime/exec_info.py
@@ -6,7 +6,12 @@ import multiprocessing
 import platform
 from typing import Optional
 
-from dlt.common.runtime.typing import TExecutionContext, TVersion, TExecInfoNames
+from dlt.common.runtime.typing import (
+    TExecutionContext,
+    TRunContextInfo,
+    TVersion,
+    TExecInfoNames,
+)
 from dlt.common.typing import StrStr, StrAny, List
 from dlt.common.utils import filter_env_vars
 from dlt.version import __version__, DLT_PKG_NAME
@@ -278,19 +283,27 @@ def get_dlthub_version() -> TVersion:
         return None
 
 
-def run_context_name() -> str:
+def run_context_info() -> TRunContextInfo:
+    "Gets name and profile (if supported) of the active run context"
+    info = TRunContextInfo(name="dlt")
     try:
         from dlt.common.configuration.container import Container
-        from dlt.common.configuration.specs.pluggable_run_context import PluggableRunContext
+        from dlt.common.configuration.specs.pluggable_run_context import (
+            PluggableRunContext,
+            ProfilesRunContext,
+        )
 
         container = Container()
         if PluggableRunContext in container:
-            return container[PluggableRunContext].context.name
+            run_ctx = container[PluggableRunContext].context
+            info["name"] = run_ctx.name
+            if isinstance(run_ctx, ProfilesRunContext):
+                info["profile"] = run_ctx.profile
 
     except Exception:
         pass
 
-    return "dlt"
+    return info
 
 
 def get_execution_context() -> TExecutionContext:
@@ -302,7 +315,7 @@ def get_execution_context() -> TExecutionContext:
         exec_info=exec_info_names(),
         os=TVersion(name=platform.system(), version=platform.release()),
         library=TVersion(name=DLT_PKG_NAME, version=__version__),
-        run_context=run_context_name(),
+        run_context=run_context_info(),
     )
     if dlthub_version := get_dlthub_version():
         context["dlthub"] = dlthub_version

--- a/dlt/common/runtime/typing.py
+++ b/dlt/common/runtime/typing.py
@@ -32,6 +32,14 @@ class TVersion(TypedDict):
     version: str
 
 
+class TRunContextInfo(TypedDict, total=False):
+    """TypeDict representing the active run context"""
+
+    name: str
+    profile: str
+    """Present only if run context supports profiles"""
+
+
 class TExecutionContext(TypedDict, total=False):
     """TypeDict representing the runtime context info"""
 
@@ -41,5 +49,5 @@ class TExecutionContext(TypedDict, total=False):
     exec_info: List[TExecInfoNames]
     library: TVersion
     os: TVersion
-    run_context: str
+    run_context: TRunContextInfo
     dlthub: TVersion

--- a/dlt/pipeline/trace.py
+++ b/dlt/pipeline/trace.py
@@ -50,13 +50,23 @@ class SerializableResolvedValueTrace(NamedTuple):
     sections: Sequence[str]
     provider_name: str
     config_type_name: str
+    provider_location: str = ""
+    """Exact location (ie. a file path) of the value within the provider"""
 
     def asdict(self) -> StrAny:
         """A dictionary representation that is safe to load."""
         return {k: v for k, v in self._asdict().items() if k not in ("value", "default_value")}
 
     def asstr(self, verbosity: int = 0) -> str:
-        return f"{self.key}->{self.value} in {'.'.join(self.sections)} by {self.provider_name}"
+        full_key = ".".join((*self.sections, self.key))
+        value = "<secret>" if self.is_secret_hint else self.value
+        msg = f"`{full_key}` = {value} from `{self.provider_name}`"
+        # provider name of toml providers is already the file name
+        if self.provider_location and self.provider_location != self.provider_name:
+            msg += f" in `{self.provider_location}`"
+        if verbosity > 1:
+            msg += f" for `{self.config_type_name}`"
+        return msg
 
     def __str__(self) -> str:
         return self.asstr(verbosity=0)
@@ -282,6 +292,7 @@ def end_trace_step(
             v.sections,
             v.provider_name,
             str(type(v.config).__qualname__),
+            v.provider_location,
         ),
         get_resolved_traces().resolved_traces,
     )

--- a/docs/website/docs/reference/telemetry.md
+++ b/docs/website/docs/reference/telemetry.md
@@ -64,7 +64,10 @@ Here is an example `dlt init` telemetry message:
       "name": "Linux",
       "version": "4.19.128-microsoft-standard"
     },
-    "python": "3.8.11"
+    "python": "3.8.11",
+    "run_context": {
+      "name": "dlt"
+    }
   },
   "event": "command_init",
   "properties": {
@@ -95,7 +98,11 @@ Example for `load` pipeline run step:
       "name": "Darwin",
       "version": "21.6.0"
     },
-    "python": "3.10.10"
+    "python": "3.10.10",
+    "run_context": {
+      "name": "my_workspace",
+      "profile": "dev"
+    }
   },
   "event": "pipeline_load",
   "properties": {
@@ -130,7 +137,10 @@ Example for data access telemetry:
       "name": "Darwin",
       "version": "21.6.0"
     },
-    "python": "3.10.10"
+    "python": "3.10.10",
+    "run_context": {
+      "name": "dlt"
+    }
   },
   "event": "data_access_connect",
   "properties": {
@@ -154,6 +164,7 @@ The message `context` contains the following information:
 - `ci_run`: a flag indicating if the message was sent from a CI environment (e.g., `GitHub Actions`, `Travis CI`).
 - `cpu`: contains the number of cores.
 - `exec_info`: contains a list of strings that identify the execution environment: (e.g., `kubernetes`, `docker`, `airflow`).
+- `run_context`: the name of the active run context (`dlt` for the default one) and, if the context supports profiles, the active profile name.
 - The `library`, `os`, and `python` give us some understanding of the runtime environment of the `dlt`.
 
 ## Send telemetry data to your own tracker

--- a/tests/common/cases/configuration/origins/config.toml
+++ b/tests/common/cases/configuration/origins/config.toml
@@ -1,0 +1,26 @@
+base_only = "base"
+shared = "from_base"
+create_indexes = false
+dotted.key = "base"
+
+[tbl]
+from_base = 1
+shared_key = "from_base"
+
+[tbl.sub]
+deep = "base"
+
+[inline]
+it = { a = 1, b = "two" }
+
+[[aot]]
+n = 1
+
+[ooo.first]
+x = "base"
+
+[other]
+y = "base"
+
+[ooo.second]
+z = "base"

--- a/tests/common/cases/configuration/origins/dev.config.toml
+++ b/tests/common/cases/configuration/origins/dev.config.toml
@@ -1,0 +1,6 @@
+dev_only = "dev"
+shared = "from_dev"
+
+[tbl]
+shared_key = "from_dev"
+from_dev = 2

--- a/tests/common/cases/configuration/origins/global/config.toml
+++ b/tests/common/cases/configuration/origins/global/config.toml
@@ -1,0 +1,6 @@
+global_only = "global base"
+shared = "from_global_base"
+
+[gtbl]
+key = "from_global_base"
+from_global_base = 1

--- a/tests/common/cases/configuration/origins/global/dev.config.toml
+++ b/tests/common/cases/configuration/origins/global/dev.config.toml
@@ -1,0 +1,5 @@
+global_dev_only = "global dev"
+shared = "from_global_dev"
+
+[gtbl]
+key = "from_global_dev"

--- a/tests/common/configuration/test_accessors.py
+++ b/tests/common/configuration/test_accessors.py
@@ -55,28 +55,36 @@ def test_getter_accessor(toml_providers: ConfigProvidersContainer, environment: 
     environment["VALUE"] = "{SET"
     assert dlt.config["value"] == "{SET"
 
+    # env provider does not know exact locations of values
     assert _resolved_traces()[".value"] == ResolvedValueTrace(
-        "value", "{SET", None, AnyType, [], EnvironProvider().name, None
+        "value", "{SET", None, AnyType, [], EnvironProvider().name, None, ""
     )
     assert dlt.secrets["value"] == "{SET"
     assert _resolved_traces()[".value"] == ResolvedValueTrace(
-        "value", "{SET", None, TSecretValue, [], EnvironProvider().name, None
+        "value", "{SET", None, TSecretValue, [], EnvironProvider().name, None, ""
     )
 
     # get sectioned values
     assert dlt.config["typecheck.str_val"] == "test string"
     assert _resolved_traces()["typecheck.str_val"] == ResolvedValueTrace(
-        "str_val", "test string", None, AnyType, ["typecheck"], CONFIG_TOML, None
+        "str_val",
+        "test string",
+        None,
+        AnyType,
+        ["typecheck"],
+        CONFIG_TOML,
+        None,
+        CONFIG_TOML,
     )
 
     environment["DLT__THIS__VALUE"] = "embedded"
     assert dlt.config["dlt.this.value"] == "embedded"
     assert _resolved_traces()["dlt.this.value"] == ResolvedValueTrace(
-        "value", "embedded", None, AnyType, ["dlt", "this"], EnvironProvider().name, None
+        "value", "embedded", None, AnyType, ["dlt", "this"], EnvironProvider().name, None, ""
     )
     assert dlt.secrets["dlt.this.value"] == "embedded"
     assert _resolved_traces()["dlt.this.value"] == ResolvedValueTrace(
-        "value", "embedded", None, TSecretValue, ["dlt", "this"], EnvironProvider().name, None
+        "value", "embedded", None, TSecretValue, ["dlt", "this"], EnvironProvider().name, None, ""
     )
 
 
@@ -134,6 +142,7 @@ def test_getter_auto_cast(toml_providers: ConfigProvidersContainer, environment:
         ["destination"],
         SECRETS_TOML,
         None,
+        SECRETS_TOML,
     )
     # equivalent
     assert (
@@ -147,6 +156,7 @@ def test_getter_auto_cast(toml_providers: ConfigProvidersContainer, environment:
         ["destination", "bigquery"],
         SECRETS_TOML,
         None,
+        SECRETS_TOML,
     )
 
 
@@ -162,7 +172,14 @@ def test_getter_accessor_typed(toml_providers: ConfigProvidersContainer, environ
     assert dlt.secrets.get("credentials", str) == credentials_str
     # note that trace keeps original value of "credentials" which was of dictionary type
     assert _resolved_traces()[".credentials"] == ResolvedValueTrace(
-        "credentials", json.loads(credentials_str), None, str, [], SECRETS_TOML, None
+        "credentials",
+        json.loads(credentials_str),
+        None,
+        str,
+        [],
+        SECRETS_TOML,
+        None,
+        SECRETS_TOML,
     )
     # unchanged type
     assert isinstance(dlt.secrets.get("credentials"), dict)
@@ -177,7 +194,14 @@ def test_getter_accessor_typed(toml_providers: ConfigProvidersContainer, environ
     c = dlt.secrets.get("databricks.credentials", ConnectionStringCredentials)
     # as before: the value in trace is the value coming from the provider (as is)
     assert _resolved_traces()["databricks.credentials"] == ResolvedValueTrace(
-        "credentials", credentials_str, None, ConnectionStringCredentials, ["databricks"], SECRETS_TOML, ConnectionStringCredentials  # type: ignore[arg-type]
+        "credentials",
+        credentials_str,
+        None,
+        ConnectionStringCredentials,
+        ["databricks"],
+        SECRETS_TOML,
+        ConnectionStringCredentials,  # type: ignore[arg-type]
+        SECRETS_TOML,
     )
     assert c.drivername == "databricks+connector"
     c2 = dlt.secrets.get("destination.credentials", GcpServiceAccountCredentialsWithoutDefaults)
@@ -243,6 +267,11 @@ def test_values_context_manager(writable_kind: str, environment: Any) -> None:
             # the dict and the tomlkit document that set_value keeps in sync are both restored
             assert "scoped" not in writable.to_toml()
             assert writable._config_doc == writable._config_toml.unwrap()
+
+        # values written at runtime are not tagged: toml falls back to its file, doc has no location
+        dlt.config["written"] = "x"
+        expected_location = CONFIG_TOML if writable_kind == "toml" else ""
+        assert writable.get_value_location("written", None) == expected_location
 
         # a preset key is restored to its previous value on exit
         dlt.config["existing"] = "before"

--- a/tests/common/configuration/test_accessors.py
+++ b/tests/common/configuration/test_accessors.py
@@ -268,10 +268,12 @@ def test_values_context_manager(writable_kind: str, environment: Any) -> None:
             assert "scoped" not in writable.to_toml()
             assert writable._config_doc == writable._config_toml.unwrap()
 
-        # values written at runtime are not tagged: toml falls back to its file, doc has no location
+        # values written at runtime are in no file so neither provider knows a location
         dlt.config["written"] = "x"
-        expected_location = CONFIG_TOML if writable_kind == "toml" else ""
-        assert writable.get_value_location("written", None) == expected_location
+        assert writable.get_value_location("written", None) == ""
+        if isinstance(writable, SettingsTomlProvider):
+            # preserve restored the origins along with the document
+            assert writable.get_value_location("api_type", None) == CONFIG_TOML
 
         # a preset key is restored to its previous value on exit
         dlt.config["existing"] = "before"

--- a/tests/common/configuration/test_configuration.py
+++ b/tests/common/configuration/test_configuration.py
@@ -851,7 +851,7 @@ def test_raises_on_unresolved_field(environment: Any, env_provider: ConfigProvid
     # has only one trace
     trace = cf_missing_exc.value.traces["NoneConfigVar"]
     assert len(trace) == 1
-    assert trace[0] == LookupTrace("Environment Variables", [], "NONECONFIGVAR", None)
+    assert trace[0] == LookupTrace("Environment Variables", [], "NONECONFIGVAR", None, "")
 
     # check the exception trace
     exception_traces = get_exception_trace_chain(cf_missing_exc.value)
@@ -897,6 +897,7 @@ def test_raises_on_many_unresolved_fields(
             [],
             environ_provider.EnvironProvider.get_key_name(exp_field),
             None,
+            "",
         )
         # field must be in exception trace
         assert tr_field in exception_trace["exception_attrs"]["fields"]
@@ -940,7 +941,7 @@ def test_raises_on_unresolved_embedded_configuration(
     trace = nested_traces[0].traces["secret_value"]
     assert len(trace) == 1
     assert trace[0] == LookupTrace(
-        "Environment Variables", ["secret"], "SECRET__SECRET_VALUE", None
+        "Environment Variables", ["secret"], "SECRET__SECRET_VALUE", None, ""
     )
 
     # check the exception trace
@@ -1376,24 +1377,32 @@ def test_resolved_trace(environment: Any) -> None:
         return tracer._get_log_as_dict(tracer.resolved_traces)
 
     prov_name = environ_provider.EnvironProvider().name
+    # env provider does not know exact locations of values
     assert _resolved_traces()[".default"] == ResolvedValueTrace(
-        "default", "DEF", "_DEFF", str, [], prov_name, c
+        "default", "DEF", "_DEFF", str, [], prov_name, c, ""
     )
     assert _resolved_traces()["instrumented.head"] == ResolvedValueTrace(
-        "head", "h", None, str, ["instrumented"], prov_name, c.instrumented
+        "head", "h", None, str, ["instrumented"], prov_name, c.instrumented, ""
     )
     # value is before casting
     assert _resolved_traces()["instrumented.tube"] == ResolvedValueTrace(
-        "tube", '["tu", "u", "be"]', None, List[str], ["instrumented"], prov_name, c.instrumented
+        "tube",
+        '["tu", "u", "be"]',
+        None,
+        List[str],
+        ["instrumented"],
+        prov_name,
+        c.instrumented,
+        "",
     )
     assert deserialize_value(
         "tube", _resolved_traces()["instrumented.tube"].value, resolve.extract_inner_hint(List[str])
     ) == ["tu", "u", "be"]
     assert _resolved_traces()["instrumented.heels"] == ResolvedValueTrace(
-        "heels", "xhe", None, str, ["instrumented"], prov_name, c.instrumented
+        "heels", "xhe", None, str, ["instrumented"], prov_name, c.instrumented, ""
     )
     assert _resolved_traces()["sectioned.password"] == ResolvedValueTrace(
-        "password", "passwd", None, str, ["sectioned"], prov_name, c.sectioned
+        "password", "passwd", None, str, ["sectioned"], prov_name, c.sectioned, ""
     )
     assert len(_resolved_traces()) == 5
 
@@ -1411,14 +1420,14 @@ def test_resolved_trace(environment: Any) -> None:
             resolve.resolve_configuration(InstrumentedConfiguration())
 
     assert _resolved_traces()[".default"] == ResolvedValueTrace(
-        "default", "UNDEF", None, str, [], prov_name, c
+        "default", "UNDEF", None, str, [], prov_name, c, ""
     )
     assert _resolved_traces()[".instrumented"] == ResolvedValueTrace(
-        "instrumented", "h>t>t>t>he", None, InstrumentedConfiguration, [], prov_name, c
+        "instrumented", "h>t>t>t>he", None, InstrumentedConfiguration, [], prov_name, c, ""
     )
 
     assert _resolved_traces()[".snake"] == ResolvedValueTrace(
-        "snake", "h>t>t>t>he", None, InstrumentedConfiguration, [], prov_name, None
+        "snake", "h>t>t>t>he", None, InstrumentedConfiguration, [], prov_name, None, ""
     )
 
 

--- a/tests/common/configuration/test_container.py
+++ b/tests/common/configuration/test_container.py
@@ -289,6 +289,8 @@ def test_container_provider(container: Container, spec: Type[InjectableTestConte
     assert isinstance(v, spec)
     assert k == spec.__name__
     assert spec in container
+    # contexts do not come from any location
+    assert provider.get_value_location("n/a", None) == ""
 
     # provider does not create default value in Container
     v, k = provider.get_value("n/a", NoDefaultInjectableContext, None)

--- a/tests/common/configuration/test_sections.py
+++ b/tests/common/configuration/test_sections.py
@@ -71,7 +71,7 @@ def test_sectioned_configuration(environment: Any, env_provider: ConfigProvider)
     # only one provider and section was tried
     assert len(traces) == 1
     assert traces[0] == LookupTrace(
-        "Environment Variables", ["DLT_TEST"], "DLT_TEST__PASSWORD", None
+        "Environment Variables", ["DLT_TEST"], "DLT_TEST__PASSWORD", None, ""
     )
     # assert traces[1] == LookupTrace("secrets.toml", ["DLT_TEST"], "DLT_TEST.password", None)
     # assert traces[2] == LookupTrace("config.toml", ["DLT_TEST"], "DLT_TEST.password", None)

--- a/tests/common/configuration/test_toml_provider.py
+++ b/tests/common/configuration/test_toml_provider.py
@@ -393,36 +393,6 @@ def test_toml_value_location() -> None:
     assert DictionaryProvider().get_value_location("log_level", None, "runtime") == ""
 
 
-@pytest.mark.parametrize(
-    "global_dir_form", ["relative", "absolute", "trailing_sep", "unnormalized"], ids=lambda x: x
-)
-def test_toml_value_location_global_dir_forms(global_dir_form: str) -> None:
-    """Global dir is recognized however it was spelled, paths are normalized before comparing"""
-    settings_dir = "./tests/common/cases/configuration/.dlt"
-    canonical_global_dir = "./tests/common/cases/configuration/dlt_home"
-    global_dir = canonical_global_dir
-    if global_dir_form == "absolute":
-        global_dir = os.path.abspath(global_dir)
-    elif global_dir_form == "trailing_sep":
-        global_dir = os.path.join(global_dir, "")
-    elif global_dir_form == "unnormalized":
-        global_dir = os.path.join(global_dir, os.pardir, "dlt_home")
-
-    config = ConfigTomlProvider(settings_dir=settings_dir, global_dir=global_dir)
-    assert config.get_value_location("param_global", None, "api", "params") == (
-        GLOBAL_ORIGIN_PREFIX + CONFIG_TOML
-    )
-    assert config.get_value_location("log_level", None, "runtime") == CONFIG_TOML
-
-    # the file path and the global dir may be spelled differently and must still match
-    assert config._is_in_global_dir(
-        os.path.join(os.path.abspath(canonical_global_dir), CONFIG_TOML)
-    )
-    assert not config._is_in_global_dir(os.path.join(settings_dir, CONFIG_TOML))
-    # a sibling dir sharing a name prefix is not inside the global dir
-    assert not config._is_in_global_dir(os.path.join(canonical_global_dir + "2", CONFIG_TOML))
-
-
 def test_toml_value_location_merged_files() -> None:
     """Exact file is reported when files with different names are merged, base or override"""
     config = _origins_provider()

--- a/tests/common/configuration/test_toml_provider.py
+++ b/tests/common/configuration/test_toml_provider.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 import yaml
 from pathlib import Path
-from typing import Any, Dict, Type
+from typing import Any, Dict, List, Tuple, Type
 import datetime  # noqa: I251
 from unittest.mock import Mock
 
@@ -18,6 +18,7 @@ from dlt.common.known_env import DLT_DATA_DIR, DLT_PROJECT_DIR
 from dlt.common.configuration.providers.toml import (
     SECRETS_TOML,
     CONFIG_TOML,
+    GLOBAL_ORIGIN_PREFIX,
     BaseDocProvider,
     CustomLoaderDocProvider,
     SettingsTomlProvider,
@@ -330,32 +331,231 @@ def test_toml_global_config() -> None:
     # assert os.path.join(settings_dir, "secrets.toml") not in secrets.present_locations
 
 
+class ProfileLikeTomlProvider(SettingsTomlProvider):
+    """Loads `dev.{file_name}` before `{file_name}` in each dir, like the workspace profiles do"""
+
+    def _resolve_toml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
+        paths = []
+        for d in resolvable_dirs:
+            paths.append(os.path.join(d, f"dev.{file_name}"))
+            paths.append(os.path.join(d, file_name))
+        return paths
+
+
+ORIGINS_CASES_DIR = "./tests/common/cases/configuration/origins"
+ORIGINS_GLOBAL_DIR = os.path.join(ORIGINS_CASES_DIR, "global")
+
+
+def _origins_provider() -> ProfileLikeTomlProvider:
+    """Profile provider over a settings and a global dir: four files, all sharing two names"""
+    return ProfileLikeTomlProvider(
+        CONFIG_TOML,
+        False,
+        CONFIG_TOML,
+        [ORIGINS_CASES_DIR, ORIGINS_GLOBAL_DIR],
+        ORIGINS_GLOBAL_DIR,
+    )
+
+
 def test_toml_value_location() -> None:
     """Provider tells the exact file a value came from, also when several files are merged"""
     global_dir = "./tests/common/cases/configuration/dlt_home"
     settings_dir = "./tests/common/cases/configuration/.dlt"
     config = ConfigTomlProvider(settings_dir=settings_dir, global_dir=global_dir)
 
-    # location is a file name so files with the same name in settings and global dir look alike
-    assert config.get_value_location("param1", None, "api", "params") == CONFIG_TOML
+    global_config_toml = GLOBAL_ORIGIN_PREFIX + CONFIG_TOML
+
+    # values from the settings dir
     assert config.get_value_location("log_level", None, "runtime") == CONFIG_TOML
     assert config.get_value_location("float_val", None, "typecheck") == CONFIG_TOML
-    assert config.get_value_location("param_global", None, "api", "params") == CONFIG_TOML
-    # bools are tagged as well
-    assert config.get_value_location("dlthub_telemetry", None, "runtime") == CONFIG_TOML
+    # settings and global file share a name so the global one is marked to tell them apart
+    assert config.get_value_location("param_global", None, "api", "params") == global_config_toml
+    assert config.get_value_location("dlthub_telemetry", None, "runtime") == global_config_toml
+    # present in both files, the settings dir wins the value and the location
+    assert config.get_value("param1", str, None, "api", "params") == ("a", "api.params.param1")
+    assert config.get_value_location("param1", None, "api", "params") == CONFIG_TOML
     # tables have locations too
     assert config.get_value_location("typecheck", None) == CONFIG_TOML
     # dotted keys and values in nested tables
     assert config.get_value_location("port", None, "api") == CONFIG_TOML
     assert config.get_value_location("max_range", None, "sources") == CONFIG_TOML
 
-    # values written at runtime are not tagged and fall back to the provider location
+    # values written at runtime are in no file
     config.set_value("written", "x", None)
-    assert config.get_value_location("written", None) == CONFIG_TOML
+    assert config.get_value_location("written", None) == ""
+
+    # without a global dir nothing is marked global
+    config = ConfigTomlProvider(settings_dir=settings_dir)
+    assert config.get_value_location("log_level", None, "runtime") == CONFIG_TOML
 
     # providers that do not know the exact location return empty string
     assert EnvironProvider().get_value_location("log_level", None, "runtime") == ""
     assert DictionaryProvider().get_value_location("log_level", None, "runtime") == ""
+
+
+@pytest.mark.parametrize(
+    "global_dir_form", ["relative", "absolute", "trailing_sep", "unnormalized"], ids=lambda x: x
+)
+def test_toml_value_location_global_dir_forms(global_dir_form: str) -> None:
+    """Global dir is recognized however it was spelled, paths are normalized before comparing"""
+    settings_dir = "./tests/common/cases/configuration/.dlt"
+    canonical_global_dir = "./tests/common/cases/configuration/dlt_home"
+    global_dir = canonical_global_dir
+    if global_dir_form == "absolute":
+        global_dir = os.path.abspath(global_dir)
+    elif global_dir_form == "trailing_sep":
+        global_dir = os.path.join(global_dir, "")
+    elif global_dir_form == "unnormalized":
+        global_dir = os.path.join(global_dir, os.pardir, "dlt_home")
+
+    config = ConfigTomlProvider(settings_dir=settings_dir, global_dir=global_dir)
+    assert config.get_value_location("param_global", None, "api", "params") == (
+        GLOBAL_ORIGIN_PREFIX + CONFIG_TOML
+    )
+    assert config.get_value_location("log_level", None, "runtime") == CONFIG_TOML
+
+    # the file path and the global dir may be spelled differently and must still match
+    assert config._is_in_global_dir(
+        os.path.join(os.path.abspath(canonical_global_dir), CONFIG_TOML)
+    )
+    assert not config._is_in_global_dir(os.path.join(settings_dir, CONFIG_TOML))
+    # a sibling dir sharing a name prefix is not inside the global dir
+    assert not config._is_in_global_dir(os.path.join(canonical_global_dir + "2", CONFIG_TOML))
+
+
+def test_toml_value_location_merged_files() -> None:
+    """Exact file is reported when files with different names are merged, base or override"""
+    config = _origins_provider()
+    dev_config_toml = "dev." + CONFIG_TOML
+    global_config_toml = GLOBAL_ORIGIN_PREFIX + CONFIG_TOML
+    global_dev_config_toml = GLOBAL_ORIGIN_PREFIX + dev_config_toml
+
+    # four merged files share two names, each value is still traced to the exact one
+    assert config.get_value_location("dev_only", None) == dev_config_toml
+    assert config.get_value_location("base_only", None) == CONFIG_TOML
+    assert config.get_value_location("global_dev_only", None) == global_dev_config_toml
+    assert config.get_value_location("global_only", None) == global_config_toml
+    # present in all four, the settings dir profile file wins value and location
+    assert config.get_value("shared", str, None) == ("from_dev", "shared")
+    assert config.get_value_location("shared", None) == dev_config_toml
+    # within the global dir the profile file still beats the base one
+    assert config.get_value("key", str, None, "gtbl") == ("from_global_dev", "gtbl.key")
+    assert config.get_value_location("key", None, "gtbl") == global_dev_config_toml
+    assert config.get_value_location("from_global_base", None, "gtbl") == global_config_toml
+    assert config.get_value_location("gtbl", None) == global_config_toml
+    # tomlkit cannot subclass bool, so bools are the one type a doc walk must not unwrap
+    assert config.get_value("create_indexes", bool, None) == (False, "create_indexes")
+    assert config.get_value_location("create_indexes", None) == CONFIG_TOML
+    # tables merge key by key, so each key keeps the file it actually came from
+    assert config.get_value_location("from_base", None, "tbl") == CONFIG_TOML
+    assert config.get_value_location("shared_key", None, "tbl") == dev_config_toml
+    assert config.get_value_location("from_dev", None, "tbl") == dev_config_toml
+    assert config.get_value_location("deep", None, "tbl", "sub") == CONFIG_TOML
+    # a table both files contribute to is reported as the lower precedence one
+    assert config.get_value_location("tbl", None) == CONFIG_TOML
+    # dotted keys, inline tables and arrays of tables
+    assert config.get_value_location("key", None, "dotted") == CONFIG_TOML
+    assert config.get_value_location("it", None, "inline") == CONFIG_TOML
+    assert config.get_value_location("a", None, "inline", "it") == CONFIG_TOML
+    assert config.get_value_location("aot", None) == CONFIG_TOML
+    # `ooo` is split by `other` so tomlkit merges it behind an out of order table proxy
+    assert config.get_value_location("x", None, "ooo", "first") == CONFIG_TOML
+    assert config.get_value_location("z", None, "ooo", "second") == CONFIG_TOML
+
+    # unknown keys have no location
+    assert config.get_value_location("unknown", None) == ""
+    assert config.get_value_location("unknown", None, "tbl") == ""
+
+
+def test_toml_value_location_runtime_writes() -> None:
+    """Values written at runtime are in no file, `preserve` brings the file origins back"""
+    config = _origins_provider()
+    dev_config_toml = "dev." + CONFIG_TOML
+
+    config.set_value("written", "x", None)
+    assert config.get_value_location("written", None) == ""
+    # overwriting a value read from a file forgets that file
+    config.set_value("base_only", "x", None)
+    assert config.get_value_location("base_only", None) == ""
+    # writing into a table forgets just the written key
+    config.set_value("from_base", 2, None, "tbl")
+    assert config.get_value_location("from_base", None, "tbl") == ""
+    assert config.get_value_location("shared_key", None, "tbl") == dev_config_toml
+    # deleting a value forgets it as well
+    config.set_value("deep", None, None, "tbl", "sub")
+    assert config.get_value_location("deep", None, "tbl", "sub") == ""
+
+    # a fragment under a key merges from the root and forgets only the keys it sets
+    config = _origins_provider()
+    config.set_fragment("tbl", "[tbl]\nfrom_base = 3\n", None)
+    assert config.get_value("from_base", int, None, "tbl") == (3, "tbl.from_base")
+    assert config.get_value_location("from_base", None, "tbl") == ""
+    assert config.get_value_location("shared_key", None, "tbl") == dev_config_toml
+
+    # a fragment without a key replaces the whole document so no value comes from a file
+    config = _origins_provider()
+    config.set_fragment(None, "[tbl]\nfrom_base = 3\n", None)
+    assert config.get_value_location("from_base", None, "tbl") == ""
+    assert config.get_value_location("base_only", None) == ""
+
+    # a value that is no fragment at all is written under `key` like set_value would
+    config = _origins_provider()
+    config.set_fragment("base_only", "plain", None)
+    assert config.get_value("base_only", str, None) == ("plain", "base_only")
+    assert config.get_value_location("base_only", None) == ""
+    assert config.get_value_location("dev_only", None) == dev_config_toml
+
+    # preserve restores the origins together with the document
+    config = _origins_provider()
+    with config.preserve():
+        config.set_value("base_only", "x", None)
+        assert config.get_value_location("base_only", None) == ""
+    assert config.get_value_location("base_only", None) == CONFIG_TOML
+    assert config.get_value_location("dev_only", None) == dev_config_toml
+
+
+def test_toml_value_location_odd_fragments() -> None:
+    """Dropping origins never raises on fragment shapes that do not match the origins doc"""
+    config = _origins_provider()
+
+    # yaml fragment with a null, a list and a table replacing what was a plain value
+    config.set_fragment("k", "shared: null\naot: [1, 2]\nbase_only:\n  nested: 1\n", None)
+    for key in ("shared", "aot", "base_only"):
+        assert config.get_value_location(key, None) == ""
+    # a key that never had an origin, and one nested under a value that is not a table
+    config.set_fragment("k", "unknown_key: 1\ncreate_indexes:\n  nested: 2\n", None)
+    assert config.get_value_location("unknown_key", None) == ""
+    assert config.get_value_location("create_indexes", None) == ""
+    # untouched keys keep their origin
+    assert config.get_value_location("dev_only", None) == "dev." + CONFIG_TOML
+
+    # docs that are not mappings and empty paths have nothing to forget
+    config._drop_origin(())
+    not_mappings: List[Any] = [{}, [1, 2], "text", None, 7]
+    for doc in not_mappings:
+        config._drop_origins(doc)
+    assert config.get_value_location("dev_only", None) == "dev." + CONFIG_TOML
+
+
+@pytest.mark.parametrize("provider_kind", ["merged_names", "settings_and_global"])
+def test_toml_value_location_covers_whole_doc(provider_kind: str) -> None:
+    """Origins doc keeps the config doc shape so every value and table has a location"""
+    if provider_kind == "merged_names":
+        config: SettingsTomlProvider = _origins_provider()
+    else:
+        config = ConfigTomlProvider(
+            settings_dir="./tests/common/cases/configuration/.dlt",
+            global_dir="./tests/common/cases/configuration/dlt_home",
+        )
+
+    def assert_located(doc: Dict[str, Any], sections: Tuple[str, ...] = ()) -> None:
+        for key, value in doc.items():
+            assert config.get_value_location(key, None, *sections) != "", ".".join((*sections, key))
+            if isinstance(value, dict):
+                assert_located(value, sections + (key,))
+
+    assert config._config_doc
+    assert_located(config._config_doc)
 
 
 def test_write_value(toml_providers: ConfigProvidersContainer) -> None:

--- a/tests/common/configuration/test_toml_provider.py
+++ b/tests/common/configuration/test_toml_provider.py
@@ -26,7 +26,10 @@ from dlt.common.configuration.providers.toml import (
     StringTomlProvider,
     TomlProviderReadException,
 )
+from dlt.common.configuration.providers.dictionary import DictionaryProvider
+from dlt.common.configuration.providers.environ import EnvironProvider
 from dlt.common.configuration.specs.config_providers_context import ConfigProvidersContainer
+from dlt.common.configuration.utils import get_resolved_traces
 from dlt.common.configuration.specs import (
     BaseConfiguration,
     GcpServiceAccountCredentialsWithoutDefaults,
@@ -70,8 +73,9 @@ def test_secrets_from_toml_secrets(toml_providers: ConfigProvidersContainer) -> 
     # only two traces because TSecretValue won't be checked in config.toml provider
     traces = py_ex.value.traces["secret_value"]
     assert len(traces) == 2
-    assert traces[0] == LookupTrace("Environment Variables", [], "SECRET_VALUE", None)
-    assert traces[1] == LookupTrace("secrets.toml", [], "secret_value", None)
+    # values that were not found have no location
+    assert traces[0] == LookupTrace("Environment Variables", [], "SECRET_VALUE", None, "")
+    assert traces[1] == LookupTrace("secrets.toml", [], "secret_value", None, "")
 
     with pytest.raises(ConfigFieldMissingException) as py_ex:
         resolve.resolve_configuration(WithCredentialsConfiguration())
@@ -87,6 +91,12 @@ def test_toml_types(toml_providers: ConfigProvidersContainer) -> None:
         if isinstance(v, datetime.datetime):
             v = pendulum.parse("1979-05-27T07:32:00-08:00")
         assert v == c[k]
+
+    # all resolved values know the file they came from, also bools, floats and inline tables
+    tracer = get_resolved_traces()
+    traces = tracer._get_log_as_dict(tracer.resolved_traces)
+    for k in COERCIONS:
+        assert traces[f"typecheck.{k}"].provider_location == CONFIG_TOML
 
 
 def test_config_provider_order(toml_providers: ConfigProvidersContainer, environment: Any) -> None:
@@ -144,6 +154,11 @@ def test_secrets_toml_credentials(
         GcpServiceAccountCredentialsWithoutDefaults(), sections=("destination", "bigquery")
     )
     assert c.project_id.endswith("destination.bigquery.credentials")
+    # credentials are enumerated field by field from a toml table, each field knows its location
+    tracer = get_resolved_traces()
+    traces = tracer._get_log_as_dict(tracer.resolved_traces)
+    assert traces["destination.bigquery.credentials.project_id"].provider_location == SECRETS_TOML
+    assert traces["destination.bigquery.credentials.private_key"].provider_location == SECRETS_TOML
     # there are no destination.gcp_storage.credentials so it will fallback to "destination"."credentials"
     c = resolve.resolve_configuration(
         GcpServiceAccountCredentialsWithoutDefaults(), sections=("destination", "gcp_storage")
@@ -313,6 +328,34 @@ def test_toml_global_config() -> None:
     assert os.path.join(settings_dir, "secrets.toml") in secrets.locations
     # CI creates secrets.toml so actually those are sometimes present
     # assert os.path.join(settings_dir, "secrets.toml") not in secrets.present_locations
+
+
+def test_toml_value_location() -> None:
+    """Provider tells the exact file a value came from, also when several files are merged"""
+    global_dir = "./tests/common/cases/configuration/dlt_home"
+    settings_dir = "./tests/common/cases/configuration/.dlt"
+    config = ConfigTomlProvider(settings_dir=settings_dir, global_dir=global_dir)
+
+    # location is a file name so files with the same name in settings and global dir look alike
+    assert config.get_value_location("param1", None, "api", "params") == CONFIG_TOML
+    assert config.get_value_location("log_level", None, "runtime") == CONFIG_TOML
+    assert config.get_value_location("float_val", None, "typecheck") == CONFIG_TOML
+    assert config.get_value_location("param_global", None, "api", "params") == CONFIG_TOML
+    # bools are tagged as well
+    assert config.get_value_location("dlthub_telemetry", None, "runtime") == CONFIG_TOML
+    # tables have locations too
+    assert config.get_value_location("typecheck", None) == CONFIG_TOML
+    # dotted keys and values in nested tables
+    assert config.get_value_location("port", None, "api") == CONFIG_TOML
+    assert config.get_value_location("max_range", None, "sources") == CONFIG_TOML
+
+    # values written at runtime are not tagged and fall back to the provider location
+    config.set_value("written", "x", None)
+    assert config.get_value_location("written", None) == CONFIG_TOML
+
+    # providers that do not know the exact location return empty string
+    assert EnvironProvider().get_value_location("log_level", None, "runtime") == ""
+    assert DictionaryProvider().get_value_location("log_level", None, "runtime") == ""
 
 
 def test_write_value(toml_providers: ConfigProvidersContainer) -> None:
@@ -546,6 +589,8 @@ key2 = "value2"
 
     assert provider.get_value("key1", "", "section1", "subsection") == ("value1", "section1.subsection.key1")  # type: ignore[arg-type]
     assert provider.get_value("key2", "", "section2", "subsection") == ("value2", "section2.subsection.key2")  # type: ignore[arg-type]
+    # provider has no locations to report
+    assert provider.get_value_location("key1", None, "section1", "subsection") == ""
 
     # test basic writing
     provider = StringTomlProvider("")
@@ -580,6 +625,8 @@ def test_custom_loader(toml_providers: ConfigProvidersContainer) -> None:
     provider = CustomLoaderDocProvider("yaml", loader, True)
     assert provider.name == "yaml"
     assert provider.supports_secrets is True
+    # loader was registered without locations
+    assert provider.get_value_location("datetime", None, "data_types") == ""
     assert provider.to_toml().startswith("[destination")
     assert provider.to_yaml().startswith("destination:")
     value, _ = provider.get_value("datetime", datetime.datetime, None, "data_types")

--- a/tests/common/runtime/test_exec_info.py
+++ b/tests/common/runtime/test_exec_info.py
@@ -2,6 +2,8 @@ import pytest
 
 from dlt.common.runtime.exec_info import (
     exec_info_names,
+    get_execution_context,
+    run_context_info,
     is_aws_lambda,
     is_claude_code,
     is_claude_code_cli,
@@ -140,3 +142,10 @@ def test_exec_info_names_excludes_agents_when_absent(environment: DictStrStr) ->
     names = exec_info_names()
     agent_names = {"claude_code", "claude_code_cli", "cursor", "codex"}
     assert agent_names.isdisjoint(set(names))
+
+
+def test_run_context_info() -> None:
+    # default run context does not support profiles
+    info = run_context_info()
+    assert info == {"name": "dlt"}
+    assert get_execution_context()["run_context"] == info

--- a/tests/common/runtime/test_telemetry.py
+++ b/tests/common/runtime/test_telemetry.py
@@ -179,7 +179,7 @@ def test_track_anon_event(mocker: MockerFixture, disable_temporary_telemetry) ->
     assert isinstance(context["ci_run"], bool)
     assert isinstance(context["exec_info"], list)
     assert ["kubernetes", "codespaces"] <= context["exec_info"]
-    assert context["run_context"] == "dlt"
+    assert context["run_context"] == {"name": "dlt"}
 
 
 def test_forced_anon_tracker() -> None:

--- a/tests/helpers/airflow_tests/test_airflow_provider.py
+++ b/tests/helpers/airflow_tests/test_airflow_provider.py
@@ -28,6 +28,8 @@ def test_airflow_secrets_toml_provider() -> None:
         # make sure provider works while creating DAG
         provider = AirflowSecretsTomlProvider()
         assert provider.get_value("api_key", str, None, "sources")[0] == "test_value"
+        # airflow variables have no location to report
+        assert provider.get_value_location("api_key", None, "sources") == ""
 
         @task()
         def test_task():

--- a/tests/helpers/providers/test_aws_secrets_provider_stub.py
+++ b/tests/helpers/providers/test_aws_secrets_provider_stub.py
@@ -45,6 +45,11 @@ def test_default_secret_name_prefix() -> None:
     )
     assert AwsSecretsManagerProvider(credentials).secret_name_prefix == "dlt/"
     assert AwsSecretsProviderConfiguration().secret_name_prefix == "dlt/"
+    # value location identifies the account and the prefix
+    assert (
+        AwsSecretsManagerProvider(credentials).get_value_location("secret_value", None)
+        == "fake_key:dlt/"
+    )
 
 
 @pytest.mark.parametrize(
@@ -104,6 +109,8 @@ def test_look_vault_with_prefix() -> None:
     )
     assert provider._look_vault("sources/my_source", TSecretValue) == "SRC_KEY"
     stubber.assert_no_pending_responses()
+    # region and prefix are part of the location
+    assert provider.get_value_location("my_source", None, "sources") == "fake_key@eu-central-1:dlt/"
 
 
 def test_list_vault_paginates() -> None:

--- a/tests/helpers/providers/test_google_secrets_provider.py
+++ b/tests/helpers/providers/test_google_secrets_provider.py
@@ -54,6 +54,8 @@ def test_regular_keys(settings: VaultProviderConfiguration) -> None:
     assert provider.to_toml().strip() == DLT_SECRETS_TOML_CONTENT.strip()
     # check location
     assert "chat-analytics" in provider.locations[0]
+    # values are traced with the vault location
+    assert provider.get_value_location("secret_value", None) == provider.locations[0]
 
     assert provider.get_value("secret_value", AnyType, None) == (2137, "secret_value")
     assert provider.get_value("secret_key", AnyType, None, "api") == ("ABCD", "api-secret_key")

--- a/tests/load/test_relation_join.py
+++ b/tests/load/test_relation_join.py
@@ -8,6 +8,7 @@ import pytest
 import dlt
 from dlt import Pipeline
 from dlt.common.destination import Destination
+from dlt.common.storages.configuration import FilesystemConfiguration
 from dlt.common.utils import uniq_id
 from dlt.dataset.relation import TJoinType
 from dlt.extract.hints import make_hints
@@ -272,7 +273,9 @@ def test_cross_dataset_explicit_join(
     assert casefold(ds_a.sql_client.dataset_name) in sql, sql
     assert casefold(ds_b.sql_client.dataset_name) in sql, sql
 
-    if ds_a.destination_client.config.protocol != "gs":  # type: ignore[attr-defined]
+    config = ds_a.destination_client.config
+    skip = isinstance(config, FilesystemConfiguration) and config.protocol == "gs"
+    if not skip:
         _assert_users_purchases(joined)
 
 

--- a/tests/pipeline/cases/contracts/trace.schema.yaml
+++ b/tests/pipeline/cases/contracts/trace.schema.yaml
@@ -89,8 +89,12 @@ tables:
         description: dlthub library version (if installed)
         data_type: text
         nullable: true
-      execution_context__run_context:
-        description: Run context class name (e.g. PluggableRunContext)
+      execution_context__run_context__name:
+        description: Run context name (e.g. dlt)
+        data_type: text
+        nullable: true
+      execution_context__run_context__profile:
+        description: Active profile name (if run context supports profiles)
         data_type: text
         nullable: true
       started_at:
@@ -917,6 +921,11 @@ tables:
         nullable: true
       config_type_name:
         description: Configuration spec class name that requested the value
+        data_type: text
+        nullable: true
+      provider_location:
+        description: Human readable location within the provider (e.g. the toml file) holding the
+          value
         data_type: text
         nullable: true
       _dlt_parent_id:

--- a/tests/pipeline/cases/contracts/trace.schema.yaml
+++ b/tests/pipeline/cases/contracts/trace.schema.yaml
@@ -1244,6 +1244,12 @@ tables:
       location:
         data_type: text
         nullable: true
+      dataset_name:
+        data_type: text
+        nullable: true
+      physical_dataset_name:
+        data_type: text
+        nullable: true
     parent: trace__steps
   trace__steps__load_info__outputs__schemas:
     columns:

--- a/tests/plugins/test_plugin_discovery.py
+++ b/tests/plugins/test_plugin_discovery.py
@@ -135,7 +135,7 @@ def test_plugin_execution_context() -> None:
     from dlt.common.runtime.exec_info import get_execution_context
 
     context = get_execution_context()
-    assert context["run_context"] == "dlt-test"
+    assert context["run_context"] == {"name": "dlt-test"}
 
 
 def test_cli_hook(script_runner: ScriptRunner) -> None:

--- a/tests/workspace/test_providers.py
+++ b/tests/workspace/test_providers.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from dlt._workspace.providers import ProfileSecretsTomlProvider
+from dlt.common.configuration.providers import SECRETS_TOML
 
 TESTS_CASES_DIR = os.path.join("tests", "workspace", "cases", "provider")
 
@@ -21,10 +22,14 @@ def test_secrets_toml() -> None:
     assert provider.get_value("api_key", str, None) == ("PASS", "api_key")
     # still has secrets.toml keys
     assert provider.get_value("log_level", str, None, "runtime") == ("WARNING", "runtime.log_level")
+    # both files are merged into one provider so only the location tells them apart
+    assert provider.get_value_location("api_key", None) == "access." + SECRETS_TOML
+    assert provider.get_value_location("log_level", None, "runtime") == SECRETS_TOML
 
     # dev profile will load just secrets.toml
     provider = ProfileSecretsTomlProvider(os.path.join(TESTS_CASES_DIR, ".dlt"), "dev")
     assert provider.get_value("api_key", str, None) == ("X", "api_key")
+    assert provider.get_value_location("api_key", None) == SECRETS_TOML
 
 
 def test_secrets_not_present() -> None:

--- a/tests/workspace/test_workspace_context.py
+++ b/tests/workspace/test_workspace_context.py
@@ -20,7 +20,9 @@ from dlt._workspace.run_context import (
     switch_profile,
 )
 from dlt._workspace.cli.echo import always_choose
+from dlt.common.configuration.providers import CONFIG_TOML, SECRETS_TOML
 from dlt.common.runtime.exceptions import RunContextNotAvailable
+from dlt.common.runtime.exec_info import get_execution_context
 from dlt.common.runtime.run_context import DOT_DLT, RunContext, global_dir
 from dlt.common.utils import custom_environ
 
@@ -86,6 +88,51 @@ def test_workspace_profile() -> None:
         assert_dev_config()
         assert ctx.configured_profiles() == ["dev"]
         assert ctx._profile_has_config("dev") is True
+
+
+def test_workspace_trace() -> None:
+    """Pipeline trace run in a workspace carries run context name and profile and resolved config values"""
+    with isolated_workspace("default", profile="dev") as ctx:
+        assert get_execution_context()["run_context"] == {"name": ctx.name, "profile": "dev"}
+
+        @dlt.resource
+        def data(
+            config_val: str = dlt.config.value,
+            config_val_ovr: str = dlt.config.value,
+            secrets_val_dev: str = dlt.secrets.value,
+        ):
+            yield {"config_val": config_val, "config_val_ovr": config_val_ovr}
+
+        pipeline = dlt.pipeline(pipeline_name="workspace_trace", destination="duckdb")
+        pipeline.run(data())
+
+        trace = pipeline.last_trace
+        assert trace.execution_context["run_context"] == {"name": ctx.name, "profile": "dev"}
+
+        resolved = {v.key: v for v in trace.resolved_config_values}
+        assert resolved["config_val"].value == "config.toml"
+        # value comes from the profile file which takes precedence
+        assert resolved["config_val_ovr"].value == "dev.config.toml"
+        # secret values are not stored in the trace
+        assert resolved["secrets_val_dev"].is_secret_hint is True
+        assert resolved["secrets_val_dev"].value is None
+        # profile and base toml files are merged into a single provider so the exact file that
+        # held the value is in the location, not in the provider name
+        assert resolved["config_val_ovr"].provider_name == CONFIG_TOML
+        assert resolved["secrets_val_dev"].provider_name == SECRETS_TOML
+        assert resolved["config_val_ovr"].provider_location == "dev." + CONFIG_TOML
+        assert resolved["secrets_val_dev"].provider_location == "dev." + SECRETS_TOML
+        # key not present in the profile file comes from the base file
+        assert resolved["config_val"].provider_location == CONFIG_TOML
+
+        # profile switch is reflected in the next trace
+        ctx = ctx.switch_profile("prod")
+        pipeline = dlt.pipeline(pipeline_name="workspace_trace", destination="duckdb")
+        pipeline.run([{"foo": 1}], table_name="table_foo")
+        assert pipeline.last_trace.execution_context["run_context"] == {
+            "name": ctx.name,
+            "profile": "prod",
+        }
 
 
 def test_profile_switch_no_workspace():

--- a/tests/workspace/test_workspace_context.py
+++ b/tests/workspace/test_workspace_context.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import pickle
 import tempfile
+import yaml
 
 import dlt
 from dlt._workspace._known_env import WORKSPACE__PROFILE
@@ -24,10 +25,11 @@ from dlt.common.configuration.providers import CONFIG_TOML, SECRETS_TOML
 from dlt.common.runtime.exceptions import RunContextNotAvailable
 from dlt.common.runtime.exec_info import get_execution_context
 from dlt.common.runtime.run_context import DOT_DLT, RunContext, global_dir
+from dlt.common.schema import Schema
 from dlt.common.utils import custom_environ
 
 from dlt.common.storages.file_storage import FileStorage
-from tests.pipeline.utils import assert_table_counts
+from tests.pipeline.utils import PIPELINE_TEST_CASES_PATH, assert_table_counts
 from tests.utils import clean_test_storage
 from tests.workspace.utils import isolated_workspace
 
@@ -92,6 +94,12 @@ def test_workspace_profile() -> None:
 
 def test_workspace_trace() -> None:
     """Pipeline trace run in a workspace carries run context name and profile and resolved config values"""
+    # the workspace is entered with a changed cwd so resolve the relative cases path first
+    with open(
+        os.path.abspath(f"{PIPELINE_TEST_CASES_PATH}/contracts/trace.schema.yaml"), encoding="utf-8"
+    ) as f:
+        trace_contract = Schema.from_dict(yaml.safe_load(f), remove_processing_hints=True)
+
     with isolated_workspace("default", profile="dev") as ctx:
         assert get_execution_context()["run_context"] == {"name": ctx.name, "profile": "dev"}
 
@@ -124,6 +132,22 @@ def test_workspace_trace() -> None:
         assert resolved["secrets_val_dev"].provider_location == "dev." + SECRETS_TOML
         # key not present in the profile file comes from the base file
         assert resolved["config_val"].provider_location == CONFIG_TOML
+
+        # only a workspace trace carries a profile, so the contract pinned by
+        # tests/pipeline/test_pipeline_trace.py can only be enforced for that shape here
+        trace_pipeline = dlt.pipeline(
+            pipeline_name="workspace_trace_contract", destination="duckdb", dev_mode=True
+        )
+        trace_pipeline.run(
+            [trace], table_name="trace", schema=trace_contract, schema_contract="freeze"
+        )
+        # freeze rejects unknown columns so the profile must land in the contracted name
+        with trace_pipeline.sql_client() as client:
+            with client.execute_query(
+                "SELECT execution_context__run_context__name,"
+                " execution_context__run_context__profile FROM trace"
+            ) as cur:
+                assert cur.fetchall() == [(ctx.name, "dev")]
 
         # profile switch is reflected in the next trace
         ctx = ctx.switch_profile("prod")


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
* adds profile to `run_context` element in trace (shape change)
* adds location of resolved config/secret in resolver trace

(also fixes skills that create worktrees - new branches origins got borked)

@sh-rp will those be stored in runtime and somehow visible in UI? if not we need another ticket

Where are new values in trace:

* `trace.execution_context["run_context"]` — was the context name as `str`, now a dict with `name` and (when the context supports profiles) `profile`. 
* `trace.resolved_config_values[*].provider_location` — new trailing field on `SerializableResolvedValueTrace`

Examples:

Pipeline run in a workspace on the `dev` profile, serialized with `trace.asdict()` (what gets loaded into the destination / sent to the platform).

`execution_context`:

```json
{
  "ci_run": false,
  "python": "3.14.4",
  "cpu": 24,
  "exec_info": ["claude_code", "claude_code_cli"],
  "os": {
    "name": "Linux",
    "version": "6.6.87.2-microsoft-standard-WSL2"
  },
  "library": {
    "name": "dlt",
    "version": "1.30.0a0"
  },
  "run_context": {
    "name": "default",
    "profile": "dev"
  }
}
```

`resolved_config_values` (`value` and `default_value` are dropped by `asdict`). `config_val` is only in `config.toml`, `config_val_ovr` is in both files and the profile one won, `secrets_val_dev` is only in `dev.secrets.toml`:

```json
[
  {
    "key": "config_val",
    "is_secret_hint": false,
    "sections": [],
    "provider_name": "config.toml",
    "config_type_name": "DataConfiguration",
    "provider_location": "config.toml"
  },
  {
    "key": "config_val_ovr",
    "is_secret_hint": false,
    "sections": [],
    "provider_name": "config.toml",
    "config_type_name": "DataConfiguration",
    "provider_location": "dev.config.toml"
  },
  {
    "key": "secrets_val_dev",
    "is_secret_hint": true,
    "sections": [],
    "provider_name": "secrets.toml",
    "config_type_name": "DataConfiguration",
    "provider_location": "dev.secrets.toml"
  }
]
```

How locations is set for different providers:

| Provider | location of a resolved value |
|---|---|
| `ConfigTomlProvider` / `SecretsTomlProvider` | `config.toml`, `secrets.toml` |
| `ProfileConfigTomlProvider` / `ProfileSecretsTomlProvider` | exact file: `dev.config.toml` when the profile file held the value, `config.toml` when it fell through to the base file |
| `GoogleSecretsProvider` | vault identity, ie. `sa@x.com@chat-analytics` |
| `AwsSecretsManagerProvider` | account, region and prefix, ie. `fake_key@eu-central-1:dlt/` |
| `AirflowSecretsTomlProvider` | `""` |
| `EnvironProvider`, `ContextProvider`, `DictionaryProvider`, `StringTomlProvider` | `""` |
| `CustomLoaderDocProvider` | whatever `locations` the caller registered, else `""` |

Values written at runtime with `set_value` are not tagged and fall back to the provider location.
