### PR TITLE
full-loading page does not say which replace strategies each destination supports (test, ignore)

### DIFF
--- a/docs/website/docs/general-usage/full-loading-snippets.py
+++ b/docs/website/docs/general-usage/full-loading-snippets.py
@@ -1,0 +1,38 @@
+def replace_strategies_snippet() -> None:
+    # @@@DLT_SNIPPET_START supported_replace_strategies
+    import dlt
+
+    pipeline = dlt.pipeline("github", destination="duckdb", dataset_name="github")
+    caps = pipeline.destination.capabilities()
+    print(caps.supported_replace_strategies)
+    # @@@DLT_SNIPPET_END supported_replace_strategies
+
+    assert caps.supported_replace_strategies[0] == "truncate-and-insert"
+
+    # @@@DLT_SNIPPET_START replace_strategies_selector
+    from dlt.destinations import filesystem
+
+    fs_caps = filesystem().capabilities()
+    select_strategies = fs_caps.replace_strategies_selector
+    # a regular table
+    print(
+        select_strategies(
+            fs_caps.supported_replace_strategies, table_schema={"name": "items"}
+        )
+    )
+    # the same table in the delta table format
+    print(
+        select_strategies(
+            fs_caps.supported_replace_strategies,
+            table_schema={"name": "items", "table_format": "delta"},
+        )
+    )
+    # @@@DLT_SNIPPET_END replace_strategies_selector
+
+    assert select_strategies(
+        fs_caps.supported_replace_strategies, table_schema={"name": "items"}
+    ) == ["truncate-and-insert"]
+    assert select_strategies(
+        fs_caps.supported_replace_strategies,
+        table_schema={"name": "items", "table_format": "delta"},
+    ) == ["insert-from-staging"]

--- a/docs/website/docs/general-usage/full-loading.md
+++ b/docs/website/docs/general-usage/full-loading.md
@@ -34,7 +34,7 @@ Note that a table does not need to receive any data to get truncated.
 
 dlt implements three different strategies for doing a full load on your table: `truncate-and-insert`, `insert-from-staging`, and `staging-optimized`. The exact behavior of these strategies can also vary between the available destinations.
 
