### PR TITLE
Add PR triage GitHub workflow

### DIFF
--- a/.github/scripts/pr-issue-policy-github.js
+++ b/.github/scripts/pr-issue-policy-github.js
@@ -1,0 +1,151 @@
+'use strict'
+
+const GITHUB_ACTIONS_BOT_LOGIN = 'github-actions[bot]'
+
+const PULL_REQUEST_QUERY = `
+  query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        number
+        state
+        isDraft
+        isCrossRepository
+        authorAssociation
+        author {
+          login
+        }
+        closingIssuesReferences(first: 100) {
+          nodes {
+            number
+            state
+            repository {
+              nameWithOwner
+            }
+            labels(first: 100) {
+              nodes {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+function isNotFound(error) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    error.status === 404
+  )
+}
+
+function createGitHubApi(github, repository) {
+  const { owner, repo } = repository
+
+  async function getPullRequest(number) {
+    const result = await github.graphql(PULL_REQUEST_QUERY, { owner, repo, number })
+    return result.repository.pullRequest
+  }
+
+  async function findGitHubActionsCommentContaining(number, marker) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: number,
+      per_page: 100,
+    })
+    return comments.find(
+      (comment) =>
+        comment.user?.login === GITHUB_ACTIONS_BOT_LOGIN &&
+        comment.body?.includes(marker),
+    )
+  }
+
+  async function addLabel(number, name) {
+    await github.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: number,
+      labels: [name],
+    })
+  }
+
+  async function removeLabel(number, name) {
+    try {
+      await github.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: number,
+        name,
+      })
+    } catch (error) {
+      if (!isNotFound(error)) throw error
+    }
+  }
+
+  async function createComment(number, body) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: number,
+      body,
+    })
+  }
+
+  async function updateComment(commentId, body) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body,
+    })
+  }
+
+  async function ensureLabels(names) {
+    for (const name of names) {
+      try {
+        await github.rest.issues.getLabel({ owner, repo, name })
+      } catch (error) {
+        if (!isNotFound(error)) throw error
+        throw new Error(`Configured label '${name}' does not exist in ${owner}/${repo}`)
+      }
+    }
+  }
+
+  async function listPullRequestsWithLabel(label) {
+    const items = await github.paginate(github.rest.issues.listForRepo, {
+      owner,
+      repo,
+      state: 'open',
+      labels: label,
+      per_page: 100,
+    })
+    return items.filter((item) => item.pull_request)
+  }
+
+  async function closePullRequest(number) {
+    await github.rest.pulls.update({
+      owner,
+      repo,
+      pull_number: number,
+      state: 'closed',
+    })
+  }
+
+  return Object.freeze({
+    addLabel,
+    closePullRequest,
+    createComment,
+    ensureLabels,
+    findGitHubActionsCommentContaining,
+    getPullRequest,
+    listPullRequestsWithLabel,
+    removeLabel,
+    updateComment,
+  })
+}
+
+module.exports = { createGitHubApi }

--- a/.github/scripts/pr-issue-policy.js
+++ b/.github/scripts/pr-issue-policy.js
@@ -29,6 +29,10 @@ function requirePositiveInteger(env, name) {
   return value
 }
 
+function optionalPositiveInteger(env, name) {
+  return env[name]?.trim() ? requirePositiveInteger(env, name) : null
+}
+
 function requireBoolean(env, name) {
   const value = env[name]?.trim().toLowerCase()
   if (value === 'true') return true
@@ -46,9 +50,7 @@ function csvSet(value, lowercase = false) {
   )
 }
 
-function loadConfig(env, eventName) {
-  const dispatchMaxClose = env.DISPATCH_MAX_CLOSE?.trim()
-  const dispatchPrNumber = env.DISPATCH_PR_NUMBER?.trim()
+function loadConfig(env) {
   const pendingLabel = requireText(env, 'PENDING_PR_LABEL')
   const verifiedLabel = requireText(env, 'VERIFIED_PR_LABEL')
 
@@ -61,13 +63,6 @@ function loadConfig(env, eventName) {
     pendingLabel,
     verifiedLabel,
     graceHours: requirePositiveNumber(env, 'GRACE_HOURS'),
-    maxClose: dispatchMaxClose
-      ? requirePositiveNumber(env, 'DISPATCH_MAX_CLOSE')
-      : requirePositiveNumber(env, 'DEFAULT_MAX_CLOSE'),
-    dryRun: eventName === 'workflow_dispatch' && requireBoolean(env, 'DRY_RUN'),
-    dispatchPrNumber: dispatchPrNumber
-      ? requirePositiveInteger(env, 'DISPATCH_PR_NUMBER')
-      : null,
     permissionBypass: requireBoolean(env, 'PERMISSION_BYPASS'),
     exemptSameRepository: requireBoolean(env, 'EXEMPT_SAME_REPOSITORY'),
     exemptAssociations: csvSet(env.EXEMPT_ASSOCIATIONS),
@@ -259,16 +254,16 @@ function isExpired(pendingSince, graceHours, now) {
   return now() >= expirationTime(pendingSince, graceHours)
 }
 
-async function sweep(dependencies) {
+async function sweep(dependencies, { dryRun, maxClose }) {
   const { api, config, core, now } = dependencies
   const candidates = await api.listPullRequestsWithLabel(config.pendingLabel)
   core.info(
-    `Starting ${config.dryRun ? 'dry-run ' : ''}sweep: found ${candidates.length} open PRs labeled '${config.pendingLabel}'`,
+    `Starting ${dryRun ? 'dry-run ' : ''}sweep: found ${candidates.length} open PRs labeled '${config.pendingLabel}'`,
   )
 
   let selected = 0
   for (const candidate of candidates) {
-    const result = await reconcilePullRequest(dependencies, candidate.number, !config.dryRun)
+    const result = await reconcilePullRequest(dependencies, candidate.number, !dryRun)
     if (result.status !== 'unverified') continue
     if (!isExpired(result.pendingSince, config.graceHours, now)) {
       const closesAfter = new Date(
@@ -277,8 +272,8 @@ async function sweep(dependencies) {
       core.info(`PR #${candidate.number} remains in its grace period until ${closesAfter}`)
       continue
     }
