### PR TITLE
fix(workspace): keep the AiContextApiError contract for invalid API bodies

### DIFF
--- a/dlt/_workspace/mcp/tools/_ai_context_api_client.py
+++ b/dlt/_workspace/mcp/tools/_ai_context_api_client.py
@@ -37,6 +37,13 @@ def search_sources(query: str = "", ai_context_api_url: str = None) -> List[TSou
     if response.status_code != 200:
         raise AiContextApiError(f"API returned status {response.status_code}: {response.text}")
 
-    data: Dict[str, Any] = response.json()
+    try:
+        data: Dict[str, Any] = response.json()
+    except ValueError as e:
+        raise AiContextApiError(f"API returned a response that is not valid JSON: {str(e)}")
+    if not isinstance(data, dict):
+        raise AiContextApiError(
+            f"API returned an unexpected JSON shape: {type(data).__name__}"
+        )
     results: List[TSourceItem] = data.get("results", [])
     return results

--- a/tests/workspace/mcp/test_ai_context_api_client.py
+++ b/tests/workspace/mcp/test_ai_context_api_client.py
@@ -58,3 +58,29 @@ def test_search_sources_server_error(requests_mock: rm.Mocker) -> None:
         search_sources(query="test", ai_context_api_url="https://api.example.com")
 
     assert "500" in str(exc_info.value)
+
+
+def test_search_sources_non_json_body(requests_mock: rm.Mocker) -> None:
+    """Test search_sources raises AiContextApiError when a 200 body is not JSON"""
+    requests_mock.get(
+        re.compile(r".*/api/v1/scaffolds/sources"),
+        text="<html>proxy interstitial</html>",
+    )
+
+    with pytest.raises(AiContextApiError) as exc_info:
+        search_sources(query="test", ai_context_api_url="https://api.example.com")
+
+    assert "not valid JSON" in str(exc_info.value)
+
+
+def test_search_sources_non_dict_json(requests_mock: rm.Mocker) -> None:
+    """Test search_sources raises AiContextApiError when the JSON is not an object"""
+    requests_mock.get(
+        re.compile(r".*/api/v1/scaffolds/sources"),
+        json=["unexpected", "shape"],
+    )
+
+    with pytest.raises(AiContextApiError) as exc_info:
+        search_sources(query="test", ai_context_api_url="https://api.example.com")
+
+    assert "unexpected JSON shape" in str(exc_info.value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

`search_sources` in the workspace MCP tools promises `Raises: AiContextApiError` and keeps that promise for connection errors and non-200 statuses, but the 200 path parses the body unguarded:

```python
    data: Dict[str, Any] = response.json()
    results: List[TSourceItem] = data.get("results", [])
```

Two ways that leaks a raw exception to the MCP tool caller instead of the contract error:

- a 200 response whose body is not JSON (captive portal, corporate proxy interstitial, a misconfigured `ai_context_api_url` pointing at an HTML page) raises `requests.exceptions.JSONDecodeError` from `response.json()`;
- a body that is valid JSON but not an object (an array, `null`) raises `AttributeError` on `data.get`.

Both cases now raise `AiContextApiError`, matching every other failure path in the function.

Two tests added in the file's existing `requests_mock` style: a non-JSON 200 body and a JSON array body.

Verification with the repo's own test file, run both directions:

- with the fix: 5 passed
- with current devel's client and only the new tests added: 2 failed, 3 passed, the failures being exactly the two new cases (JSONDecodeError and AttributeError leaking)

### Related Issues

None filed.

### Additional Context

Follow-up in the same spirit as #4385: keeping curated errors from being replaced by raw parse exceptions.
