### PR TITLE
(feat) switches default tz-aware timestamp on Snowflake to LTZ

### DIFF
--- a/dlt/destinations/impl/lancedb/lancedb_client.py
+++ b/dlt/destinations/impl/lancedb/lancedb_client.py
@@ -120,7 +120,7 @@ class LanceDBClient(JobClientBase, WithStateSync, WithSqlClient):
             name=self.config.embedding_model,
             max_retries=self.config.options.max_retries,
             # actually the model func doesnt need the api-key!
-            **({"host": embedding_model_host} if embedding_model_host else {}),
+            **({"host": embedding_model_host, "base_url": embedding_model_host} if embedding_model_host else {}),
         )
 
     @property

--- a/dlt/destinations/impl/snowflake/configuration.py
+++ b/dlt/destinations/impl/snowflake/configuration.py
@@ -189,6 +189,9 @@ class SnowflakeClientConfiguration(DestinationClientDwhWithStagingConfiguration)
     use_nested_types: bool = False
     """When true, arrow-nested `json` columns are created as native ARRAY/OBJECT (structured) types instead of VARIANT."""
 
+    use_timestamp_tz: bool = False
+    """When true, timezone-aware timestamps are created as `TIMESTAMP_TZ`, which stores the offset written with each value, instead of `TIMESTAMP_LTZ`"""
+
     def fingerprint(self) -> str:
         """Returns a fingerprint of the account host."""
         if self.credentials and self.credentials.host:

--- a/dlt/destinations/impl/snowflake/factory.py
+++ b/dlt/destinations/impl/snowflake/factory.py
@@ -29,7 +29,6 @@ class SnowflakeTypeMapper(TypeMapperImpl):
         "double": "FLOAT",
         "bool": "BOOLEAN",
         "date": "DATE",
-        "timestamp": "TIMESTAMP_TZ",
         "bigint": f"NUMBER({BIGINT_PRECISION},0)",  # Snowflake has no integer types
         "binary": "BINARY",
         "time": "TIME",
@@ -38,7 +37,6 @@ class SnowflakeTypeMapper(TypeMapperImpl):
 
     sct_to_dbt = {
         "text": "VARCHAR(%i)",
-        "timestamp": "TIMESTAMP_TZ(%i)",
         "decimal": "NUMBER(%i,%i)",
         "time": "TIME(%i)",
         "wei": "NUMBER(%i,%i)",
@@ -49,6 +47,7 @@ class SnowflakeTypeMapper(TypeMapperImpl):
         "FLOAT": "double",
         "BOOLEAN": "bool",
         "DATE": "date",
+        "TIMESTAMP_LTZ": "timestamp",
         "TIMESTAMP_TZ": "timestamp",
         "BINARY": "binary",
         "VARIANT": "json",
@@ -65,9 +64,11 @@ class SnowflakeTypeMapper(TypeMapperImpl):
         self,
         capabilities: DestinationCapabilitiesContext,
         use_decfloat: bool = False,
+        use_timestamp_tz: bool = False,
     ) -> None:
         super().__init__(capabilities)
         self.use_decfloat = use_decfloat
