### PR TITLE
fix: annotate PipelineTrace last step accessors as Optional

### DIFF
--- a/dlt/pipeline/trace.py
+++ b/dlt/pipeline/trace.py
@@ -170,7 +170,7 @@ class PipelineTrace(SupportsHumanize, _PipelineTrace):
             msg += "\n" + "\n\n".join([s.asstr(verbosity) for s in self.steps])
         return msg
 
-    def last_pipeline_step_trace(self, step_name: TPipelineStep) -> PipelineStepTrace:
+    def last_pipeline_step_trace(self, step_name: TPipelineStep) -> Optional[PipelineStepTrace]:
         matching_steps = [step for step in self.steps if step.step == step_name]
         if not matching_steps:
             return None
@@ -188,21 +188,21 @@ class PipelineTrace(SupportsHumanize, _PipelineTrace):
         return d
 
     @property
-    def last_extract_info(self) -> ExtractInfo:
+    def last_extract_info(self) -> Optional[ExtractInfo]:
         step_trace = self.last_pipeline_step_trace("extract")
         if step_trace and isinstance(step_trace.step_info, ExtractInfo):
             return step_trace.step_info
         return None
 
     @property
-    def last_normalize_info(self) -> NormalizeInfo:
+    def last_normalize_info(self) -> Optional[NormalizeInfo]:
         step_trace = self.last_pipeline_step_trace("normalize")
         if step_trace and isinstance(step_trace.step_info, NormalizeInfo):
             return step_trace.step_info
         return None
 
     @property
-    def last_load_info(self) -> LoadInfo:
+    def last_load_info(self) -> Optional[LoadInfo]:
         step_trace = self.last_pipeline_step_trace("load")
         if step_trace and isinstance(step_trace.step_info, LoadInfo):
             return step_trace.step_info

--- a/tests/pipeline/test_pipeline_trace.py
+++ b/tests/pipeline/test_pipeline_trace.py
@@ -18,6 +18,7 @@ from dlt.common.configuration.utils import get_resolved_traces
 from dlt.common.metrics import TDataLocation, TDatasetDataLocation
 from dlt.common.pipeline import ExtractInfo, NormalizeInfo, LoadInfo
 from dlt.common.schema import Schema
+from dlt.common.runtime.exec_info import get_execution_context
 from dlt.common.runtime.telemetry import stop_telemetry
 from dlt.common.typing import DictStrAny, DictStrStr, TRefreshMode, TSecretValue
 from dlt.common.utils import digest128, uniq_id
@@ -892,6 +893,23 @@ def test_last_pipeline_step_trace_returns_latest() -> None:
     assert p.last_trace.last_extract_info.loads_ids == third_load_info.loads_ids
     assert p.last_trace.last_normalize_info.loads_ids == third_load_info.loads_ids
     assert p.last_trace.last_load_info.loads_ids == third_load_info.loads_ids
+
+
+def test_trace_accessors_return_none_for_missing_steps() -> None:
+    """Last step accessors return None (not raise) when a step never ran, per their Optional type hints."""
+    trace = PipelineTrace(
+        uniq_id(),
+        "test",
+        get_execution_context(),
+        pendulum.now(),
+        steps=[],
+        resolved_config_values=[],
+    )
+
+    assert trace.last_pipeline_step_trace("extract") is None
+    assert trace.last_extract_info is None
+    assert trace.last_normalize_info is None
+    assert trace.last_load_info is None
 
 
 def test_trace_custom_metrics_schema() -> None:


### PR DESCRIPTION
### Description

`PipelineTrace`'s last-step accessors were typed as returning their info type directly, but they return `None` whenever the step never ran (or its step info is missing). The false non-optional hints leak into downstream integrations: dagster-dlt dereferences `last_normalize_info.row_counts` and crashes with `AttributeError: 'NoneType' object has no attribute 'row_counts'` instead of being able to do an optional check.

This changes the four accessors to `Optional[...]`, matching their actual contract:

- `last_pipeline_step_trace` -> `Optional[PipelineStepTrace]`
- `last_extract_info` -> `Optional[ExtractInfo]`
- `last_normalize_info` -> `Optional[NormalizeInfo]`
- `last_load_info` -> `Optional[LoadInfo]`

Added a regression test asserting all accessors return `None` (and do not raise) on an empty trace.

### Related Issues

- Closes #4321

### Additional Context

Tested locally: the new regression test passes, and `tests/pipeline/test_pipeline_trace.py` shows the same pass/fail set as on `main` (the only delta is the new passing test). The remaining failures in that file are pre-existing `ModuleNotFoundError` for optional deps (`duckdb`, `pandas`) not installed in the local test environment.

Per the discussion with @zilto on #4321, only the type annotations in `dlt` are addressed here; the deeper dagster-side handling is tracked separately by the dagster team.
