### PR TITLE
fix(extract): warn when incremental lag unit is inferred from a string cursor format

### DIFF
--- a/dlt/extract/incremental/lag.py
+++ b/dlt/extract/incremental/lag.py
@@ -12,6 +12,20 @@ from dlt.common.time import (
 from . import TCursorValue, LastValueFunc
 
 
+def string_lag_unit(value: Any) -> Optional[str]:
+    """Returns the time unit lag uses for a date/datetime cursor value given as a string.
+
+    Returns `days` for date-shaped strings, `seconds` for datetime-shaped ones, or `None`
+    when the value is not a datetime string and the unit is not inferred from its format.
+    """
+    if not isinstance(value, str):
+        return None
+    value_format = detect_datetime_format(value)
+    if not value_format:
+        return None
+    return "days" if value_format in ("%Y%m%d", "%Y-%m-%d") else "seconds"
+
+
 def _apply_lag_to_value(
     lag: float, value: Any, last_value_func: LastValueFunc[TCursorValue]
 ) -> Any:

--- a/dlt/extract/incremental/transform.py
+++ b/dlt/extract/incremental/transform.py
@@ -26,6 +26,7 @@ from dlt.common.incremental.typing import (
     OnCursorValueMissing,
     TIncrementalRange,
 )
+from dlt.extract.incremental.lag import string_lag_unit
 from dlt.extract.utils import resolve_column_value
 from dlt.extract.items import TTableHintTemplate
 
@@ -172,6 +173,26 @@ class IncrementalTransform:
                 )
         return cursor_value
 
+    def _warn_string_lag_unit(self, row_value: Any) -> None:
+        """Warn when the lag unit is inferred from the cursor value's string format.
+
+        A date-shaped string means `lag` is days, a datetime-shaped one means seconds, so the
+        same `lag` can mean days or seconds depending on how the source writes timestamps.
+        """
+        if not self.lag or self.last_value_func not in (min, max) or self.end_value is not None:
+            return
+        unit = string_lag_unit(row_value)
+        if unit is None:
+            return
+        kind = "date" if unit == "days" else "datetime"
+        logger.warning(
+            f"Lag {self.lag} on {self.resource_name} is applied in {unit} because the cursor value"
+            f" {row_value!r} is a string parsed as a {kind}. The unit is inferred from the value's"
+            " format, not from configuration, so the same lag can mean days or seconds depending on"
+            " how the source writes timestamps. Pass a typed initial_value or use"
+            " Incremental[date] / Incremental[datetime] to pin it."
+        )
+
     def compute_deduplication_disabled(self) -> bool:
         """Skip deduplication when length of the key is 0 or if lag is applied."""
         # disable deduplication if end value is set - state is not saved
@@ -254,6 +275,8 @@ class JsonIncremental(IncrementalTransform):
                 return row, False, False
         last_value = self.last_value
         last_value_func = self.last_value_func
+        if not self.seen_data:
+            self._warn_string_lag_unit(row_value)
         # correct tz-awareness if last_value/start_value not matching
         if not self.seen_data and self.start_value_is_datetime and isinstance(row_value, datetime):
             # NOTE: we are making sure that last_value == start_value here (self.seen_data)
@@ -469,6 +492,8 @@ class ArrowIncremental(IncrementalTransform):
         # The new max/min value
         row_value_scalar = self.compute(tbl[cursor_path])
         row_value = from_arrow_scalar(row_value_scalar)
+        if not self.seen_data:
+            self._warn_string_lag_unit(row_value)
         # correct tz-awareness
         if not self.seen_data and self.start_value_is_datetime and isinstance(row_value, datetime):
             # NOTE: we are making sure that last_value == start_value here (self.seen_data)

--- a/docs/website/docs/general-usage/incremental/lag.md
+++ b/docs/website/docs/general-usage/incremental/lag.md
@@ -16,6 +16,8 @@ The `lag` parameter is a float that supports several types of incremental cursor
 
 This flexibility allows `lag` to adapt to different data contexts.
 
