### PR TITLE
fix: evolve hint-driven data type changes into variant columns

### DIFF
--- a/dlt/extract/extractors.py
+++ b/dlt/extract/extractors.py
@@ -297,6 +297,23 @@ class Extractor:
 
             # merge with schema table
             if computed_table:
+                # do not let hints overwrite the data type of an existing complete
+                # column. The existing type is kept in the schema and incoming values
+                # of a different type are evolved by the normalizer into variant
+                # columns (like values without explicit hints). Otherwise the mismatch
+                # is deferred to load time and fails the destination (issue #4340).
+                existing_table = self.schema._schema_tables.get(table_name)
+                if existing_table:
+                    existing_columns = existing_table["columns"]
+                    for col_name, col in computed_table["columns"].items():
+                        existing_col = existing_columns.get(col_name)
+                        if (
+                            existing_col
+                            and utils.is_complete_column(existing_col)
+                            and col.get("data_type")
+                            and col["data_type"] != existing_col["data_type"]
+                        ):
+                            col.pop("data_type")
                 # computed table identifiers already normalized
                 self.schema.update_table(
                     computed_table,

--- a/tests/pipeline/test_schema_contracts.py
+++ b/tests/pipeline/test_schema_contracts.py
@@ -444,6 +444,38 @@ def test_variant_columns(contract_setting: TSchemaEvolutionMode, setting_locatio
         assert VARIANT_COLUMN_NAME not in pipeline.default_schema.tables[SUBITEMS_TABLE]["columns"]
 
 
+def test_hint_type_change_evolves_into_variant() -> None:
+    """Issue #4340: an explicit hint that changes the data type of an existing column
+    must evolve into a variant column (like an inferred type change) instead of
+    silently overwriting the schema and failing the load at the destination."""
+    pipeline = get_pipeline()
+
+    @dlt.resource(table_name="hint_evolve", columns={"value": {"data_type": "bigint"}})
+    def data_bigint():
+        yield {"value": 3}
+
+    @dlt.resource(table_name="hint_evolve", columns={"value": {"data_type": "text"}})
+    def data_text():
+        yield {"value": "test"}
+
+    pipeline.run(data_bigint())
+    assert (
+        pipeline.default_schema.tables["hint_evolve"]["columns"]["value"]["data_type"]
+        == "bigint"
+    )
+
+    # the type change via hint must not overwrite the schema nor fail the load:
+    # the existing column keeps its type and the new type goes to a variant column
+    pipeline.run(data_text())
+    columns = pipeline.default_schema.tables["hint_evolve"]["columns"]
+    assert columns["value"]["data_type"] == "bigint"
+    assert "value__v_text" in columns
+    assert columns["value__v_text"]["data_type"] == "text"
+
+    table_counts = load_table_counts(pipeline)
+    assert table_counts["hint_evolve"] == 2
+
+
 def test_settings_precedence() -> None:
     pipeline = get_pipeline()
 


### PR DESCRIPTION
## Summary

Fixes #4340

A resource hint that changes the data type of an existing complete column was merged over the schema before normalization, silently overwriting the existing type. The normalizer then coerced the value to the hinted type and the mismatch surfaced only at load time, failing the destination with a `Conversion Error` instead of creating a variant column like an inferred type change does.

## Root cause

In `Extractor._compute_and_update_tables`, the hint column is merged over the existing complete column via `merge_column`, which overwrites `data_type`. The normalizer then sees no mismatch (the schema now says the new type), coerces the value, and the destination rejects it at load time.

## Fix

Drop the conflicting `data_type` from computed columns before `update_table` when:
- The existing column is a complete column (has a `data_type`)
- The hint provides a different `data_type`

The schema keeps the existing type and the normalizer evolves incoming values into a variant column (`value__v_text`), matching the behavior for inferred type changes. The `merge_column`/`merge_table` overwrite semantics are unchanged for all other column properties.

## Changes

- `dlt/extract/extractors.py`: 17-line guard that pops `data_type` from conflicting hints before schema merge
- `tests/pipeline/test_schema_contracts.py`: Regression test `test_hint_type_change_evolves_into_variant` that fails before the fix and passes after

## Testing

- Regression test: fails on unpatched code, passes with fix
- Schema + extract suites (341 + 325 tests) green, zero new failures
- Variant suite (12 tests) green