### PR TITLE
fix(config): resolve GCP credentials from a file path, aggregate union parse errors

### DIFF
--- a/dlt/common/configuration/resolve.py
+++ b/dlt/common/configuration/resolve.py
@@ -308,6 +308,7 @@ def _resolve_config_fields(
             if not current_value:
                 if len(specs_in_union) > 1:
                     is_optional = is_optional_type(hint)
+                    invalid_native_value_exceptions: List[Tuple[Type[Any], InvalidNativeValue]] = []
                     for idx, alt_spec in enumerate(specs_in_union):
                         # return first resolved config from an union
                         try:
@@ -334,9 +335,26 @@ def _resolve_config_fields(
                                     cfm_ex.traces,
                                 )
                             )
-                        except InvalidNativeValue:
-                            # if none of specs in union parsed
+                        except InvalidNativeValue as inv_ex:
+                            # none of the specs tried so far could parse the value: keep track of why,
+                            # so if the whole union fails we can explain what happened with each type
+                            # instead of just reporting the error from the last (often least relevant) spec
+                            invalid_native_value_exceptions.append((alt_spec, inv_ex))
                             if idx == len(specs_in_union) - 1:
+                                if len(invalid_native_value_exceptions) > 1:
+                                    attempts = "; ".join(
+                                        f"`{spec.__name__}`: {ex.inner_exception}"
+                                        for spec, ex in invalid_native_value_exceptions
+                                    )
+                                    raise InvalidNativeValue(
+                                        specs_in_union[0],
+                                        type(explicit_value),
+                                        embedded_sections,
+                                        Exception(
+                                            "None of the credential/configuration types in this"
+                                            f" union could parse the provided value. Attempts: {attempts}"
+                                        ),
+                                    ) from inv_ex
                                 raise
                 else:
                     try:

--- a/dlt/common/configuration/specs/gcp_credentials.py
+++ b/dlt/common/configuration/specs/gcp_credentials.py
@@ -1,4 +1,5 @@
 import dataclasses
+import os
 import sys
 from typing import Any, ClassVar, Final, List, Tuple, Union, Dict, Optional
 
@@ -26,6 +27,21 @@ from dlt.common.utils import is_interactive
 
 # GCS scope required for OAuth2 token requests
 GCS_SCOPE = "https://www.googleapis.com/auth/devstorage.read_write"
+
+
+def _read_native_value_from_file_if_path(native_value: Any) -> Any:
+    """If `native_value` is a string pointing at an existing file (e.g. the path to a downloaded
+    Google service account or OAuth client JSON file, following the common `GOOGLE_APPLICATION_CREDENTIALS`
+    convention), read and return the file's contents. Otherwise return `native_value` unchanged."""
+    if isinstance(native_value, str):
+        try:
+            if os.path.isfile(native_value):
+                with open(native_value, "r", encoding="utf-8") as f:
+                    return f.read()
+        except (OSError, ValueError):
+            # not a usable path (e.g. too long, contains null bytes): treat as a regular value
+            pass
+    return native_value
 
 
 def _get_pyiceberg_fileio_config(credentials: Any, project_id: Optional[str]) -> Dict[str, Any]:
