### PR TITLE
Dcs/move plaoyground workspace

### DIFF
--- a/docs/website/docs/hub/getting-started/installation.md
+++ b/docs/website/docs/hub/getting-started/installation.md
@@ -42,7 +42,7 @@ If you don't have `uv` yet, either [install it first](#setting-up-your-environme
 pipx run dlthub-start
 ```
 
-Either way, it runs a guided first experience — it scaffolds the workspace, installs `dlt[hub]` and dependencies with `uv sync`, logs you in to the dltHub platform, connects your personal [Playground workspace](playground-workspace.md), then prompts you to pick a coding agent (Claude / Cursor / Codex) and launches it. Your agent deploys and runs the sample pipeline, then is ready to build your own source.
+Either way, it runs a guided first experience — it scaffolds the workspace, installs `dlt[hub]` and dependencies with `uv sync`, logs you in to the dltHub platform, connects your personal [Playground workspace](../pipeline-operations/playground-workspace.md), then prompts you to pick a coding agent (Claude / Cursor / Codex) and launches it. Your agent deploys and runs the sample pipeline, then is ready to build your own source.
 
 :::tip
 Run `dlthub-start` yourself with no arguments — it's interactive and guides you through each step. It scaffolds into your current folder, so the AI skills land right where your coding agent is open. For a walkthrough of the whole flow, see [Deploy your first pipeline](onboarding.md).

--- a/docs/website/docs/hub/getting-started/introduction.md
+++ b/docs/website/docs/hub/getting-started/introduction.md
@@ -20,7 +20,7 @@ Use of the dltHub platform and toolkits is subject to a commercial [dltHub Licen
 uvx dlthub-start@latest
 ```
 
-Runs a guided first experience: it scaffolds a local workspace (dltHub AI Workbench + `dlt[hub]`), installs dependencies, logs you in to the dltHub platform, connects your personal [Playground workspace](playground-workspace.md), and launches your coding agent — which then deploys and runs the sample pipeline for you. Follow it step by step in [Deploy your first pipeline](onboarding.md), and see [installation](installation.md) for prerequisites and alternative install paths.
+Runs a guided first experience: it scaffolds a local workspace (dltHub AI Workbench + `dlt[hub]`), installs dependencies, logs you in to the dltHub platform, connects your personal [Playground workspace](../pipeline-operations/playground-workspace.md), and launches your coding agent — which then deploys and runs the sample pipeline for you. Follow it step by step in [Deploy your first pipeline](onboarding.md), and see [installation](installation.md) for prerequisites and alternative install paths.
 
 On the [dltHub platform](../pipeline-operations/overview.md), set `destination="playground"` for a [zero-config destination](../ingestion/playground.md) that is ideal for testing and a quick first run.
 

