### PR TITLE
Update GitHub token configuration in documentation

### DIFF
--- a/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
+++ b/docs/website/docs/dlt-ecosystem/verified-sources/rest_api/basic.md
@@ -101,7 +101,7 @@ The GitHub API [requires an access token](https://docs.github.com/en/rest/authen
 After you get the token, add it to the `secrets.toml` file:
 
 ```toml
-[sources.rest_api_pipeline.github]
+[sources.rest_api_pipeline.github_source]
 github_token = "your_github_token"
 ```
 


### PR DESCRIPTION
fix incorrect docs example

### What's wrong
The dlt docs page for the REST API source shows an example that doesn't work if you copy-paste it. 

The function is:

```
@dlt.source
def github_source(github_token=dlt.secrets.value):
```

The docs tell you to put your token here:
```
[sources.rest_api_pipeline.github]
github_token = "your_github_token"
```

dlt looks for the token under the module name + the function's actual name:

- `[sources.rest_api_pipeline.github]` → fails, dlt can't find the token
- `[sources.rest_api_pipeline.github_source]` → works

<!--
### Additional Context
I stumbled upon this because I am using Claude Plan Mode to help me learn dlt, Stripe, and DuckDB. It asserted this example was incorrect. I opened a new session and asked it to verify in an isolated environment by running code and after several rounds of evaluation believe this fix is correct.

Also, since this is a small, self-contained correction to documentation that does not seem to be subjective, broad, or requiring product decisions I am submitting it. Hopefully, I am not breaking the contributing guidelines!
-->