### PR TITLE
Docs/add environment variables docs

### DIFF
--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "dlt"
-version = "1.30.0a0"
+version = "1.30.0"
 source = { editable = "../" }
 dependencies = [
     { name = "click" },
@@ -956,7 +956,7 @@ requires-dist = [
     { name = "db-dtypes", marker = "extra == 'bigquery'", specifier = ">=1.2.0" },
     { name = "db-dtypes", marker = "extra == 'gcp'", specifier = ">=1.2.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=0.25.1" },
-    { name = "dlthub", marker = "extra == 'hub'", specifier = ">=0.29.0,<0.31" },
+    { name = "dlthub", marker = "extra == 'hub'", specifier = ">=0.30.0a1,<0.31" },
     { name = "dlthub-client", marker = "extra == 'hub'", specifier = ">=0.28.1" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
     { name = "duckdb", marker = "extra == 'ducklake'", specifier = ">=1.2.0" },
@@ -1257,16 +1257,16 @@ hub = [{ name = "dlt", extras = ["hub"], editable = "../" }]
 
 [[package]]
 name = "dlthub"
-version = "0.29.0"
+version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/58/155eeebd831c402127289ff6d97dcb0e7cf0072c753470098e71b46952e8/dlthub-0.29.0.tar.gz", hash = "sha256:60e514446747d6e7a9005e74a71b2ccfa3759ba822af7515a40ac34b0afd47f2", size = 170583, upload-time = "2026-07-10T13:21:28.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/16/7ba6ca3b3be3212cd13225f614fba9b654719a858a40e6dd6824a346e072/dlthub-0.30.0.tar.gz", hash = "sha256:6b13c732ad81fc2e96d629a0e7f45f9d1cb4b8a5f230256cb1ef6d5b6b2bec1a", size = 173007, upload-time = "2026-08-11T12:20:33.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/89/6daedf3a2d78324ae153d4b23307663d01e06439679dd6e2015bf15af799/dlthub-0.29.0-py3-none-any.whl", hash = "sha256:1f96df548d290bd62712eeaa35e8d89bff05ef027b19e31ebb86cab74d21ceb5", size = 227905, upload-time = "2026-07-10T13:21:29.786Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b2/ac1c1cea00bc7808d1a05649207d126d5e4694595327c2e685fda26ae110/dlthub-0.30.0-py3-none-any.whl", hash = "sha256:205d52ef8b10e8b613b90df9c6c73911a2eff3cb5f5f07747d7f140db83747e0", size = 230487, upload-time = "2026-08-11T12:20:34.948Z" },
 ]
 
 [[package]]
 name = "dlthub-client"
-version = "0.28.1"
+version = "0.28.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1277,9 +1277,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/87/53412615805aadf53d3c95e9d94e7f703b33a8fe8f441ff3bf9d73e0f7ea/dlthub_client-0.28.1.tar.gz", hash = "sha256:2a47d950aa5e1ba77409655b2cecb5f3e626a2964a3952fb32a9d3292e6ba1db", size = 146048, upload-time = "2026-07-07T11:09:04.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/02/97cac28340139106ba4b15f4402152d96ac2b3e30a70b0b903d1f4d3c90e/dlthub_client-0.28.2.tar.gz", hash = "sha256:2505c2f598e0528923d1275520df4a69a48825276b3e1be151568d992340c82c", size = 172345, upload-time = "2026-08-07T20:21:55.998Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/93/453841023154ef23d8def64cc4d48ee4e61a76451303a3046fe405230bb6/dlthub_client-0.28.1-py3-none-any.whl", hash = "sha256:04f7b86181e09db69714ac297ad7fa829c7c939096bbc2a65cb781df511082bf", size = 336690, upload-time = "2026-07-07T11:09:02.927Z" },
+    { url = "https://files.pythonhosted.org/packages/38/34/ed305801559f7927abde53fe39d1fa3f72c262e96466907c602d3e12f550/dlthub_client-0.28.2-py3-none-any.whl", hash = "sha256:fd1a2fb1f44b50ad7aeb0167b27c7a1ada61ab142b298cc4bec00c790b4f9a72", size = 415388, upload-time = "2026-08-07T20:21:54.652Z" },
 ]
 
 [[package]]
@@ -1755,6 +1755,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1765,6 +1766,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1775,6 +1777,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },

--- a/docs/website/docs/hub/command-line-interface.md
+++ b/docs/website/docs/hub/command-line-interface.md
@@ -31,7 +31,7 @@ Creates, adds, inspects and deploys dlt pipelines. Further help is available at 
 ```sh
 dlthub [-h] [-v] [--non-interactive] [-y] [--debug] [--version]
     [--disable-telemetry] [--enable-telemetry] [--no-pwd]
-    {dbt,workspace,show,serve,run,logout,login,job,deploy,profile,pipeline,local,init,ai}
+    {dbt,workspace,variable,show,serve,run,logout,login,job,deploy,dashboard,profile,pipeline,local,init,ai}
     ...
 ```
 