+        self.use_timestamp_tz = use_timestamp_tz
 
     def from_destination_type(
         self, db_type: str, precision: Optional[int] = None, scale: Optional[int] = None
@@ -90,11 +91,12 @@ class SnowflakeTypeMapper(TypeMapperImpl):
         timezone = column.get("timezone", True)
         precision = column.get("precision")
 
-        if timezone and precision is None:
-            # use lookup table for non-precision types
-            return None
-
-        timestamp = "TIMESTAMP_TZ" if timezone else "TIMESTAMP_NTZ"
+        if not timezone:
+            timestamp = "TIMESTAMP_NTZ"
+        elif self.use_timestamp_tz:
+            timestamp = "TIMESTAMP_TZ"
+        else:
+            timestamp = "TIMESTAMP_LTZ"
 
         # append precision if specified and valid
         if precision is not None:
@@ -242,6 +244,7 @@ class snowflake(Destination[SnowflakeClientConfiguration, "SnowflakeClient"]):
         create_indexes: bool = False,
         use_decfloat: bool = False,
         use_nested_types: bool = False,
+        use_timestamp_tz: bool = False,
         enable_atomic_swap: bool = False,
         destination_name: str = None,
         environment: str = None,
@@ -264,6 +267,9 @@ class snowflake(Destination[SnowflakeClientConfiguration, "SnowflakeClient"]):
                 Only works with text-based staging formats (jsonl, csv) - not parquet.
             use_nested_types (bool, optional): Whether to create arrow-nested `json` columns as native
                 ARRAY/OBJECT (structured) types instead of VARIANT. Requires loading via parquet.
+            use_timestamp_tz (bool, optional): Whether to create timezone-aware timestamps as TIMESTAMP_TZ,
+                which stores the offset written with each value, instead of TIMESTAMP_LTZ. Columns of
+                tables that already exist keep the type they were created with.
             enable_atomic_swap (bool, optional): Whether to use atomic swap when replacing with replace strategy `staging-optimized`.
             destination_name (str, optional): Name of the destination. Defaults to None.
             environment (str, optional): Environment name. Defaults to None.
@@ -278,6 +284,7 @@ class snowflake(Destination[SnowflakeClientConfiguration, "SnowflakeClient"]):
             create_indexes=create_indexes,
             use_decfloat=use_decfloat,
             use_nested_types=use_nested_types,
+            use_timestamp_tz=use_timestamp_tz,
             enable_atomic_swap=enable_atomic_swap,
             destination_name=destination_name,
             environment=environment,

--- a/dlt/destinations/impl/snowflake/snowflake.py
+++ b/dlt/destinations/impl/snowflake/snowflake.py
@@ -173,7 +173,9 @@ class SnowflakeClient(SqlJobClientWithStagingDataset, SupportsStagingDestination
         super().__init__(schema, config, sql_client)
         self.config: SnowflakeClientConfiguration = config
         self.sql_client: SnowflakeSqlClient = sql_client  # type: ignore
-        self.type_mapper = self.capabilities.get_type_mapper(config.use_decfloat)
+        self.type_mapper = self.capabilities.get_type_mapper(
+            config.use_decfloat, config.use_timestamp_tz
+        )
         self.active_hints = SUPPORTED_HINTS if self.config.create_indexes else {}
 
     def create_load_job(

--- a/docs/docs_tools/examples/prepare_examples_tests.py
+++ b/docs/docs_tools/examples/prepare_examples_tests.py
@@ -17,6 +17,7 @@ SKIP_EXAMPLES: List[str] = [
     "backfill_in_chunks",
     "connector_x_arrow",
     "transformers",
+    "custom_destination_lancedb",
     "qdrant_zendesk",
     "incremental_loading",
     "logfire_telemetry_export",

--- a/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/snowflake.md
@@ -179,6 +179,7 @@ will pass `client_session_keep_alive` as a string to the connect method (which w
 ### Session timezone
 `dlt` sets the session `TIMEZONE` to `UTC`, so a load does not take the timezone of the account. It
 does not change the column types that `CREATE TABLE` produces.
+[`TIMESTAMP_LTZ` columns](#timestamp_ltz-or-timestamp_tz) render in this timezone.
 
 ```toml
 [destination.snowflake.credentials]
@@ -241,7 +242,7 @@ keep_staged_files = false
 - **Precision**: Allows you to specify the number of decimal places for fractional seconds, ranging from 0 to 9. It can be used in combination with the `timezone` flag.
 - **Timezone**:
   - Setting `timezone=False` maps to `TIMESTAMP_NTZ`.
-  - Setting `timezone=True` (or omitting the flag, which defaults to `True`) maps to `TIMESTAMP_TZ`.
+  - Setting `timezone=True` (or omitting the flag, which defaults to `True`) maps to `TIMESTAMP_LTZ`.
 
 #### Example precision and timezone: TIMESTAMP_NTZ(3)
 ```py
@@ -255,6 +256,49 @@ def events():
 pipeline = dlt.pipeline(destination="snowflake")
 pipeline.run(events())
 ```
+
+#### TIMESTAMP_LTZ or TIMESTAMP_TZ
+
+`TIMESTAMP_LTZ` stores an absolute instant. Every session reads it in its own timezone, which is
+what a timezone-aware `dlt` timestamp means.
+
+`TIMESTAMP_TZ` stores an offset next to each value and returns that offset to every reader. Because
+`dlt` normalizes timestamps to UTC before it writes them, that stored offset is always UTC. It tells
+a reader nothing about the source, and it does not change with the session.
+
+`TIMESTAMP_LTZ` is therefore the default.
+
+Set the session timezone with the `session_timezone` credential (`UTC` by default) to control what
+`TIMESTAMP_LTZ` renders.
+
+If a downstream consumer depends on the stored offset, keep `TIMESTAMP_TZ`:
+
+```toml
+[destination.snowflake]
+use_timestamp_tz = true
+```
+
+Or as an argument to `dlt.destinations.snowflake`:
+
+```py
+import dlt
+
+pipeline = dlt.pipeline(
+    pipeline_name="...",
+    destination=dlt.destinations.snowflake(use_timestamp_tz=True),
+)
+```
+
+:::note
+`dlt` never alters a column that already exists. A pipeline that ran while `TIMESTAMP_TZ` was the
+default keeps those columns. Only new tables and new columns get `TIMESTAMP_LTZ`.
+
+[Structured types](#nested-types-array-and-object) are the exception. `dlt` re-applies the full type
+of a structured column on every load. Snowflake then rejects the changed nested field with
+`cannot change column PAYLOAD.ts from type TIMESTAMP_TZ(6) to TIMESTAMP_LTZ(6)`. If you enabled
+`use_nested_types` before `TIMESTAMP_LTZ` became the default, and a structured column holds a
+timestamp, set `use_timestamp_tz = true`.
+:::
 
 ### DECFLOAT type
 

--- a/tests/load/pipeline/test_pipelines.py
+++ b/tests/load/pipeline/test_pipelines.py
@@ -1097,11 +1097,11 @@ def test_dest_column_hint_timezone(destination_config: DestinationTestConfigurat
                     "timestamp_values": output_values,
                 },
                 "EVENTS_TIMEZONE_ON": {
-                    "timestamp_type": "TIMESTAMP_TZ",
+                    "timestamp_type": "TIMESTAMP_LTZ",
                     "timestamp_values": output_values,
                 },
                 "EVENTS_TIMEZONE_UNSET": {
-                    "timestamp_type": "TIMESTAMP_TZ",
+                    "timestamp_type": "TIMESTAMP_LTZ",
                     "timestamp_values": output_values,
                 },
             },

--- a/tests/load/pipeline/test_session_timezone.py
+++ b/tests/load/pipeline/test_session_timezone.py
@@ -17,10 +17,16 @@ SESSION_TIMEZONE = "America/New_York"
 SESSION_OFFSET = timedelta(hours=-5)
 
 # destinations that render a stored instant in the session timezone, so the read carries its offset.
-# the others tie the offset to the value instead: clickhouse writes the zone into the column type as
-# `DateTime64(p,'UTC')`, and snowflake `TIMESTAMP_TZ` keeps the offset that was written, which makes
-# the offset depend on the loader file format rather than on the session
-SESSION_OFFSET_ON_READ = ("duckdb", "motherduck", "ducklake", "postgres", "redshift")
+# clickhouse ties the offset to the value instead. it writes the zone into the column type
+# as `DateTime64(p,'UTC')`
+SESSION_OFFSET_ON_READ = (
+    "duckdb",
+    "motherduck",
+    "ducklake",
+    "postgres",
+    "redshift",
+    "snowflake",
+)
 
 
 def _items(item_type: TestDataItemFormat) -> Any:

--- a/tests/load/pipeline/test_snowflake_pipeline.py
+++ b/tests/load/pipeline/test_snowflake_pipeline.py
@@ -917,7 +917,7 @@ def test_snowflake_staging_with_default_chain_credentials(
 
 
 ALL_TYPES_STRUCT_DDL = (
-    "OBJECT(s VARCHAR(16777216), i NUMBER(19,0), f FLOAT, b BOOLEAN, ts TIMESTAMP_TZ(6), d DATE,"
+    "OBJECT(s VARCHAR(16777216), i NUMBER(19,0), f FLOAT, b BOOLEAN, ts TIMESTAMP_LTZ(6), d DATE,"
     " t TIME(6), dec NUMBER(38,9), bin BINARY(8388608), arr ARRAY(NUMBER(19,0)),"
     " nested OBJECT(x VARCHAR(16777216), y NUMBER(19,0)), mp MAP(VARCHAR(16777216), NUMBER(19,0)),"
     " with space VARCHAR(16777216), 日本語 NUMBER(19,0))"
@@ -1286,3 +1286,43 @@ def test_snowflake_json_columns_stay_variant(
         types = col_types(client)
         assert types["PAYLOAD"] == "VARIANT"
         assert types["EXTRA"] == "VARIANT"
+
+
+@pytest.mark.parametrize(
+    "destination_config",
+    destinations_configs(default_sql_configs=True, subset=["snowflake"]),
+    ids=lambda x: x.name,
+)
+def test_snowflake_timestamp_tz_keeps_written_offset(
+    destination_config: DestinationTestConfiguration,
+) -> None:
+    """`use_timestamp_tz` freezes the offset stored with each value, so every session returns the
+    same offset. `TIMESTAMP_LTZ` renders the instant in the session timezone instead."""
+    instant = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+
+    pipeline = destination_config.setup_pipeline(
+        "test_snowflake_timestamp_tz_" + uniq_id(),
+        dev_mode=True,
+        destination=destination_config.destination_factory(use_timestamp_tz=True),
+    )
+    assert_load_info(
+        pipeline.run(
+            [{"id": 1, "ts": instant}], table_name="events", **destination_config.run_kwargs
+        )
+    )
+
+    with pipeline.sql_client() as client:
+        column_type = client.execute_sql(
+            "SELECT data_type FROM information_schema.columns WHERE table_schema = %s AND"
+            " table_name = 'EVENTS' AND column_name = 'TS'",
+            client.fully_qualified_dataset_name(quote=False),
+        )[0][0]
+        assert column_type == "TIMESTAMP_TZ"
+
+        qualified_name = client.make_qualified_table_name("events")
+        for session_timezone in ("America/New_York", "Asia/Tokyo"):
+            client.execute_sql(f"ALTER SESSION SET TIMEZONE = '{session_timezone}'")
+            value = client.execute_sql(f"SELECT ts FROM {qualified_name}")[0][0]
+            # dlt normalizes to UTC before writing, so UTC is the stored offset
+            assert value.utcoffset() == datetime.timedelta(0)
+            assert value == instant

--- a/tests/load/snowflake/test_snowflake_configuration.py
+++ b/tests/load/snowflake/test_snowflake_configuration.py
@@ -197,7 +197,7 @@ def test_query_additional_params() -> None:
 
 
 def test_session_timezone() -> None:
-    # UTC is pinned so the offset stored in `TIMESTAMP_TZ` does not follow the account
+    # UTC is pinned so the offset `TIMESTAMP_LTZ` renders does not follow the account
     c = SnowflakeCredentialsWithoutDefaults("snowflake://user1:pass1@host1/db1")
     assert c.to_connector_params()["timezone"] == "UTC"
 

--- a/tests/load/snowflake/test_snowflake_table_builder.py
+++ b/tests/load/snowflake/test_snowflake_table_builder.py
@@ -3,12 +3,13 @@ from tests.utils import skip_if_not_active
 skip_if_not_active("snowflake")
 
 from copy import deepcopy
-from typing import cast
+from typing import Optional, cast
 
 import pytest
 import sqlfluff
 
-from dlt.common.utils import uniq_id
+from dlt.common.exceptions import TerminalValueError
+from dlt.common.utils import uniq_id, without_none
 from dlt.common.schema import Schema
 from dlt.common.schema.utils import new_table
 from dlt.common.destination.typing import PreparedTableSchema
@@ -49,14 +50,24 @@ def snowflake_client(empty_schema: Schema) -> SnowflakeClient:
 
 
 def create_client(
-    schema: Schema, use_decfloat: bool = False, use_nested_types: bool = False
+    schema: Schema,
+    use_decfloat: bool = False,
+    use_nested_types: bool = False,
+    use_timestamp_tz: bool = False,
 ) -> SnowflakeClient:
     # return client without opening connection
     creds = SnowflakeCredentials()
-    return snowflake(use_decfloat=use_decfloat, use_nested_types=use_nested_types).client(
+    return snowflake(
+        use_decfloat=use_decfloat,
+        use_nested_types=use_nested_types,
+        use_timestamp_tz=use_timestamp_tz,
+    ).client(
         schema,
         SnowflakeClientConfiguration(
-            credentials=creds, use_decfloat=use_decfloat, use_nested_types=use_nested_types
+            credentials=creds,
+            use_decfloat=use_decfloat,
+            use_nested_types=use_nested_types,
+            use_timestamp_tz=use_timestamp_tz,
         )._bind_dataset_name(dataset_name="test_" + uniq_id()),
     )
 
@@ -88,7 +99,7 @@ def test_create_table(snowflake_client: SnowflakeClient) -> None:
     assert '"COL1" NUMBER(19,0)  NOT NULL' in sql
     assert '"COL2" FLOAT  NOT NULL' in sql
     assert '"COL3" BOOLEAN  NOT NULL' in sql
-    assert '"COL4" TIMESTAMP_TZ  NOT NULL' in sql
+    assert '"COL4" TIMESTAMP_LTZ  NOT NULL' in sql
     assert '"COL5" VARCHAR' in sql
     assert '"COL6" NUMBER(38,9)  NOT NULL' in sql
     assert '"COL7" BINARY' in sql
@@ -191,7 +202,7 @@ def test_create_table_with_hints(snowflake_client: SnowflakeClient) -> None:
     assert '"COL1" NUMBER(19,0)  NOT NULL' in sql
     assert '"COL2" FLOAT UNIQUE NOT NULL' in sql
     assert '"COL3" BOOLEAN  NOT NULL' in sql
-    assert '"COL4" TIMESTAMP_TZ  NOT NULL' in sql
+    assert '"COL4" TIMESTAMP_LTZ  NOT NULL' in sql
     assert '"COL5" VARCHAR' in sql
     assert '"COL6" NUMBER(38,9)  NOT NULL' in sql
     assert '"COL7" BINARY' in sql
@@ -221,7 +232,7 @@ def test_alter_table(snowflake_client: SnowflakeClient) -> None:
     assert '"COL1"' not in add_column_sql
     assert '"COL2" FLOAT  NOT NULL' in add_column_sql
     assert '"COL3" BOOLEAN  NOT NULL' in add_column_sql
-    assert '"COL4" TIMESTAMP_TZ  NOT NULL' in add_column_sql
+    assert '"COL4" TIMESTAMP_LTZ  NOT NULL' in add_column_sql
     assert '"COL5" VARCHAR' in add_column_sql
     assert '"COL6" NUMBER(38,9)  NOT NULL' in add_column_sql
     assert '"COL7" BINARY' in add_column_sql
@@ -461,3 +472,84 @@ def test_decfloat_type_mapper_from_destination() -> None:
 
     result = mapper.from_destination_type("DECFLOAT")
     assert result == {"data_type": "decimal"}
+
+
+@pytest.mark.parametrize(
+    "use_timestamp_tz,timezone,precision,expected",
+    [
+        (False, None, None, "TIMESTAMP_LTZ"),
+        (False, None, 3, "TIMESTAMP_LTZ(3)"),
+        (False, True, None, "TIMESTAMP_LTZ"),
+        (False, False, None, "TIMESTAMP_NTZ"),
+        (False, False, 0, "TIMESTAMP_NTZ(0)"),
+        (True, None, None, "TIMESTAMP_TZ"),
+        (True, None, 3, "TIMESTAMP_TZ(3)"),
+        (True, True, None, "TIMESTAMP_TZ"),
+        (True, False, None, "TIMESTAMP_NTZ"),
+    ],
+    ids=[
+        "ltz-unset",
+        "ltz-precision",
+        "ltz-timezone-on",
+        "ltz-timezone-off",
+        "ltz-timezone-off-precision",
+        "tz-unset",
+        "tz-precision",
+        "tz-timezone-on",
+        "tz-timezone-off",
+    ],
+)
+def test_timestamp_type_mapper(
+    use_timestamp_tz: bool, timezone: Optional[bool], precision: Optional[int], expected: str
+) -> None:
+    caps = snowflake()._raw_capabilities()
+    mapper = SnowflakeTypeMapper(caps, use_timestamp_tz=use_timestamp_tz)
+
+    col = cast(
+        TColumnSchema,
+        without_none(
+            {
+                "name": "test_col",
+                "data_type": "timestamp",
+                "timezone": timezone,
+                "precision": precision,
+            }
+        ),
+    )
+    table = cast(PreparedTableSchema, {"name": "test_table", "columns": {"test_col": col}})
+    assert mapper.to_destination_type(col, table) == expected
+
+    # precision above the Snowflake maximum is still rejected
+    col["precision"] = caps.max_timestamp_precision + 1
+    with pytest.raises(TerminalValueError):
+        mapper.to_destination_type(col, table)
+
+
+def test_timestamp_type_mapper_from_destination() -> None:
+    """All three Snowflake timestamp types reflect back to `timestamp`. Only NTZ drops the timezone."""
+    mapper = SnowflakeTypeMapper(snowflake()._raw_capabilities())
+
+    assert mapper.from_destination_type("TIMESTAMP_LTZ", 6) == {
+        "data_type": "timestamp",
+        "precision": 6,
+    }
+    # tables created before LTZ became the default
+    assert mapper.from_destination_type("TIMESTAMP_TZ", 6) == {
+        "data_type": "timestamp",
+        "precision": 6,
+    }
+    assert mapper.from_destination_type("TIMESTAMP_NTZ", 6)["timezone"] is False
+
+
+def test_create_and_alter_table_timestamp_tz(empty_schema: Schema) -> None:
+    """`use_timestamp_tz` keeps `TIMESTAMP_TZ` in both CREATE and ALTER."""
+    client = create_client(empty_schema, use_timestamp_tz=True)
+
+    sql = client._get_table_update_sql("event_test_table", TABLE_UPDATE, False)[0]
+    sqlfluff.parse(sql, dialect="snowflake")
+    assert '"COL4" TIMESTAMP_TZ  NOT NULL' in sql
+
+    add_column_sql = client._get_table_update_sql(
+        "event_test_table", deepcopy(TABLE_UPDATE[3:5]), True
+    )[0]
+    assert '"COL4" TIMESTAMP_TZ  NOT NULL' in add_column_sql


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please provide a brief description of your changes below.
-->
### Description
fixes #4317

## Breaking change
Default timestamp type is LTZ now - stored without offset. Thanks to that timestamps are consistent regardless of loader file format type (for example parquet was not able to pass offsets anyway).

to switch back to TZ: set `use_timestamp_tz=True` on snowflake destination factory or via configuration
