### PR TITLE
fix(fabric): add a timeout to the token initialization request

### DIFF
--- a/dlt/destinations/impl/fabric/fabric.py
+++ b/dlt/destinations/impl/fabric/fabric.py
@@ -92,6 +92,10 @@ class FabricCopyFileLoadJob(SynapseCopyFileLoadJob):
             """)
             self._sql_client.execute_sql(sql)
 
+    # Timeout for the Fabric token-initialization request. Without one, a
+    # stalled connection would hang pipeline startup indefinitely.
+    FABRIC_TOKEN_INIT_TIMEOUT = 30
+
     def _ensure_fabric_token_initialized(
         self, credentials: AzureServicePrincipalCredentialsWithoutDefaults
     ) -> None:
@@ -127,7 +131,11 @@ class FabricCopyFileLoadJob(SynapseCopyFileLoadJob):
 
         # Call Fabric API to initialize token (list workspaces as a simple test)
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-        resp = requests.get("https://api.fabric.microsoft.com/v1/workspaces", headers=headers)
+        resp = requests.get(
+            "https://api.fabric.microsoft.com/v1/workspaces",
+            headers=headers,
+            timeout=FABRIC_TOKEN_INIT_TIMEOUT,
+        )
 
         if resp.status_code != 200:
             raise ConfigurationException(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

`_ensure_fabric_token_initialized` in the Fabric destination calls the workspaces endpoint with no timeout:

```python
resp = requests.get("https://api.fabric.microsoft.com/v1/workspaces", headers=headers)
```

requests waits forever by default, so a stalled connection during credential setup hangs pipeline startup indefinitely, with no error and nothing in the logs to say why. This runs once per client id on the first load, which is exactly the moment a hang is most confusing to debug.

The fix adds a timeout via a named class constant, following the convention `_ai_context_api_client.py` already uses (`AI_CONTEXT_API_TIMEOUT = 20`). A timeout that trips surfaces as `requests.RequestException`, and the existing `except` handling around token initialization deals with it the same way it deals with any other connection failure.

No test added since the change is a kwarg passthrough with no behavioral seam to assert beyond the constant itself; happy to add a mock-based assertion that the timeout is passed if you would like one.

### Related Issues

None filed.

### Additional Context

Third in the series with #4385 and #4389: small hardening of error paths so failures surface as curated errors instead of hangs or leaked exceptions.
