### PR TITLE
fix(fabric): widen tinyint integer precision to smallint

### DIFF
--- a/dlt/destinations/impl/fabric/factory.py
+++ b/dlt/destinations/impl/fabric/factory.py
@@ -8,6 +8,7 @@ that extends Synapse capabilities with Fabric-specific requirements:
 - Supports COPY INTO for efficient data loading from staging
 """
 
+from copy import copy
 from typing import Type, TYPE_CHECKING, Optional
 
 from dlt.common.destination import DestinationCapabilitiesContext
@@ -61,6 +62,14 @@ class FabricTypeMapper(SynapseTypeMapper):
         if loader_file_format == "parquet" and column["data_type"] == "time":
             return
         super().ensure_supported_type(column, table, loader_file_format)
+
+    def to_db_integer_type(self, column: TColumnSchema, table: PreparedTableSchema = None) -> str:
+        """Override to widen tinyint to smallint, the narrowest integer type Fabric supports"""
+        precision = column.get("precision")
+        if precision is not None and precision <= 8:
+            column = copy(column)
+            column["precision"] = 16
+        return super().to_db_integer_type(column, table)
 
     def to_destination_type(self, column: TColumnSchema, table: PreparedTableSchema) -> str:
         """Override to use varchar instead of nvarchar and datetime2 instead of datetimeoffset"""

--- a/tests/load/fabric/test_fabric_configuration.py
+++ b/tests/load/fabric/test_fabric_configuration.py
@@ -253,3 +253,21 @@ def test_fabric_type_mapper_scales_varchar_precision(data_type: TDataType) -> No
         TColumnSchema, {"name": "c", "data_type": data_type, "precision": 10, "nullable": True}
     )
     assert mapper.to_destination_type(col, table) == "varchar(40)"
+
+
+@pytest.mark.parametrize(
+    "precision,expected",
+    [(None, "bigint"), (8, "smallint"), (16, "smallint"), (32, "int"), (64, "bigint")],
+    ids=["no_precision", "tinyint", "smallint", "int", "bigint"],
+)
+def test_fabric_type_mapper_integer_precision(precision: Optional[int], expected: str) -> None:
+    """Fabric Warehouse has no tinyint, so a precision inherited from SQL Server widens to smallint"""
+    mapper = FabricTypeMapper(DestinationCapabilitiesContext.generic_capabilities("parquet"))
+    table = cast(PreparedTableSchema, {"name": "test_table", "columns": {}})
+    column = cast(TColumnSchema, {"name": "c", "data_type": "bigint", "nullable": True})
+    if precision is not None:
+        column["precision"] = precision
+
+    assert mapper.to_destination_type(column, table) == expected
+    # widening must not leak back into the caller's schema
+    assert column.get("precision") == precision


### PR DESCRIPTION
Fixes #4306

## Summary

- Override `to_db_integer_type` in `FabricTypeMapper` so a `bigint` column with `precision <= 8` maps to `smallint` instead of `tinyint`
- Copy the column before adjusting it, so the widening does not leak back into the caller's schema

## Root cause

Fabric Warehouse has no `tinyint`; `smallint` is its narrowest integer type. `sql_database` reflects a SQL Server `TINYINT` as dlt type `bigint` with `precision=8`, and `MsSqlTypeMapper.to_db_integer_type` maps that to `tinyint`. `FabricTypeMapper` inherits that through `SynapseTypeMapper` and previously overrode only the datetime and string mappings, so `CREATE TABLE` failed with a `DatabaseTerminalException`. Being terminal, the load was not retried and every subsequent run failed on the same table.

Widening is safe: `TINYINT` values (0-255) all fit in `smallint`. Nothing changes for `mssql` or `synapse`, where `tinyint` is valid.

## Test plan

- Added `test_fabric_type_mapper_integer_precision`, parametrized over no precision, 8, 16, 32 and 64, asserting `bigint`, `smallint`, `smallint`, `int`, `bigint`. It also asserts the input column is left untouched.
- Verified on `devel` before the change that precision 8 yields `tinyint`, so the test is a real regression guard.
- `tests/load/fabric`: 20 passed, 1 skipped (the table builder module skips without an ODBC driver).
- mypy, ruff, flake8 (including the docstring pass over `impl/**/factory.py`) and black all clean.