@@ -53,13 +53,15 @@ dlthub [-h] [-v] [--non-interactive] [-y] [--debug] [--version]
 **Available subcommands**
 * [`dbt`](#dlthub-dbt) - Dlthub dbt transformation generator
 * [`workspace`](#dlthub-workspace) - Workspace operations: connect, list, info, show, deploy, deployment, configuration
-* [`show`](#dlthub-show) - Open the dlthub dashboard (alias for `dlthub workspace show`)
+* [`variable`](#dlthub-variable) - Workspace variable operations: list, set, delete
+* [`show`](#dlthub-show) - Open the current workspace in the dlthub web app (alias for `dlthub workspace show`)
 * [`serve`](#dlthub-serve) - Deploy and serve an interactive notebook/app (alias for `dlthub job serve`)
 * [`run`](#dlthub-run) - Deploy code/config and run a script (alias for `dlthub job run`)
 * [`logout`](#dlthub-logout) - Log out from dlthub
 * [`login`](#dlthub-login) - Log in to dlthub (identity only)
-* [`job`](#dlthub-job) - Job operations: list, info, run, serve, trigger, publish, unpublish, logs, cancel, runs
+* [`job`](#dlthub-job) - Job operations: list, info, run, serve, trigger, publish, unpublish, pause, resume, logs, cancel, runs
 * [`deploy`](#dlthub-deploy) - Sync code/config and deploy jobs
+* [`dashboard`](#dlthub-dashboard) - Open the workspace dashboard in the dlthub web app (deploys a default one if missing)
 * [`profile`](#dlthub-profile) - Manage workspace built-in profiles
 * [`pipeline`](#dlthub-pipeline) - Interact with pipelines running in dlthub
 * [`local`](#dlthub-local) - Operations on the local workspace (run, serve, info, show, clean, schema, telemetry, pipeline)
@@ -134,7 +136,7 @@ Workspace operations: connect, list, info, show, deploy, deployment, configurati
 **Usage**
 ```sh
 dlthub workspace [-h] [--timestamps]
-    {list,connect,info,show,deploy,deployment,configuration} ...
+    {list,connect,info,show,dashboard,deploy,deployment,configuration} ...
 ```
 
 **Description**
@@ -155,7 +157,8 @@ Inherits arguments from [`dlthub`](#dlthub).
 * [`list`](#dlthub-workspace-list) - List all workspaces you have access to
 * [`connect`](#dlthub-workspace-connect) - Connects local to a remote workspace by name or id
 * [`info`](#dlthub-workspace-info) - Show overview of current dlthub workspace (workspace, job count, latest run, latest deployment, latest configuration)
-* [`show`](#dlthub-workspace-show) - Open the dlthub dashboard (alias for `dlthub workspace show`)
+* [`show`](#dlthub-workspace-show) - Open the current workspace in the dlthub web app (alias for `dlthub workspace show`)
+* [`dashboard`](#dlthub-workspace-dashboard) - Open the workspace dashboard in the dlthub web app (deploys a default one if missing)
 * [`deploy`](#dlthub-workspace-deploy) - Sync code/config and deploy jobs
 * [`deployment`](#dlthub-workspace-deployment) - Manipulate deployments in the workspace
 * [`configuration`](#dlthub-workspace-configuration) - Manipulate configurations in the workspace
@@ -206,7 +209,7 @@ Connects local and remote workspaces. Jobs, pipelines and code available locally
 Inherits arguments from [`dlthub workspace`](#dlthub-workspace).
 
 **Positional arguments**
-* `workspace` - Workspace name or id to connect to. when omitted interactive picker will allow to select existing or create a new one
+* `workspace` - Workspace name or id to connect to. when omitted interactive picker will allow to select existing or create a new one. required when using an api key.
 
 **Options**
 * `-h, --help` - Show this help message and exit
@@ -241,7 +244,7 @@ Inherits arguments from [`dlthub workspace`](#dlthub-workspace).
 
 ### `dlthub workspace show`
 
-Open the dltHub dashboard (alias for `dlthub workspace show`).
+Open the current workspace in the dltHub web app (alias for `dlthub workspace show`).
 
 **Usage**
 ```sh
@@ -250,7 +253,31 @@ dlthub workspace show [-h]
 
 **Description**
 
-Open link to the dltHub dashboard for current remote workspace.
+Open the workspace overview for the current remote workspace in the browser.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub workspace`](#dlthub-workspace).
+
+**Options**
+* `-h, --help` - Show this help message and exit
+
+</details>
+
+### `dlthub workspace dashboard`
+
+Open the workspace dashboard in the dltHub web app (deploys a default one if missing).
+
+**Usage**
+```sh
+dlthub workspace dashboard [-h]
+```
+
+**Description**
+
+Open the dltHub dashboard for the current remote workspace, deploying a default dashboard if none exists.
 
 <details>
 
@@ -275,7 +302,7 @@ dlthub workspace deploy [-h] [--deployment DEPLOYMENT] [--dry-run]
 
 **Description**
 
-Sync workspace files, generate job manifest from \_\_deployment__.py, and reconcile jobs with the runtime. Use --dry-run to preview changes.
+Sync workspace files, generate job manifest from \_\_deployment\_\_.py, and reconcile jobs with the runtime. Use --dry-run to preview changes.
 
 <details>
 
@@ -285,7 +312,7 @@ Inherits arguments from [`dlthub workspace`](#dlthub-workspace).
 
 **Options**
 * `-h, --help` - Show this help message and exit
-* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment__)
+* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment\_\_)
 * `--dry-run` - Preview changes without applying them
 * `--show-manifest` - Dump the expanded deployment manifest as yaml and exit
 
@@ -329,7 +356,8 @@ List all deployments in workspace.
 
 **Usage**
 ```sh
-dlthub workspace deployment [deployment_version_no] list [-h]
+dlthub workspace deployment                             [deployment_version_no]
+    list [-h]
 ```
 
 **Description**
@@ -353,7 +381,8 @@ Get detailed information about a deployment.
 
 **Usage**
 ```sh
-dlthub workspace deployment [deployment_version_no] info [-h]
+dlthub workspace deployment                             [deployment_version_no]
+    info [-h]
 ```
 
 **Description**
@@ -377,7 +406,8 @@ Create new deployment if local workspace content changed.
 
 **Usage**
 ```sh
-dlthub workspace deployment [deployment_version_no] sync [-h] [--dry-run] [-v]
+dlthub workspace deployment                             [deployment_version_no]
+    sync [-h] [--dry-run] [-v]
 ```
 
 **Description**
@@ -436,7 +466,8 @@ List all configuration versions.
 
 **Usage**
 ```sh
-dlthub workspace configuration [configuration_version_no] list [-h]
+dlthub workspace configuration
+    [configuration_version_no] list [-h]
 ```
 
 **Description**
@@ -460,7 +491,8 @@ Get detailed information about a configuration.
 
 **Usage**
 ```sh
-dlthub workspace configuration [configuration_version_no] info [-h]
+dlthub workspace configuration
+    [configuration_version_no] info [-h]
 ```
 
 **Description**
@@ -484,8 +516,8 @@ Create new configuration if local config content changed.
 
 **Usage**
 ```sh
-dlthub workspace configuration [configuration_version_no] sync [-h] [--dry-run]
-    [-v]
+dlthub workspace configuration
+    [configuration_version_no] sync [-h] [--dry-run] [-v]
 ```
 
 **Description**
@@ -505,9 +537,129 @@ Inherits arguments from [`dlthub workspace configuration`](#dlthub-workspace-con
 
 </details>
 
+## `dlthub variable`
+
+Workspace variable operations: list, set, delete.
+
+**Usage**
+```sh
+dlthub variable [-h] [--timestamps] {list,set,delete} ...
+```
+
+**Description**
+
+Manage workspace variables — plain or secret values injected into every run's environment. Scope them workspace-wide or to a single profile.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub`](#dlthub).
+
+**Options**
+* `-h, --help` - Show this help message and exit
+* `--timestamps` - Show exact iso timestamps and precise durations (e.g. 1.291 s) instead of humanized relative times.
+
+**Available subcommands**
+* [`list`](#dlthub-variable-list) - List variables in every scope, or in one scope
+* [`set`](#dlthub-variable-set) - Create or update one variable
+* [`delete`](#dlthub-variable-delete) - Remove one variable
+
+</details>
+
+### `dlthub variable list`
+
+List variables in every scope, or in one scope.
+
+**Usage**
+```sh
+dlthub variable list [-h] [--profile PROFILE | --workspace]
+```
+
+**Description**
+
+List workspace variables. Without a scope selector every scope is listed, with the profile shown per row. Secret values are masked.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub variable`](#dlthub-variable).
+
+**Options**
+* `-h, --help` - Show this help message and exit
+* `--profile PROFILE` - Target the scope of this profile
+* `--workspace` - Target the workspace-wide scope
+
+</details>
+
+### `dlthub variable set`
+
+Create or update one variable.
+
+**Usage**
+```sh
+dlthub variable set [-h] [--value VALUE] (--plain | --secret) (--profile PROFILE
+    | --workspace) name
+```
+
+**Description**
+
+Create or update a variable. The value is read from stdin unless --value is given, so secrets need not appear in argv or shell history.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub variable`](#dlthub-variable).
+
+**Positional arguments**
+* `name` - Variable name
+
+**Options**
+* `-h, --help` - Show this help message and exit
+* `--value VALUE` - Value to store. omit to read it from stdin
+* `--plain` - Store a readable value
+* `--secret` - Store a write-only value, never shown again
+* `--profile PROFILE` - Target the scope of this profile
+* `--workspace` - Target the workspace-wide scope
+
+</details>
+
+### `dlthub variable delete`
+
+Remove one variable.
+
+**Usage**
+```sh
+dlthub variable delete [-h] [--allow-missing] (--profile PROFILE | --workspace)
+    name
+```
+
+**Description**
+
+Remove a variable from the workspace or a profile scope.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub variable`](#dlthub-variable).
+
+**Positional arguments**
+* `name` - Variable name
+
+**Options**
+* `-h, --help` - Show this help message and exit
+* `--allow-missing` - Treat an absent variable as success instead of an error
+* `--profile PROFILE` - Target the scope of this profile
+* `--workspace` - Target the workspace-wide scope
+
+</details>
+
 ## `dlthub show`
 
-Open the dltHub dashboard (alias for `dlthub workspace show`).
+Open the current workspace in the dltHub web app (alias for `dlthub workspace show`).
 
 **Usage**
 ```sh
@@ -516,7 +668,7 @@ dlthub show [-h]
 
 **Description**
 
-Open link to the dltHub dashboard for current remote workspace.
+Open the workspace overview for the current remote workspace in the browser.
 
 <details>
 
@@ -554,7 +706,7 @@ Inherits arguments from [`dlthub`](#dlthub).
 
 **Options**
 * `-h, --help` - Show this help message and exit
-* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment__)
+* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment\_\_)
 * `--timestamps` - Show exact iso timestamps and precise durations (e.g. 1.291 s) instead of humanized relative times.
 * `-f, --follow` - Stream logs until the app stops
 * `--job-ref REF` - Pick this job from the matched candidate set when the selector matches multiple jobs. errors if ref is not in the matched set.
@@ -586,7 +738,7 @@ Inherits arguments from [`dlthub`](#dlthub).
 
 **Options**
 * `-h, --help` - Show this help message and exit
-* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment__)
+* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment\_\_)
 * `--timestamps` - Show exact iso timestamps and precise durations (e.g. 1.291 s) instead of humanized relative times.
 * `-f, --follow` - Follow status changes and stream logs until the run completes
 * `--refresh` - Re-run from scratch (full reload). cascades to freshness-graph downstream jobs.
@@ -624,12 +776,12 @@ Log in to dltHub (identity only).
 
 **Usage**
 ```sh
-dlthub login [-h] [--resume DEVICE_CODE]
+dlthub login [-h] [--resume DEVICE_CODE] [--device]
 ```
 
 **Description**
 
-Log in to dltHub. Authenticates the current user; does not connect a workspace. Run `dlthub workspace connect` to bind this project to a remote workspace.
+Log in to dltHub. Authenticates the current user; does not connect a workspace. Run `dlthub workspace connect` to bind this project to a remote workspace. Opens your browser to authenticate by default; use `--device` to force the device-code flow (e.g. on a remote session).
 
 <details>
 
@@ -640,17 +792,19 @@ Inherits arguments from [`dlthub`](#dlthub).
 **Options**
 * `-h, --help` - Show this help message and exit
 * `--resume DEVICE_CODE` - Resume a previously started device flow login. the device_code is printed by `dlthub login` when no tty is attached.
+* `--device` - Force the device authorization flow instead of the default browser loopback login.
 
 </details>
 
 ## `dlthub job`
 
-Job operations: list, info, run, serve, trigger, publish, unpublish, logs, cancel, runs.
+Job operations: list, info, run, serve, trigger, publish, unpublish, pause, resume, logs, cancel, runs.
 
 **Usage**
 ```sh
 dlthub job [-h] [--timestamps]
-    {list,info,show,trigger,publish,unpublish,logs,cancel,runs,serve,run} ...
+    {list,info,show,trigger,publish,unpublish,pause,resume,logs,cancel,runs,serve,run}
+    ...
 ```
 
 **Description**
@@ -674,6 +828,8 @@ Inherits arguments from [`dlthub`](#dlthub).
 * [`trigger`](#dlthub-job-trigger) - Trigger jobs matching selectors (does not sync or deploy)
 * [`publish`](#dlthub-job-publish) - Generate or revoke a public link for an interactive notebook/app
 * [`unpublish`](#dlthub-job-unpublish) - Revoke the public link for an interactive notebook/app
+* [`pause`](#dlthub-job-pause) - Pause the schedule of one or more jobs
+* [`resume`](#dlthub-job-resume) - Resume the schedule of one or more jobs
 * [`logs`](#dlthub-job-logs) - Show logs for latest or selected job run
 * [`cancel`](#dlthub-job-cancel) - Cancel active runs for matching jobs
 * [`runs`](#dlthub-job-runs) - Manage job runs: list, info, logs, cancel
@@ -844,6 +1000,60 @@ Inherits arguments from [`dlthub job`](#dlthub-job).
 
 **Positional arguments**
 * `script_path` - Local path to the notebook/app
+
+**Options**
+* `-h, --help` - Show this help message and exit
+
+</details>
+
+### `dlthub job pause`
+
+Pause the schedule of one or more jobs.
+
+**Usage**
+```sh
+dlthub job pause [-h] selector_or_job_name [selector_or_job_name ...]
+```
+
+**Description**
+
+Pause the schedule of every job matching the given names, refs or selectors (batch, schedule:*, tag:ops, ...). Only jobs with a schedule can be paused.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub job`](#dlthub-job).
+
+**Positional arguments**
+* `selector_or_job_name` - Job names, script paths, job refs, or selectors.
+
+**Options**
+* `-h, --help` - Show this help message and exit
+
+</details>
+
+### `dlthub job resume`
+
+Resume the schedule of one or more jobs.
+
+**Usage**
+```sh
+dlthub job resume [-h] selector_or_job_name [selector_or_job_name ...]
+```
+
+**Description**
+
+Resume the schedule of every job matching the given names, refs or selectors (batch, schedule:*, tag:ops, ...). The first run covers the whole period the job was paused for.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub job`](#dlthub-job).
+
+**Positional arguments**
+* `selector_or_job_name` - Job names, script paths, job refs, or selectors.
 
 **Options**
 * `-h, --help` - Show this help message and exit
@@ -1105,7 +1315,7 @@ Inherits arguments from [`dlthub job`](#dlthub-job).
 
 **Options**
 * `-h, --help` - Show this help message and exit
-* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment__)
+* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment\_\_)
 * `--timestamps` - Show exact iso timestamps and precise durations (e.g. 1.291 s) instead of humanized relative times.
 * `-f, --follow` - Stream logs until the app stops
 * `--job-ref REF` - Pick this job from the matched candidate set when the selector matches multiple jobs. errors if ref is not in the matched set.
@@ -1137,7 +1347,7 @@ Inherits arguments from [`dlthub job`](#dlthub-job).
 
 **Options**
 * `-h, --help` - Show this help message and exit
-* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment__)
+* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment\_\_)
 * `--timestamps` - Show exact iso timestamps and precise durations (e.g. 1.291 s) instead of humanized relative times.
 * `-f, --follow` - Follow status changes and stream logs until the run completes
 * `--refresh` - Re-run from scratch (full reload). cascades to freshness-graph downstream jobs.
@@ -1157,7 +1367,7 @@ dlthub deploy [-h] [--timestamps] [--deployment DEPLOYMENT] [--dry-run]
 
 **Description**
 
-Sync workspace files, generate job manifest from \_\_deployment__.py, and reconcile jobs with the runtime. Use --dry-run to preview changes.
+Sync workspace files, generate job manifest from \_\_deployment\_\_.py, and reconcile jobs with the runtime. Use --dry-run to preview changes.
 
 <details>
 
@@ -1168,9 +1378,33 @@ Inherits arguments from [`dlthub`](#dlthub).
 **Options**
 * `-h, --help` - Show this help message and exit
 * `--timestamps` - Show exact iso timestamps and precise durations (e.g. 1.291 s) instead of humanized relative times.
-* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment__)
+* `--deployment DEPLOYMENT` - Python file to use as manifest source (instead of \_\_deployment\_\_)
 * `--dry-run` - Preview changes without applying them
 * `--show-manifest` - Dump the expanded deployment manifest as yaml and exit
+
+</details>
+
+## `dlthub dashboard`
+
+Open the workspace dashboard in the dltHub web app (deploys a default one if missing).
+
+**Usage**
+```sh
+dlthub dashboard [-h]
+```
+
+**Description**
+
+Open the dltHub dashboard for the current remote workspace, deploying a default dashboard if none exists.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub`](#dlthub).
+
+**Options**
+* `-h, --help` - Show this help message and exit
 
 </details>
 
@@ -1493,7 +1727,7 @@ Inherits arguments from [`dlthub local`](#dlthub-local).
 
 **Options**
 * `-h, --help` - Show this help message and exit
-* `--deployment FILE` - Path to a .py deployment module. defaults to \_\_deployment__.py.
+* `--deployment FILE` - Path to a .py deployment module. defaults to \_\_deployment\_\_.py.
 * `--job-ref REF` - Pick this job when the selector matches multiple jobs.
 * `--profile NAME` - Override require.profile and the workspace pinned profile.
 * `--dry-run` - Resolve the job and print the entry point without launching
@@ -1529,7 +1763,7 @@ Inherits arguments from [`dlthub local`](#dlthub-local).
 
 **Options**
 * `-h, --help` - Show this help message and exit
-* `--deployment FILE` - Path to a .py deployment module. defaults to \_\_deployment__.py.
+* `--deployment FILE` - Path to a .py deployment module. defaults to \_\_deployment\_\_.py.
 * `--job-ref REF` - Pick this job when the selector matches multiple jobs.
 * `--profile NAME` - Override require.profile and the workspace pinned profile.
 * `--dry-run` - Resolve the job and print the entry point without launching
@@ -1677,7 +1911,7 @@ Local pipeline operations (info, drop, sync, load-package, etc.).
 **Usage**
 ```sh
 dlthub local pipeline [-h] [--pipelines-dir PIPELINES_DIR]
-    {list,run,info,show,failed-jobs,drop-pending-packages,sync,trace,schema,drop,load-package}
+    {list,run,info,show,failed-jobs,drop-pending-packages,abort-packages,sync,trace,schema,drop,load-package}
     ...
 ```
 
@@ -1701,12 +1935,13 @@ Inherits arguments from [`dlthub local`](#dlthub-local).
 * [`info`](#dlthub-local-pipeline-info) - Displays state of the pipeline, use -v or -vv for more info
 * [`show`](#dlthub-local-pipeline-show) - Generates and launches workspace dashboard with the loading status and dataset explorer
 * [`failed-jobs`](#dlthub-local-pipeline-failed-jobs) - Displays information on all the failed loads in all completed packages, failed jobs and associated error messages
-* [`drop-pending-packages`](#dlthub-local-pipeline-drop-pending-packages) - Deletes all extracted and normalized packages including those that are partially loaded.
+* [`drop-pending-packages`](#dlthub-local-pipeline-drop-pending-packages) - [deprecated: use abort-packages] deletes all extracted and normalized packages including those that are partially loaded.
+* [`abort-packages`](#dlthub-local-pipeline-abort-packages) - Safely cancels pending loads: marks packages as aborted, records failed jobs, then resyncs pipeline state from the destination.
 * [`sync`](#dlthub-local-pipeline-sync) - Drops the local state of the pipeline and resets all the schemas and restores it from destination. the destination state, data and schemas are left intact.
 * [`trace`](#dlthub-local-pipeline-trace) - Displays last run trace, use -v or -vv for more info
 * [`schema`](#dlthub-local-pipeline-schema) - Displays default schema
 * [`drop`](#dlthub-local-pipeline-drop) - Selectively drop tables and reset state
-* [`load-package`](#dlthub-local-pipeline-load-package) - Displays information on load package, use -v or -vv for more info
+* [`load-package`](#dlthub-local-pipeline-load-package) - Displays information on a load package or acts on it (abort, fail-job, ...).
 
 </details>
 
@@ -1859,7 +2094,7 @@ Inherits arguments from [`dlthub local pipeline`](#dlthub-local-pipeline).
 
 ### `dlthub local pipeline drop-pending-packages`
 
-Deletes all extracted and normalized packages including those that are partially loaded.
+[Deprecated: use abort-packages] Deletes all extracted and normalized packages including those that are partially loaded.
 
 **Usage**
 ```sh
@@ -1868,10 +2103,45 @@ dlthub local pipeline drop-pending-packages [-h] [pipeline_name]
 
 **Description**
 
+DEPRECATED: use `abort-packages` instead. That command properly records failed jobs
+and resyncs pipeline state from the destination.
+
 Removes all extracted and normalized packages in the pipeline's working dir.
 `dlt` keeps extracted and normalized load packages in the pipeline working directory. When the `run` method is called, it will attempt to normalize and load
 pending packages first. This command removes such packages. Note that **pipeline state** is not reverted to the state at which the deleted packages
 were created. Using the `sync` sub-command is recommended if your destination supports state sync.
+
+<details>
+
+<summary>Show Arguments and Options</summary>
+
+Inherits arguments from [`dlthub local pipeline`](#dlthub-local-pipeline).
+
+**Positional arguments**
+* `pipeline_name` - Pipeline name
+
+**Options**
+* `-h, --help` - Show this help message and exit
+
+</details>
+
+### `dlthub local pipeline abort-packages`
+
+Safely cancels pending loads: marks packages as aborted, records failed jobs, then resyncs pipeline state from the destination.
+
+**Usage**
+```sh
+dlthub local pipeline abort-packages [-h] [pipeline_name]
+```
+
+**Description**
+
+Use this when a load is stuck or you want to discard pending work without losing track of what
+happened. The oldest normalized package (the one being loaded) is aborted: its retry/pending
+jobs move to failed_jobs so they stay visible in `failed-jobs` output and the package completes
+as aborted. All other pending packages, extracted ones included, are deleted. It then
+restores local pipeline state and schemas from the snapshot
+taken when the oldest pending package started and you can safely re-extract and re-run.
 
 <details>
 
@@ -2093,20 +2363,22 @@ Inherits arguments from [`dlthub local pipeline`](#dlthub-local-pipeline).
 
 ### `dlthub local pipeline load-package`
 
-Displays information on load package, use -v or -vv for more info.
+Displays information on a load package or acts on it (abort, fail-job, ...).
 
 **Usage**
 ```sh
 dlthub local pipeline load-package [-h] [pipeline_name] [load-id]
+    [{info,row-counts,abort,job,fail-job}] [job]
 ```
 
 **Description**
 
-Shows information on a load package with a given `load_id`. The `load_id` parameter defaults to the
-most recent package. Package information includes its state (`COMPLETED/PROCESSED`) and list of all
-jobs in a package with their statuses, file sizes, types, and in case of failed jobs—the error
-messages from the destination. With the verbose flag set (`-v`), you can also see the
-list of all tables and columns created at the destination during the loading of that package.
+Shows information on a load package with a given `load_id`, or runs an action on it. The `load_id`
+parameter defaults to the most recent package. Package information includes its state
+(`COMPLETED/PROCESSED`) and list of all jobs in a package with their statuses, file sizes, types,
+and in case of failed jobs—the error messages from the destination. With the verbose flag set
+(`-v`), you can also see the list of all tables and columns created at the destination during the
+loading of that package.
 
 <details>
 
@@ -2117,6 +2389,7 @@ Inherits arguments from [`dlthub local pipeline`](#dlthub-local-pipeline).
 **Positional arguments**
 * `pipeline_name` - Pipeline name
 * `load-id` - Load id of completed or normalized package. defaults to the most recent package.
+* `job` - Pattern for the `job` action, or job id / file name for `fail-job`.
 
 **Options**
 * `-h, --help` - Show this help message and exit

--- a/docs/website/docs/hub/pipeline-operations/environment-variables.md
+++ b/docs/website/docs/hub/pipeline-operations/environment-variables.md
@@ -1,0 +1,84 @@
+---
+title: Environment variables
+description: Set workspace-scoped and profile-scoped environment variables for dltHub platform runs from the web app or the CLI
+keywords: [environment variables, workspace variables, secrets, profiles, CLI, hub, dltHub]
+---
+
+# Environment variables
+
+Workspace **owners** define environment variables on a dltHub workspace. A shared workspace set applies to every run. Optional per-[profile](profiles.md) values apply when that profile is in use (for example `prod` or `access`). When a job starts, the dltHub platform merges those variables into the run’s process environment (`os.environ`).
+
+Variables are managed on the platform — in the **web app** or with the **CLI** — rather than in the deployable `.dlt` config tree. They are not isolated from it, though: at run time they take priority over it, as described in [What runs receive](#what-runs-receive). [Workspace owners](../platform-capabilities/users-and-roles.md#workspace-roles) can list and change them.
+
+## Scopes and precedence
+
+| Scope | Meaning |
+| ----- | ------- |
+| **Workspace** | Shared variables applied to every run in the workspace |
+| **Profile** | Variables applied when the run uses that profile |
+
+When the same name exists in both scopes, the **profile value** is used.
+
+On the dltHub platform, [batch jobs](overview.md#batch-vs-interactive) use the `prod` profile and [interactive jobs](overview.md#batch-vs-interactive) use the `access` profile. Profile-scoped variables for those names apply on top of the workspace-wide set. See [Profiles](profiles.md) and [Workspace setup](workspace-setup.md#understanding-workspace-profiles).
+
+## Plain and secret variables
+
+| Kind | Behavior |
+| ---- | -------- |
+| **Plain** | Values are readable when you list variables. An empty value is allowed. |
+| **Secret** | Values are write-only. After save, the UI keeps them hidden and the CLI lists them masked. Secrets require a non-empty value. Update a secret by replacing it. |
+
+## Manage variables in the web app
+
+1. Open the workspace, go to **Settings**, and open **Environment Variables**.
+2. Add or edit variables. Choose the **workspace** scope or a specific **profile**.
+3. Optionally **import a `.env` file** by copying its content, to stage many entries at once.
+4. Review the pending changes, then **Save**. Staged edits apply only after that explicit save.
+
+:::caution
+Secret values are visible only while you enter them. After save they are write-only — replace a secret to change its value.
+:::
+
+## Manage variables with the CLI
+
+From a connected workspace (see [Workspace setup](workspace-setup.md)), owners use `dlthub variable`:
+
+```sh
+# List every scope (secret values are masked)
+dlthub variable list
+
+# List one scope
+dlthub variable list --workspace
+dlthub variable list --profile prod
+
+# Set a plain workspace-wide variable (value from stdin, or pass --value)
+echo "INFO" | dlthub variable set LOG_LEVEL --plain --workspace
+
+# Set a secret for the prod profile (stdin / prompt keeps the value out of shell history)
+dlthub variable set SENTRY_DSN --secret --profile prod
+
+# Remove a variable (-y accepts the confirmation prompt)
+dlthub variable delete LOG_LEVEL --workspace -y
+
+# Succeed even if the variable is not there
+dlthub variable delete LOG_LEVEL --workspace --allow-missing -y
+```
+
+On `set`, choose both a kind (`--plain` or `--secret`) and a scope (`--workspace` or `--profile`).
+
+On `delete`, the two flags are orthogonal: `-y` accepts the confirmation prompt, while `--allow-missing` decides whether an absent variable is an error or a success. Scripts that must be repeatable usually want both.
+
+Full command reference: [CLI reference](../command-line-interface.md).
+
+## What runs receive
+
+At run start, the dltHub platform injects the workspace-wide variables and the variables for that run’s profile into the process environment, with profile values overriding workspace-wide values for the same name.
+
+Because they land in the process environment, `dlt` reads them through its [environment variables provider](../../general-usage/credentials/setup.md#environment-variables), which has the highest priority of all config providers. A variable named in the `SECTION__KEY` form therefore overrides the same key in the deployed `secrets.toml` or `config.toml` — a workspace variable `DESTINATION__POSTGRES__CREDENTIALS` wins over the value committed in `prod.secrets.toml`. See [Credentials setup](../../general-usage/credentials/setup.md) for the full provider order.
+
+## See also
+
+- [Credentials setup](../../general-usage/credentials/setup.md) — dlt config providers (TOML, environment, vaults)
+- [Secrets management](secrets-management.md) — dltHub-managed secrets and external vaults for cloud runs
+- [Profiles](profiles.md) — `dev`, `prod`, `access`, and custom profiles
+- [Settings](../platform-capabilities/settings.md) — workspace settings entry point

--- a/docs/website/docs/hub/pipeline-operations/overview.md
+++ b/docs/website/docs/hub/pipeline-operations/overview.md
@@ -18,6 +18,7 @@ For a high-level summary of platform capabilities, see [Pipeline operations](../
 | Push code to the cloud — ad-hoc runs or full manifest deploys | [Deployments](deployments.md) |
 | Schedule with cron/intervals, chain follow-ups, backfill with scheduler-driven intervals, gate on freshness, cascade refreshes, tag jobs for bulk operations | [Triggers and scheduling](triggers.md) |
 | Configure timeouts, dependencies, timezone, and per-job TOML sections | [Job configuration](job-configuration.md) |
+| Set workspace or profile environment variables for cloud runs | [Environment variables](environment-variables.md) |
 | Stream logs in real time, inspect run states, view metric dashboards, diagnose failures, cancel runs | [Monitoring and debugging](monitoring.md) |
 | Pick a deployment region | [Regions](../platform-capabilities/regions.md) |
 

--- a/docs/website/docs/hub/pipeline-operations/profiles.md
+++ b/docs/website/docs/hub/pipeline-operations/profiles.md
@@ -245,6 +245,7 @@ Note that the dltHub platform will automatically use the `prod` profile you just
 * Keep secrets in separate `<profile>.secrets.toml` files—never in code.
 * Use **named destinations** (like `warehouse`) to simplify switching.
 * Commit `config.toml`, but exclude all `.secrets.toml` files.
+* For process environment that should not live in the repo, set [workspace environment variables](environment-variables.md); profile-scoped values override the shared workspace set for that profile’s runs.
 
 
 ## Next steps
@@ -252,3 +253,4 @@ Note that the dltHub platform will automatically use the `prod` profile you just
 * [Configure the workspace](../getting-started/installation.md#what-is-a-dlthub-workspace)
 * [Deploy your pipeline](deployments.md)
 * [Monitor and debug pipelines](../../general-usage/pipeline#monitor-the-loading-progress)
+* [Environment variables](environment-variables.md)

--- a/docs/website/docs/hub/pipeline-operations/secrets-management.md
+++ b/docs/website/docs/hub/pipeline-operations/secrets-management.md
@@ -98,4 +98,5 @@ A built-in dltHub vault is on the roadmap, so you'll be able to manage secrets n
 - [Adding credentials](../../walkthroughs/add_credentials.md): general guide to dlt credentials.
 - [Vaults](../../general-usage/credentials/vaults.md): OSS reference for vault providers.
 - [Profiles](profiles.md): how `dev`, `prod`, and `access` profiles separate environments.
+- [Environment variables](environment-variables.md): workspace- and profile-scoped process environment for platform runs.
 - [Static egress IPs](job-configuration.md#static-egress-ips): pin job outbound traffic to known IPs for vault and destination allowlisting.

--- a/docs/website/docs/hub/platform-capabilities/settings.md
+++ b/docs/website/docs/hub/platform-capabilities/settings.md
@@ -14,6 +14,7 @@ Workspace settings are scoped to a single workspace. Workspace [Owners](users-an
 
 - **Name and description.** Edit the workspace name and description. Changes save immediately.
 - **Connection info.** Connection details that external tools and integrations use to talk to the workspace.
+- **Environment variables.** Define plain and secret process environment variables for the whole workspace or for a specific profile. See [Environment variables](../pipeline-operations/environment-variables.md).
 - **Usage chart.** A monthly bar chart showing workspace consumption for the previous six months.
 
 ### Members
@@ -68,5 +69,6 @@ Existing keys can be deleted at any time. Once deleted, the key can no longer au
 ## See also
 
 - [Users and roles](users-and-roles.md)
+- [Environment variables](../pipeline-operations/environment-variables.md)
 - [Regions and data residency](regions.md)
 - [dltHub platform overview](../pipeline-operations/overview.md)

--- a/docs/website/docs/hub/platform-capabilities/users-and-roles.md
+++ b/docs/website/docs/hub/platform-capabilities/users-and-roles.md
@@ -85,6 +85,7 @@ Role-based restrictions apply to both the dashboard and the API, so a viewer can
 | Cancel runs | Yes | Yes | No |
 | Publish or revoke public links for interactive applications | Yes | Yes | No |
 | Change workspace settings | Yes | No | No |
+| Manage environment variables | Yes | No | No |
 | Manage members and invites | Yes | No | No |
 | Manage workspace API keys | Yes | No | No |
 

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -519,6 +519,7 @@ const sidebars = {
         "hub/pipeline-operations/workspace-setup",
         "hub/pipeline-operations/profiles",
         "hub/pipeline-operations/secrets-management",
+        "hub/pipeline-operations/environment-variables",
         "hub/pipeline-operations/deployments",
         "hub/pipeline-operations/triggers",
         "hub/pipeline-operations/job-configuration",


### PR DESCRIPTION
Adds a Hub docs page for workspace and profile-scoped environment variables, with cross-links from profiles, secrets-management, settings, users-and-roles, and the pipeline-operations overview.

Also bumps `docs/uv.lock` to `dlthub` 0.30.0 and regenerates `docs/hub/command-line-interface.md` via `docs/tools/dlthub_cli` — that's what makes `dlthub variable` available to document. The regeneration also picks up `dlthub dashboard`, `job pause`/`resume`, `local pipeline abort-packages`, `login --device`, and `__deployment__` escaping fixes; all generator output, not hand edits.