### PR TITLE
feat: `yaml` config provider

### DIFF
--- a/dlt/_workspace/_workspace_context.py
+++ b/dlt/_workspace/_workspace_context.py
@@ -25,7 +25,13 @@ from dlt.common.typing import copy_sig_ret
 from dlt._workspace.configuration import WorkspaceConfiguration, WorkspaceRuntimeConfiguration
 from dlt._workspace.exceptions import WorkspaceRunContextNotAvailable
 from dlt._workspace.profile import BUILT_IN_PROFILES, DEFAULT_PROFILE, read_profile_pin
-from dlt._workspace.providers import ProfileConfigTomlProvider, ProfileSecretsTomlProvider
+from dlt._workspace.providers import (
+    ProfileConfigTomlProvider,
+    ProfileSecretsTomlProvider,
+    ProfileConfigYamlProvider,
+    ProfileSecretsYamlProvider,
+)
+from dlt.common.configuration.providers.utils import warn_on_toml_yaml_collision
 from dlt._workspace.run_context import (
     DEFAULT_LOCAL_FOLDER,
     DEFAULT_WORKSPACE_WORKING_FOLDER,
@@ -225,10 +231,18 @@ class WorkspaceRunContext(ProfilesRunContext):
         return list(configured)
 
     def _initial_providers(self, profile_name: str) -> List[ConfigProvider]:
+        secrets_toml = ProfileSecretsTomlProvider(self.settings_dir, profile_name, self.global_dir)
+        config_toml = ProfileConfigTomlProvider(self.settings_dir, profile_name, self.global_dir)
+        secrets_yaml = ProfileSecretsYamlProvider(self.settings_dir, profile_name, self.global_dir)
+        config_yaml = ProfileConfigYamlProvider(self.settings_dir, profile_name, self.global_dir)
+        warn_on_toml_yaml_collision(secrets_toml, secrets_yaml)
+        warn_on_toml_yaml_collision(config_toml, config_yaml)
         providers = [
             EnvironProvider(),
-            ProfileSecretsTomlProvider(self.settings_dir, profile_name, self.global_dir),
-            ProfileConfigTomlProvider(self.settings_dir, profile_name, self.global_dir),
+            secrets_toml,
+            secrets_yaml,
+            config_toml,
+            config_yaml,
         ]
         return providers
 

--- a/dlt/_workspace/providers.py
+++ b/dlt/_workspace/providers.py
@@ -11,12 +11,17 @@ from dlt.common.configuration.providers.yaml import (
 
 
 class ProfilePathMixin:
+    """A mixin that adds profile-aware path resolution.
+
+    Overrides both `_resolve_toml_paths` and `_resolve_yaml_paths` with the same logic, so it can
+    be combined with either a toml or a yaml settings provider.
+    """
+
     def __init__(self, *args: Any, profile: str, **kwargs: Any) -> None:
-        """A mixin that adds profile-aware path resolution by overriding `_resolve_toml_paths`"""
         self._profile = profile
         super().__init__(*args, **kwargs)
 
-    def _resolve_toml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
+    def _resolve_profile_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
         resolvable_files = []
         for d in resolvable_dirs:
             # append each a profile and a base file name for each directory
@@ -24,6 +29,9 @@ class ProfilePathMixin:
             resolvable_files.append(os.path.join(d, f"{self._profile}.{file_name}"))
             resolvable_files.append(os.path.join(d, file_name))
         return resolvable_files
+
+    _resolve_toml_paths = _resolve_profile_paths
+    _resolve_yaml_paths = _resolve_profile_paths
 
 
 class ProfileSecretsTomlProvider(ProfilePathMixin, SecretsTomlProvider):
@@ -38,29 +46,13 @@ class ProfileConfigTomlProvider(ProfilePathMixin, ConfigTomlProvider):
         super().__init__(settings_dir=settings_dir, global_dir=global_dir, profile=profile)
 
 
-class ProfileYamlPathMixin:
-    def __init__(self, *args: Any, profile: str, **kwargs: Any) -> None:
-        """A mixin that adds profile-aware path resolution by overriding `_resolve_yaml_paths`"""
-        self._profile = profile
-        super().__init__(*args, **kwargs)
-
-    def _resolve_yaml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
-        resolvable_files = []
-        for d in resolvable_dirs:
-            # append each a profile and a base file name for each directory
-            # profile name is always first
-            resolvable_files.append(os.path.join(d, f"{self._profile}.{file_name}"))
-            resolvable_files.append(os.path.join(d, file_name))
-        return resolvable_files
-
-
-class ProfileSecretsYamlProvider(ProfileYamlPathMixin, SecretsYamlProvider):
+class ProfileSecretsYamlProvider(ProfilePathMixin, SecretsYamlProvider):
     def __init__(self, settings_dir: str, profile: str, global_dir: Optional[str] = None) -> None:
         """a secret yaml provider loading from {profile}.secrets.yaml file."""
         super().__init__(settings_dir=settings_dir, global_dir=global_dir, profile=profile)
 
 
-class ProfileConfigYamlProvider(ProfileYamlPathMixin, ConfigYamlProvider):
+class ProfileConfigYamlProvider(ProfilePathMixin, ConfigYamlProvider):
     def __init__(self, settings_dir: str, profile: str, global_dir: Optional[str] = None) -> None:
         """a config yaml provider loading from {profile}.config.yaml file."""
         super().__init__(settings_dir=settings_dir, global_dir=global_dir, profile=profile)

--- a/dlt/_workspace/providers.py
+++ b/dlt/_workspace/providers.py
@@ -4,6 +4,10 @@ from dlt.common.configuration.providers.toml import (
     ConfigTomlProvider,
     SecretsTomlProvider,
 )
+from dlt.common.configuration.providers.yaml import (
+    ConfigYamlProvider,
+    SecretsYamlProvider,
+)
 
 
 class ProfilePathMixin:
@@ -31,4 +35,32 @@ class ProfileSecretsTomlProvider(ProfilePathMixin, SecretsTomlProvider):
 class ProfileConfigTomlProvider(ProfilePathMixin, ConfigTomlProvider):
     def __init__(self, settings_dir: str, profile: str, global_dir: Optional[str] = None) -> None:
         """a config toml provider loading from {profile}.config.toml file."""
+        super().__init__(settings_dir=settings_dir, global_dir=global_dir, profile=profile)
+
+
+class ProfileYamlPathMixin:
+    def __init__(self, *args: Any, profile: str, **kwargs: Any) -> None:
+        """A mixin that adds profile-aware path resolution by overriding `_resolve_yaml_paths`"""
+        self._profile = profile
+        super().__init__(*args, **kwargs)
+
+    def _resolve_yaml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
+        resolvable_files = []
+        for d in resolvable_dirs:
+            # append each a profile and a base file name for each directory
+            # profile name is always first
+            resolvable_files.append(os.path.join(d, f"{self._profile}.{file_name}"))
+            resolvable_files.append(os.path.join(d, file_name))
+        return resolvable_files
+
+
+class ProfileSecretsYamlProvider(ProfileYamlPathMixin, SecretsYamlProvider):
+    def __init__(self, settings_dir: str, profile: str, global_dir: Optional[str] = None) -> None:
+        """a secret yaml provider loading from {profile}.secrets.yaml file."""
+        super().__init__(settings_dir=settings_dir, global_dir=global_dir, profile=profile)
+
+
+class ProfileConfigYamlProvider(ProfileYamlPathMixin, ConfigYamlProvider):
+    def __init__(self, settings_dir: str, profile: str, global_dir: Optional[str] = None) -> None:
+        """a config yaml provider loading from {profile}.config.yaml file."""
         super().__init__(settings_dir=settings_dir, global_dir=global_dir, profile=profile)

--- a/dlt/common/configuration/providers/__init__.py
+++ b/dlt/common/configuration/providers/__init__.py
@@ -9,6 +9,14 @@ from .toml import (
     SECRETS_TOML,
     StringTomlProvider,
 )
+from .yaml import (
+    SecretsYamlProvider,
+    ConfigYamlProvider,
+    SettingsYamlProvider,
+    CONFIG_YAML,
+    SECRETS_YAML,
+    StringYamlProvider,
+)
 from .doc import CustomLoaderDocProvider
 from .vault import SECRETS_TOML_KEY, VaultDocProvider
 from .google_secrets import GoogleSecretsProvider
@@ -25,6 +33,12 @@ __all__ = [
     "CONFIG_TOML",
     "SECRETS_TOML",
     "StringTomlProvider",
+    "SecretsYamlProvider",
+    "ConfigYamlProvider",
+    "SettingsYamlProvider",
+    "CONFIG_YAML",
+    "SECRETS_YAML",
+    "StringYamlProvider",
     "SECRETS_TOML_KEY",
     "ContextProvider",
     "CustomLoaderDocProvider",

--- a/dlt/common/configuration/providers/settings.py
+++ b/dlt/common/configuration/providers/settings.py
@@ -1,0 +1,149 @@
+"""Shared logic for file-based settings providers (`toml.py`, `yaml.py`).
+
+`SettingsTomlProvider` and `SettingsYamlProvider` differ only in how they read and write their
+backing files (and, for TOML, in keeping a `tomlkit` document in sync for comment/formatting
+preservation and in the Google Colab / Streamlit fallbacks). Everything else -- resolving profile
+aware paths, tracking where each value came from (`_value_origins`) and undoing writes on
+`preserve()` -- is format agnostic and lives here.
+"""
+
+import os
+from contextlib import contextmanager
+from pathlib import PurePath
+from typing import Any, Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+from dlt.common.configuration.exceptions import ConfigProviderException
+from dlt.common.configuration.utils import auto_config_fragment
+
+from .doc import CustomLoaderDocProvider
+
+GLOBAL_ORIGIN_PREFIX = "global:"
+
+
+class TValueOrigins(Dict[str, Any]):
+    """Mirrors a config doc shape: leaf values are origin names, tables carry their own origin."""
+
+    origin: str = ""
+
+    def clone(self) -> "TValueOrigins":
+        cloned = TValueOrigins(
+            {k: v.clone() if isinstance(v, TValueOrigins) else v for k, v in self.items()}
+        )
+        cloned.origin = self.origin
+        return cloned
+
+
+class SettingsDocProvider(CustomLoaderDocProvider):
+    """Base class for providers backed by one or more settings files (toml, yaml, ...).
+
+    Subclasses are responsible for resolving file paths, reading/merging/writing the files
+    in their native format and keeping any format specific representation (ie. a `tomlkit`
+    document) they need for round-tripping. This class implements the rest: tracking the file
+    (or fallback source) each value came from, and restoring that bookkeeping on `preserve()`.
+    """
+
+    _present_locations: List[str]
+    _global_dir: Optional[str]
+    _value_origins: TValueOrigins
+
+    def get_value_location(self, key: str, pipeline_name: Optional[str], *sections: str) -> str:
+        """Get location (file name) of a value from the origins doc built when files were loaded.
+        Values from it are located with a `global:` prefix so that files sharing a name are told apart.
+        """
+        node = self._origins_node(self.get_key_path(key, pipeline_name, *sections))
+        if node is None:
+            return ""
+        return node.origin if isinstance(node, TValueOrigins) else node
+
+    def set_value(self, key: str, value: Any, pipeline_name: Optional[str], *sections: str) -> None:
+        self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
+        super().set_value(key, value, pipeline_name, *sections)
+
+    def set_fragment(
+        self, key: Optional[str], value_or_fragment: str, pipeline_name: str, *sections: str
+    ) -> None:
+        if (fragment := auto_config_fragment(value_or_fragment)) is not None:
+            if key is None:
+                self._value_origins = TValueOrigins()
+            else:
+                self._drop_origins(fragment)
+        else:
+            self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
+        super().set_fragment(key, value_or_fragment, pipeline_name, *sections)
+
+    @contextmanager
+    def preserve(self) -> Iterator[None]:
+        saved_origins = self._value_origins.clone()
+        with super().preserve():
+            try:
+                yield
+            finally:
+                self._value_origins = saved_origins
+
+    @property
+    def present_locations(self) -> List[str]:
+        return self._present_locations
+
+    def _is_in_global_dir(self, path: str) -> bool:
+        """Tells if `path` sits in the global dir. On Windows paths compare case insensitively."""
+        if not self._global_dir:
+            return False
+        # PurePath folds case and separators on Windows but keeps ".." verbatim, abspath resolves it
+        return PurePath(os.path.abspath(path)).is_relative_to(os.path.abspath(self._global_dir))
+
+    def _path_origin(self, path: str) -> str:
+        """Names the file `path`, marking the global dir so files sharing a name are told apart."""
+        if self._is_in_global_dir(path):
+            return GLOBAL_ORIGIN_PREFIX + os.path.basename(path)
+        return os.path.basename(path)
+
+    @staticmethod
+    def _doc_origins(doc: Mapping[str, Any], origin: str) -> TValueOrigins:
+        """Mirrors `doc` shape replacing each value with `origin`, tables carry `origin` as well."""
+        origins = TValueOrigins()
+        origins.origin = origin
+        for k, v in doc.items():
+            origins[k] = (
+                SettingsDocProvider._doc_origins(v, origin) if isinstance(v, dict) else origin
+            )
+        return origins
+
+    def _origins_node(self, full_path: Sequence[str]) -> Any:
+        """Returns origins doc node under `full_path` or None if not known."""
+        node: Any = self._value_origins
+        for k in full_path:
+            if not isinstance(node, dict) or k not in node:
+                return None
+            node = node[k]
+        return node
+
+    def _drop_origin(self, full_path: Sequence[str]) -> None:
+        """Forgets origin of a value under `full_path`, dropping whole subtree for tables."""
+        if not full_path:
+            return
+        parent = self._origins_node(full_path[:-1])
+        if isinstance(parent, dict):
+            parent.pop(full_path[-1], None)
+
+    def _drop_origins(self, doc: Mapping[str, Any], path: Tuple[str, ...] = ()) -> None:
+        """Forgets origins of all values present in `doc`, a fragment merged from the root."""
+        if not isinstance(doc, dict):
+            return
+        for k, v in doc.items():
+            sub_path = path + (k,)
+            # a fragment table merges key by key, but it replaces a value that was not a table
+            if isinstance(v, dict) and isinstance(self._origins_node(sub_path), dict):
+                self._drop_origins(v, sub_path)
+            else:
+                self._drop_origin(sub_path)
+
+
+class SettingsProviderReadException(ConfigProviderException):
+    def __init__(
+        self, provider_name: str, file_name: str, full_paths: List[str], doc_exception: str
+    ) -> None:
+        self.file_name = file_name
+        self.full_paths = full_paths
+        msg = f"A problem encountered when loading {provider_name} from paths {full_paths}:\n"
+        msg += doc_exception
+        super().__init__(provider_name, msg)

--- a/dlt/common/configuration/providers/toml.py
+++ b/dlt/common/configuration/providers/toml.py
@@ -3,33 +3,24 @@ import tomlkit
 import tomlkit.exceptions
 import tomlkit.items
 from contextlib import contextmanager
-from pathlib import PurePath
-from typing import Any, Dict, Iterator, Mapping, Optional, List, Sequence, Tuple
+from typing import Any, Iterator, Optional, List
 
 from dlt.common.configuration.utils import auto_config_fragment
 from dlt.common.utils import update_dict_nested
-from dlt.common.configuration.exceptions import ConfigProviderException
 
 from .doc import BaseDocProvider, CustomLoaderDocProvider
+from .settings import (
+    # exported for backwards compatibility
+    GLOBAL_ORIGIN_PREFIX,
+    SettingsDocProvider,
+    SettingsProviderReadException,
+    TValueOrigins,
+)
 
 CONFIG_TOML = "config.toml"
 SECRETS_TOML = "secrets.toml"
 GOOGLE_COLAB_ORIGIN = "google_colab"
 STREAMLIT_ORIGIN = "streamlit"
-GLOBAL_ORIGIN_PREFIX = "global:"
-
-
-class TValueOrigins(Dict[str, Any]):
-    """Mirrors a config doc shape: leaf values are origin names, tables carry their own origin."""
-
-    origin: str = ""
-
-    def clone(self) -> "TValueOrigins":
-        cloned = TValueOrigins(
-            {k: v.clone() if isinstance(v, TValueOrigins) else v for k, v in self.items()}
-        )
-        cloned.origin = self.origin
-        return cloned
 
 
 class StringTomlProvider(BaseDocProvider):
@@ -55,7 +46,7 @@ class StringTomlProvider(BaseDocProvider):
         return "memory"
 
 
-class SettingsTomlProvider(CustomLoaderDocProvider):
+class SettingsTomlProvider(SettingsDocProvider):
     _config_toml: tomlkit.TOMLDocument
     """Holds tomlkit document with config values that is in sync with _config_doc"""
 
@@ -112,15 +103,6 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
     def _resolve_toml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
         return [os.path.join(d, file_name) for d in resolvable_dirs]
 
-    def get_value_location(self, key: str, pipeline_name: Optional[str], *sections: str) -> str:
-        """Get location (file name) of a value from the origins doc built when files were loaded.
-        Values from it are located with a `global:` prefix so that files sharing a name are told apart.
-        """
-        node = self._origins_node(self.get_key_path(key, pipeline_name, *sections))
-        if node is None:
-            return ""
-        return node.origin if isinstance(node, TValueOrigins) else node
-
     def write_toml(self) -> None:
         assert (
             len(self._toml_paths) == 1
@@ -143,28 +125,21 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             pass
         if hasattr(value, "unwrap"):
             value = value.unwrap()
-        self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
         super().set_value(key, value, pipeline_name, *sections)
 
     @contextmanager
     def preserve(self) -> Iterator[None]:
         # set_value writes the tomlkit document in sync with the dict, so restore it too
         saved_toml = tomlkit.parse(tomlkit.dumps(self._config_toml))
-        saved_origins = self._value_origins.clone()
         with super().preserve():
             try:
                 yield
             finally:
                 self._config_toml = saved_toml
-                self._value_origins = saved_origins
 
     @property
     def is_empty(self) -> bool:
         return len(self._config_toml.body) == 0 and super().is_empty
-
-    @property
-    def present_locations(self) -> List[str]:
-        return self._present_locations
 
     def set_fragment(
         self, key: Optional[str], value_or_fragment: str, pipeline_name: str, *sections: str
@@ -181,14 +156,6 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
             )
         except ConvertError:
             pass
-        # re-parse to learn what _set_fragment actually wrote: a whole doc, a root merge or a value
-        if (fragment := auto_config_fragment(value_or_fragment)) is not None:
-            if key is None:
-                self._value_origins = TValueOrigins()
-            else:
-                self._drop_origins(fragment)
-        else:
-            self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
         super().set_fragment(key, value_or_fragment, pipeline_name, *sections)
 
     def to_toml(self) -> str:
@@ -243,59 +210,6 @@ class SettingsTomlProvider(CustomLoaderDocProvider):
         except Exception:
             # Not in a Streamlit context
             return None
-
-    def _is_in_global_dir(self, path: str) -> bool:
-        """Tells if `path` sits in the global dir. On Windows paths compare case insensitively."""
-        if not self._global_dir:
-            return False
-        # PurePath folds case and separators on Windows but keeps ".." verbatim, abspath resolves it
-        return PurePath(os.path.abspath(path)).is_relative_to(os.path.abspath(self._global_dir))
-
-    def _path_origin(self, path: str) -> str:
-        """Names the file `path`, marking the global dir so files sharing a name are told apart."""
-        if self._is_in_global_dir(path):
-            return GLOBAL_ORIGIN_PREFIX + os.path.basename(path)
-        return os.path.basename(path)
-
-    @staticmethod
-    def _doc_origins(doc: Mapping[str, Any], origin: str) -> TValueOrigins:
-        """Mirrors `doc` shape replacing each value with `origin`, tables carry `origin` as well."""
-        origins = TValueOrigins()
-        origins.origin = origin
-        for k, v in doc.items():
-            origins[k] = (
-                SettingsTomlProvider._doc_origins(v, origin) if isinstance(v, dict) else origin
-            )
-        return origins
-
-    def _origins_node(self, full_path: Sequence[str]) -> Any:
-        """Returns origins doc node under `full_path` or None if not known."""
-        node: Any = self._value_origins
-        for k in full_path:
-            if not isinstance(node, dict) or k not in node:
-                return None
-            node = node[k]
-        return node
-
-    def _drop_origin(self, full_path: Sequence[str]) -> None:
-        """Forgets origin of a value under `full_path`, dropping whole subtree for tables."""
-        if not full_path:
-            return
-        parent = self._origins_node(full_path[:-1])
-        if isinstance(parent, dict):
-            parent.pop(full_path[-1], None)
-
-    def _drop_origins(self, doc: Mapping[str, Any], path: Tuple[str, ...] = ()) -> None:
-        """Forgets origins of all values present in `doc`, a fragment merged from the root."""
-        if not isinstance(doc, dict):
-            return
-        for k, v in doc.items():
-            sub_path = path + (k,)
-            # a fragment table merges key by key, but it replaces a value that was not a table
-            if isinstance(v, dict) and isinstance(self._origins_node(sub_path), dict):
-                self._drop_origins(v, sub_path)
-            else:
-                self._drop_origin(sub_path)
 
     def _read_toml_file(self, toml_path: str) -> tomlkit.TOMLDocument:
         if os.path.isfile(toml_path):
@@ -360,12 +274,5 @@ class SecretsTomlProvider(SettingsTomlProvider):
         return True
 
 
-class TomlProviderReadException(ConfigProviderException):
-    def __init__(
-        self, provider_name: str, file_name: str, full_paths: List[str], toml_exception: str
-    ) -> None:
-        self.file_name = file_name
-        self.full_paths = full_paths
-        msg = f"A problem encountered when loading {provider_name} from paths {full_paths}:\n"
-        msg += toml_exception
-        super().__init__(provider_name, msg)
+class TomlProviderReadException(SettingsProviderReadException):
+    pass

--- a/dlt/common/configuration/providers/utils.py
+++ b/dlt/common/configuration/providers/utils.py
@@ -1,0 +1,21 @@
+from dlt.common import logger
+
+from .toml import SettingsTomlProvider
+from .yaml import SettingsYamlProvider
+
+
+def warn_on_toml_yaml_collision(
+    toml_provider: SettingsTomlProvider, yaml_provider: SettingsYamlProvider
+) -> None:
+    """Logs a warning if both `toml_provider` and `yaml_provider` found files on disk.
+
+    Config/secret resolution order gives precedence to `toml` files over `yaml` files (see
+    `RunContext.initial_providers`), so values present in both formats may silently shadow
+    the `yaml` ones. This warns the user so name collisions do not go unnoticed.
+    """
+    if toml_provider.present_locations and yaml_provider.present_locations:
+        logger.warning(
+            f"Both {toml_provider.present_locations} and {yaml_provider.present_locations} were"
+            " found. Values from toml files take precedence over yaml files with the same name,"
+            " which may silently shadow yaml configuration."
+        )

--- a/dlt/common/configuration/providers/yaml.py
+++ b/dlt/common/configuration/providers/yaml.py
@@ -1,15 +1,11 @@
 import os
 import yaml
-from contextlib import contextmanager
-from pathlib import PurePath
-from typing import Any, Dict, Iterator, Mapping, Optional, List, Sequence, Tuple
+from typing import Any, Dict, Optional, List
 
-from dlt.common.configuration.utils import auto_config_fragment
-from dlt.common.configuration.exceptions import ConfigProviderException
 from dlt.common.utils import update_dict_nested
 
-from .doc import BaseDocProvider, CustomLoaderDocProvider
-from .toml import GLOBAL_ORIGIN_PREFIX, TValueOrigins
+from .doc import BaseDocProvider
+from .settings import SettingsDocProvider, SettingsProviderReadException, TValueOrigins
 
 CONFIG_YAML = "config.yaml"
 SECRETS_YAML = "secrets.yaml"
@@ -35,7 +31,7 @@ class StringYamlProvider(BaseDocProvider):
         return "memory"
 
 
-class SettingsYamlProvider(CustomLoaderDocProvider):
+class SettingsYamlProvider(SettingsDocProvider):
     def __init__(
         self,
         name: str,
@@ -85,15 +81,6 @@ class SettingsYamlProvider(CustomLoaderDocProvider):
     def _resolve_yaml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
         return [os.path.join(d, file_name) for d in resolvable_dirs]
 
-    def get_value_location(self, key: str, pipeline_name: Optional[str], *sections: str) -> str:
-        """Get location (file name) of a value from the origins doc built when files were loaded.
-        Values from it are located with a `global:` prefix so that files sharing a name are told apart.
-        """
-        node = self._origins_node(self.get_key_path(key, pipeline_name, *sections))
-        if node is None:
-            return ""
-        return node.origin if isinstance(node, TValueOrigins) else node
-
     def write_yaml(self) -> None:
         assert (
             len(self._yaml_paths) == 1
@@ -102,88 +89,6 @@ class SettingsYamlProvider(CustomLoaderDocProvider):
         )
         with open(self._yaml_paths[0], "w", encoding="utf-8") as f:
             yaml.safe_dump(self._config_doc, f, sort_keys=False, default_flow_style=False)
-
-    def set_value(self, key: str, value: Any, pipeline_name: Optional[str], *sections: str) -> None:
-        self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
-        super().set_value(key, value, pipeline_name, *sections)
-
-    @contextmanager
-    def preserve(self) -> Iterator[None]:
-        saved_origins = self._value_origins.clone()
-        with super().preserve():
-            try:
-                yield
-            finally:
-                self._value_origins = saved_origins
-
-    @property
-    def present_locations(self) -> List[str]:
-        return self._present_locations
-
-    def set_fragment(
-        self, key: Optional[str], value_or_fragment: str, pipeline_name: str, *sections: str
-    ) -> None:
-        if (fragment := auto_config_fragment(value_or_fragment)) is not None:
-            if key is None:
-                self._value_origins = TValueOrigins()
-            else:
-                self._drop_origins(fragment)
-        else:
-            self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
-        super().set_fragment(key, value_or_fragment, pipeline_name, *sections)
-
-    def _is_in_global_dir(self, path: str) -> bool:
-        """Tells if `path` sits in the global dir. On Windows paths compare case insensitively."""
-        if not self._global_dir:
-            return False
-        # PurePath folds case and separators on Windows but keeps ".." verbatim, abspath resolves it
-        return PurePath(os.path.abspath(path)).is_relative_to(os.path.abspath(self._global_dir))
-
-    def _path_origin(self, path: str) -> str:
-        """Names the file `path`, marking the global dir so files sharing a name are told apart."""
-        if self._is_in_global_dir(path):
-            return GLOBAL_ORIGIN_PREFIX + os.path.basename(path)
-        return os.path.basename(path)
-
-    @staticmethod
-    def _doc_origins(doc: Mapping[str, Any], origin: str) -> TValueOrigins:
-        """Mirrors `doc` shape replacing each value with `origin`, tables carry `origin` as well."""
-        origins = TValueOrigins()
-        origins.origin = origin
-        for k, v in doc.items():
-            origins[k] = (
-                SettingsYamlProvider._doc_origins(v, origin) if isinstance(v, dict) else origin
-            )
-        return origins
-
-    def _origins_node(self, full_path: Sequence[str]) -> Any:
-        """Returns origins doc node under `full_path` or None if not known."""
-        node: Any = self._value_origins
-        for k in full_path:
-            if not isinstance(node, dict) or k not in node:
-                return None
-            node = node[k]
-        return node
-
-    def _drop_origin(self, full_path: Sequence[str]) -> None:
-        """Forgets origin of a value under `full_path`, dropping whole subtree for tables."""
-        if not full_path:
-            return
-        parent = self._origins_node(full_path[:-1])
-        if isinstance(parent, dict):
-            parent.pop(full_path[-1], None)
-
-    def _drop_origins(self, doc: Mapping[str, Any], path: Tuple[str, ...] = ()) -> None:
-        """Forgets origins of all values present in `doc`, a fragment merged from the root."""
-        if not isinstance(doc, dict):
-            return
-        for k, v in doc.items():
-            sub_path = path + (k,)
-            # a fragment table merges key by key, but it replaces a value that was not a table
-            if isinstance(v, dict) and isinstance(self._origins_node(sub_path), dict):
-                self._drop_origins(v, sub_path)
-            else:
-                self._drop_origin(sub_path)
 
     def _read_yaml_file(self, yaml_path: str) -> Dict[str, Any]:
         if os.path.isfile(yaml_path):
@@ -236,12 +141,5 @@ class SecretsYamlProvider(SettingsYamlProvider):
         return True
 
 
-class YamlProviderReadException(ConfigProviderException):
-    def __init__(
-        self, provider_name: str, file_name: str, full_paths: List[str], yaml_exception: str
-    ) -> None:
-        self.file_name = file_name
-        self.full_paths = full_paths
-        msg = f"A problem encountered when loading {provider_name} from paths {full_paths}:\n"
-        msg += yaml_exception
-        super().__init__(provider_name, msg)
+class YamlProviderReadException(SettingsProviderReadException):
+    pass

--- a/dlt/common/configuration/providers/yaml.py
+++ b/dlt/common/configuration/providers/yaml.py
@@ -1,0 +1,247 @@
+import os
+import yaml
+from contextlib import contextmanager
+from pathlib import PurePath
+from typing import Any, Dict, Iterator, Mapping, Optional, List, Sequence, Tuple
+
+from dlt.common.configuration.utils import auto_config_fragment
+from dlt.common.configuration.exceptions import ConfigProviderException
+from dlt.common.utils import update_dict_nested
+
+from .doc import BaseDocProvider, CustomLoaderDocProvider
+from .toml import GLOBAL_ORIGIN_PREFIX, TValueOrigins
+
+CONFIG_YAML = "config.yaml"
+SECRETS_YAML = "secrets.yaml"
+
+
+class StringYamlProvider(BaseDocProvider):
+    def __init__(self, yaml_string: str) -> None:
+        super().__init__(StringYamlProvider.loads(yaml_string))
+
+    def dumps(self) -> str:
+        return yaml.safe_dump(self._config_doc, sort_keys=False, default_flow_style=False)
+
+    @staticmethod
+    def loads(yaml_string: str) -> Dict[str, Any]:
+        return yaml.safe_load(yaml_string) or {}
+
+    @property
+    def supports_secrets(self) -> bool:
+        return True
+
+    @property
+    def name(self) -> str:
+        return "memory"
+
+
+class SettingsYamlProvider(CustomLoaderDocProvider):
+    def __init__(
+        self,
+        name: str,
+        supports_secrets: bool,
+        file_name: str,
+        resolvable_dirs: List[str],
+        global_dir: str = None,
+    ) -> None:
+        """Creates config provider from a `yaml` file
+
+        The provider loads the `yaml` file with specified name and from specified folder. If `global_dir` is specified,
+        it will additionally look for `file_name` in `dlt` global dir (home dir by default) and merge the content.
+        The "settings" (`settings_dir`) values overwrite the "global" values.
+
+        If none of the files exist, an empty provider is created.
+
+        Args:
+            name(str): name of the provider when registering in context
+            supports_secrets(bool): allows to store secret values in this provider
+            file_name (str): The name of `yaml` file to load
+            resolvable_dirs (List[str]): A list of directories to resolve the file from.
+                              Files will be merged into each other in the order the directories are specified. Provider is writeable if only one dir specified.
+            global_dir (str, optional): Which of the `resolvable_dirs` is the `dlt` global dir.
+
+        Raises:
+            YamlProviderReadException: File could not be read, most probably `yaml` parsing error
+        """
+        # set supports_secrets early, we need this flag to read config
+        self._supports_secrets = supports_secrets
+        # read yaml file from local
+        self._yaml_paths = self._resolve_yaml_paths(
+            file_name, [d for d in resolvable_dirs if d is not None]
+        )
+        # read yaml files and set present locations
+        self._present_locations: List[str] = []
+        self._global_dir = global_dir
+        self._value_origins = TValueOrigins()
+        config_doc = self._read_yaml_files(name, file_name, self._yaml_paths)
+
+        super().__init__(
+            name,
+            lambda: config_doc,
+            supports_secrets,
+            self._yaml_paths,
+        )
+
+    def _resolve_yaml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
+        return [os.path.join(d, file_name) for d in resolvable_dirs]
+
+    def get_value_location(self, key: str, pipeline_name: Optional[str], *sections: str) -> str:
+        """Get location (file name) of a value from the origins doc built when files were loaded.
+        Values from it are located with a `global:` prefix so that files sharing a name are told apart.
+        """
+        node = self._origins_node(self.get_key_path(key, pipeline_name, *sections))
+        if node is None:
+            return ""
+        return node.origin if isinstance(node, TValueOrigins) else node
+
+    def write_yaml(self) -> None:
+        assert (
+            len(self._yaml_paths) == 1
+        ), "Will not write configs when more than one yaml path was resolved. Found paths: " + str(
+            self._yaml_paths
+        )
+        with open(self._yaml_paths[0], "w", encoding="utf-8") as f:
+            yaml.safe_dump(self._config_doc, f, sort_keys=False, default_flow_style=False)
+
+    def set_value(self, key: str, value: Any, pipeline_name: Optional[str], *sections: str) -> None:
+        self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
+        super().set_value(key, value, pipeline_name, *sections)
+
+    @contextmanager
+    def preserve(self) -> Iterator[None]:
+        saved_origins = self._value_origins.clone()
+        with super().preserve():
+            try:
+                yield
+            finally:
+                self._value_origins = saved_origins
+
+    @property
+    def present_locations(self) -> List[str]:
+        return self._present_locations
+
+    def set_fragment(
+        self, key: Optional[str], value_or_fragment: str, pipeline_name: str, *sections: str
+    ) -> None:
+        if (fragment := auto_config_fragment(value_or_fragment)) is not None:
+            if key is None:
+                self._value_origins = TValueOrigins()
+            else:
+                self._drop_origins(fragment)
+        else:
+            self._drop_origin(self.get_key_path(key, pipeline_name, *sections))
+        super().set_fragment(key, value_or_fragment, pipeline_name, *sections)
+
+    def _is_in_global_dir(self, path: str) -> bool:
+        """Tells if `path` sits in the global dir. On Windows paths compare case insensitively."""
+        if not self._global_dir:
+            return False
+        # PurePath folds case and separators on Windows but keeps ".." verbatim, abspath resolves it
+        return PurePath(os.path.abspath(path)).is_relative_to(os.path.abspath(self._global_dir))
+
+    def _path_origin(self, path: str) -> str:
+        """Names the file `path`, marking the global dir so files sharing a name are told apart."""
+        if self._is_in_global_dir(path):
+            return GLOBAL_ORIGIN_PREFIX + os.path.basename(path)
+        return os.path.basename(path)
+
+    @staticmethod
+    def _doc_origins(doc: Mapping[str, Any], origin: str) -> TValueOrigins:
+        """Mirrors `doc` shape replacing each value with `origin`, tables carry `origin` as well."""
+        origins = TValueOrigins()
+        origins.origin = origin
+        for k, v in doc.items():
+            origins[k] = (
+                SettingsYamlProvider._doc_origins(v, origin) if isinstance(v, dict) else origin
+            )
+        return origins
+
+    def _origins_node(self, full_path: Sequence[str]) -> Any:
+        """Returns origins doc node under `full_path` or None if not known."""
+        node: Any = self._value_origins
+        for k in full_path:
+            if not isinstance(node, dict) or k not in node:
+                return None
+            node = node[k]
+        return node
+
+    def _drop_origin(self, full_path: Sequence[str]) -> None:
+        """Forgets origin of a value under `full_path`, dropping whole subtree for tables."""
+        if not full_path:
+            return
+        parent = self._origins_node(full_path[:-1])
+        if isinstance(parent, dict):
+            parent.pop(full_path[-1], None)
+
+    def _drop_origins(self, doc: Mapping[str, Any], path: Tuple[str, ...] = ()) -> None:
+        """Forgets origins of all values present in `doc`, a fragment merged from the root."""
+        if not isinstance(doc, dict):
+            return
+        for k, v in doc.items():
+            sub_path = path + (k,)
+            # a fragment table merges key by key, but it replaces a value that was not a table
+            if isinstance(v, dict) and isinstance(self._origins_node(sub_path), dict):
+                self._drop_origins(v, sub_path)
+            else:
+                self._drop_origin(sub_path)
+
+    def _read_yaml_file(self, yaml_path: str) -> Dict[str, Any]:
+        if os.path.isfile(yaml_path):
+            with open(yaml_path, "r", encoding="utf-8") as f:
+                return yaml.safe_load(f) or {}
+        else:
+            return None
+
+    def _read_yaml_files(
+        self, name: str, file_name: str, yaml_paths: List[str]
+    ) -> Dict[str, Any]:
+        """Merge all yaml files into one"""
+        try:
+            result_doc: Optional[Dict[str, Any]] = None
+            for path in yaml_paths:
+                if (loaded_doc := self._read_yaml_file(path)) is not None:
+                    origins = self._doc_origins(loaded_doc, self._path_origin(path))
+                    if result_doc is None:
+                        result_doc, self._value_origins = loaded_doc, origins
+                    else:
+                        # files are merged highest precedence first, so accumulated values win
+                        result_doc = update_dict_nested(loaded_doc, result_doc)
+                        self._value_origins = update_dict_nested(origins, self._value_origins)
+                    # store as present location
+                    self._present_locations.append(path)
+
+            if result_doc is None:
+                result_doc = {}
+
+            return result_doc
+        except Exception as ex:
+            raise YamlProviderReadException(name, file_name, yaml_paths, str(ex))
+
+
+class ConfigYamlProvider(SettingsYamlProvider):
+    def __init__(self, settings_dir: str, global_dir: str = None) -> None:
+        super().__init__(CONFIG_YAML, False, CONFIG_YAML, [settings_dir, global_dir], global_dir)
+
+    @property
+    def is_writable(self) -> bool:
+        return True
+
+
+class SecretsYamlProvider(SettingsYamlProvider):
+    def __init__(self, settings_dir: str, global_dir: str = None) -> None:
+        super().__init__(SECRETS_YAML, True, SECRETS_YAML, [settings_dir, global_dir], global_dir)
+
+    @property
+    def is_writable(self) -> bool:
+        return True
+
+
+class YamlProviderReadException(ConfigProviderException):
+    def __init__(
+        self, provider_name: str, file_name: str, full_paths: List[str], yaml_exception: str
+    ) -> None:
+        self.file_name = file_name
+        self.full_paths = full_paths
+        msg = f"A problem encountered when loading {provider_name} from paths {full_paths}:\n"
+        msg += yaml_exception
+        super().__init__(provider_name, msg)

--- a/dlt/common/runtime/run_context.py
+++ b/dlt/common/runtime/run_context.py
@@ -14,8 +14,11 @@ from dlt.common.configuration.providers import (
     EnvironProvider,
     SecretsTomlProvider,
     ConfigTomlProvider,
+    SecretsYamlProvider,
+    ConfigYamlProvider,
 )
 from dlt.common.configuration.providers.provider import ConfigProvider
+from dlt.common.configuration.providers.utils import warn_on_toml_yaml_collision
 from dlt.common.configuration.resolve import resolve_configuration
 from dlt.common.configuration.specs.base_configuration import BaseConfiguration
 from dlt.common.configuration.specs.pluggable_run_context import (
@@ -68,10 +71,18 @@ class RunContext(RunContextBase):
         return os.environ.get(known_env.DLT_DATA_DIR, self.global_dir)
 
     def initial_providers(self) -> List[ConfigProvider]:
+        secrets_toml = SecretsTomlProvider(self.settings_dir, self.global_dir)
+        config_toml = ConfigTomlProvider(self.settings_dir, self.global_dir)
+        secrets_yaml = SecretsYamlProvider(self.settings_dir, self.global_dir)
+        config_yaml = ConfigYamlProvider(self.settings_dir, self.global_dir)
+        warn_on_toml_yaml_collision(secrets_toml, secrets_yaml)
+        warn_on_toml_yaml_collision(config_toml, config_yaml)
         providers = [
             EnvironProvider(),
-            SecretsTomlProvider(self.settings_dir, self.global_dir),
-            ConfigTomlProvider(self.settings_dir, self.global_dir),
+            secrets_toml,
+            secrets_yaml,
+            config_toml,
+            config_yaml,
         ]
         return providers
 

--- a/docs/website/docs/general-usage/credentials/setup.md
+++ b/docs/website/docs/general-usage/credentials/setup.md
@@ -24,7 +24,7 @@ files or secure vaults. It understands both simple and verbose layouts of [confi
 
 1. [Environment Variables](#environment-variables): If a value is found in an environment variable, `dlt` uses it and doesn't check lower-priority providers.
 
-2. [secrets.toml and config.toml files](#secretstoml-and-configtoml): These files store configuration values and secrets. `secrets.toml` contains sensitive information, while `config.toml` holds non-sensitive configuration.
+2. [secrets.toml and config.toml files](#secretstoml-and-configtoml) / [secrets.yaml and config.yaml files](#secretsyaml-and-configyaml): These files store configuration values and secrets. `secrets.toml`/`secrets.yaml` contains sensitive information, while `config.toml`/`config.yaml` holds non-sensitive configuration.
 
 3. [Vaults](#vaults): Credentials stored in secure vaults like Google Secrets Manager, Azure Key Vault, or AWS Secrets Manager. Airflow Variables are also included here.
 
@@ -338,6 +338,31 @@ The TOML provider also reads configuration from special locations depending on y
 2. **Google Colab**: When running in Colab, you can use Colab Secrets named `secrets.toml` and `config.toml`. The provider reads these as if they were TOML files. This functionality is disabled if files exist in the `.dlt` folder.
 
 3. **Streamlit**: When running in Streamlit without local `.dlt/secrets.toml`, the provider uses Streamlit secrets. You can add `dlt` secrets directly to your Streamlit secrets.
+
+## secrets.yaml and config.yaml
+
+As an alternative to TOML, `dlt` also reads `config.yaml` and `secrets.yaml` from the same `.dlt` folder(s), with the same `~/.dlt` home directory merge described above. They accept the same section layout as TOML but as YAML, which can be clearer for deeply nested configuration:
+
+```yaml
+sources:
+  notion:
+    api_key: "your-notion-api-key"
+
+destination:
+  filesystem:
+    bucket_url: "s3://[your_bucket_name]"
+    credentials:
+      aws_access_key_id: "ABCDEFGHIJKLMNOPQRST"
+      aws_secret_access_key: "1234567890_access_key"
+```
+
+The full provider precedence, highest to lowest, is:
+
+```text
+env vars > secrets.toml > secrets.yaml > config.toml > config.yaml
+```
+
+Secrets (`toml` or `yaml`) always take precedence over config files, and within each pair `toml` takes precedence over `yaml` (`secrets.toml` over `secrets.yaml`, `config.toml` over `config.yaml`). If `dlt` finds both a `toml` and a `yaml` file of the same kind (e.g. both `config.toml` and `config.yaml`), it logs a warning because values in the `toml` file will shadow the `yaml` ones.
 
 ## Custom providers
 

--- a/tests/common/cases/configuration/.dlt_yaml/config.yaml
+++ b/tests/common/cases/configuration/.dlt_yaml/config.yaml
@@ -1,0 +1,33 @@
+api_type: REST
+
+api:
+  url: http
+  port: 1024
+  params:
+    param1: a
+    param2: b
+
+sources:
+  max_range: 10
+
+typecheck:
+  str_val: test string
+  int_val: 12345
+  bool_val: true
+  list_val: [1, "2", [3]]
+  dict_val: {a: 1, b: "2"}
+  float_val: 1.18927
+  date_val: "1979-05-27T07:32:00-08:00"
+  dec_val: "22.38"
+  bytes_val: "0x48656c6c6f20576f726c6421"
+  any_val: "function() {}"
+  none_val: "none"
+  sequence_val: ["A", "B", "KAPPA"]
+  gen_list_val: ["C", "Z", "N"]
+  mapping_val: {FL: 1, FR: {"1": 2}}
+  mutable_mapping_val: {str: str}
+  tuple_val: [1, 2, {"1": "complicated dicts allowed in literal eval"}]
+  NESTED_VAL: {"_": [1440, ["*"], []], "change-email": [560, ["*"], []]}
+
+runtime:
+  log_level: ERROR

--- a/tests/common/cases/configuration/.dlt_yaml/secrets.yaml
+++ b/tests/common/cases/configuration/.dlt_yaml/secrets.yaml
@@ -1,0 +1,74 @@
+secret_value: "2137"
+api:
+  port: 1023
+
+source:
+  credentials: |
+    {
+        "type": "service_account",
+        "project_id": "mock-project-id-source.credentials",
+        "private_key_id": "62c1f8f00836dec27c8d96d1c0836df2c1f6bce4",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCNEN0bL39HmD+S\n...\n-----END PRIVATE KEY-----\n",
+        "client_email": "loader@a7513.iam.gserviceaccount.com",
+        "client_id": "114701312674477307596",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/loader%40mock-project-id-2.iam.gserviceaccount.com",
+        "file_upload_timeout": 819872989
+      }
+
+databricks:
+  credentials: "databricks+connector://token:<databricks_token>@<databricks_host>:443/<database_or_schema_name>?conn_timeout=15&search_path=a,b,c"
+
+credentials:
+  secret_value: "2137"
+  project_id: mock-project-id-credentials
+
+gcp_storage:
+  project_id: mock-project-id-gcp-storage
+  private_key: "-----BEGIN PRIVATE KEY-----\nMIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCNEN0bL39HmD+S\n....\n-----END PRIVATE KEY-----\n"
+  client_email: loader@a7513.iam.gserviceaccount.com
+
+destination:
+  redshift:
+    credentials:
+      database: destination.redshift.credentials
+      username: loader
+      host: 3.73.90.3
+      password: set-me-up
+
+  credentials:
+    type: service_account
+    project_id: mock-project-id-destination.credentials
+    private_key_id: 62c1f8f00836dec27c8d96d1c0836df2c1f6bce4
+    private_key: "-----BEGIN PRIVATE KEY-----\nMIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCNEN0bL39HmD+S\n....\n-----END PRIVATE KEY-----\n"
+    client_email: loader@a7513.iam.gserviceaccount.com
+    client_id: "114701312674477307596"
+    auth_uri: https://accounts.google.com/o/oauth2/auth
+    token_uri: https://oauth2.googleapis.com/token
+    auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
+    client_x509_cert_url: https://www.googleapis.com/robot/v1/metadata/x509/loader%40mock-project-id-1.iam.gserviceaccount.com
+
+  bigquery:
+    type: service_account
+    project_id: mock-project-id-destination.bigquery
+    private_key_id: 62c1f8f00836dec27c8d96d1c0836df2c1f6bce4
+    private_key: "-----BEGIN PRIVATE KEY-----\nMIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCNEN0bL39HmD+S\n....\n-----END PRIVATE KEY-----\n"
+    client_email: loader@a7513.iam.gserviceaccount.com
+    client_id: "114701312674477307596"
+    auth_uri: https://accounts.google.com/o/oauth2/auth
+    token_uri: https://oauth2.googleapis.com/token
+    auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
+    client_x509_cert_url: https://www.googleapis.com/robot/v1/metadata/x509/loader%40mock-project-id-1.iam.gserviceaccount.com
+    credentials:
+      type: service_account
+      project_id: mock-project-id-destination.bigquery.credentials
+      private_key_id: 62c1f8f00836dec27c8d96d1c0836df2c1f6bce4
+      private_key: "-----BEGIN PRIVATE KEY-----\nMIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCNEN0bL39HmD+S\n....\n-----END PRIVATE KEY-----\n"
+      client_email: loader@a7513.iam.gserviceaccount.com
+      client_id: "114701312674477307596"
+      auth_uri: https://accounts.google.com/o/oauth2/auth
+      token_uri: https://oauth2.googleapis.com/token
+      auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
+      client_x509_cert_url: https://www.googleapis.com/robot/v1/metadata/x509/loader%40mock-project-id-1.iam.gserviceaccount.com

--- a/tests/common/cases/configuration/.wrong_yaml/config.yaml
+++ b/tests/common/cases/configuration/.wrong_yaml/config.yaml
@@ -1,0 +1,4 @@
+api_type: "REST"
+typecheck:
+  - a: 1
+  b: 2

--- a/tests/common/cases/configuration/dlt_home_yaml/config.yaml
+++ b/tests/common/cases/configuration/dlt_home_yaml/config.yaml
@@ -1,0 +1,8 @@
+runtime:
+  # disable telemetry
+  dlthub_telemetry: false
+
+api:
+  params:
+    param1: GLOBAL
+    param_global: G

--- a/tests/common/cases/configuration/origins_yaml/config.yaml
+++ b/tests/common/cases/configuration/origins_yaml/config.yaml
@@ -1,0 +1,9 @@
+base_only: base
+shared: from_base
+create_indexes: false
+
+tbl:
+  from_base: 1
+  shared_key: from_base
+  sub:
+    deep: base

--- a/tests/common/cases/configuration/origins_yaml/dev.config.yaml
+++ b/tests/common/cases/configuration/origins_yaml/dev.config.yaml
@@ -1,0 +1,6 @@
+dev_only: dev
+shared: from_dev
+
+tbl:
+  shared_key: from_dev
+  from_dev: 2

--- a/tests/common/cases/configuration/origins_yaml/global/config.yaml
+++ b/tests/common/cases/configuration/origins_yaml/global/config.yaml
@@ -1,0 +1,6 @@
+global_only: global base
+shared: from_global_base
+
+gtbl:
+  key: from_global_base
+  from_global_base: 1

--- a/tests/common/cases/configuration/origins_yaml/global/dev.config.yaml
+++ b/tests/common/cases/configuration/origins_yaml/global/dev.config.yaml
@@ -1,0 +1,5 @@
+global_dev_only: global dev
+shared: from_global_dev
+
+gtbl:
+  key: from_global_dev

--- a/tests/common/configuration/test_yaml_provider.py
+++ b/tests/common/configuration/test_yaml_provider.py
@@ -1,0 +1,412 @@
+import os
+import pytest
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Tuple, Type
+import datetime  # noqa: I251
+
+import dlt
+from dlt.common import pendulum
+from dlt.common.configuration import configspec, ConfigFieldMissingException, resolve
+from dlt.common.configuration.inject import with_config
+from dlt.common.configuration.exceptions import LookupTrace
+from dlt.common.configuration.providers.yaml import (
+    CONFIG_YAML,
+    SECRETS_YAML,
+    SettingsYamlProvider,
+    SecretsYamlProvider,
+    ConfigYamlProvider,
+    StringYamlProvider,
+    YamlProviderReadException,
+)
+from dlt.common.configuration.providers.toml import GLOBAL_ORIGIN_PREFIX, BaseDocProvider
+from dlt.common.configuration.providers.utils import warn_on_toml_yaml_collision
+from dlt.common.configuration.specs.config_providers_context import ConfigProvidersContainer
+from dlt.common.configuration.utils import get_resolved_traces
+from dlt.common.configuration.specs import (
+    GcpServiceAccountCredentialsWithoutDefaults,
+    ConnectionStringCredentials,
+)
+from dlt.common.typing import TSecretValue
+
+from tests.utils import preserve_environ, _reset_yaml_providers, capture_dlt_logger
+from tests.common.configuration.utils import (
+    ConnectionStringCompatCredentials,
+    CoercionTestConfiguration,
+    COERCIONS,
+    environment,
+)
+
+YAML_CASES_DIR = "./tests/common/cases/configuration/.dlt_yaml"
+
+
+@pytest.fixture
+def yaml_providers() -> Iterator[ConfigProvidersContainer]:
+    """Injects yaml providers reading from ./tests/common/cases/configuration/.dlt_yaml"""
+    yield from _reset_yaml_providers(os.path.abspath(YAML_CASES_DIR))
+
+
+def test_toml_types(yaml_providers: ConfigProvidersContainer) -> None:
+    c = resolve.resolve_configuration(CoercionTestConfiguration(), sections=("typecheck",))
+    for k, v in COERCIONS.items():
+        if isinstance(v, tuple):
+            v = list(v)
+        if isinstance(v, datetime.datetime):
+            v = pendulum.parse("1979-05-27T07:32:00-08:00")
+        assert v == c[k]
+
+    tracer = get_resolved_traces()
+    traces = tracer._get_log_as_dict(tracer.resolved_traces)
+    for k in COERCIONS:
+        assert traces[f"typecheck.{k}"].provider_location == CONFIG_YAML
+
+
+def test_config_provider_order(yaml_providers: ConfigProvidersContainer, environment: Any) -> None:
+    @with_config(sections=("api",))
+    def single_val(port=None):
+        return port
+
+    # secrets have api.port=1023 and this will be used
+    assert single_val(dlt.secrets.value) == 1023
+
+    environment["PORT"] = "UNKNOWN"
+    assert single_val() == "UNKNOWN"
+
+    environment["API__PORT"] = "1025"
+    assert single_val() == "1025"
+
+
+def test_yaml_sections(yaml_providers: ConfigProvidersContainer) -> None:
+    cfg = yaml_providers["config.yaml"]
+    assert cfg.get_value("api_type", str, None) == ("REST", "api_type")
+    assert cfg.get_value("port", int, None, "api") == (1024, "api.port")
+    assert cfg.get_value("param1", str, None, "api", "params") == ("a", "api.params.param1")
+
+
+def test_secrets_yaml_credentials(
+    environment: Any, yaml_providers: ConfigProvidersContainer
+) -> None:
+    c = resolve.resolve_configuration(
+        GcpServiceAccountCredentialsWithoutDefaults(), sections=("destination", "bigquery")
+    )
+    assert c.project_id.endswith("destination.bigquery.credentials")
+    tracer = get_resolved_traces()
+    traces = tracer._get_log_as_dict(tracer.resolved_traces)
+    assert traces["destination.bigquery.credentials.project_id"].provider_location == SECRETS_YAML
+    assert traces["destination.bigquery.credentials.private_key"].provider_location == SECRETS_YAML
+    # there are no destination.gcp_storage.credentials so it will fallback to "destination"."credentials"
+    c = resolve.resolve_configuration(
+        GcpServiceAccountCredentialsWithoutDefaults(), sections=("destination", "gcp_storage")
+    )
+    assert c.project_id.endswith("destination.credentials")
+    c2 = ConnectionStringCompatCredentials()
+    c2.update({"drivername": "postgres"})
+    c2 = resolve.resolve_configuration(c2, sections=("destination", "redshift"))
+    assert c2.database == "destination.redshift.credentials"
+
+
+def test_secrets_yaml_credentials_from_native_repr(
+    environment: Any, yaml_providers: ConfigProvidersContainer
+) -> None:
+    c = resolve.resolve_configuration(
+        GcpServiceAccountCredentialsWithoutDefaults(), sections=("source",)
+    )
+    assert (
+        c.private_key
+        == "-----BEGIN PRIVATE"
+        " KEY-----\nMIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQCNEN0bL39HmD+S\n...\n-----END"
+        " PRIVATE KEY-----\n"
+    )
+    assert c.project_id.endswith("mock-project-id-source.credentials")
+    c2 = resolve.resolve_configuration(ConnectionStringCredentials(), sections=("databricks",))
+    assert c2.drivername == "databricks+connector"
+    assert c2.username == "token"
+    assert c2.password == "<databricks_token>"
+    assert c2.host == "<databricks_host>"
+    assert c2.port == 443
+    assert c2.database == "<database_or_schema_name>"
+    assert c2.query == {"conn_timeout": "15", "search_path": "a,b,c"}
+
+
+def test_yaml_read_exception() -> None:
+    pipeline_root = "./tests/common/cases/configuration/.wrong_yaml"
+    with pytest.raises(YamlProviderReadException) as py_ex:
+        ConfigYamlProvider(settings_dir=pipeline_root)
+    assert py_ex.value.file_name == "config.yaml"
+
+
+def test_yaml_global_config() -> None:
+    global_dir = "./tests/common/cases/configuration/dlt_home_yaml"
+    settings_dir = YAML_CASES_DIR
+    config = ConfigYamlProvider(settings_dir=settings_dir, global_dir=global_dir)
+    assert config._yaml_paths[1] == os.path.join(global_dir, CONFIG_YAML)
+    assert isinstance(config._config_doc, dict)
+    assert len(config._config_doc) > 0
+    # kept from global
+    v, key = config.get_value("dlthub_telemetry", bool, None, "runtime")
+    assert v is False
+    assert key == "runtime.dlthub_telemetry"
+    v, _ = config.get_value("param_global", bool, None, "api", "params")
+    assert v == "G"
+    # kept from project
+    v, _ = config.get_value("log_level", bool, None, "runtime")
+    assert v == "ERROR"
+    # project overwrites
+    v, _ = config.get_value("param1", bool, None, "api", "params")
+    assert v == "a"
+    # verify global location
+    assert os.path.join(global_dir, "config.yaml") in config.locations
+    assert os.path.join(global_dir, "config.yaml") in config.present_locations
+    # verify local location
+    assert os.path.join(settings_dir, "config.yaml") in config.locations
+    assert os.path.join(settings_dir, "config.yaml") in config.present_locations
+
+    secrets = SecretsYamlProvider(settings_dir=settings_dir, global_dir=global_dir)
+    secrets_project = SecretsYamlProvider(settings_dir=settings_dir)
+    assert secrets._config_doc == secrets_project._config_doc
+    assert os.path.join(global_dir, "secrets.yaml") in secrets.locations
+    assert os.path.join(global_dir, "secrets.yaml") not in secrets.present_locations
+
+
+class ProfileLikeYamlProvider(SettingsYamlProvider):
+    """Loads `dev.{file_name}` before `{file_name}` in each dir, like the workspace profiles do"""
+
+    def _resolve_yaml_paths(self, file_name: str, resolvable_dirs: List[str]) -> List[str]:
+        paths = []
+        for d in resolvable_dirs:
+            paths.append(os.path.join(d, f"dev.{file_name}"))
+            paths.append(os.path.join(d, file_name))
+        return paths
+
+
+ORIGINS_CASES_DIR = "./tests/common/cases/configuration/origins_yaml"
+ORIGINS_GLOBAL_DIR = os.path.join(ORIGINS_CASES_DIR, "global")
+
+
+def _origins_provider() -> ProfileLikeYamlProvider:
+    return ProfileLikeYamlProvider(
+        CONFIG_YAML,
+        False,
+        CONFIG_YAML,
+        [ORIGINS_CASES_DIR, ORIGINS_GLOBAL_DIR],
+        ORIGINS_GLOBAL_DIR,
+    )
+
+
+def test_yaml_value_location_merged_files() -> None:
+    """Exact file is reported when files with different names are merged, base or override"""
+    config = _origins_provider()
+    dev_config_yaml = "dev." + CONFIG_YAML
+    global_config_yaml = GLOBAL_ORIGIN_PREFIX + CONFIG_YAML
+    global_dev_config_yaml = GLOBAL_ORIGIN_PREFIX + dev_config_yaml
+
+    assert config.get_value_location("dev_only", None) == dev_config_yaml
+    assert config.get_value_location("base_only", None) == CONFIG_YAML
+    assert config.get_value_location("global_dev_only", None) == global_dev_config_yaml
+    assert config.get_value_location("global_only", None) == global_config_yaml
+    # present in all four, the settings dir profile file wins value and location
+    assert config.get_value("shared", str, None) == ("from_dev", "shared")
+    assert config.get_value_location("shared", None) == dev_config_yaml
+    assert config.get_value("key", str, None, "gtbl") == ("from_global_dev", "gtbl.key")
+    assert config.get_value_location("key", None, "gtbl") == global_dev_config_yaml
+    assert config.get_value_location("from_global_base", None, "gtbl") == global_config_yaml
+    assert config.get_value_location("gtbl", None) == global_config_yaml
+    assert config.get_value("create_indexes", bool, None) == (False, "create_indexes")
+    assert config.get_value_location("create_indexes", None) == CONFIG_YAML
+    assert config.get_value_location("from_base", None, "tbl") == CONFIG_YAML
+    assert config.get_value_location("shared_key", None, "tbl") == dev_config_yaml
+    assert config.get_value_location("from_dev", None, "tbl") == dev_config_yaml
+    assert config.get_value_location("deep", None, "tbl", "sub") == CONFIG_YAML
+    assert config.get_value_location("tbl", None) == CONFIG_YAML
+
+    assert config.get_value_location("unknown", None) == ""
+    assert config.get_value_location("unknown", None, "tbl") == ""
+
+
+def test_yaml_value_location_runtime_writes() -> None:
+    """Values written at runtime are in no file, `preserve` brings the file origins back"""
+    config = _origins_provider()
+    dev_config_yaml = "dev." + CONFIG_YAML
+
+    config.set_value("written", "x", None)
+    assert config.get_value_location("written", None) == ""
+    config.set_value("base_only", "x", None)
+    assert config.get_value_location("base_only", None) == ""
+    config.set_value("from_base", 2, None, "tbl")
+    assert config.get_value_location("from_base", None, "tbl") == ""
+    assert config.get_value_location("shared_key", None, "tbl") == dev_config_yaml
+    config.set_value("deep", None, None, "tbl", "sub")
+    assert config.get_value_location("deep", None, "tbl", "sub") == ""
+
+    # a fragment under a key merges from the root and forgets only the keys it sets
+    config = _origins_provider()
+    config.set_fragment("tbl", "tbl:\n  from_base: 3\n", None)
+    assert config.get_value("from_base", int, None, "tbl") == (3, "tbl.from_base")
+    assert config.get_value_location("from_base", None, "tbl") == ""
+    assert config.get_value_location("shared_key", None, "tbl") == dev_config_yaml
+
+    # a fragment without a key replaces the whole document so no value comes from a file
+    config = _origins_provider()
+    config.set_fragment(None, "tbl:\n  from_base: 3\n", None)
+    assert config.get_value_location("from_base", None, "tbl") == ""
+    assert config.get_value_location("base_only", None) == ""
+
+    # preserve restores the origins together with the document
+    config = _origins_provider()
+    with config.preserve():
+        config.set_value("base_only", "x", None)
+        assert config.get_value_location("base_only", None) == ""
+    assert config.get_value_location("base_only", None) == CONFIG_YAML
+    assert config.get_value_location("dev_only", None) == dev_config_yaml
+
+
+@pytest.mark.parametrize("provider_kind", ["merged_names", "settings_and_global"])
+def test_yaml_value_location_covers_whole_doc(provider_kind: str) -> None:
+    """Origins doc keeps the config doc shape so every value and table has a location"""
+    if provider_kind == "merged_names":
+        config: SettingsYamlProvider = _origins_provider()
+    else:
+        config = ConfigYamlProvider(
+            settings_dir=YAML_CASES_DIR,
+            global_dir="./tests/common/cases/configuration/dlt_home_yaml",
+        )
+
+    def assert_located(doc: Dict[str, Any], sections: Tuple[str, ...] = ()) -> None:
+        for key, value in doc.items():
+            assert config.get_value_location(key, None, *sections) != "", ".".join((*sections, key))
+            if isinstance(value, dict):
+                assert_located(value, sections + (key,))
+
+    assert config._config_doc
+    assert_located(config._config_doc)
+
+
+def test_write_value(yaml_providers: ConfigProvidersContainer) -> None:
+    provider: SettingsYamlProvider
+    for provider in yaml_providers.providers:  # type: ignore[assignment]
+        if not provider.is_writable:
+            continue
+        provider.set_value("_new_key_bool", True, None)
+        TAny: Type[Any] = Any
+        assert provider.get_value("_new_key_bool", TAny, None) == (True, "_new_key_bool")
+        provider.set_value("_new_key_literal", TSecretValue("literal"), None)
+        assert provider.get_value("_new_key_literal", TAny, None) == ("literal", "_new_key_literal")
+        # this will create path of tables
+        provider.set_value("deep_int", 2137, "deep_pipeline", "deep", "deep", "deep", "deep")
+        assert (
+            provider._config_doc["deep_pipeline"]["deep"]["deep"]["deep"]["deep"]["deep_int"]
+            == 2137
+        )
+        assert provider.get_value(
+            "deep_int", TAny, "deep_pipeline", "deep", "deep", "deep", "deep"
+        ) == (2137, "deep_pipeline.deep.deep.deep.deep.deep_int")
+        provider.set_value("deep_list", [1, 2, 3], None, "deep", "deep", "deep")
+        assert provider.get_value("deep_list", TAny, None, "deep", "deep", "deep") == (
+            [1, 2, 3],
+            "deep.deep.deep.deep_list",
+        )
+        provider.set_value("deep_list", [1, 2, 3, 4], None, "deep", "deep", "deep")
+        assert provider.get_value("deep_list", TAny, None, "deep", "deep", "deep") == (
+            [1, 2, 3, 4],
+            "deep.deep.deep.deep_list",
+        )
+
+        test_d1 = {"key": "top", "embed": {"inner": "bottom", "inner_2": True}}
+        provider.set_value("deep_dict", test_d1, None, "dict_test")
+        assert provider.get_value("deep_dict", TAny, None, "dict_test") == (
+            test_d1,
+            "dict_test.deep_dict",
+        )
+        # merge dicts
+        test_d2 = {"key": "_top", "key2": "new2", "embed": {"inner": "_bottom", "inner_3": 2121}}
+        provider.set_value("deep_dict", test_d2, None, "dict_test")
+        test_m_d1_d2 = {
+            "key": "_top",
+            "embed": {"inner": "_bottom", "inner_2": True, "inner_3": 2121},
+            "key2": "new2",
+        }
+        assert provider.get_value("deep_dict", TAny, None, "dict_test") == (
+            test_m_d1_d2,
+            "dict_test.deep_dict",
+        )
+
+
+def test_set_value_none_deletes_key(yaml_providers: ConfigProvidersContainer) -> None:
+    """value=None deletes the key from the config doc."""
+    TAny: Type[Any] = Any
+    provider: SettingsYamlProvider
+    for provider in yaml_providers.providers:  # type: ignore[assignment]
+        if not provider.is_writable:
+            continue
+
+        provider.set_value("_to_delete_top", "value", None)
+        assert provider.get_value("_to_delete_top", TAny, None)[0] == "value"
+        provider.set_value("_to_delete_top", None, None)
+        assert provider.get_value("_to_delete_top", TAny, None)[0] is None
+        assert "_to_delete_top" not in provider._config_doc
+
+        provider.set_value("a", 1, None, "_del_section", "sub")
+        provider.set_value("b", 2, None, "_del_section", "sub")
+        provider.set_value("a", None, None, "_del_section", "sub")
+        assert provider.get_value("a", TAny, None, "_del_section", "sub")[0] is None
+        assert provider.get_value("b", TAny, None, "_del_section", "sub")[0] == 2
+        assert provider._config_doc["_del_section"]["sub"] == {"b": 2}
+
+        provider.set_value("k", None, None, "_no_such_section", "deeper")
+        assert "_no_such_section" not in provider._config_doc
+
+        provider.set_value("_never_existed", None, None, "_del_section", "sub")
+        assert provider.get_value("_never_existed", TAny, None, "_del_section", "sub")[0] is None
+
+
+def test_set_fragment(yaml_providers: ConfigProvidersContainer) -> None:
+    provider: SettingsYamlProvider
+    for provider in yaml_providers.providers:  # type: ignore[assignment]
+        if not isinstance(provider, BaseDocProvider):
+            continue
+        new_yaml = "int_val: 2232\ntable:\n  inner_int_val: 2121\n"
+
+        # key == None replaces the whole document
+        provider.set_fragment(None, new_yaml, None)
+        assert provider._config_doc == {"int_val": 2232, "table": {"inner_int_val": 2121}}
+        val, _ = provider.get_value("table", dict, None)
+        assert val is not None
+
+        to_merge_yaml = "int_val: 2137\n\nbabble:\n  word1: do\n  word2: you\n"
+        provider.set_fragment("", to_merge_yaml, None)
+        assert provider._config_doc == {
+            "int_val": 2137,
+            "table": {"inner_int_val": 2121},
+            "babble": {"word1": "do", "word2": "you"},
+        }
+
+
+def test_yaml_string_provider() -> None:
+    provider = StringYamlProvider(
+        "section1:\n  subsection:\n    key1: value1\nsection2:\n  subsection:\n    key2: value2\n"
+    )
+
+    assert provider.get_value("key1", "", "section1", "subsection") == ("value1", "section1.subsection.key1")  # type: ignore[arg-type]
+    assert provider.get_value("key2", "", "section2", "subsection") == ("value2", "section2.subsection.key2")  # type: ignore[arg-type]
+    assert provider.get_value_location("key1", None, "section1", "subsection") == ""
+
+    provider = StringYamlProvider("")
+    assert provider.dumps() == "{}\n"
+
+    provider.set_value("key1", "value1", "section1", "subsection")
+    assert provider.dumps() == "section1:\n  subsection:\n    key1: value1\n"
+
+
+def test_warn_on_toml_yaml_collision(caplog: pytest.LogCaptureFixture) -> None:
+    settings_dir = os.path.abspath("./tests/common/cases/configuration/.dlt")
+    yaml_settings_dir = os.path.abspath(YAML_CASES_DIR)
+
+    from dlt.common.configuration.providers.toml import ConfigTomlProvider
+
+    toml_provider = ConfigTomlProvider(settings_dir=settings_dir)
+    yaml_provider = ConfigYamlProvider(settings_dir=yaml_settings_dir)
+    assert toml_provider.present_locations
+    assert yaml_provider.present_locations
+
+    with capture_dlt_logger(caplog):
+        warn_on_toml_yaml_collision(toml_provider, yaml_provider)
+    assert any("toml" in rec.message and "yaml" in rec.message for rec in caplog.records)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,6 +26,8 @@ from dlt.common.configuration.providers import (
     EnvironProvider,
     SecretsTomlProvider,
     ConfigTomlProvider,
+    SecretsYamlProvider,
+    ConfigYamlProvider,
 )
 from dlt.common.configuration.providers.provider import ConfigProvider
 from dlt.common.configuration.resolve import resolve_configuration
@@ -693,6 +695,17 @@ def _reset_providers(settings_dir: str) -> Iterator[ConfigProvidersContainer]:
             EnvironProvider(),
             SecretsTomlProvider(settings_dir=settings_dir),
             ConfigTomlProvider(settings_dir=settings_dir),
+        ]
+    )
+
+
+def _reset_yaml_providers(settings_dir: str) -> Iterator[ConfigProvidersContainer]:
+    """Same as `_reset_providers` but with yaml providers initialized from `settings_dir`"""
+    yield from _inject_providers(
+        [
+            EnvironProvider(),
+            SecretsYamlProvider(settings_dir=settings_dir),
+            ConfigYamlProvider(settings_dir=settings_dir),
         ]
     )
 


### PR DESCRIPTION
Solves #4345  (and #1596). It expands on previous work that allowed custom config provider.

## Changes
There are a lot of files and lines of code changes, but it's inflated by `.yaml` test cases.

The main changes:
- move logic of the `toml` config provider to a base class `SettingsDocProvider`
- keep read/write logic in `toml` and `yaml` specific classes

## Future work
- update the docs to make more mentions of `config.yaml` and `secrets.yaml`
- ensure this is supported by `dlthub`
- ensure the dltHub AI Harness handles `.yaml` files properly (e.g., MCP tool to read values, mentions in skills)