### PR TITLE
fix(incremental): keep last_value forward-only when it is exactly 0

### DIFF
--- a/dlt/extract/incremental/__init__.py
+++ b/dlt/extract/incremental/__init__.py
@@ -686,7 +686,7 @@ class Incremental(
 
         cached_state = self._cached_state
         # ensure last_value maintains forward-only progression when lag is applied
-        if self.lag and (cached_last_value := cached_state.get("last_value")):
+        if self.lag and (cached_last_value := cached_state.get("last_value")) is not None:
             transformer.last_value = self.last_value_func(
                 (transformer.last_value, cached_last_value)
             )

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -3705,6 +3705,39 @@ def test_incremental_lag_int_with_initial_values(lag: float, last_value_func) ->
         assert result == expected_results[int(lag)]
 
 
+@pytest.mark.parametrize("first_cursor", [10, 0])
+def test_incremental_lag_forward_only_with_zero_last_value(first_cursor: int) -> None:
+    """
+    The forward-only guard for `lag` must not use a truthiness test on the
+    persisted `last_value`: when the cursor is exactly `0` (falsy), the guard
+    was skipped and `lag` rewound the cursor by one window on the next run.
+
+    Regression for #4363.
+    """
+
+    pipeline = dlt.pipeline(
+        pipeline_name="p" + uniq_id(),
+        destination=dlt.destinations.duckdb(credentials=duckdb.connect(":memory:")),
+    )
+    is_second_run = False
+
+    @dlt.resource(name="events", primary_key="id", write_disposition="append")
+    def events_resource(_=dlt.sources.incremental("counter", lag=5, last_value_func=max)):
+        if is_second_run:
+            yield {"id": 2, "counter": first_cursor - 10}
+        else:
+            yield {"id": 1, "counter": first_cursor}
+
+    pipeline.run(events_resource)
+    is_second_run = True
+    pipeline.run(events_resource)
+
+    last_value = pipeline.state["sources"][pipeline.default_schema_name]["resources"]["events"][
+        "incremental"
+    ]["counter"]["last_value"]
+    assert last_value == first_cursor
+
+
 @pytest.mark.parametrize("lag", [0, 1.0, 1.5, 2.0])
 @pytest.mark.parametrize("last_value_func", [min, max])
 def test_incremental_lag_float(lag: float, last_value_func) -> None:


### PR DESCRIPTION
Fixes dlt-hub/dlt#4363

## Summary
The forward-only guard for `lag` used a truthiness test on the persisted `last_value`:

```python
if self.lag and (cached_last_value := cached_state.get("last_value")):
```

When the cursor is exactly `0` (falsy), the guard was skipped, so `lag` rewound the cursor by one window on the next run (`0` → `-5` for `max` with `lag=5`). Numeric cursors at epoch-0 were the affected case; the issue reporter noted epoch-0 datetimes are truthy and unaffected.

Changed the guard to an identity check (`is not None`), so `0` behaves like any other value: the cursor stays put.

## Test
Added `test_incremental_lag_forward_only_with_zero_last_value`, parametrized over first cursors `10` (control) and `0` (subject) — both now keep `last_value == first_cursor` across two runs. Verified locally against the reporter's reproducer: before the fix `0` regressed to `-5`, after it stays `0`.
