### PR TITLE
fix(test): disable anon telemetry in platform connection test

### DIFF
--- a/tests/pipeline/test_platform_connection.py
+++ b/tests/pipeline/test_platform_connection.py
@@ -3,6 +3,8 @@ import pytest
 import requests_mock
 
 import dlt
+from dlt.common.configuration import resolve_configuration
+from dlt.common.configuration.specs import RuntimeConfiguration
 
 from tests.utils import start_test_telemetry, stop_telemetry
 
@@ -14,7 +16,10 @@ STATE_URL_SUFFIX = "/state"
 def test_platform_connection() -> None:
     mock_platform_url = "http://platform.com/endpoint"
     os.environ["RUNTIME__DLTHUB_DSN"] = mock_platform_url
-    start_test_telemetry()
+    # platform only; anon telemetry HTTP is not under test and can segfault on macOS after fork
+    runtime_config = resolve_configuration(RuntimeConfiguration())
+    runtime_config.dlthub_telemetry = False
+    start_test_telemetry(runtime_config)
 
     trace_url = mock_platform_url + TRACE_URL_SUFFIX
     state_url = mock_platform_url + STATE_URL_SUFFIX


### PR DESCRIPTION
### Why

`test_platform_connection` verifies platform sync — trace and state POSTed to `dlthub_dsn`. It also switched on anonymous usage telemetry via `start_test_telemetry()`, which no assertion in the test covers.

Under `@pytest.mark.forked` on macOS CI, that anon background `requests.post` can reach urllib's `proxy_bypass_macosx_sysconf` and segfault.

### What

Pass a `RuntimeConfiguration` with `dlthub_telemetry=False` to `start_test_telemetry()`, so only the platform tracker is initialized. `RUNTIME__DLTHUB_DSN` is still set before resolving, so platform HTTP remains mocked and fully asserted — only the unrelated anon path is off.

`start_test_telemetry()` with no argument forces `dlthub_telemetry = True`, so an env var cannot disable it — hence the explicit config.