-    if (selected >= config.maxClose) {
-      core.warning(`Reached max-close limit of ${config.maxClose}`)
+    if (selected >= maxClose) {
+      core.warning(`Reached max-close limit of ${maxClose}`)
       break
     }
 
@@ -295,7 +290,7 @@ async function sweep(dependencies) {
     }
 
     selected++
-    if (config.dryRun) {
+    if (dryRun) {
       core.warning(`[dry-run] Would close PR #${candidate.number}`)
       continue
     }
@@ -305,11 +300,11 @@ async function sweep(dependencies) {
     core.info(`Closed PR #${candidate.number}`)
   }
 
-  core.info(`${config.dryRun ? 'Selected' : 'Closed'} ${selected} PRs`)
+  core.info(`${dryRun ? 'Selected' : 'Closed'} ${selected} PRs`)
 }
 
 async function run({ github, context, core, env = process.env, now = Date.now }) {
-  const config = loadConfig(env, context.eventName)
+  const config = loadConfig(env)
   const repositoryName = `${context.repo.owner}/${context.repo.repo}`.toLowerCase()
   const api = createGitHubApi(github, context.repo)
   const dependencies = Object.freeze({ api, config, core, now, repositoryName })
@@ -335,25 +330,34 @@ async function run({ github, context, core, env = process.env, now = Date.now })
     config.verifiedLabel,
   ])
 
