### PR TITLE
Docs: Add a page on how to use dlt with rick and morty API

### DIFF
--- a/docs/website/docs/walkthroughs/how-to-load-data-with-dlt.md
+++ b/docs/website/docs/walkthroughs/how-to-load-data-with-dlt.md
@@ -1,0 +1,247 @@
+---
+title: How to load data with dlt
+description: Load the Rick and Morty API into DuckDB with dlt and explore the tables it creates
+keywords: [rest api, duckdb, rick and morty, nested tables, merge]
+---
+
+# How to load data with dlt
+
+This is a practical example of loading a public REST API into a local database. We use the
+[Rick and Morty API](https://rickandmortyapi.com/documentation), which needs no credentials, and
+[duckdb](../dlt-ecosystem/destinations/duckdb) as a destination. The API paginates its responses and
+returns nested objects and lists, so it shows what `dlt` does with a typical API payload: pagination,
+nested tables, and reloading without duplicates.
+
+## Setup
+
+Install `dlt` with duckdb support:
+
+```sh
+pip install "dlt[duckdb]"
+```
+
+## 1. Load three endpoints
+
+Create a new file `rick_and_morty_pipeline.py` and paste the following code:
+
+```py
+import dlt
+from dlt.sources.rest_api import rest_api_source
+
+source = rest_api_source({
+    "client": {
+        "base_url": "https://rickandmortyapi.com/api/",
+    },
+    "resource_defaults": {
+        "primary_key": "id",
+        "write_disposition": "merge",
+    },
+    "resources": ["character", "episode", "location"],
+})
+
+pipeline = dlt.pipeline(
+    pipeline_name="rick_and_morty",
+    destination="duckdb",
+    dataset_name="rick_and_morty_data",
+)
+
+load_info = pipeline.run(source)
+print(load_info)
+```
+
+Now run the script:
+
+```sh
+python rick_and_morty_pipeline.py
+```
+
+```text
+Pipeline rick_and_morty load step finished in 0.49 seconds
+1 load package(s) were loaded to destination duckdb and into dataset rick_and_morty_data
+The duckdb destination used duckdb:////home/user-name/rick_and_morty.duckdb location to store data
+Load package 1786268457.810038 is LOADED and contains no failed jobs
+```
+
+What the configuration does:
+
+* Each string in `resources` is used as the endpoint path, the resource name, and the table name. So
+  `"character"` is requested from `https://rickandmortyapi.com/api/character` and lands in the
+  `character` table.
+* Nothing in the configuration mentions pagination. The API returns `{"info": {...}, "results": [...]}`
+  with a link to the next page in `info.next`, and the [REST API source detects both the paginator and
+  the `results` field](../dlt-ecosystem/verified-sources/rest_api/basic#pagination) on its own.
+* `resource_defaults` applies `primary_key` and `write_disposition` to all three resources at once, so
+  every endpoint is loaded with the [merge write disposition](../general-usage/merge-loading) on `id`.
+
+## 2. See the tables that were created
+
+The three endpoints produce six tables. Objects nested in a record are flattened into columns of the
+parent table, and lists become separate [nested tables](../general-usage/destination-tables#nested-tables)
+linked to their parent:
+
+| Table | What it holds |
+| --- | --- |
+| `character` | One row per character. The `origin` and `location` objects become the `origin__name`, `origin__url`, `location__name`, and `location__url` columns. |
+| `character__episode` | One row per entry of a character's `episode` list, in the `value` column. |
+| `episode` | One row per episode. |
+| `episode__characters` | One row per entry of an episode's `characters` list. |
+| `location` | One row per location. |
+| `location__residents` | One row per entry of a location's `residents` list. |
+
+`dlt` also adds `_dlt_id` and `_dlt_load_id` columns and its own tables for load history and pipeline
+state - see [destination tables](../general-usage/destination-tables).
+
+Print the schema that was inferred from the API responses:
+
+```sh
+dlt pipeline rick_and_morty schema
+```
+
+Or browse the data and the load status in the workspace dashboard:
+
+```sh
+pip install marimo
+dlt pipeline rick_and_morty show
+```
+
+:::tip
+Nested tables are convenient, but you do not have to keep them: you can
+[reduce the nesting level](../general-usage/source#reduce-the-nesting-level-of-generated-tables) and
+store the lists as JSON columns instead.
+:::
+
+## 3. Query the loaded data
+
+You do not need a duckdb client to look at the result. Every pipeline exposes its
+[dataset](../general-usage/dataset-access/dataset):
+
+```py
+import dlt
+
+pipeline = dlt.pipeline(
+    pipeline_name="rick_and_morty",
+    destination="duckdb",
+    dataset_name="rick_and_morty_data",
+)
+dataset = pipeline.dataset()
+
+# a table_name / row_count overview of the whole dataset
+print(dataset.row_counts().df())
+
+# a few characters, as a pandas dataframe
+print(
+    dataset["character"]
+    .select("id", "name", "status", "species", "location__name")
+    .limit(5)
+    .df()
+)
+```
+
+```text
+   id          name status species                 location__name
+0   1  Rick Sanchez  Alive   Human               Citadel of Ricks
+1   2   Morty Smith  Alive   Human               Citadel of Ricks
+2   3  Summer Smith  Alive   Human  Earth (Replacement Dimension)
+3   4    Beth Smith  Alive   Human  Earth (Replacement Dimension)
+4   5   Jerry Smith  Alive   Human  Earth (Replacement Dimension)
+```
+
+`select`, `limit`, and `df` are executed on duckdb, not in Python, so you can explore tables that do
+not fit in memory. Use `arrow()` or `fetchall()` instead of `df()` if you prefer Arrow tables or plain
+rows.
+
+## 4. Run the pipeline again
+
+Run `python rick_and_morty_pipeline.py` a second time and query `dataset.row_counts()` again: the
+counts stay the same. Because the resources declare `primary_key="id"` and
+`write_disposition="merge"`, a character that is loaded again replaces the row with the same `id`
+instead of being appended, and the rows of its nested tables are replaced along with it.
+
+The Rick and Morty API has no "changed since" filter, so every run still downloads all pages. If your
+API can return only new or updated records, configure
+[incremental loading](../general-usage/incremental-loading) and let `dlt` pass the last seen value as
+a query parameter.
+
+:::tip
+When the API starts returning a field you have not seen before, `dlt` adds the column on the next run
+rather than failing the load. See [schema evolution](../general-usage/schema-evolution) for how to
+follow and control those changes.
+:::
+
+## 5. Load only part of an endpoint
+
+The character endpoint accepts filters as query parameters. Configure a resource explicitly to pass
+them, and give it a name so that it lands in a table of its own:
+
+```py
+import dlt
+from dlt.sources.rest_api import rest_api_source
+
+alive_humans = rest_api_source({
+    "client": {
+        "base_url": "https://rickandmortyapi.com/api/",
+    },
+    "resources": [
+        {
+            "name": "alive_human",
+            "primary_key": "id",
+            "write_disposition": "merge",
+            "endpoint": {
+                "path": "character",
+                "params": {"status": "alive", "species": "human"},
+            },
+        },
+    ],
+})
+
+pipeline = dlt.pipeline(
+    pipeline_name="rick_and_morty",
+    destination="duckdb",
+    dataset_name="rick_and_morty_data",
+)
+
+load_info = pipeline.run(alive_humans)
+print(load_info)
+```
+
+This requests `https://rickandmortyapi.com/api/character?status=alive&species=human` and loads the
+result into the `alive_human` table, next to the tables from the previous runs.
+
+## 6. Write the source in Python instead
+
+Declarative configuration is not the only option. When you need full control over the requests, write
+a [resource](../general-usage/resource) as a Python generator. The `paginate` helper does the same
+paginator detection the REST API source does:
+
+```py
+import dlt
+from dlt.sources.helpers.rest_client import paginate
+
+@dlt.resource(name="character", primary_key="id", write_disposition="merge")
+def characters(status: str = "alive"):
+    for page in paginate(
+        "https://rickandmortyapi.com/api/character",
+        params={"status": status},
+    ):
+        yield page
+
+pipeline = dlt.pipeline(
+    pipeline_name="rick_and_morty_python",
+    destination="duckdb",
+    dataset_name="rick_and_morty_data",
+)
+
+load_info = pipeline.run(characters)
+print(load_info)
+```
+
+The resource yields whole pages - `dlt` unpacks lists of records for you - and the decorator carries
+the same table name, primary key, and write disposition you configured declaratively above.
+
+## Next steps
+
+* [Run and troubleshoot a pipeline](run-a-pipeline) to inspect load packages and traces.
+* [REST API source](../dlt-ecosystem/verified-sources/rest_api/basic) for authentication, resource
+  relationships, and response transformations.
+* [Moving from local to production](share-a-dataset) to send the same data to a warehouse instead of
+  duckdb.

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -62,6 +62,7 @@ const sidebars = {
               id: "walkthroughs/run-a-pipeline",
               label: "Run & troubleshoot a pipeline",
             },
+            "walkthroughs/how-to-load-data-with-dlt",
           ],
         },
         {


### PR DESCRIPTION
Documentation for #4322: Docs: Add a page on how to use dlt with rick and morty API

Closes #4322

## What changed

Added a new page `walkthroughs/how-to-load-data-with-dlt.md`, registered in the sidebar under **Getting started > Quickstart**, after `walkthroughs/run-a-pipeline`.

Sections: *Setup*, *1. Load three endpoints*, *2. See the tables that were created*, *3. Query the loaded data*, *4. Run the pipeline again*, *5. Load only part of an endpoint*, *6. Write the source in Python instead*, *Next steps*.

## How this was checked

Everything on the page was run against this checkout (dlt 1.30.0a0, Python 3.11) in a temp working directory with `DLT_DATA_DIR` pointed at it. The folder convention is `fenced`, so there is no snippet file; all four `py` blocks were executed verbatim (extracted from the markdown with a regex, then `exec`ed one by one).

- Block 1 (`rest_api_source` with `character`, `episode`, `location`) ran three times. Each run printed a LOADED package with no failed jobs. The normalize info listed exactly the six tables named in the "See the tables that were created" section: `character`, `character__episode`, `episode`, `episode__characters`, `location`, `location__residents` (plus `_dlt_pipeline_state`).
- Column names in the table description come from the inferred schema, printed with `pipeline.default_schema.tables["character"]["columns"]`: `id, name, status, species, type, gender, image, url, created, location__name, location__url, origin__name, origin__url, _dlt_load_id, _dlt_id`; `character__episode` has `value, _dlt_root_id, _dlt_parent_id, _dlt_list_idx, _dlt_id`.
- No paginator or data selector is configured; the source resolved `info.next` / `results` on its own, which is why all 42 character pages were fetched.
- Section 4's claim was checked by comparing `dataset.row_counts().df()` after the first and after the third run of block 1 — identical for every table, so merge on `id` did not duplicate rows or nested rows. The page states this without printing the numbers, since the API can add characters.
- Block 2 output in the page is the real printout of the `character` preview from my run. The `row_counts()` output is described, not pasted, for the same reason.
- `arrow()` and `fetchall()` were called on the same relation and returned a `pyarrow.Table` and a list of tuples.
- Block 3 (`params` filter) loaded into a separate `alive_human` table alongside the others; block 4 (plain-Python resource with `dlt.sources.helpers.rest_client.paginate`) loaded a `character` table into its own pipeline. Both printed LOADED packages with no failed jobs.
- `dlt pipeline rick_and_morty schema` was executed and printed the schema; `dlt pipeline --help` confirms `show` "Generates and launches workspace dashboard", and `dlt/_workspace/cli/commands.py:201` states it requires `pip install marimo`.
- Snippet checks reproduced locally: the template header from `docs_tools/snippets/lint_setup/template.py` concatenated with the four blocks passes `ruff check` (repo ignore list, preview) and `mypy --check-untyped-defs` with `docs_tools/snippets/lint_setup/mypy.ini` ("Success: no issues found").

Rewritten for presentation: in the `load_info` text block, the duckdb file path from my run (`duckdb:////tmp/rmdemo/rick_and_morty.duckdb`) was replaced with `/home/user-name/...`, matching how run-a-pipeline shows it. Nothing else in the output blocks was altered.

## What I could not confirm

- The example code hits a live third-party API on every page build that runs it; these are fenced blocks, so nothing re-executes them in CI, but a reviewer copying them needs network access.
- Row counts are deliberately not printed anywhere on the page (the API can add characters), so section 4 asserts only that the counts are unchanged. The one pasted result — the five-character preview — is real output but will drift if the API edits those records.
- Section 6 uses `dlt.sources.helpers.rest_client.paginate`, whose auto-detection I confirmed only against this API; I did not check which paginator it picked internally.
- The Rick and Morty API exposes a `created` field on every record, but no query parameter to filter on it, so I did not write an incremental example and only linked to the incremental docs instead.

---

Draft opened by [agentic-docs](https://github.com/dlt-hub/agentic-docs) from the labelled issue.

Verification ran dlt's linters, the link and anchor checker and the style rules over this page. Its code is in fenced blocks: type-checked, but never executed by CI. The agent ran it while writing — see above.

<!-- agentic-docs -->