### PR TITLE
ci(agentic-docs): pass the Actions run URL to the job

### DIFF
--- a/.github/workflows/agentic-docs.yml
+++ b/.github/workflows/agentic-docs.yml
@@ -58,8 +58,8 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     # Label events must carry both labels. Comment events must look like a
-    # command, and may be on either an issue (`/position`, before any PR exists)
-    # or a pull request (`/revise`, which is where maintainers review).
+    # command, and must be on a pull request — `/revise`, which is where
+    # maintainers review. Nothing a comment says starts a run on an issue.
     #
     # GitHub models PR comments as issue comments, so for a comment on a PR
     # `github.event.issue.number` is the PR number, not the issue's. The step
@@ -103,7 +103,8 @@ jobs:
     #
     # `/position` is deliberately absent. It sets the location and nothing else;
     # arming is the label's job, so a `/position` comment on an unlabelled issue no
-    # longer starts a job.
+    # longer starts a job. The generation run reads it out of the issue's comments
+    # instead — which is why it must be posted before the label goes on.
     if: |
       (github.event_name == 'issues' &&
        github.event.label.name == 'agent' &&
@@ -166,14 +167,13 @@ jobs:
       # Exactly one of ISSUE_NUMBER / PR_NUMBER is set, and both are numbers:
       #
       #   labelled issue        ISSUE_NUMBER, no COMMENT_ID  -> generation
-      #   comment on an issue   ISSUE_NUMBER + COMMENT_ID    -> /position
       #   comment on a PR       PR_NUMBER + COMMENT_ID       -> /revise
       #   review on a PR        PR_NUMBER + REVIEW_ID        -> /revise
       #
       # `github.event.issue.pull_request` is present only for a comment on a PR,
-      # which is how the two comment cases are told apart. A review event has no
-      # `issue` at all — its number is on `pull_request` — so it is handled
-      # separately rather than folded into the same expression.
+      # which is how a comment that reaches here is known to be one. A review
+      # event has no `issue` at all — its number is on `pull_request` — so it is
+      # handled separately rather than folded into the same expression.
       #
       # Only numeric IDs cross this boundary. The job fetches the comment or
       # review text itself, so nothing a stranger wrote passes through this shell.
@@ -197,6 +197,10 @@ jobs:
           # this file could send any name. Authorisation is settled by asking
           # GitHub who wrote the artifact the run is reacting to.
           ACTOR: ${{ github.actor }}
+          # Linked from the "process triggered" comment the job posts on the issue,
+          # so whoever labelled it can watch. Safe in the comma-separated list
+          # below: an Actions run URL contains no comma.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           if [[ "$IS_REVIEW" == "true" ]]; then
@@ -206,6 +210,7 @@ jobs:
           else
             target="ISSUE_NUMBER=${ISSUE_NUMBER},COMMENT_ID=${COMMENT_ID},ACTOR=${ACTOR}"
           fi
+          target="${target},RUN_URL=${RUN_URL}"
           gcloud run jobs execute agentic-docs \
             --region=europe-west3 \
             --update-env-vars="${target}" \


### PR DESCRIPTION
## What

Adds one variable to the `agentic-docs` trigger workflow: `RUN_URL`, built from `github.run_id`.

## Why

The docs bot now comments on an issue as soon as a run starts, so whoever applied the labels can see that something is happening — before this, a labelled issue showed nothing at all for the 15–25 minutes until the pull request appeared, and the only notification went to `#doc-alerts`, a channel rather than a person.

That comment links the Actions run, which means the job has to be told where the run is. GitHub does not pass it in, hence this variable.

```
Agentic docs process triggered. You will be notified here and in Slack.

You can check the logs here.
```

Without `RUN_URL` the job omits the link and posts only the first line, so this is additive — nothing breaks if it is not merged.

## Safety

Nothing attacker-controlled crosses the boundary. The URL is assembled from the run's own id, not from anything a commenter wrote, and an Actions run URL contains no comma, so it is safe inside the comma-separated `--update-env-vars` list.

## Also in this diff

Three comments that still described older behaviour, where a `/position` comment on an issue started a run. It no longer does — arming is the labels' job, and the generation run reads `/position` out of the issue's comments instead. **The `if:` condition itself is unchanged**; only a labelled issue, or a comment or review on one of the bot's own pull requests, triggers anything.

The workflow is vendored in the bot's repository so that it owns the trigger contract it depends on, and a test there pins this variable to the driver that consumes it.