-  // pull request target
-  if (context.eventName === 'pull_request_target') {
-    const number = context.payload.pull_request.number
-    core.info(`Handling pull_request_target '${context.payload.action}' for PR #${number}`)
-    await reconcilePullRequest(dependencies, number, true)
-    return
+  switch (context.eventName) {
+    case 'pull_request_target': {
+      const number = context.payload.pull_request.number
+      core.info(`Handling pull_request_target '${context.payload.action}' for PR #${number}`)
+      return reconcilePullRequest(dependencies, number, true)
+    }
+    case 'workflow_dispatch': {
+      const dryRun = requireBoolean(env, 'DRY_RUN')
+      const prNumber = optionalPositiveInteger(env, 'DISPATCH_PR_NUMBER')
+      if (prNumber !== null) {
+        core.info(
+          `Handling ${dryRun ? 'dry-run ' : ''}manual reclassification for PR #${prNumber}`,
+        )
+        return reconcilePullRequest(dependencies, prNumber, !dryRun)
+      }
+      return sweep(dependencies, {
+        dryRun,
+        maxClose: requirePositiveInteger(env, 'DISPATCH_MAX_CLOSE'),
+      })
+    }
+    case 'schedule':
+      return sweep(dependencies, {
+        dryRun: false,
+        maxClose: requirePositiveInteger(env, 'DEFAULT_MAX_CLOSE'),
+      })
+    default:
+      throw new Error(`Unsupported workflow event: ${context.eventName}`)
   }
-
-  // manual dispatch with PR number
-  if (config.dispatchPrNumber !== null) {
-    core.info(
-      `Handling ${config.dryRun ? 'dry-run ' : ''}manual reclassification for PR #${config.dispatchPrNumber}`,
-    )
-    await reconcilePullRequest(dependencies, config.dispatchPrNumber, !config.dryRun)
-    return
-  }
-
-  // periodic sweep
-  await sweep(dependencies)
 }
 
 module.exports = {

--- a/.github/scripts/pr-issue-policy.js
+++ b/.github/scripts/pr-issue-policy.js
@@ -1,0 +1,363 @@
+'use strict'
+
+const { createGitHubApi } = require('./pr-issue-policy-github')
+
+const POLICY_MARKER = '<!-- pr-issue-policy -->'
+const PENDING_MARKER_PATTERN = /<!-- pr-issue-policy:pending-since=([^ ]+) -->/
+const CLOSED_MARKER = '<!-- pr-issue-policy:closed -->'
+const HOUR_IN_MS = 60 * 60 * 1000
+
+function requireText(env, name) {
+  const value = env[name]?.trim()
+  if (!value) throw new Error(`${name} must not be empty`)
+  return value
+}
+
+function requirePositiveNumber(env, name) {
+  const value = Number(env[name])
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number; received ${env[name]}`)
+  }
+  return value
+}
+
+function requirePositiveInteger(env, name) {
+  const value = Number(env[name])
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer; received ${env[name]}`)
+  }
+  return value
+}
+
+function requireBoolean(env, name) {
+  const value = env[name]?.trim().toLowerCase()
+  if (value === 'true') return true
+  if (value === 'false') return false
+  throw new Error(`${name} must be true or false; received ${env[name]}`)
+}
+
+function csvSet(value, lowercase = false) {
+  return new Set(
+    (value ?? '')
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .map((item) => lowercase ? item.toLowerCase() : item.toUpperCase()),
+  )
+}
+
+function loadConfig(env, eventName) {
+  const dispatchMaxClose = env.DISPATCH_MAX_CLOSE?.trim()
+  const dispatchPrNumber = env.DISPATCH_PR_NUMBER?.trim()
+  const pendingLabel = requireText(env, 'PENDING_PR_LABEL')
+  const verifiedLabel = requireText(env, 'VERIFIED_PR_LABEL')
+
+  if (pendingLabel.toLowerCase() === verifiedLabel.toLowerCase()) {
+    throw new Error('PENDING_PR_LABEL and VERIFIED_PR_LABEL must be different labels')
+  }
+
+  return Object.freeze({
+    authorizingIssueLabel: requireText(env, 'AUTHORIZING_ISSUE_LABEL'),
+    pendingLabel,
+    verifiedLabel,
+    graceHours: requirePositiveNumber(env, 'GRACE_HOURS'),
+    maxClose: dispatchMaxClose
+      ? requirePositiveNumber(env, 'DISPATCH_MAX_CLOSE')
+      : requirePositiveNumber(env, 'DEFAULT_MAX_CLOSE'),
+    dryRun: eventName === 'workflow_dispatch' && requireBoolean(env, 'DRY_RUN'),
+    dispatchPrNumber: dispatchPrNumber
+      ? requirePositiveInteger(env, 'DISPATCH_PR_NUMBER')
+      : null,
+    permissionBypass: requireBoolean(env, 'PERMISSION_BYPASS'),
+    exemptSameRepository: requireBoolean(env, 'EXEMPT_SAME_REPOSITORY'),
+    exemptAssociations: csvSet(env.EXEMPT_ASSOCIATIONS),
+    exemptLogins: csvSet(env.EXEMPT_LOGINS, true),
+  })
+}
+
+function findQualifyingIssue(pr, config, repositoryName) {
+  return pr.closingIssuesReferences.nodes.find(
+    (issue) =>
+      issue.state === 'OPEN' &&
+      issue.repository.nameWithOwner.toLowerCase() === repositoryName &&
+      issue.labels.nodes.some(
+        (label) => label.name.toLowerCase() === config.authorizingIssueLabel.toLowerCase(),
+      ),
+  )
+}
+
+function classifyPullRequest(pr, config, repositoryName) {
+  if (!pr) return Object.freeze({ status: 'missing' })
+  if (pr.state !== 'OPEN') return Object.freeze({ status: 'closed', pr })
+  if (pr.isDraft) return Object.freeze({ status: 'draft', pr })
+
+  if (config.exemptSameRepository && !pr.isCrossRepository) {
+    return Object.freeze({
+      status: 'exempt',
+      pr,
+      exemption: Object.freeze({
+        type: 'same-repository',
+        value: repositoryName,
+      }),
+    })
+  }
+
+  if (
+    config.permissionBypass &&
+    config.exemptAssociations.has(pr.authorAssociation)
+  ) {
+    return Object.freeze({
+      status: 'exempt',
+      pr,
+      exemption: Object.freeze({
+        type: 'association',
+        value: pr.authorAssociation,
+      }),
+    })
+  }
+
+  const login = pr.author?.login?.toLowerCase()
+  if (login && config.exemptLogins.has(login)) {
+    return Object.freeze({
+      status: 'exempt',
+      pr,
+      exemption: Object.freeze({ type: 'login', value: login }),
+    })
+  }
+
+  const issue = findQualifyingIssue(pr, config, repositoryName)
+  if (issue) return Object.freeze({ status: 'verified', pr, issue })
+  return Object.freeze({ status: 'unverified', pr })
+}
+
+function pendingBody(config, since) {
+  const days = config.graceHours / 24
+  const duration = Number.isInteger(days) ? `${days} days` : `${config.graceHours} hours`
+  return `${POLICY_MARKER}
+<!-- pr-issue-policy:pending-since=${since} -->
+Thanks for contributing to dlt!
+
+We ask new contributors to open pull requests only for issues labeled \`${config.authorizingIssueLabel}\`. To link the issue you’re addressing, add \`Closes #123\` to the pull request description, replacing \`123\` with the issue number. You can also ask a maintainer to link the issue through GitHub’s Development sidebar.
+
+We’ll periodically check whether the linked issue is still open and has the required label. If this pull request remains unverified for ${duration}, it may be closed automatically.`
+}
+
+function resolvedBody(config, issueNumber) {
+  return `${POLICY_MARKER}
+This pull request now references eligible issue #${issueNumber}. The \`${config.pendingLabel}\` classification has been replaced with \`${config.verifiedLabel}\`.`
+}
+
+function closedBody() {
+  return `${CLOSED_MARKER}
+This pull request has been automatically closed because it remained unverified for too long. It may be reopened after it references an eligible issue.`
+}
+
+async function setClassificationLabels(api, config, number, classification) {
+  if (classification === 'verified') {
+    await api.removeLabel(number, config.pendingLabel)
+    await api.addLabel(number, config.verifiedLabel)
+    return
+  }
+  if (classification === 'unverified') {
+    await api.removeLabel(number, config.verifiedLabel)
+    await api.addLabel(number, config.pendingLabel)
+    return
+  }
+  if (classification === 'exempt') {
+    await api.removeLabel(number, config.pendingLabel)
+    await api.removeLabel(number, config.verifiedLabel)
+    return
+  }
+  throw new Error(`Unsupported label classification '${classification}'`)
+}
+
+async function markUnverified(api, config, number, apply, now) {
+  const comment = await api.findGitHubActionsCommentContaining(number, POLICY_MARKER)
+  const existingSince = comment?.body?.match(PENDING_MARKER_PATTERN)?.[1]
+  if (existingSince) {
+    if (apply) await setClassificationLabels(api, config, number, 'unverified')
+    return existingSince
+  }
+
+  const since = new Date(now()).toISOString()
+  if (!apply) return since
+
+  await setClassificationLabels(api, config, number, 'unverified')
+  if (comment) {
+    await api.updateComment(comment.id, pendingBody(config, since))
+  } else {
+    await api.createComment(number, pendingBody(config, since))
+  }
+  return since
+}
+
+async function markVerified(api, config, number, issueNumber, apply) {
+  if (!apply) return
+  await setClassificationLabels(api, config, number, 'verified')
+  const comment = await api.findGitHubActionsCommentContaining(number, POLICY_MARKER)
+  if (!comment?.body?.match(PENDING_MARKER_PATTERN)) return
+  await api.updateComment(comment.id, resolvedBody(config, issueNumber))
+}
+
+function exemptionReason(exemption) {
+  if (exemption.type === 'same-repository') {
+    return `source branch belongs to ${exemption.value}`
+  }
+  if (exemption.type === 'association') {
+    return `author association ${exemption.value} is configured for permission bypass`
+  }
+  return `author @${exemption.value} is listed in PR_EXEMPT_LOGINS`
+}
+
+function skippedReason(status) {
+  if (status === 'missing') return 'the pull request was not returned by GitHub'
+  if (status === 'closed') return 'the pull request is not open'
+  if (status === 'draft') return 'draft pull requests are outside the policy'
+  return `unsupported classification '${status}'`
+}
+
+async function reconcilePullRequest(dependencies, number, apply) {
+  const { api, config, core, now, repositoryName } = dependencies
+  const pr = await api.getPullRequest(number)
+  const result = classifyPullRequest(pr, config, repositoryName)
+
+  if (result.status === 'verified') {
+    await markVerified(api, config, number, result.issue.number, apply)
+    core.info(
+      `PR #${number} is verified: linked issue #${result.issue.number} is open and labeled '${config.authorizingIssueLabel}'`,
+    )
+    return result
+  }
+
+  if (result.status === 'exempt') {
+    if (apply) await setClassificationLabels(api, config, number, 'exempt')
+    core.info(`PR #${number} is exempt: ${exemptionReason(result.exemption)}`)
+    return result
+  }
+
+  if (result.status !== 'unverified') {
+    core.info(`Skipping PR #${number}: ${skippedReason(result.status)}`)
+    return result
+  }
+
+  const pendingSince = await markUnverified(api, config, number, apply, now)
+  core.info(
+    `PR #${number} is unverified since ${pendingSince}: no linked open issue in ${repositoryName} has label '${config.authorizingIssueLabel}'`,
+  )
+  return Object.freeze({ ...result, pendingSince })
+}
+
+function expirationTime(pendingSince, graceHours) {
+  const timestamp = Date.parse(pendingSince)
+  if (Number.isNaN(timestamp)) {
+    throw new Error(`Invalid pending timestamp: ${pendingSince}`)
+  }
+  return timestamp + graceHours * HOUR_IN_MS
+}
+
+function isExpired(pendingSince, graceHours, now) {
+  return now() >= expirationTime(pendingSince, graceHours)
+}
+
+async function sweep(dependencies) {
+  const { api, config, core, now } = dependencies
+  const candidates = await api.listPullRequestsWithLabel(config.pendingLabel)
+  core.info(
+    `Starting ${config.dryRun ? 'dry-run ' : ''}sweep: found ${candidates.length} open PRs labeled '${config.pendingLabel}'`,
+  )
+
+  let selected = 0
+  for (const candidate of candidates) {
+    const result = await reconcilePullRequest(dependencies, candidate.number, !config.dryRun)
+    if (result.status !== 'unverified') continue
+    if (!isExpired(result.pendingSince, config.graceHours, now)) {
+      const closesAfter = new Date(
+        expirationTime(result.pendingSince, config.graceHours),
+      ).toISOString()
+      core.info(`PR #${candidate.number} remains in its grace period until ${closesAfter}`)
+      continue
+    }
+    if (selected >= config.maxClose) {
+      core.warning(`Reached max-close limit of ${config.maxClose}`)
+      break
+    }
+
+    // Re-read immediately before closing to avoid acting on stale sweep data.
+    const finalPr = await api.getPullRequest(candidate.number)
+    const finalResult = classifyPullRequest(
+      finalPr,
+      config,
+      dependencies.repositoryName,
+    )
+    if (finalResult.status !== 'unverified') {
+      core.info(`PR #${candidate.number} changed classification before closure; skipping`)
+      continue
+    }
+
+    selected++
+    if (config.dryRun) {
+      core.warning(`[dry-run] Would close PR #${candidate.number}`)
+      continue
+    }
+
+    await api.createComment(candidate.number, closedBody())
+    await api.closePullRequest(candidate.number)
+    core.info(`Closed PR #${candidate.number}`)
+  }
+
+  core.info(`${config.dryRun ? 'Selected' : 'Closed'} ${selected} PRs`)
+}
+
+async function run({ github, context, core, env = process.env, now = Date.now }) {
+  const config = loadConfig(env, context.eventName)
+  const repositoryName = `${context.repo.owner}/${context.repo.repo}`.toLowerCase()
+  const api = createGitHubApi(github, context.repo)
+  const dependencies = Object.freeze({ api, config, core, now, repositoryName })
+
+  core.info(
+    `Same-repository bypass ${config.exemptSameRepository ? 'enabled' : 'disabled'}`,
+  )
+
+  if (config.permissionBypass) {
+    const associations = [...config.exemptAssociations].join(', ') || '(none)'
+    core.info(`Permission bypass enabled for author associations: ${associations}`)
+  } else {
+    core.info('Permission bypass disabled; author associations are evaluated normally')
+  }
+
+  if (config.exemptLogins.size > 0) {
+    core.info(`Explicit login exemptions: ${[...config.exemptLogins].map((login) => `@${login}`).join(', ')}`)
+  }
+
+  await api.ensureLabels([
+    config.authorizingIssueLabel,
+    config.pendingLabel,
+    config.verifiedLabel,
+  ])
+
+  // pull request target
+  if (context.eventName === 'pull_request_target') {
+    const number = context.payload.pull_request.number
+    core.info(`Handling pull_request_target '${context.payload.action}' for PR #${number}`)
+    await reconcilePullRequest(dependencies, number, true)
+    return
+  }
+
+  // manual dispatch with PR number
+  if (config.dispatchPrNumber !== null) {
+    core.info(
+      `Handling ${config.dryRun ? 'dry-run ' : ''}manual reclassification for PR #${config.dispatchPrNumber}`,
+    )
+    await reconcilePullRequest(dependencies, config.dispatchPrNumber, !config.dryRun)
+    return
+  }
+
+  // periodic sweep
+  await sweep(dependencies)
+}
+
+module.exports = {
+  classifyPullRequest,
+  loadConfig,
+  run,
+}

