### PR TITLE
fix(sql_database): reflect timestamp/datetime precision at full_with_precision

### DIFF
--- a/dlt/sources/sql_database/schema_types.py
+++ b/dlt/sources/sql_database/schema_types.py
@@ -165,6 +165,8 @@ def sqla_col_to_column_schema(
         col["data_type"] = "timestamp"
         # special handling for MSSQL
         col["timezone"] = sql_t.timezone or sql_t.__visit_name__ in ("DATETIMEOFFSET",)
+        if add_precision and getattr(sql_t, "precision", None) is not None:
+            col["precision"] = sql_t.precision
     elif isinstance(sql_t, sqltypes.Date):
         col["data_type"] = "date"
     elif isinstance(sql_t, sqltypes.Time):

--- a/tests/sources/sql_database/test_schema_types.py
+++ b/tests/sources/sql_database/test_schema_types.py
@@ -218,3 +218,35 @@ def test_get_table_references() -> None:
 
     refs = get_table_references(child)
     assert refs == []
+
+
+def test_timestamp_precision_reflected_full_with_precision() -> None:
+    """DateTime precision is captured at reflection_level="full_with_precision" (issue #4316)."""
+    from sqlalchemy.dialects.mssql import DATETIME2
+
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("col", DATETIME2(precision=3)))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full_with_precision")
+    assert col_schema is not None
+    assert col_schema["data_type"] == "timestamp"
+    assert col_schema["precision"] == 3
+
+
+def test_timestamp_precision_omitted_without_full_with_precision() -> None:
+    """No precision key at reflection_level="full" (or lower)."""
+    from sqlalchemy.dialects.mssql import DATETIME2
+
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("col", DATETIME2(precision=3)))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full")
+    assert col_schema is not None
+    assert "precision" not in col_schema
+
+
+def test_generic_datetime_has_no_precision_key() -> None:
+    """Generic sa.DateTime has no precision attribute; no precision key must be emitted."""
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("col", sa.DateTime()))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full_with_precision")
+    assert col_schema is not None
+    assert "precision" not in col_schema


### PR DESCRIPTION
Fixes #4316

## Problem
`sqla_col_to_column_schema` never reads `.precision` from `DateTime` types, so timestamp/datetime columns lose their fractional-seconds precision even at `reflection_level="full_with_precision"` (the level explicitly gated by `add_precision`). Only `Numeric`, `SmallInteger`, `String`, and `_Binary` had precision handling.

## Change
In the `DateTime` branch, when `add_precision` is set and the reflected type exposes a `precision` attribute (e.g. Oracle `TIMESTAMP(p)`, MSSQL `DATETIME2(p)`), emit `col["precision"]`. Guarded with `getattr` since generic `sa.DateTime` has no such attribute.

## Tests
- `test_timestamp_precision_reflected_full_with_precision` — `DATETIME2(3)` → `precision: 3` at `full_with_precision`
- `test_timestamp_precision_omitted_without_full_with_precision` — no precision key at `"full"`
- `test_generic_datetime_has_no_precision_key` — generic `DateTime` emits no precision key

Verified: `tests/sources/sql_database/test_schema_types.py` — 20 passed under SQLAlchemy **2.0.51** and **2.1.0b3**.