@@ -134,6 +150,8 @@ class GcpServiceAccountCredentialsWithoutDefaults(GcpCredentials, WithPyicebergC
         if service_dict is None:
             # check if type is str
             GcpCredentials.parse_native_representation(self, native_value)
+            # if given a path to a service account JSON file, read its contents
+            native_value = _read_native_value_from_file_if_path(native_value)
             # if not instance of service account credentials then check type and try to parse native value
             try:
                 service_dict = json.loads(native_value)
@@ -203,6 +221,8 @@ class GcpOAuthCredentialsWithoutDefaults(GcpCredentials, OAuth2Credentials, With
         if oauth_dict is None:
             # check if type is str
             GcpCredentials.parse_native_representation(self, native_value)
+            # if given a path to an OAuth client JSON file, read its contents
+            native_value = _read_native_value_from_file_if_path(native_value)
             # if not instance of oauth2 credentials try to parse native value
             try:
                 oauth_dict = json.loads(native_value)

--- a/tests/common/configuration/test_credentials.py
+++ b/tests/common/configuration/test_credentials.py
@@ -59,11 +59,14 @@ OAUTH_USER_INFO = """
     }
 """
 
-OAUTH_APP_USER_INFO = """
+OAUTH_APP_USER_INFO = (
+    """
 {
     "installed": %s
 }
-""" % OAUTH_USER_INFO
+"""
+    % OAUTH_USER_INFO
+)
 
 
 def test_credentials_resolve_from_init_value() -> None:
@@ -265,6 +268,29 @@ def test_gcp_service_credentials_native_representation(environment) -> None:
     assert gcpc_2.default_credentials() is None
 
 
+def test_gcp_service_credentials_native_representation_from_file_path(
+    environment, tmp_path
+) -> None:
+    # a path to a service account JSON file (the common GOOGLE_APPLICATION_CREDENTIALS
+    # convention) must resolve the same way as passing the JSON content directly
+    service_json_path = tmp_path / "service_account.json"
+    service_json_path.write_text(
+        SERVICE_JSON
+        % '"private_key": "-----BEGIN PRIVATE KEY-----\\n\\n-----END PRIVATE KEY-----\\n",'
+    )
+
+    gcpc = GcpServiceAccountCredentials()
+    gcpc.parse_native_representation(str(service_json_path))
+    assert gcpc.private_key == "-----BEGIN PRIVATE KEY-----\n\n-----END PRIVATE KEY-----\n"
+    assert gcpc.project_id == "chat-analytics"
+    assert gcpc.client_email == "loader@iam.gserviceaccount.com"
+
+    # a plain string that happens to not exist as a file is still handled as JSON content,
+    # and still raises the usual error if it isn't valid JSON
+    with pytest.raises(InvalidGoogleServicesJson):
+        GcpServiceAccountCredentials().parse_native_representation("notjson")
+
+
 def test_gcp_service_credentials_resolved_from_native_representation(environment: Any) -> None:
     gcpc = GcpServiceAccountCredentialsWithoutDefaults()
 
@@ -320,6 +346,17 @@ def test_gcp_oauth_credentials_native_representation(environment) -> None:
     gcpc_3 = GcpOAuthCredentials()
     gcpc_3.parse_native_representation(OAUTH_USER_INFO % '"refresh_token": "refresh_token",')
     assert dict(gcpc_3) == dict(gcpc_2)
+
+
+def test_gcp_oauth_credentials_native_representation_from_file_path(environment, tmp_path) -> None:
+    # a path to an OAuth client JSON file must resolve the same way as passing its content directly
+    oauth_json_path = tmp_path / "oauth_client.json"
+    oauth_json_path.write_text(OAUTH_APP_USER_INFO % '"refresh_token": "refresh_token",')
+
+    gcoauth = GcpOAuthCredentials()
+    gcoauth.parse_native_representation(str(oauth_json_path))
+    assert gcoauth.project_id == "level-dragon-333983"
+    assert gcoauth.refresh_token == "refresh_token"
 
 
 def test_needs_scopes_for_refresh_token() -> None:

--- a/tests/common/configuration/test_spec_union.py
+++ b/tests/common/configuration/test_spec_union.py
@@ -13,7 +13,10 @@ from dlt.common.configuration.providers import EnvironProvider
 from dlt.common.configuration.providers.provider import ConfigProvider
 from dlt.common.configuration.specs import CredentialsConfiguration, BaseConfiguration
 from dlt.common.configuration import configspec, resolve_configuration
-from dlt.common.configuration.specs.gcp_credentials import GcpServiceAccountCredentials
+from dlt.common.configuration.specs.gcp_credentials import (
+    GcpServiceAccountCredentials,
+    GcpOAuthCredentials,
+)
 from dlt.common.typing import TSecretStrValue
 from dlt.common.configuration.specs.connection_string_credentials import ConnectionStringCredentials
 from dlt.common.configuration.resolve import initialize_credentials
@@ -206,10 +209,14 @@ def test_union_decorator() -> None:
 
     # pass explicit dict
     assert list(zen_source(credentials={"email": "emx", "password": "pass"}))[0].email == "emx"  # type: ignore[arg-type]
-    assert list(zen_source(credentials={"api_key": "🔑", "api_secret": ":secret:"}))[0].api_key == "🔑"  # type: ignore[arg-type]
+    assert (
+        list(zen_source(credentials={"api_key": "🔑", "api_secret": ":secret:"}))[0].api_key == "🔑"
+    )  # type: ignore[arg-type]
     # mixed credentials will not work
     with pytest.raises(ConfigFieldMissingException):
-        assert list(zen_source(credentials={"api_key": "🔑", "password": "pass"}))[0].api_key == "🔑"  # type: ignore[arg-type]
+        assert (
+            list(zen_source(credentials={"api_key": "🔑", "password": "pass"}))[0].api_key == "🔑"
+        )  # type: ignore[arg-type]
 
 
 class GoogleAnalyticsCredentialsBase(CredentialsConfiguration):
@@ -237,7 +244,7 @@ class GoogleAnalyticsCredentialsOAuth(GoogleAnalyticsCredentialsBase):
 def google_analytics(
     credentials: Union[
         GoogleAnalyticsCredentialsOAuth, GcpServiceAccountCredentials
-    ] = dlt.secrets.value
+    ] = dlt.secrets.value,
 ):
     yield dlt.resource([credentials], name="creds")
 
