### PR TITLE
test(common): apply auto_test_run_context so tests stop writing to ~/.dlt

### DIFF
--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -1,1 +1,1 @@
-from tests.utils import preserve_environ
+from tests.utils import auto_test_run_context, preserve_environ


### PR DESCRIPTION

Related: #4319

`tests/utils.py` is not a conftest, so the `autouse` fixtures defined there only apply where they are imported. `tests/load`, `tests/extract`, `tests/destinations` and `tests/workspace` all pull `auto_test_run_context` into their package conftest; `tests/common/conftest.py` imports only `preserve_environ`. Tests under `tests/common` therefore run against the real run context, and anything that creates a pipeline writes to the developer's `~/.dlt/pipelines`.

`test_get_run_context_warning_cli` does exactly that — it calls `dlt.pipeline(pipeline_name="test_get_run_context_warning")`, leaving `~/.dlt/pipelines/test_get_run_context_warning` behind on the machine running the suite.

This adds the fixture to the `tests/common` conftest, following the same pattern as the other packages.

### How this was found and verified

Running the suite with `HOME` pointed at an empty directory and checking what appears there afterwards:

```
HOME=/tmp/fakehome uv run pytest tests/common -q -p no:randomly
find /tmp/fakehome/.dlt
```

Before: `/tmp/fakehome/.dlt/pipelines/test_get_run_context_warning`
After: no `~/.dlt` is created at all.

`tests/common` results are unchanged by this: 15 failed, 1545 passed, 37 skipped both before and after (the failures are pre-existing `tests/common/runtime/test_telemetry.py` ones on my machine, identical on an unmodified checkout).

### Scope

The issue mentions "many tests", and this fixes the `tests/common` gap only — that is the one I could confirm. Applying the same check to `tests/destinations` (343 tests), `tests/normalize` (336) and `tests/reflection` showed no writes to `~/.dlt`. Several other directories fail collection without their optional extras installed, so I could not sweep those; happy to extend this PR if you want the remaining packages audited the same way.
