### PR TITLE
fix(sql_database): map Oracle TIMESTAMP WITH LOCAL TIME ZONE to timezone=true

### DIFF
--- a/dlt/sources/sql_database/schema_types.py
+++ b/dlt/sources/sql_database/schema_types.py
@@ -163,8 +163,13 @@ def sqla_col_to_column_schema(
             col["precision"] = sql_t.length
     elif isinstance(sql_t, sqltypes.DateTime):
         col["data_type"] = "timestamp"
-        # special handling for MSSQL
-        col["timezone"] = sql_t.timezone or sql_t.__visit_name__ in ("DATETIMEOFFSET",)
+        # special handling for MSSQL and Oracle TIMESTAMP WITH LOCAL TIME ZONE
+        # (Oracle reflects the latter with timezone=False but local_timezone=True)
+        col["timezone"] = (
+            sql_t.timezone
+            or getattr(sql_t, "local_timezone", False)
+            or sql_t.__visit_name__ in ("DATETIMEOFFSET",)
+        )
     elif isinstance(sql_t, sqltypes.Date):
         col["data_type"] = "date"
     elif isinstance(sql_t, sqltypes.Time):

--- a/tests/sources/sql_database/test_schema_types.py
+++ b/tests/sources/sql_database/test_schema_types.py
@@ -218,3 +218,26 @@ def test_get_table_references() -> None:
 
     refs = get_table_references(child)
     assert refs == []
+
+
+def test_oracle_local_time_zone_mapped_to_timezone_true() -> None:
+    """Oracle TIMESTAMP WITH LOCAL TIME ZONE (local_timezone=True) maps to timezone=True (issue #4315)."""
+    from sqlalchemy.dialects.oracle import TIMESTAMP as OracleTIMESTAMP
+
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("col", OracleTIMESTAMP(local_timezone=True)))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full")
+    assert col_schema is not None
+    assert col_schema["data_type"] == "timestamp"
+    assert col_schema["timezone"] is True
+
+
+def test_oracle_timestamp_plain_maps_to_timezone_false() -> None:
+    """Plain Oracle TIMESTAMP stays timezone=False; local_timezone defaults to False."""
+    from sqlalchemy.dialects.oracle import TIMESTAMP as OracleTIMESTAMP
+
+    metadata = sa.MetaData()
+    table = sa.Table("t", metadata, sa.Column("col", OracleTIMESTAMP()))
+    col_schema = sqla_col_to_column_schema(table.c.col, "full")
+    assert col_schema is not None
+    assert col_schema["timezone"] is False


### PR DESCRIPTION
Fixes #4315

## Problem
`sqla_col_to_column_schema` infers timezone-awareness from `sql_t.timezone` only. Oracle's `TIMESTAMP WITH LOCAL TIME ZONE` columns are reflected by SQLAlchemy with `timezone=False` but `local_timezone=True`, so they were mapped to `timezone: false` in the dlt schema — forcing downstream timestamp normalization and breaking round-trips for LTZ data.

## Change
Also honor the `local_timezone` attribute (Oracle-only), via `getattr` so other dialects are unaffected.

## Tests
- `test_oracle_local_time_zone_mapped_to_timezone_true` — `TIMESTAMP(local_timezone=True)` → `timezone: true`
- `test_oracle_timestamp_plain_maps_to_timezone_false` — plain `TIMESTAMP` stays `timezone: false`

Verified: `tests/sources/sql_database/test_schema_types.py` — 19 passed under SQLAlchemy **2.0.51** and **2.1.0b3**.