@@ -259,6 +266,22 @@ def test_google_auth_union(environment: Any) -> None:
     credentials = list(google_analytics(credentials=info))[0]  # type: ignore[arg-type]
     print(dict(credentials))
     assert isinstance(credentials, GcpServiceAccountCredentials)
+
+
+@configspec
+class GcpCredentialsUnionConfig(BaseConfiguration):
+    credentials: Union[GcpServiceAccountCredentials, GcpOAuthCredentials] = None
+
+
+def test_gcp_credentials_union_reports_all_attempts_on_failure(environment: Any) -> None:
+    # neither GcpServiceAccountCredentials nor GcpOAuthCredentials can parse this value:
+    # the error should explain why each of them failed, not just the last one tried
+    environment["CREDENTIALS"] = "not valid json for either credential type"
+    with pytest.raises(InvalidNativeValue) as py_ex:
+        resolve_configuration(GcpCredentialsUnionConfig())
+    message = str(py_ex.value)
+    assert "GcpServiceAccountCredentials" in message
+    assert "GcpOAuthCredentials" in message
 
 
 class Engine:


### PR DESCRIPTION
### Description

`GcpServiceAccountCredentials`/`GcpOAuthCredentials.parse_native_representation()` called
`json.loads()` directly on the given string, so pointing `credentials` at a file path (the
common `GOOGLE_APPLICATION_CREDENTIALS` convention) failed to parse. Since GCS/GDrive type
credentials as `Union[GcpServiceAccountCredentials, GcpOAuthCredentials]`, the resolver
silently fell through to try OAuth next, which also failed - and only OAuth's confusing
error surfaced to the user, even though the value was a valid service account file all along.

Two changes:
- `gcp_credentials.py`: read the file's contents first when the given string is an existing
  file path, for both ServiceAccount and OAuth credentials.
- `resolve.py`: when every spec in a `Union` fails to parse, report why each one failed
  instead of only the last one tried. This is generic to all Union-typed credentials in dlt,
  not just GCP, so it improves error messages beyond this one bug.

### Related Issues

- Fixes #3328

### Additional Context

Added tests for both changes (file-path resolution for both credential types, and the
aggregated union error message). Full `tests/common/configuration/` suite passes locally
(249 tests), `ruff check`/`ruff format --check` clean.