--- a/docs/website/docs/hub/getting-started/onboarding.md
+++ b/docs/website/docs/hub/getting-started/onboarding.md
@@ -20,7 +20,7 @@ project into a dltHub workspace.
 - **Python 3.10–3.14** and [uv](https://docs.astral.sh/uv/) (recommended). See [Installation](installation.md) for
   alternatives.                               
 - **A coding agent**: Claude Code, Cursor, or Codex.                                                 
-- **A GitHub, Google, or email login.** `dlthub-start` uses OAuth 2.0 (GitHub, Google, or email) to sign you in and creates your dltHub account on first login. You automatically get a [Playground workspace](playground-workspace.md), so you don't need to configure cloud credentials to complete this guide.
+- **A GitHub, Google, or email login.** `dlthub-start` uses OAuth 2.0 (GitHub, Google, or email) to sign you in and creates your dltHub account on first login. You automatically get a [Playground workspace](../pipeline-operations/playground-workspace.md), so you don't need to configure cloud credentials to complete this guide.
 
 dltHub is commercial. Use is governed by the [license](../license.md). 
 
@@ -79,7 +79,7 @@ starter-test/
 └── .claude/            # agent toolkits: skills + MCP server (or .cursor/ / .codex/)
 ```
 
-`pipeline.py` loads the Sample Shop dataset from a public sample REST API into the platform-managed [Playground destination](../getting-started/playground-workspace.md). No warehouse, bucket, or credentials are required.
+`pipeline.py` loads the Sample Shop dataset from a public sample REST API into the platform-managed [Playground destination](../ingestion/playground.md). No warehouse, bucket, or credentials are required.
 
 The pipeline is decorated with `@run.pipeline` and registered as a deployable job in `__deployment__.py`. See [Deployments](../pipeline-operations/deployments.md) for how the manifest works.
 
@@ -152,7 +152,7 @@ To run jobs locally instead, use `dlthub run local`. Local runs use the `dev` [P
 
 The Playground destination is great for testing but isn't meant for production. For real data, you'll want to load into a destination you own.
 
-You can use profiles to run the same pipeline with different destinations and credentials in development and production. See [Workspace setup](../getting-started/playground-workspace.md) and [Profiles](../pipeline-operations/profiles) for the complete configuration.
+You can use profiles to run the same pipeline with different destinations and credentials in development and production. See [Workspace setup](../pipeline-operations/workspace-setup.md) and [Profiles](../pipeline-operations/profiles) for the complete configuration.
 
 Set the destination on the `dlt.pipeline` inside your decorated job. Use a [named destination](../../general-usage/destination.md#use-named-destinations) such as `warehouse` so that the same pipeline code can run against different destinations in `dev` and `prod` profile:
 

--- a/docs/website/docs/hub/pipeline-operations/playground-workspace.md
+++ b/docs/website/docs/hub/pipeline-operations/playground-workspace.md
@@ -10,13 +10,13 @@ keywords: [playground, workspace, onboarding, dlthub platform, profiles]
 
 The **Playground workspace** is a regular dltHub [workspace](../getting-started/installation.md#what-is-a-dlthub-workspace) that the platform creates for you automatically when you create your account, so you always have somewhere to try dltHub without setting one up yourself. It is personal (single-member) and, unlike other workspaces, cannot be renamed or deleted.
 
-When you run `uvx dlthub-start`, it connects your local project to this workspace and provides a sample pipeline that loads to the [Playground destination](../ingestion/playground.md), so data lands on dltHub-managed storage with no warehouse, bucket, or credentials to configure. See [Deploy your first pipeline](onboarding.md) for the full flow.
+When you run `uvx dlthub-start`, it connects your local project to this workspace and provides a sample pipeline that loads to the [Playground destination](../ingestion/playground.md), so data lands on dltHub-managed storage with no warehouse, bucket, or credentials to configure. See [Deploy your first pipeline](../getting-started/onboarding.md) for the full flow.
 
 ## When to use it
 
 Use the Playground workspace to get started with dltHub:
 
-* Complete [onboarding](onboarding.md) and the guided tour (`uvx dlthub-start`).
+* Complete [onboarding](../getting-started/onboarding.md) and the guided tour (`uvx dlthub-start`).
 * Learn how dltHub works: deployments, cloud runs, and the dashboard.
 * Run examples, paired with the [Playground destination](../ingestion/playground.md) so you can load and explore data without any setup.
 
@@ -41,7 +41,7 @@ Any organization **Member** can create workspaces; **Owners** additionally manag
 
 ## Next steps
 
-* [Workspace setup](../pipeline-operations/workspace-setup.md): configure destinations, config, and secrets.
-* [Profiles](../pipeline-operations/profiles.md): target different destinations from the same code.
-* [Deployments](../pipeline-operations/deployments.md): declare jobs and run them on the platform.
+* [Workspace setup](workspace-setup.md): configure destinations, config, and secrets.
+* [Profiles](profiles.md): target different destinations from the same code.
+* [Deployments](deployments.md): declare jobs and run them on the platform.
 * [Users and roles](../platform-capabilities/users-and-roles.md): invite teammates and manage access.

--- a/docs/website/docs/hub/pipeline-operations/what-is-a-workspace.md
+++ b/docs/website/docs/hub/pipeline-operations/what-is-a-workspace.md
@@ -1,0 +1,42 @@
+---
+title: What is a workspace
+description: A dltHub workspace bundles pipelines, configuration, and AI toolkit into a single deployable unit that runs locally and in the cloud.
+keywords: [workspace, dlthub, workspace mode, dlt project, profiles, deployment]
+---
+
+# What is a workspace?
+
+A workspace is a Python project layout that bundles your dlt pipelines, transformations, configuration, and AI toolkit setup into a single deployable unit. The same folder runs on your local machine, in CI, and — when you deploy — on the managed dltHub platform, so what you build locally is what runs in production.
+
+
+A workspace is where you:
+
+- Connect a local repo to a remote workspace on dltHub (`dlthub workspace connect`)
+- Configure [destinations](../../dlt-ecosystem/destinations/index.md), config, and secrets (often via [profiles](profiles.md) like `dev`, `prod`, `access`)
+- Create and manage pipelines, [deployments](deployments.md), jobs/runs, logs, and notebooks
+- Control access via [workspace roles](../platform-capabilities/users-and-roles.md) (owner, developer, viewer)
+
+When you create an account, dltHub automatically creates a personal [Playground workspace](playground-workspace.md) so you can try things without any setup.
+
+
+Every workspace contains:
+
+- **`.dlt/.workspace`** — a marker file that activates the `dlthub` CLI, [profile support](profiles.md), and the managed-platform commands. Without this file you're using plain OSS `dlt`.
+- **`.dlt/config.toml`** and **`.dlt/secrets.toml`** — settings and credentials, with optional per-profile overrides (`dev`, `prod`, `tests`, `access`).
+- **`pyproject.toml`** (or `requirements.txt`) — workspace-level dependencies like `dlt[hub]`, `duckdb`, `marimo`.
+- **Pipeline files** and an optional **`__deployment__.py`** manifest — the code you run, and the description of how it's deployed.
+- **AI toolkit configuration** — skills, rules, and MCP wiring for Claude Code, Cursor, or Codex (added when you opt in during scaffolding).
+
+
+## Creating a workspace
+
+```sh
+uv run dlthub login
+uv run dlthub workspace connect "<name>" --create
+```
+
+## Next steps
+
+* [Workspace setup](workspace-setup.md): convert a Python project into a workspace and configure credentials.
+* [The Playground workspace](playground-workspace.md): the auto-created workspace for trying dltHub.
+* [Profiles](profiles.md): target different destinations from the same code.

--- a/docs/website/docs/hub/pipeline-operations/what-is-a-workspace.md
+++ b/docs/website/docs/hub/pipeline-operations/what-is-a-workspace.md
@@ -35,6 +35,12 @@ uv run dlthub login
 uv run dlthub workspace connect "<name>" --create
 ```
 
+When you [deploy](deployments.md), all files from your local project directory are mirrored to the remote workspace on the dltHub platform. To exclude files you don't want deployed (temp directories, data/state directories, local IDE files), list them in `.gitignore`. Files not excluded can cause deployments to fail with:
+
+```text
+Upload failed (HTTP 413): {"status_code":413,"detail":"Request Entity Too Large"}
+```
+
 ## Next steps
 
 * [Workspace setup](workspace-setup.md): convert a Python project into a workspace and configure credentials.

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -481,7 +481,6 @@ const sidebars = {
         "hub/getting-started/oss-and-dlthub",
         "hub/getting-started/installation",
         "hub/getting-started/onboarding",
-        "hub/getting-started/playground-workspace",
       ],
     },
     {
@@ -517,7 +516,15 @@ const sidebars = {
       label: "Pipeline operations",
       items: [
         "hub/pipeline-operations/overview",
-        "hub/pipeline-operations/workspace-setup",
+        {
+          type: "category",
+          label: "Workspaces",
+          items: [
+            "hub/pipeline-operations/what-is-a-workspace",
+            "hub/pipeline-operations/workspace-setup",
+            "hub/pipeline-operations/playground-workspace",
+          ],
+        },
         "hub/pipeline-operations/profiles",
         "hub/pipeline-operations/secrets-management",
         "hub/pipeline-operations/deployments",


### PR DESCRIPTION
Move `playground-workspace.md` to `pipeline-operations` and restructure `workspace` section:

```
Pipeline operations:
 - Workspaces:
    - What is a workspace
    - Workspace setup
    - Playground workspace
```