--- a/.github/scripts/pr-issue-policy.js
+++ b/.github/scripts/pr-issue-policy.js
@@ -63,7 +63,6 @@ function loadConfig(env) {
     pendingLabel,
     verifiedLabel,
     graceHours: requirePositiveNumber(env, 'GRACE_HOURS'),
-    permissionBypass: requireBoolean(env, 'PERMISSION_BYPASS'),
     exemptSameRepository: requireBoolean(env, 'EXEMPT_SAME_REPOSITORY'),
     exemptAssociations: csvSet(env.EXEMPT_ASSOCIATIONS),
     exemptLogins: csvSet(env.EXEMPT_LOGINS, true),
@@ -97,10 +96,7 @@ function classifyPullRequest(pr, config, repositoryName) {
     })
   }
 
-  if (
-    config.permissionBypass &&
-    config.exemptAssociations.has(pr.authorAssociation)
-  ) {
+  if (config.exemptAssociations.has(pr.authorAssociation)) {
     return Object.freeze({
       status: 'exempt',
       pr,
@@ -313,12 +309,8 @@ async function run({ github, context, core, env = process.env, now = Date.now })
     `Same-repository bypass ${config.exemptSameRepository ? 'enabled' : 'disabled'}`,
   )
 
-  if (config.permissionBypass) {
-    const associations = [...config.exemptAssociations].join(', ') || '(none)'
-    core.info(`Permission bypass enabled for author associations: ${associations}`)
-  } else {
-    core.info('Permission bypass disabled; author associations are evaluated normally')
-  }
+  const associations = [...config.exemptAssociations].join(', ') || '(none)'
+  core.info(`Author association exemptions: ${associations}`)
 
   if (config.exemptLogins.size > 0) {
     core.info(`Explicit login exemptions: ${[...config.exemptLogins].map((login) => `@${login}`).join(', ')}`)

--- a/.github/workflows/pr-issue-policy.yml
+++ b/.github/workflows/pr-issue-policy.yml
@@ -1,0 +1,64 @@
+name: PR issue policy
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review]
+  schedule:
+    # recheck periodically (random minute to avoid congestion)
+    - cron: "39 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log actions without changing or closing PRs
+        type: boolean
+        default: true
+      max-close:
+        description: Maximum PRs to close during this run
+        type: number
+        default: 25
+      pr-number:
+        description: Reclassify only this PR (useful after manually linking an issue)
+        type: number
+        required: false
+
+concurrency:
+  group: pr-issue-policy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      AUTHORIZING_ISSUE_LABEL: 'help wanted'
+      PENDING_PR_LABEL: 'unverified'
+      VERIFIED_PR_LABEL: 'issue-approved'
+      GRACE_HOURS: ${{ vars.PR_GRACE_HOURS || '168' }}
+      DEFAULT_MAX_CLOSE: ${{ vars.PR_MAX_CLOSE || '25' }}
+      DISPATCH_MAX_CLOSE: ${{ inputs['max-close'] }}
+      DRY_RUN: ${{ inputs['dry-run'] || false }}
+      DISPATCH_PR_NUMBER: ${{ inputs['pr-number'] }}
+      PERMISSION_BYPASS: ${{ vars.PR_PERMISSION_BYPASS || 'true' }}
+      EXEMPT_SAME_REPOSITORY: 'true'
+      EXEMPT_ASSOCIATIONS: 'OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR'
+      EXEMPT_LOGINS: ${{ vars.PR_EXEMPT_LOGINS || '' }}
+    steps:
+      - name: Check out trusted policy code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Enforce issue approval policy
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const policyPath = `${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-issue-policy.js`
+            const { run } = require(policyPath)
+            await run({ github, context, core, env: process.env })

--- a/.github/workflows/pr-issue-policy.yml
+++ b/.github/workflows/pr-issue-policy.yml
@@ -43,7 +43,6 @@ jobs:
       DISPATCH_MAX_CLOSE: ${{ inputs['max-close'] }}
       DRY_RUN: ${{ inputs['dry-run'] || false }}
       DISPATCH_PR_NUMBER: ${{ inputs['pr-number'] }}
-      PERMISSION_BYPASS: ${{ vars.PR_PERMISSION_BYPASS || 'true' }}
       EXEMPT_SAME_REPOSITORY: 'true'
       EXEMPT_ASSOCIATIONS: 'OWNER,MEMBER,COLLABORATOR,CONTRIBUTOR'
       EXEMPT_LOGINS: ${{ vars.PR_EXEMPT_LOGINS || '' }}


### PR DESCRIPTION
General structure of the script: 
```text
   run
   ├─ loadConfig
   ├─ reconcilePullRequest  // main classification logic lies here
   │  ├─ classifyPullRequest
   │  └─ markVerified / markUnverified
   │     └─ setClassificationLabels
   └─ sweep
      └─ reconcilePullRequest
 ```

Things to especially double check:
- default configuration we have now (e.g. 7 days until auto close...)
- wording in messages