### PR TITLE
fix(agentic-docs): arm the run on the agent label, not the label set

### DIFF
--- a/.github/workflows/agentic-docs.yml
+++ b/.github/workflows/agentic-docs.yml
@@ -88,14 +88,26 @@ jobs:
     # Filtering by author cannot work, because the PAT belongs to a person.
     # `github.event.comment.body` is the raw body here, markers included, unlike
     # what the driver's fetch returns.
+    # `github.event.label.name` is the label that was *just added*, not the set the
+    # issue now carries. Testing the set fires once per label: two labels applied
+    # together produce two `labeled` events, both evaluated against an issue that
+    # already has both, so both match. That happened on issue #4334 and opened two
+    # pull requests. Only `agent` arms a run, and `documentation` scopes it — the
+    # same split as dlt-hub/runtime's UI loop, where `frontend` alone never
+    # triggers.
+    #
+    # The cost is that order matters: add `documentation` first, then `agent`. And
+    # `agent` is the retry — remove it and add it again to re-run. Do not "fix" this
+    # by also matching a `documentation` add on an issue that already has `agent`:
+    # both events would satisfy their own clause and the double run returns.
+    #
+    # `/position` is deliberately absent. It sets the location and nothing else;
+    # arming is the label's job, so a `/position` comment on an unlabelled issue no
+    # longer starts a job.
     if: |
       (github.event_name == 'issues' &&
-       contains(github.event.issue.labels.*.name, 'documentation') &&
-       contains(github.event.issue.labels.*.name, 'agent')) ||
-      (github.event_name == 'issue_comment' &&
-       !contains(github.event.comment.body, '<!-- agentic-docs -->') &&
-       !github.event.issue.pull_request &&
-       contains(github.event.comment.body, '/position')) ||
+       github.event.label.name == 'agent' &&
+       contains(github.event.issue.labels.*.name, 'documentation')) ||
       (github.event_name == 'issue_comment' &&
        !contains(github.event.comment.body, '<!-- agentic-docs -->') &&
        github.event.issue.pull_request &&
@@ -110,6 +122,13 @@ jobs:
       # Gate on the actor — whoever applied the label or wrote the comment —
       # because that is who causes the spend. Matching is exact against list
       # entries, so "ann" cannot be satisfied by "annabel".
+      #
+      # This gate is a courtesy, not the boundary. GitHub decides which copy of a
+      # workflow file runs, and for `pull_request_review` that is the copy on the
+      # pull request's head branch — so a branch could carry a copy without this
+      # step. The job checks the allowlist again itself, asking GitHub who wrote
+      # the comment or review rather than trusting what it was passed. What this
+      # step buys is not spending a Cloud Run execution on a stranger.
       # A comment from someone not on the list is ordinary traffic, not an
       # error, so this reports "false" and the run ends green rather than
       # leaving a failed check on every unrelated /revise mention.
@@ -167,17 +186,23 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           COMMENT_ID: ${{ github.event.comment.id }}
           REVIEW_ID: ${{ github.event.review.id }}
-          # Whoever applied the label. In practice a maintainer says where the
-          # page goes and then labels the issue, so the job reads that person's
-          # comments as an instruction rather than as untrusted prose. A login,
-          # not free text — it cannot carry a payload through this shell.
+          # Whoever applied the label or wrote the comment. In practice a
+          # maintainer says where the page goes and then labels the issue, so the
+          # job reads that person's comments as an instruction rather than as
+          # untrusted prose. A login, not free text — it cannot carry a payload
+          # through this shell.
+          #
+          # Passed for *placement* only. The job never uses it to decide whether
+          # the run is allowed: this workflow chooses what it sends, so a copy of
+          # this file could send any name. Authorisation is settled by asking
+          # GitHub who wrote the artifact the run is reacting to.
           ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
           if [[ "$IS_REVIEW" == "true" ]]; then
-            target="PR_NUMBER=${PR_NUMBER},REVIEW_ID=${REVIEW_ID}"
+            target="PR_NUMBER=${PR_NUMBER},REVIEW_ID=${REVIEW_ID},ACTOR=${ACTOR}"
           elif [[ "$IS_PR_COMMENT" == "true" ]]; then
-            target="PR_NUMBER=${ISSUE_NUMBER},COMMENT_ID=${COMMENT_ID}"
+            target="PR_NUMBER=${ISSUE_NUMBER},COMMENT_ID=${COMMENT_ID},ACTOR=${ACTOR}"
           else
             target="ISSUE_NUMBER=${ISSUE_NUMBER},COMMENT_ID=${COMMENT_ID},ACTOR=${ACTOR}"
           fi


### PR DESCRIPTION
## What changed

The `issues` trigger now arms on the **label that was just added** rather than on the label set the issue happens to carry:

```diff
-      contains(github.event.issue.labels.*.name, 'documentation') &&
-      contains(github.event.issue.labels.*.name, 'agent')
+      github.event.label.name == 'agent' &&
+      contains(github.event.issue.labels.*.name, 'documentation')
```

And the `/position` arm is removed, so a comment no longer starts a run.

## Why

Applying `documentation` and `agent` together sends two `labeled` webhooks. Both are evaluated against an issue that, by the time either is processed, already carries both labels — so both matched. On dlt-hub/dlt#4334 that started two runs in the same second, and they opened two pull requests for one issue (#4335 and #4336; #4335 has been closed as the duplicate).

`github.event.label.name` is the label that actually arrived, so exactly one of the two events matches.

`/position` was doing two jobs: naming where a page goes, and starting a run. The second meant a comment on an unlabelled issue could open a pull request, which made the labels that are supposed to authorise the run redundant. It still sets the location — it is read from the comments when a run starts — it just no longer triggers one.

## Behaviour change for maintainers

- **Apply `documentation` first, then `agent`.** `agent` is what arms it. Adding them in the other order does nothing until `agent` is re-added.
- **Re-adding `agent` is the retry.** Remove it and add it again to re-run, for example after correcting the page location.
- `/position` and `/instructions` comments no longer start anything; write them, then label.

This is the same scope-then-arm split as the UI agent loop in dlt-hub/runtime, where `frontend` alone never triggers and `agent:triage` arms.

## Also in this diff

`ACTOR` is now passed on the review and PR-comment arms too. It was already passed on the issue arm; the two copies of this file had drifted. It is inert for those paths — the job only uses `ACTOR` to decide whose comments are trusted for *placement*, which happens on the generation path — and it is never used to decide whether a run is allowed. Authorisation is settled inside the job by asking GitHub who wrote the comment or review that triggered it.

The rest of the diff is explanatory comments.

## Risk

Trigger-only. No change to what the job does once it starts, and the job re-checks the allowlist itself. Worst case if the expression were wrong is that labelling stops starting runs, which is visible immediately and reversible by revert.
