### PR TITLE
fix: raise ValueError coercing a non-finite decimal to bigint

### DIFF
--- a/dlt/common/data_types/type_helpers.py
+++ b/dlt/common/data_types/type_helpers.py
@@ -166,7 +166,14 @@ def _float_to_wei(value: float) -> Wei:
 
 
 def _numeric_to_bigint(value: Any) -> int:
-    if value % 1 != 0:
+    try:
+        if value % 1 != 0:
+            raise ValueError(value)
+    except InvalidOperation:
+        # A non-finite Decimal/Wei (Infinity, -Infinity) has no integer form,
+        # and `value % 1` raises InvalidOperation rather than returning a
+        # remainder. Surface it as a normal coercion failure, the same way the
+        # text-to-decimal coercers already do.
         raise ValueError(value)
     return int(value)
 

--- a/tests/common/schema/test_coercion.py
+++ b/tests/common/schema/test_coercion.py
@@ -110,6 +110,15 @@ def test_coerce_type_to_bigint() -> None:
     with pytest.raises(ValueError):
         coerce_value("bigint", "wei", Wei(912.12))
 
+    # non-finite decimals/wei have no integer form: they must raise ValueError,
+    # not leak decimal.InvalidOperation
+    with pytest.raises(ValueError):
+        coerce_value("bigint", "decimal", Decimal("Infinity"))
+    with pytest.raises(ValueError):
+        coerce_value("bigint", "decimal", Decimal("-Infinity"))
+    with pytest.raises(ValueError):
+        coerce_value("bigint", "wei", Wei("Infinity"))
+
     # non parsable floats and ints
     with pytest.raises(ValueError):
         coerce_value("bigint", "text", "f912.12")


### PR DESCRIPTION
`coerce_value("bigint", "decimal", ...)` leaks `decimal.InvalidOperation` on a non-finite value instead of the `ValueError` the coercion layer expects:

```python
from decimal import Decimal
from dlt.common.data_types import coerce_value

coerce_value("bigint", "decimal", Decimal("Infinity"))
# decimal.InvalidOperation: [<class 'decimal.InvalidOperation'>]
```

`_numeric_to_bigint` checks for a fractional part with `value % 1`, but for `Decimal("Infinity")` / `Decimal("-Infinity")` (and `Wei`) that modulo raises `InvalidOperation` rather than returning a remainder. `coerce_value` only catches `OverflowError`, so it propagates uncaught and takes down normalization instead of being handled as a failed coercion (which would fall back to a variant column).

The text coercers already convert `InvalidOperation` into `ValueError` (`_text_to_decimal`, `_text_to_wei`); this makes `_numeric_to_bigint` consistent. `Decimal("NaN")` already raised `ValueError` and still does. Added regression cases to `test_coerce_type_to_bigint`.