+When the cursor value is a string, dlt infers whether it is a date or a datetime from the string's format, so `2024-01-01` is treated as a date (`lag` in days) while `2024-01-01T00:00:00Z` is treated as a datetime (`lag` in seconds). dlt logs a warning when the unit is inferred this way. To pin the unit regardless of how the source formats its values, pass a typed `initial_value` or type the cursor as `Incremental[pendulum.Date]` / `Incremental[pendulum.DateTime]`.
+
 
 ### Example using `datetime` incremental cursor with `merge` as `write_disposition`
 

--- a/tests/extract/test_incremental.py
+++ b/tests/extract/test_incremental.py
@@ -52,6 +52,7 @@ from tests.pipeline.utils import assert_query_column
 from tests.utils import (
     ALL_TEST_DATA_ITEM_FORMATS,
     TestDataItemFormat,
+    capture_dlt_logger,
     data_item_length,
     data_to_item_format,
 )
@@ -3592,6 +3593,42 @@ def test_incremental_lag_date_datetime(lag: int, last_value_func) -> None:
             for row in sql_client.execute_sql(f"SELECT event FROM {name} ORDER BY _dlt_load_id, id")
         ]
         assert result == expected_results[lag]
+
+
+@pytest.mark.parametrize("item_type", ALL_TEST_DATA_ITEM_FORMATS)
+def test_incremental_lag_string_unit_warning(
+    item_type: TestDataItemFormat, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Lag warns once per run when the day/second unit is inferred from a string cursor value."""
+
+    def extract(data: Any) -> Any:
+        @dlt.resource(name="events", write_disposition="append")
+        def events(_=dlt.sources.incremental("created_at", lag=1)):
+            yield from data_to_item_format(item_type, data)
+
+        pipeline = dlt.pipeline(pipeline_name="p" + uniq_id(), destination="duckdb", dev_mode=True)
+        caplog.clear()
+        with capture_dlt_logger(caplog) as cap:
+            pipeline.extract(events())
+        return cap.text
+
+    # datetime-shaped strings -> lag is seconds, warned once and points at the type-based fix
+    dt_rows = [{"id": i, "created_at": f"2023-03-0{i}T00:00:00Z"} for i in (1, 2, 3)]
+    text = extract(dt_rows)
+    assert text.count("is applied in seconds") == 1
+    assert "is applied in days" not in text
+    assert "Incremental[datetime]" in text
+
+    # date-shaped strings -> lag is days
+    date_rows = [{"id": i, "created_at": f"2023-03-0{i}"} for i in (1, 2, 3)]
+    text = extract(date_rows)
+    assert text.count("is applied in days") == 1
+    assert "is applied in seconds" not in text
+
+    # typed datetime cursor is unambiguous -> no warning
+    typed_rows = [{"id": i, "created_at": pendulum.datetime(2023, 3, i)} for i in (1, 2, 3)]
+    text = extract(typed_rows)
+    assert "is applied in" not in text
 
 
 @pytest.mark.parametrize("lag", [200, 1000])


### PR DESCRIPTION
### Description

`lag=N` silently means days or seconds depending on the cursor value's string shape (`2026-08-27` vs `2026-08-27T00:00:00Z`) — the unit comes from the data format, not config.

The real fix is the datetime-cursor normalization in #2565. This ships the non-breaking interim: a warning when the unit is inferred from a string, pointing users at typed values (`initial_value` or `Incremental[date]` / `Incremental[datetime]`). Behavior is otherwise unchanged.

Mirrors the existing `_adapt_timezone` warning (same class of problem): `_warn_string_lag_unit` in `transform.py`, called from the Json and Arrow paths under the same `not self.seen_data` guard (warns once per run). Test follows `test_timezone_naive_datetime` — parametrized over item formats, asserting the log via `capture_dlt_logger`.

### Related Issues

- Fixes #4401
- Follow-up: #2565 (consistent unit from cursor type)

### Additional Context

Only warns when lag is active (`min`/`max`, no `end_value`) and the unit came from a string; typed and numeric cursors stay quiet.
