### PR TITLE
docs: rename Notifications sidebar category to Alerts

### DIFF
--- a/docs/website/sidebars.js
+++ b/docs/website/sidebars.js
@@ -550,7 +550,7 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Notifications",
+      label: "Alerts",
       items: ["hub/notifications/slack", "hub/notifications/email"],
     },
     {


### PR DESCRIPTION
Fixes dlt-hub/dlt#4370

## Summary
The docs sidebar category was labelled `Notifications`, but the platform feature is called `Alerts`. Renamed the category label in `docs/website/sidebars.js` to match — documentation-only change, so it skips the PR gate.
