### PR TITLE
docs: fix garbled sentence and typo in examples CONTRIBUTING

### DIFF
--- a/docs/examples/CONTRIBUTING.md
+++ b/docs/examples/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Note: All paths in this guide are relative to the `dlt` repository directory.
 The command `npm start`  starts a local development server and opens up a browser window.
 
 - To install npm read [README](../website/README.md).
-- You should your example be automatically added to the examples section in the local version of the docs. Check the rendered output and see wether it looks the way you intended.
+- Your example should be automatically added to the examples section in the local version of the docs. Check the rendered output and see whether it looks the way you intended.
 
 ## Add ENV variables
 


### PR DESCRIPTION
Two fixes on `docs/examples/CONTRIBUTING.md:23`.

**Garbled sentence.** The line currently reads:

> - You should your example be automatically added to the examples section…

The subject and modal are transposed. Corrected to:

> - Your example should be automatically added to the examples section…

**Typo.** Same line: "see wether it looks the way you intended" → "whether".

Docs only.
