### PR TITLE
ci: add the agentic-docs workflow

### DIFF
--- a/.github/workflows/agentic-docs.yml
+++ b/.github/workflows/agentic-docs.yml
@@ -1,0 +1,174 @@
+# Copy this file to dlt-hub/dlt as .github/workflows/agentic-docs.yml.
+# It lives here so the bot repo owns the trigger contract it depends on.
+#
+# Repository secrets required in dlt-hub/dlt:
+#   AGENTIC_DOCS_ALLOWLIST   comma-separated GitHub usernames allowed to trigger
+#   GCP_WORKLOAD_IDENTITY_PROVIDER   projects/.../workloadIdentityPools/.../providers/...
+#   GCP_SERVICE_ACCOUNT      service account the workflow impersonates
+#
+# Nothing attacker-controlled is interpolated into a shell script: the job
+# receives only numeric IDs and fetches the comment text itself.
+#
+# ---------------------------------------------------------------------------
+# MAINTAINERS: triggering this is a privileged act, not a convenience.
+#
+# The job feeds the issue and its comments — text anyone on the internet can
+# write — to a model, then EXECUTES the Python that model writes, because a dlt
+# page whose snippets have not run is not worth publishing. That code runs in a
+# container whose identity can read GH_TOKEN, a PAT with write access to this
+# repository and shared with two other bots.
+#
+# So before you apply the labels or write /revise:
+#   * read the RAW issue body and every comment, not the rendered page. Text
+#     that instructs the bot rather than describing a feature is an attack,
+#     however politely it is phrased.
+#   * review the resulting PR's diff, not only its prose. Its snippets executed;
+#     that is not the same as anyone having vetted them.
+#   * if a run does something unexpected, assume GH_TOKEN is exposed and say so
+#     — rotating it stops all three bots until they are redeployed.
+#
+# Only names in AGENTIC_DOCS_ALLOWLIST can do any of this. Adding a name grants
+# the ability to spend money and to cause code to run. See the security section
+# of the agentic-docs README.
+# ---------------------------------------------------------------------------
+
+name: Agentic Docs
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  # A maintainer reviewing prose clicks a line in the Files tab and types.
+  # That is not an issue_comment — it is a review, and without this trigger the
+  # bot never wakes up for the review mode maintainers actually use.
+  #
+  # Deliberately only `submitted`, not `pull_request_review_comment`. A reviewer
+  # leaving six line comments submits one review; triggering per comment would
+  # start six jobs racing on the same branch. The run reads every inline comment
+  # once it starts, so nothing is lost by waiting for the submit.
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    # Label events must carry both labels. Comment events must look like a
+    # command, and may be on either an issue (`/position`, before any PR exists)
+    # or a pull request (`/revise`, which is where maintainers review).
+    #
+    # GitHub models PR comments as issue comments, so for a comment on a PR
+    # `github.event.issue.number` is the PR number, not the issue's. The step
+    # below therefore passes it under a different name and lets the driver map
+    # PR back to issue through its own state.
+    #
+    # Submitting a review is itself the request; no command is needed. Both
+    # `commented` and `changes_requested` start a run, because GitHub preselects
+    # "Comment" in the Submit review dialog — gating on `changes_requested` would
+    # mean a maintainer who writes notes on lines and clicks the green button
+    # without touching the radios gets silence. An approval starts nothing.
+    # The driver re-checks the state; `if:` here is only the cheap filter.
+    # Anything on the pull-request side must additionally carry the bot's own
+    # label. `pull_request_review` fires for EVERY pull request in this
+    # repository, and dlt has many: without this, a maintainer reviewing an
+    # unrelated pull request passes the allowlist gate and starts a job that can
+    # only fail. The bot labels the pull requests it opens.
+    if: |
+      (github.event_name == 'issues' &&
+       contains(github.event.issue.labels.*.name, 'documentation') &&
+       contains(github.event.issue.labels.*.name, 'agent')) ||
+      (github.event_name == 'issue_comment' &&
+       !github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/position')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.issue.labels.*.name, 'agentic-docs') &&
+       contains(github.event.comment.body, '/revise')) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.pull_request.labels.*.name, 'agentic-docs') &&
+       (github.event.review.state == 'commented' ||
+        github.event.review.state == 'changes_requested'))
+
+    steps:
+      # Gate on the actor — whoever applied the label or wrote the comment —
+      # because that is who causes the spend. Matching is exact against list
+      # entries, so "ann" cannot be satisfied by "annabel".
+      # A comment from someone not on the list is ordinary traffic, not an
+      # error, so this reports "false" and the run ends green rather than
+      # leaving a failed check on every unrelated /revise mention.
+      - name: Check allowlist
+        id: allowlist
+        env:
+          ALLOWLIST: ${{ secrets.AGENTIC_DOCS_ALLOWLIST }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          allowed=false
+          IFS=',' read -ra names <<< "$ALLOWLIST"
+          for name in "${names[@]}"; do
+            if [[ "$(echo "$name" | xargs)" == "$ACTOR" ]]; then
+              allowed=true
+              break
+            fi
+          done
+          if [[ "$allowed" == "false" ]]; then
+            echo "::notice::$ACTOR is not in AGENTIC_DOCS_ALLOWLIST; skipping"
+          fi
+          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        if: steps.allowlist.outputs.allowed == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        if: steps.allowlist.outputs.allowed == 'true'
+        uses: google-github-actions/setup-gcloud@v2
+
+      # Exactly one of ISSUE_NUMBER / PR_NUMBER is set, and both are numbers:
+      #
+      #   labelled issue        ISSUE_NUMBER, no COMMENT_ID  -> generation
+      #   comment on an issue   ISSUE_NUMBER + COMMENT_ID    -> /position
+      #   comment on a PR       PR_NUMBER + COMMENT_ID       -> /revise
+      #   review on a PR        PR_NUMBER + REVIEW_ID        -> /revise
+      #
+      # `github.event.issue.pull_request` is present only for a comment on a PR,
+      # which is how the two comment cases are told apart. A review event has no
+      # `issue` at all — its number is on `pull_request` — so it is handled
+      # separately rather than folded into the same expression.
+      #
+      # Only numeric IDs cross this boundary. The job fetches the comment or
+      # review text itself, so nothing a stranger wrote passes through this shell.
+      - name: Execute agentic-docs job
+        if: steps.allowlist.outputs.allowed == 'true'
+        env:
+          IS_REVIEW: ${{ github.event_name == 'pull_request_review' && 'true' || 'false' }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || 'false' }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REVIEW_ID: ${{ github.event.review.id }}
+          # Whoever applied the label. In practice a maintainer says where the
+          # page goes and then labels the issue, so the job reads that person's
+          # comments as an instruction rather than as untrusted prose. A login,
+          # not free text — it cannot carry a payload through this shell.
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if [[ "$IS_REVIEW" == "true" ]]; then
+            target="PR_NUMBER=${PR_NUMBER},REVIEW_ID=${REVIEW_ID}"
+          elif [[ "$IS_PR_COMMENT" == "true" ]]; then
+            target="PR_NUMBER=${ISSUE_NUMBER},COMMENT_ID=${COMMENT_ID}"
+          else
+            target="ISSUE_NUMBER=${ISSUE_NUMBER},COMMENT_ID=${COMMENT_ID},ACTOR=${ACTOR}"
+          fi
+          gcloud run jobs execute agentic-docs \
+            --region=europe-west3 \
+            --update-env-vars="${target}" \
+            --wait


### PR DESCRIPTION
Adds the trigger for the agentic-docs bot, which drafts documentation pages from
labelled issues and revises them from review feedback.

**This workflow does almost nothing itself.** It checks an allowlist and starts a
Cloud Run job in `dlthub-analytics`; the reading, writing, verifying and PR
creation all happen in that container. Only numeric IDs cross the boundary — the
job fetches issue and comment text itself, so nothing anyone wrote passes through
a shell step here.

### How it fires

| Event | Condition |
|---|---|
| Issue labelled | carries both `documentation` and `agent` |
| Comment on an issue | contains `/position` |
| Comment on a PR | contains `/revise`, and the PR carries `agentic-docs` |
| Review submitted | Comment or Request changes, and the PR carries `agentic-docs` |

Every one of them is additionally gated on the actor being in
`AGENTIC_DOCS_ALLOWLIST`. Someone not on the list gets a green no-op rather than a
failed check, so an unrelated `/revise` in prose doesn't leave red marks.

The `agentic-docs` label requirement matters: `pull_request_review` fires for every
PR in this repository, so without it a maintainer reviewing anything at all would
start a job. The bot labels the PRs it opens.

### What the bot may touch

Writes are confined to `docs/website/docs/**` plus `sidebars.js` by name, enforced
in the one place content reaches disk. Nothing in it deletes, renames or moves a
file, and it cannot write `docusaurus.config.js`, so redirects and site config are
out of reach. Every PR it opens is a draft against `devel` and a human merges.

### Required before merge

Three repository secrets (Settings → Secrets and variables → Actions):

- `AGENTIC_DOCS_ALLOWLIST` — comma-separated GitHub logins allowed to trigger it
- `GCP_WORKLOAD_IDENTITY_PROVIDER`
- `GCP_SERVICE_ACCOUNT`

Authentication is Workload Identity Federation — no service account key is stored
here. The provider is pinned to this file path on `devel`, so a token minted by any
other workflow, including one added in a PR, cannot impersonate the trigger
account. That account can start this one job and can read no secrets.

Also needs the `agentic-docs` label to exist.

### Expected on the first run

The agent session isn't finished, so a trigger currently gets as far as cloning and
locating the target page, then fails at the handover. That's deliberate — it
cannot report success having produced nothing. Merging this is what makes the
trigger path testable at all.

Source and full documentation: `dlt-hub/agentic-docs`.
