### PR TITLE
Feat/3269 snowflake workload identity provider

### DIFF
--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -31,6 +31,7 @@ class SnowflakeCredentialsWithoutDefaults(ConnectionStringCredentials):
     role: Optional[str] = None
     authenticator: Optional[str] = None
     token: Optional[str] = None
+    workload_identity_provider: Optional[str] = None
     private_key: Optional[TSecretStrValue] = None
     private_key_path: Optional[str] = None
     private_key_passphrase: Optional[TSecretStrValue] = None
@@ -52,6 +53,7 @@ class SnowflakeCredentialsWithoutDefaults(ConnectionStringCredentials):
         "role",
         "authenticator",
         "token",
+        "workload_identity_provider",
         "private_key",
         "private_key_path",
         "private_key_passphrase",

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -145,6 +145,19 @@ or
 destination.snowflake.credentials="snowflake:///dlt_data?authenticator=oauth"  # host and token not specified
 ```
 
+In **Workload Identity Federation (WIF)** authentication, set `authenticator` to
+`WORKLOAD_IDENTITY` and pass `workload_identity_provider` as `AWS`, `AZURE`, `GCP`,
+or `OIDC`. For `OIDC`, also set `token`. Requires `snowflake-connector-python>=3.17.0`.
+See [Snowflake WIF](https://docs.snowflake.com/en/user-guide/workload-identity-federation).
+
+```toml
+[destination.snowflake.credentials]
+database = "dlt_data"
+host = "kgiotue-wn98412"
+authenticator = "WORKLOAD_IDENTITY"
+workload_identity_provider = "AWS"
+```
+
 ### Additional connection options
 
 We pass all query parameters to the `connect` function of the Snowflake Python Connector. For example:

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -152,6 +152,29 @@ def test_only_authenticator() -> None:
     }
 
 
+def test_workload_identity_provider() -> None:
+    c = resolve_configuration(
+        SnowflakeCredentialsWithoutDefaults(
+            "snowflake://host1/db1?authenticator=WORKLOAD_IDENTITY"
+            "&workload_identity_provider=AWS&warehouse=wh1"
+        )
+    )
+    assert c.authenticator == "WORKLOAD_IDENTITY"
+    assert c.workload_identity_provider == "AWS"
+    assert c.warehouse == "wh1"
+    assert c.to_connector_params() == {
+        "timezone": "UTC",
+        "authenticator": "WORKLOAD_IDENTITY",
+        "workload_identity_provider": "AWS",
+        "warehouse": "wh1",
+        "user": None,
+        "password": None,
+        "account": "host1",
+        "database": "db1",
+        "application": "dltHub_dlt",
+    }
+
+
 # def test_no_query(environment) -> None:
 #     c = SnowflakeCredentialsWithoutDefaults("snowflake://user1:pass1@host1/db1")
 #     assert str(c.to_url()) == "snowflake://user1:pass1@host1/db1"


### PR DESCRIPTION
Description
Adds support for Snowflake Workload Identity Federation by accepting workload_identity_provider as a first-class credentials field (and connection-string query param). It is forwarded to the Snowflake connector via to_connector_params(), so users can set authenticator=WORKLOAD_IDENTITY with a provider such as AWS, AZURE, GCP, or OIDC.

Includes a unit test covering URL resolve → connector params, and a short WIF note in the Snowflake destination docs.

Related Issues
Fixes #3269
Additional Context
Requires snowflake-connector-python>=3.17.0 for WIF (documented; dependency not bumped in this PR).
Local check: tests/load/snowflake/test_snowflake_configuration.py — 28 passed.