### PR TITLE
ci(agentic-docs): do not start a run for the bot's own comments

### DIFF
--- a/.github/workflows/agentic-docs.yml
+++ b/.github/workflows/agentic-docs.yml
@@ -77,14 +77,27 @@ jobs:
     # repository, and dlt has many: without this, a maintainer reviewing an
     # unrelated pull request passes the allowlist gate and starts a job that can
     # only fail. The bot labels the pull requests it opens.
+    #
+    # A comment carrying `<!-- agentic-docs -->` is the bot's own and starts
+    # nothing. This is not hygiene, it is a self-trigger that happened: the bot's
+    # position request shows an example line reading `/position under Pipeline
+    # operations, add a section to Profiles`, which matched the `/position` arm
+    # below. The comment is posted with the maintainer's PAT, so the allowlist
+    # gate passed, and the driver read the bot's own example as an instruction —
+    # resolving to a real dlt page and starting to write the wrong page into it.
+    # Filtering by author cannot work, because the PAT belongs to a person.
+    # `github.event.comment.body` is the raw body here, markers included, unlike
+    # what the driver's fetch returns.
     if: |
       (github.event_name == 'issues' &&
        contains(github.event.issue.labels.*.name, 'documentation') &&
        contains(github.event.issue.labels.*.name, 'agent')) ||
       (github.event_name == 'issue_comment' &&
+       !contains(github.event.comment.body, '<!-- agentic-docs -->') &&
        !github.event.issue.pull_request &&
        contains(github.event.comment.body, '/position')) ||
       (github.event_name == 'issue_comment' &&
+       !contains(github.event.comment.body, '<!-- agentic-docs -->') &&
        github.event.issue.pull_request &&
        contains(github.event.issue.labels.*.name, 'agentic-docs') &&
        contains(github.event.comment.body, '/revise')) ||


### PR DESCRIPTION
The agentic-docs workflow triggered on a comment the bot itself had posted, and
the resulting run began writing the wrong page.

When the bot cannot work out where a new page belongs, it asks on the issue. That
request shows an example:

    /position under Pipeline operations, add a section to Profiles

Posting it matched this workflow's own `/position` arm. The comment goes out under
a PAT belonging to a maintainer, so the allowlist gate passed. The job then read
the bot's own example as an instruction:

    mode=position target=issue #4322
    target page from the sidebar: docs/website/docs/hub/pipeline-operations/profiles.md

It was about to edit `hub/pipeline-operations/profiles.md` with content for an
unrelated issue. An out-of-memory kill stopped it before it opened a PR.

This adds `!contains(github.event.comment.body, '<!-- agentic-docs -->')` to both
comment arms. Every comment the bot posts carries that marker.

Filtering by author would not work — the PAT belongs to a person, so the bot's
comments are indistinguishable from theirs by login.

The label arm is deliberately unfiltered: a label event has no comment body.

The bot has its own check for this as well, so this is the cheaper of two
defences rather than the only one — it keeps a pointless job off the Actions tab
for every comment the bot posts. Both exist because this file and the bot live in
different repositories and can drift apart.

No change to what maintainers do.