### PR TITLE
includes initialize_storage in schema update error handling

### DIFF
--- a/dlt/common/destination/exceptions.py
+++ b/dlt/common/destination/exceptions.py
@@ -228,7 +228,10 @@ class DestinationSchemaTampered(DestinationTerminalException):
 
 
 class SchemaUpdateError(DestinationException):
-    """Raised when applying a schema update (DDL migration) to the destination fails."""
+    """Raised when dlt cannot create the dataset or apply a schema update (DDL migration).
+
+    `table_names` is empty when dlt cannot create the dataset.
+    """
 
     def __init__(
         self,
@@ -242,9 +245,16 @@ class SchemaUpdateError(DestinationException):
         self.staging_dataset = staging_dataset
         self.cause = cause
         dataset = "staging dataset" if staging_dataset else "dataset"
+        if self.table_names:
+            failed_op = f"update tables {self.table_names} in the {dataset}"
+        else:
+            failed_op = f"create the {dataset}"
         super().__init__(
-            f"Schema update for tables {self.table_names} in {dataset} of schema `{schema_name}`"
-            f" failed. Cause: {cause}"
+            f"dlt cannot {failed_op} of schema `{schema_name}`. Cause: {cause}. This error happens"
+            " when several pipelines load to the same dataset at the same time. A retry is safe."
+            " dlt reads the destination again and applies only the missing changes. To retry the"
+            " load, use the `retry_schema_update` helper. For more information, see"
+            " https://dlthub.com/docs/running-in-production/running#retrying-only-the-schema-update-evolution"
         )
 
     @staticmethod

--- a/dlt/common/destination/exceptions.py
+++ b/dlt/common/destination/exceptions.py
@@ -249,11 +249,13 @@ class SchemaUpdateError(DestinationException):
             failed_op = f"update tables {self.table_names} in the {dataset}"
         else:
             failed_op = f"create the {dataset}"
+        # cause may be unrelated (ie. missing permissions) so the concurrency hint is optionality
         super().__init__(
-            f"dlt cannot {failed_op} of schema `{schema_name}`. Cause: {cause}. This error happens"
-            " when several pipelines load to the same dataset at the same time. A retry is safe."
-            " dlt reads the destination again and applies only the missing changes. To retry the"
-            " load, use the `retry_schema_update` helper. For more information, see"
+            f"dlt cannot {failed_op} of schema `{schema_name}`. Cause: {cause}. If you are running"
+            " several pipelines that load to the same dataset at the same time, the cause above may"
+            " indicate a conflict between them. In that case a retry is safe: dlt reads the"
+            " destination again and applies only the missing changes. To retry the load, use the"
+            " `retry_schema_update` helper. For more information, see"
             " https://dlthub.com/docs/running-in-production/running#retrying-only-the-schema-update-evolution"
         )
 

--- a/dlt/load/utils.py
+++ b/dlt/load/utils.py
@@ -1,4 +1,5 @@
-from typing import List, Set, Iterable, Callable, Optional, Tuple, Sequence
+from contextlib import contextmanager
+from typing import List, Set, Iterable, Iterator, Callable, Optional, Tuple, Sequence
 
 from dlt.common import logger
 from dlt.common.storages.load_package import PackageStorage, TPackageJobState
@@ -182,6 +183,29 @@ def init_client(
     return applied_update, applied_dropped, applied_truncated
 
 
+@contextmanager
+def _raise_as_schema_update_error(
+    job_client: JobClientBase, table_names: Iterable[str], staging_dataset: bool
+) -> Iterator[None]:
+    """Converts a destination error from applied DDL into `SchemaUpdateError`.
+
+    `retry_schema_update` retries this error.
+    `table_names` is empty when the DDL creates the dataset itself.
+    """
+    try:
+        yield
+    except (DestinationSchemaTampered, DestinationUndefinedEntity):
+        # a tampered schema or a genuinely missing entity are terminal and must surface as-is
+        raise
+    except DestinationException as schema_ex:
+        raise SchemaUpdateError.from_cause(
+            job_client.schema.name,
+            table_names,
+            schema_ex,
+            staging_dataset=staging_dataset,
+        ) from schema_ex
+
+
 def _init_dataset_and_update_schema(
     job_client: JobClientBase,
     expected_update: TSchemaTables,
@@ -218,29 +242,20 @@ def _init_dataset_and_update_schema(
                 f" Following tables {drop_tables} will not be dropped {staging_text}"
             )
 
-    job_client.initialize_storage()
+    with _raise_as_schema_update_error(job_client, (), staging_info):
+        job_client.initialize_storage()
 
     logger.info(
         f"Client for {job_client.config.destination_type} will update schema to package schema"
         f" {staging_text}"
     )
-    try:
+    with _raise_as_schema_update_error(job_client, update_tables, staging_info):
         applied_update = job_client.update_stored_schema(
             only_tables=update_tables,
             expected_update=expected_update,
             # force schema update if tables dropped or truncated via refresh
             force=bool(drop_tables or initial_truncate_tables),
         )
-    except (DestinationSchemaTampered, DestinationUndefinedEntity):
-        # a tampered schema or a genuinely missing entity are terminal and must surface as-is
-        raise
-    except DestinationException as schema_ex:
-        raise SchemaUpdateError.from_cause(
-            job_client.schema.name,
-            update_tables,
-            schema_ex,
-            staging_dataset=staging_info,
-        ) from schema_ex
     if truncate_tables or initial_truncate_tables:
         if initial_truncate_tables:
             truncate_tables = initial_truncate_tables | (truncate_tables or set())

--- a/docs/website/docs/running-in-production/running.md
+++ b/docs/website/docs/running-in-production/running.md
@@ -639,14 +639,17 @@ if __name__ == "__main__":
 
 #### Retrying only the schema update (evolution)
 
-When several pipelines run **in parallel against the same dataset** — parallel Airflow tasks, partitioned
-backfills, or several processes sharing one schema — they can race on DDL. Each run independently reads the
-destination, sees that a table does not exist yet (or that a new column has not been added), and emits its own
-`CREATE TABLE` / `ALTER TABLE ... ADD COLUMN`. The first run wins; the others fail because the table or column
-now already exists. The same happens during schema evolution when two runs add the same new column at once.
+When several pipelines run **in parallel against the same dataset**, they can collide on DDL. This collision
+happens with parallel Airflow tasks, partitioned backfills, or several processes that share one schema.
 
-`dlt` wraps such a failure in a `SchemaUpdateError`. It is safe to retry: on the next attempt `dlt` re-reads the destination and applies
-only what is still missing, so parallel runs converge. Use `retry_schema_update` to retry just this part:
+Each run reads the destination and sees that the dataset, a table, or a column does not exist yet. Each run then
+emits its own `CREATE SCHEMA`, `CREATE TABLE`, or `ALTER TABLE ... ADD COLUMN`. The first run succeeds. The others
+fail, because the dataset, table, or column already exists. The same happens during schema evolution, when two
+runs add the same new column at once.
+
+`dlt` wraps such a failure in a `SchemaUpdateError`. A retry is safe. On the next attempt, `dlt` reads the
+destination again and applies only what is still missing. Parallel runs converge. Use `retry_schema_update` to
+retry this part:
 
 ```py
 from tenacity import retry, stop_after_attempt, retry_if_exception, wait_random_exponential
@@ -669,13 +672,14 @@ if __name__ == "__main__":
     load_info = load()
 ```
 
-Why the **random jitter** matters: when many parallel runs collide on the same DDL and all back off by the same
-fixed amount, they wake up together and collide again — a "thundering herd". `wait_random_exponential` adds
-randomness to each wait, so the runs spread out over time and converge instead of fighting.
+The **random jitter** matters. When many parallel runs collide on the same DDL and all wait the same fixed time,
+they retry together and collide again. This effect is a "thundering herd". `wait_random_exponential` adds
+randomness to each wait. The runs then spread over time and converge.
 
-`retry_schema_update` retries a schema-update failure regardless of whether its cause is transient or terminal
-(it assumes that other updates run in parallel and next run will reconcile invalid migration).
-It composes with `retry_load` — retry the schema evolution here and defer every other load failure to `retry_load`:
+`retry_schema_update` retries a schema-update failure, whether its cause is transient or terminal.
+`retry_schema_update` assumes that other updates run in parallel, and that the next run reconciles the invalid
+migration. `retry_schema_update` composes with `retry_load`. Retry the schema evolution here. Defer every other
+load failure to `retry_load`:
 
 ```py
 from tenacity import retry, stop_after_attempt, retry_if_exception, wait_random_exponential

--- a/tests/load/pipeline/test_athena.py
+++ b/tests/load/pipeline/test_athena.py
@@ -7,11 +7,11 @@ import sqlglot.expressions as sge
 import dlt
 from dlt.common import pendulum
 from dlt.common.configuration.specs.aws_credentials import AwsCredentials
-from dlt.common.destination.exceptions import UnsupportedDataType
+from dlt.common.destination.exceptions import DestinationTransientException, UnsupportedDataType
 from dlt.common.utils import uniq_id
 from dlt.common.libs.sqlglot import resolve_timestamp_cast, build_typed_literal
 
-from dlt.destinations.exceptions import CantExtractTablePrefix, DatabaseTransientException
+from dlt.destinations.exceptions import CantExtractTablePrefix
 from dlt.destinations.adapters import athena_partition, athena_adapter
 from dlt.pipeline.exceptions import PipelineStepFailed
 
@@ -496,7 +496,7 @@ def test_athena_no_query_result_bucket(
     # NOT with ConfigFieldMissingException
     with pytest.raises(PipelineStepFailed) as pip_ex:
         pipeline.run(items, **destination_config.run_kwargs)
-    assert isinstance(pip_ex.value.__cause__, DatabaseTransientException)
+    assert isinstance(pip_ex.value.__cause__, DestinationTransientException)
     # athena rejects queries when no output location is set and workgroup doesn't manage it
     assert "output location" in str(pip_ex.value.__cause__).lower() or "ResultConfiguration" in str(
         pip_ex.value.__cause__

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -37,6 +37,7 @@ from dlt.common.destination.exceptions import (
     DestinationLoadingViaStagingNotSupported,
     DestinationNoStagingMode,
     DestinationTerminalException,
+    DestinationTransientException,
     SchemaUpdateError,
     SchemaUpdateTerminalError,
     SchemaUpdateTransientError,
@@ -2628,21 +2629,56 @@ def test_schema_update_error(
     assert retry_schema_update()(step_failed) is True
 
 
-def test_retry_schema_update() -> None:
-    # retry_schema_update drives recovery: fail the first schema update, then succeed
+@pytest.mark.parametrize(
+    "cause,expected_error,retried_by_retry_load",
+    [
+        (DestinationTerminalException, SchemaUpdateTerminalError, False),
+        (DestinationTransientException, SchemaUpdateTransientError, True),
+    ],
+    ids=["terminal", "transient"],
+)
+def test_dataset_creation_error(
+    cause: Type[Exception], expected_error: Type[SchemaUpdateError], retried_by_retry_load: bool
+) -> None:
+    """dlt wraps a failed dataset creation like a schema update and keeps the terminality of the cause"""
     p = dlt.pipeline(pipeline_name="pipe_" + uniq_id(), destination=dummy(completed_prob=1.0))
-    orig = DummyClient.update_stored_schema
-    calls = 0
 
-    def flaky_update(self: Any, *args: Any, **kwargs: Any) -> Any:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            raise DestinationTerminalException("schema update failed once")
+    def failing_init(self: Any, truncate_tables: Any = None) -> None:
+        raise cause("dataset already exists")
+
+    with patch.object(DummyClient, "initialize_storage", failing_init):
+        with pytest.raises(PipelineStepFailed) as py_ex:
+            p.run([1, 2, 3], table_name="digits")
+
+    step_failed = py_ex.value
+    assert step_failed.step == "load"
+    schema_ex = step_failed.__cause__
+    assert isinstance(schema_ex, expected_error)
+    assert schema_ex.staging_dataset is False
+    # no table is at fault when dlt cannot create the dataset
+    assert schema_ex.table_names == []
+    assert "cannot create the dataset" in str(schema_ex)
+
+    assert retry_load()(step_failed) is retried_by_retry_load
+    assert retry_schema_update()(step_failed) is True
+
+
+@pytest.mark.parametrize("failing_method", ["initialize_storage", "update_stored_schema"])
+def test_retry_schema_update(failing_method: str) -> None:
+    # retry_schema_update drives recovery: the first DDL call fails, the second succeeds
+    p = dlt.pipeline(pipeline_name="pipe_" + uniq_id(), destination=dummy(completed_prob=1.0))
+    orig = getattr(DummyClient, failing_method)
+    failures = 0
+
+    def flaky_ddl(self: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal failures
+        if not failures:
+            failures += 1
+            raise DestinationTerminalException(f"{failing_method} failed once")
         return orig(self, *args, **kwargs)
 
     info = None
-    with patch.object(DummyClient, "update_stored_schema", flaky_update):
+    with patch.object(DummyClient, failing_method, flaky_ddl):
         for attempt in Retrying(
             stop=stop_after_attempt(3),
             retry=retry_if_exception(retry_schema_update()),
@@ -2651,7 +2687,7 @@ def test_retry_schema_update() -> None:
             with attempt:
                 info = p.run([1, 2, 3], table_name="digits")
 
-    assert calls == 2
+    assert failures == 1
     assert_load_info(info)
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
Recent improvement described in https://dlthub.com/docs/devel/running-in-production/running#retrying-only-the-schema-update-evolution excluded `initialize_storage` (ie. CREATE SCHEMA). this PR corrects it
