### PR TITLE
docs(hub): move the streamlit page under a renamed Data Apps category and retitle

### DIFF
--- a/docs/website/docs/hub/cookbook/build-streamlit-dashboard.md
+++ b/docs/website/docs/hub/cookbook/build-streamlit-dashboard.md
@@ -1,10 +1,10 @@
 ---
-title: Build and Deploy Streamlit App
+title: Build and deploy a Streamlit app
 description: Build, serve, and deploy a Streamlit app on dltHub.
 keywords: [streamlit, dashboard, hub, app, deploy, dltHub]
 ---
 
-# Build and Deploy Streamlit App
+# Build and deploy a Streamlit app
 
 [Streamlit](https://docs.streamlit.io/) is a Python framework for turning a script into an interactive web app. On dltHub, a Streamlit app is a plain `.py` file that imports `streamlit`, and the runtime serves it as an interactive dashboard.
 

--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -541,8 +541,12 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Data discovery & serving",
-      items: ["hub/data-discovery/datasets", { type: "doc", id: "general-usage/dataset-access/marimo" }],
+      label: "Data Apps",
+      items: [
+        "hub/data-discovery/datasets",
+        { type: "doc", id: "general-usage/dataset-access/marimo" },
+        "hub/cookbook/build-streamlit-dashboard",
+      ],
     },
     {
       type: "category",
@@ -581,13 +585,6 @@ const sidebars = {
             "walkthroughs/create-new-destination",
             "walkthroughs/zendesk-weaviate",
           ],
-        },
-        {
-          type: "category",
-          label: "dltHub",
-          collapsible: true,
-          collapsed: true,
-          items: ["hub/cookbook/build-streamlit-dashboard"],
         },
       ],
     },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description

Renames the hub sidebar category Data discovery & serving to Data Apps, moves Build and deploy a Streamlit app into it from the Cookbook's dltHub section (which had no other pages and was removed), and retitles that page to sentence case.