-You can select a strategy with a setting in your `config.toml` file. If you do not select a strategy, dlt will default to `truncate-and-insert`.
+You can select a strategy with a setting in your `config.toml` file. If you do not select a strategy, dlt uses the first strategy that the destination supports for the table being loaded. For all built-in destinations, that is `truncate-and-insert`, except for tables in the `delta` or `iceberg` table format - see [Check which strategies your destination supports](#check-which-strategies-your-destination-supports).
 
 ```toml
 [destination]
@@ -61,4 +61,18 @@ The `staging-optimized` strategy has all the upsides of the `insert-from-staging
 * BigQuery: After loading the new data into the staging tables, the destination tables will be dropped and recreated with a [clone command](https://cloud.google.com/bigquery/docs/table-clones-create) from the staging tables. This is a low-cost and fast way to create a second independent table from the data of another. Learn more about [table cloning on BigQuery](https://cloud.google.com/bigquery/docs/table-clones-intro).
 * Snowflake: After loading the new data into the staging tables, the destination tables will be dropped and recreated with a [clone command](https://docs.snowflake.com/en/sql-reference/sql/create-clone) from the staging tables. This is a low-cost and fast way to create a second independent table from the data of another. Learn more about [table cloning on Snowflake](https://docs.snowflake.com/en/user-guide/object-clone).
 
-For all other destinations, please look at their respective documentation pages to see if and how the `staging-optimized` strategy is implemented. If it is not implemented, `dlt` will fall back to the `insert-from-staging` strategy.
+For all other destinations, look at their respective documentation pages to see if and how the `staging-optimized` strategy is implemented. A destination that accepts `staging-optimized` but has no optimization for a given table loads that table like `insert-from-staging`. A destination that does not accept the strategy at all fails the load instead of falling back, as described below.
+
+### Check which strategies your destination supports
+
+Each destination declares the replace strategies it accepts in its [capabilities](destination.md#inspect-destination-capabilities):
+
+<!--@@@DLT_SNIPPET ./full-loading-snippets.py::supported_replace_strategies-->
+
+dlt uses the first strategy on that list when you do not configure `replace_strategy`.
+
+The list is not always fixed per destination: `filesystem` and `athena` narrow it per table, based on the table format. Tables in the `delta` or `iceberg` table format accept only `insert-from-staging`, while regular tables accept only `truncate-and-insert`. Apply the destination's `replace_strategies_selector` to a table schema to see what remains for that table:
+
+<!--@@@DLT_SNIPPET ./full-loading-snippets.py::replace_strategies_selector-->
+
+If the strategy you configured is not among the strategies left for a table that is loaded with the `replace` write disposition, dlt does not pick another one. The `load` step raises an error that names the table, and the load package stays pending.


### PR DESCRIPTION
Documentation for #4334: full-loading page does not say which replace strategies each destination supports (test, ignore)

Closes #4334

## What changed

Edited the existing page `general-usage/full-loading.md`. The sidebar is unchanged.

Its runnable code is in `full-loading-snippets.py`, which pytest executed during verification.

Sections: *Performing a full load*, *Choosing the correct replace strategy for your full load*.

## How this was checked

All claims checked against the checkout (dlt installed from source in the repo venv).

Source read:
- `dlt/common/destination/utils.py::resolve_replace_strategy` - takes the destination's `supported_replace_strategies`, passes them through `replace_strategies_selector` when the destination declares one, returns `None` if the list is empty or if `required_strategy` is not in it, otherwise `required_strategy or supported_replace_strategies[0]`. This is where "first supported strategy" as the default comes from.
- `dlt/common/destination/client.py::DestinationClientDwhConfiguration.replace_strategy` defaults to `None` with the docstring "uses first strategy from caps if not declared".
- `dlt/destinations/utils.py::verify_schema_replace_disposition` raises `SchemaCorruptedException` ("Requested replace strategy ... not available for table") when `resolve_replace_strategy` returns `None`; `dlt/destinations/job_client_impl.py` and `dlt/destinations/impl/filesystem/filesystem.py` raise it from `verify_schema`. No fallback path exists.
- Selectors: only `dlt/destinations/impl/filesystem/factory.py::filesystem_replace_strategies_selector` and `dlt/destinations/impl/athena/factory.py::athena_replace_strategies_selector` exist (grep for `replace_strategies_selector`); both return `["insert-from-staging"]` for delta/iceberg tables and `["truncate-and-insert"]` otherwise.
- `dlt/destinations/sql_jobs.py::SqlStagingReplaceFollowupJob.generate_sql` clones only when the strategy is `staging-optimized` and `supports_clone_table` is set; otherwise it emits the truncate + insert-from-staging SQL.

Ran in the repo venv:
- Enumerated `capabilities().supported_replace_strategies` for every factory in `dlt.destinations`. `truncate-and-insert` is first everywhere. Three-strategy destinations: bigquery, clickhouse, databricks, mssql, postgres, snowflake. Two: athena, dremio, duckdb, ducklake, fabric, filesystem, motherduck, redshift, sqlalchemy, synapse. One (`truncate-and-insert` only): lance, lancedb, qdrant, weaviate.
- Ran the snippet file: prints `['truncate-and-insert', 'insert-from-staging']` for duckdb, `['truncate-and-insert']` for a regular filesystem table and `['insert-from-staging']` for the same table with `table_format="delta"`; its assertions pass. `mypy` on the snippet file reports no issues.
- Requested an unsupported strategy twice to confirm there is no fallback: `DESTINATION__DUCKDB__REPLACE_STRATEGY=staging-optimized` and `DESTINATION__FILESYSTEM__REPLACE_STRATEGY=insert-from-staging` (regular table, local bucket). Both fail with `PipelineStepFailed` at `step=load`, wrapping `AssertionError: Must be able to get replace strategy for items`, and the message states that the load package is left pending.

## What I could not confirm

The page says the load "raises an error that names the table" rather than naming an exception class: in both of my runs the failure came from the assertion in `SqlJobClientBase.prepare_load_table` / `FilesystemClient` (`AssertionError: Must be able to get replace strategy for <table>`), not from the `SchemaCorruptedException("Requested replace strategy ... not available for table")` that `verify_schema_replace_disposition` is meant to raise, so the exact message a user sees depends on which check runs first. A reviewer may want to decide whether that assertion should be removed so the schema check produces the message.

I did not verify the `staging-optimized` behaviour of any destination that needs credentials (bigquery, snowflake, postgres, mssql, clickhouse, databricks); the existing per-destination bullets are unchanged and the new sentence about "no optimization for a given table" is based on reading `SqlStagingReplaceFollowupJob.generate_sql`.

I deliberately did not list per-destination supported strategies on the page, as the brief asked, even though I enumerated them (see evidence).

---

Draft opened by [agentic-docs](https://github.com/dlt-hub/agentic-docs) from the labelled issue.

Verification ran dlt's linters, the link and anchor checker and the style rules over this page. Its examples are in `full-loading-snippets.py`, which pytest executed here and runs again in dlt's CI.

<!-- agentic-docs -->