### PR TITLE
fix(sql_database): map FLOAT/REAL/DOUBLE to double under SQLAlchemy 2.1

### DIFF
--- a/dlt/sources/sql_database/schema_types.py
+++ b/dlt/sources/sql_database/schema_types.py
@@ -147,6 +147,10 @@ def sqla_col_to_column_schema(
                     col["scale"] = sql_t.scale
                 elif sql_t.decimal_return_scale is not None:
                     col["scale"] = sql_t.decimal_return_scale
+    elif isinstance(sql_t, sqltypes.Float):
+        # SQLAlchemy 2.1 makes Float (and REAL/DOUBLE) no longer a subclass of Numeric,
+        # so the Numeric branch above no longer matches; float types always assume "double"
+        col["data_type"] = "double"
     elif isinstance(sql_t, sqltypes.SmallInteger):
         col["data_type"] = "bigint"
         if add_precision:

--- a/tests/sources/sql_database/test_schema_types.py
+++ b/tests/sources/sql_database/test_schema_types.py
@@ -218,3 +218,38 @@ def test_get_table_references() -> None:
 
     refs = get_table_references(child)
     assert refs == []
+
+
+@pytest.mark.parametrize(
+    "sql_type",
+    [sa.Float(), sa.REAL()],
+    ids=["float", "real"],
+)
+def test_float_types_mapped_to_double(sql_type: sa.types.TypeEngine) -> None:
+    """FLOAT/REAL/DOUBLE map to data_type="double", incl. SA 2.1 where Float is not a Numeric subclass."""
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("col", sql_type))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full")
+    assert col_schema is not None
+    assert col_schema["data_type"] == "double"
+
+
+def test_double_mapped_to_double_sa2() -> None:
+    """sa.Double (SA >= 2.0) also maps to data_type="double"."""
+    sa2 = pytest.importorskip("sqlalchemy", minversion="2.0")
+    metadata = sa2.MetaData()
+    table = sa2.Table("t", metadata, sa2.Column("col", sa2.Double()))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full")
+    assert col_schema is not None
+    assert col_schema["data_type"] == "double"
+
+
+def test_numeric_mapped_to_decimal_not_shadowed() -> None:
+    """Numeric(10, 2) still maps to data_type="decimal" with precision/scale."""
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("col", sa.Numeric(10, 2)))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full")
+    assert col_schema is not None
+    assert col_schema["data_type"] == "decimal"
+    assert col_schema["precision"] == 10
+    assert col_schema["scale"] == 2


### PR DESCRIPTION
Fixes #4313

## Problem
`sqla_col_to_column_schema` dispatches float columns via `isinstance(sql_t, sqltypes.Numeric)`. In SQLAlchemy 2.1, `Float` (and `REAL`/`DOUBLE`) no longer subclass `Numeric` — both now derive from the new `NumericCommon` base — so FLOAT/REAL/DOUBLE columns fall through to the unknown-type warning branch and lose their `data_type` entirely.

## Change
Add a dedicated `isinstance(sql_t, sqltypes.Float)` branch after the `Numeric` branch, mapping float types to `data_type: "double"` (the same value the Numeric branch produces for `asdecimal=False`). Version-safe: on SA < 2.1 the Numeric branch still matches first; on 2.1 the Float branch catches `Float`/`REAL`/`Double`.

## Tests
- `test_float_types_mapped_to_double` (sa.Float, sa.REAL)
- `test_double_mapped_to_double_sa2` (sa.Double, SA >= 2.0)
- `test_numeric_mapped_to_decimal_not_shadowed` (Numeric(10,2) still → decimal + precision/scale)

Verified: `tests/sources/sql_database/test_schema_types.py` — 21 passed under **SQLAlchemy 2.0.51** and **2.1.0b3** (where `issubclass(Float, Numeric) is False`).