### PR TITLE
(feat) background agent launcher

### DIFF
--- a/.claude/skills/review-vocabulary/SKILL.md
+++ b/.claude/skills/review-vocabulary/SKILL.md
@@ -130,6 +130,9 @@ Groups defined so far:
 | [G3 — Transformations and materialization](#g3--transformations-and-materialization) | relations, transformations, model jobs, eager and lazy paths |
 | [G4 — Identifiers and SQL generation](#g4--identifiers-and-sql-generation) | naming conventions, case-folding, query binding |
 | [G5 — Configuration and credentials](#g5--configuration-and-credentials) | configs, credentials, secrets |
+| [G6 — Jobs, triggers and the deployment manifest](#g6--jobs-triggers-and-the-deployment-manifest) | jobs, job runs, launchers, triggers, selectors |
+| [G7 — Agents, loops and prompts](#g7--agents-loops-and-prompts) | agent definitions, agent jobs, agent runs, loops, system prompts, user turns, traces |
+| [G8 — Workspace access and tools](#g8--workspace-access-and-tools) | the `access` declaration, axes, verbs, tools, feature groups |
 
 Two rules apply across every group:
 
@@ -160,9 +163,11 @@ Two rules apply across every group:
 
 **Rulings**
 
-- **`access` is a VERB.** Do not introduce noun uses — no "data access", no "access is one-way".
-  Write "the engine accesses the data", "only one direction accesses the data". Pre-existing noun
-  uses stay.
+- **`access` is a verb for the act, and a noun for what a job may touch.** Keep the verb for the
+  act of reading data: "the engine accesses the data", not "data access is one-way". The noun is
+  legal only in the sense G8 defines — the `access` declaration, and the grant that answers it.
+  dlt's docs already write "grant access", "read access" and "denied access" 40 times over; that
+  usage was always compliant and stays.
 - **`reach` is not always `access`.** "`SET SESSION` would not reach the cloned sessions" means
   *propagate to*, not *read data from*. A literal swap changes the meaning — restructure
   (Rule 9.1).
@@ -260,10 +265,157 @@ Two rules apply across every group:
 
 ---
 
+### G6 — Jobs, triggers and the deployment manifest
+
+**Included**
+
+| Concept | Write |
+|---|---|
+| the unit a workspace deploys and runs | **job** |
+| one execution of it | **job run** |
+| its identity | **job ref** |
+| its entry in the manifest | **job definition** |
+| the dlt module that starts a job | **launcher** |
+| the machine the platform gives the job | **runner** |
+| the dltHub platform itself | **runtime** |
+| the string that starts a job | **trigger** |
+| the pattern that expands into triggers | **selector** |
+| the trigger a manual run stands in for | **default trigger** |
+| the file that describes every job | **deployment manifest** |
+
+**Excluded**
+
+| Never | Because |
+|---|---|
+| task, workload, script (for a dlt job) | one name — **job**; the runtime's `Script` model keeps its own name |
+| job execution, invocation (for one run) | **job run**, the noun the manifest and the beacon use |
+| primary trigger | **default trigger**, the name of the manifest field |
+| manifest (unqualified, for `AGENT.md`) | **deployment manifest** is the only manifest; see G7 |
+
+**Rulings**
+
+- **`run` is a verb; `job run` is the noun.** "dlt runs the job" and "the job run failed". The
+  command `dlthub local run` is a technical name (Rule 8.6) and stays.
+- **launcher, runner and runtime are three things.** The launcher is dlt code. The runner is a
+  machine. The runtime is the platform. Never swap them, and never write "the runtime launches".
+- **`task` is legal in two places only:** the work an agent must do (G7), and an Airflow task when
+  the sentence says "Airflow task". It is never a dlt job.
+
+---
+
+### G7 — Agents, loops and prompts
+
+Three nouns carry the feature, and they nest: a definition is written once, a job adds how it
+operates, a run is one execution.
+
+**Included**
+
+| Concept | Write |
+|---|---|
+| what an `AGENT.md` or a decorated function declares: system prompt, inputs, output, tools, skills, rules, access | **agent definition** (`TAgentSpec` in code, `TAgentDefinition` for the block the manifest carries; pydantic-ai's `AgentSpec`) |
+| the file it is read from | **`AGENT.md`**, and **agent file** for the path |
+| the name a definition is referred to by | **agent definition reference**: `<toolkit>:<agent>`, a workspace path, or `<module>:<function>` for a function with no `AGENT.md` behind it |
+| the definition plus the runtime settings that say how it operates: model, limits, trigger, instructions, loop, identity | **agent job** (`run.agent(...)`; what pydantic-ai and claude-agent-sdk call an Agent, and what the web UI lists as one) |
+| one execution of an agent job: inputs in, output and trace out, settings overridable for that run | **agent run** (`Agent.run()` in the frameworks) |
+| what the model returns: `status`, `summary` and the declared fields | **agent output** |
+| the envelope the launcher delivers | **job result** (G6 owns it; an agent job's is `TAgentJobResult`) |
+| the binding to one agent framework | **loop**, or **agent loop** |
+| the text the model gets as its role and task | **system prompt** |
+| the first message of the run | **user turn** |
+| what a person tells this run to do | **instructions** |
+| one model request | **turn** |
+| the record of what the loop ran and did | **agent trace** |
+| `{{ name }}` in a body | **placeholder** |
+
+**Excluded**
+
+| Never | Because |
+|---|---|
+| agent spec (in prose) | **agent definition**; `TAgentSpec` keeps its name as a type |
+| agent reference, agent ref (in prose) | **agent definition reference**; the field `agent_ref` keeps its name |
+| agent (bare) where the sentence needs one of the three | say which: **agent definition**, **agent job** or **agent run** |
+| harness (for the Claude Code CLI) | the **dltHub AI Harness** owns that word; write **the Claude Code CLI** |
+| adapter (for a loop) | dlt's adapters are `bigquery_adapter` and friends; write **loop** |
+| prompt (bare) | say which one: **system prompt** or **user turn** |
+| spec (bare, for an agent) | bare `spec` is the configspec; write **agent definition** |
+| trace (bare, for an agent) | bare `trace` is the pipeline trace; write **agent trace** |
+| manifest (for `AGENT.md`) | **agent file**; the manifest is the deployment manifest (G6) |
+| framework (as a loop's name) | name it: **pydantic-ai**, **claude-agent-sdk** |
+
+**Rulings**
+
+- **Bare `agent` is the actor.** "The agent reads the logs", "the agent returns `aborted`": the
+  model acting during a run. That stays. The moment a sentence is about the file, the `run.agent`
+  product or one execution, it names the definition, the job or the run.
+- **`Agent` (capitalised) is the agent job.** That is how the web UI labels it and how pydantic-ai
+  and claude-agent-sdk name the same thing. Legal in UI copy and when talking about a framework;
+  in dlt prose write **agent job**.
+- **An agent run is a job run.** Use **agent run** when the sentence is about what the agent
+  received and produced; **job run** when it is about scheduling, status or logs, as for any job.
+- **`instructions` means two opposite things across the boundary.** In dlt it is the user turn. In
+  pydantic-ai, `AgentSpec.instructions` is the system prompt. Qualify every mention of the
+  framework field: "pydantic-ai's `instructions` field (its system prompt)".
+- **`turn` is one model request.** The **user turn** is the first message. A turn counter counts
+  requests. Do not let one word carry both without the qualifier.
+- **`loop` is the agent loop.** In a file that also has Python loops, write **agent loop** once,
+  then `loop`.
+- **Model names and aliases are technical nouns** (Rule 1.8): `sonnet`, `opus`, `claude-sonnet-5`.
+
+---
+
+### G8 — Workspace access and tools
+
+**Included**
+
+| Concept | Write |
+|---|---|
+| the declaration of what a job may touch | **access** (the `access` block, `TWorkspaceAccess`) |
+| one of its four keys | **access axis** |
+| a value on an axis | **verb** |
+| what the runtime or a loop does with the declaration | **grant**, **deny** (verbs) |
+| what it did grant | **granted access** |
+| what it did not grant | **denied access** |
+| what a loop supplies beyond the declaration | **over-granted** |
+| what a tool needs before it is served | **required access** |
+| what a model can call | **tool** |
+| the MCP grouping a manifest requests | **feature group** |
+
+**Excluded**
+
+| Never | Because |
+|---|---|
+| permission, entitlement, scope (for the declaration) | **access**, the word dlt's docs already use; `permission` is legal only when naming the SDK's `permission_mode` |
+| narrowed, narrowing | say the fact: **with less access** |
+| grant (as a noun) | **the declared access**; `granted` as an adjective is legal (Rule 3.3) |
+| capability (for a dlt tool) | **tool**; legal only for pydantic-ai `capabilities` |
+| ceiling, floor (as prose metaphor) | say what it does: "access is the most a loop can wire" |
+| honor, honour, honored, unhonoured (any spelling) | access is **granted** or **denied**, never honored |
+
+**Rulings**
+
+- **Grant and deny are the verbs.** A job declares access; the runtime and the loop grant what they
+  can; the rest is denied. dlt's docs already write "grant access" 13 times and "denied access"
+  twice, so this is the house pairing, not a new one. A loop that supplies more than the
+  declaration **over-grants**.
+- **The declaration is a request, not a claim.** A manifest `access` block says what the job wants.
+  Nothing in it is granted until the runtime says so. Say "the job declares", never "the job has".
+- **`access` is the noun, and no synonym joins it.** `permissions`, `scopes`, `capabilities` and
+  `entitlements` each name this concept somewhere in the industry; dlt named it `access` before this
+  feature existed — the built-in `access` profile is coarse-grained data access, and `profile_for()`
+  derives that profile from `access.data`. One concept, one word (Rule 1.11).
+- **`tools:` in an `AGENT.md` holds feature groups, not tools.** Write "feature groups" whenever the
+  sentence is about that field, or a reader counts 4 tools and gets 19.
+---
+
 ### Legal technical nouns — never replace, any group (Rules 1.5, 1.8)
 
 attach, attach alias, attach info, attach statement, catalog, config, data location, dataset,
 destination, duckdb, iceberg, materialization, model job, pipeline, relation, scanner, vended.
+
+access, access axis, agent, agent definition, agent definition reference, agent file, agent job,
+agent output, agent run, agent trace, default trigger, feature group, instructions, job, job definition, job ref, job result,
+job run, launcher, loop, placeholder, runner, runtime, selector, skill, system prompt, tool, toolkit,
+trigger, turn, user turn, verb.
 
 ## Rules this codebase breaks most
 

--- a/.github/workflows/test_destinations_remote.yml
+++ b/.github/workflows/test_destinations_remote.yml
@@ -285,7 +285,7 @@ jobs:
           PYTEST_ARGS: ${{ matrix.rerun_args || '' }}
 
   run_vault_providers:
-    name: vault providers
+    name: vault providers and agents
     env:
       # Prevent implicit resyncs by `uv run`; this is ignored by explicit `uv sync` commands.
       UV_NO_SYNC: "1"
@@ -318,11 +318,16 @@ jobs:
           enable-cache: ${{ github.event_name != 'pull_request_target' }}
 
       - name: Install dependencies
-        # google-api-python-client for google secrets, botocore (s3 extra) for aws secrets manager
-        run: uv sync --group providers --extra s3
+        # google-api-python-client for google secrets, botocore (s3 extra) for aws secrets manager,
+        # the workspace and both agent loops for the agent runs
+        run: uv sync --group providers --extra s3 --group workspace-deps --extra cli --group agent --group agent-claude
 
       - name: create secrets.toml
         run: pwd && echo "$DLT_SECRETS_TOML" > tests/.dlt/secrets.toml
 
       - name: Run vault provider tests
         run: uv run pytest tests/helpers/providers
+
+      - name: Run agents on real loops and models
+        # skipped unless the secrets carry `jobs.agent.api_key`
+        run: make test-workspace-agents

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ has-uv:
 	uv --version
 
 dev: has-uv ## Prepares development environment
-	uv sync --all-extras --no-extra hub --group workspace-deps --group dev --group providers --group pipeline --group sources --group sentry-sdk --group ibis --group adbc --group dashboard-tests
+	uv sync --all-extras --no-extra hub --group workspace-deps --group dev --group providers --group pipeline --group sources --group sentry-sdk --group ibis --group adbc --group dashboard-tests --group agent --group agent-claude
 
 dev-airflow: has-uv ## Prepares development environment with airflow support
 	uv sync --all-extras --no-extra hub --group workspace-deps --group providers --group pipeline --group sources --group sentry-sdk --group ibis --group airflow
@@ -278,12 +278,15 @@ test-pipeline-arrow:
 # ----------------------------------------------------------------------
 
 install-workspace:
-	uv sync $(UV_SYNC_ARGS) --group workspace-deps --extra cli --group streamlit
+	uv sync $(UV_SYNC_ARGS) --group workspace-deps --extra cli --group streamlit --group agent --group agent-claude
 
-TEST_WORKSPACE_PATHS = tests/workspace
+TEST_WORKSPACE_PATHS = tests/workspace --ignore tests/workspace/deployment/test_agent_e2e.py
 
 test-workspace:
 	$(call RUN_XDIST_SAFE_SPLIT,$(TEST_WORKSPACE_PATHS))
+
+test-workspace-agents: ## Runs agents on real loops and models (needs jobs.agent.api_key in tests/.dlt/secrets.toml)
+	$(PYTEST_BASE) tests/workspace/deployment/test_agent_e2e.py
 
 # ----------------------------------------------------------------------
 # CI: hub minimal (no ibis)

--- a/dlt/_workspace/_plugins.py
+++ b/dlt/_workspace/_plugins.py
@@ -132,7 +132,7 @@ def plug_mcp_context(features: Set[str]) -> Optional[McpFeatures]:
 
 
 @_plugins.hookimpl(specname="plug_agent_loop")
-def plug_agent_loop_pydantic_ai(loop_type: str) -> Optional[Type[Any]]:
+def plug_agent_loop_pydantic_ai(loop_type: str) -> Optional[Type[_plugins.SupportsAgentLoop]]:
     """Contribute the Pydantic AI agent loop."""
     # the plugin module loads with the run context, so the deployment package stays out of it
     from dlt._workspace.deployment.launchers import LOOP_PYDANTIC_AI
@@ -145,7 +145,7 @@ def plug_agent_loop_pydantic_ai(loop_type: str) -> Optional[Type[Any]]:
 
 
 @_plugins.hookimpl(specname="plug_agent_loop")
-def plug_agent_loop_claude_sdk(loop_type: str) -> Optional[Type[Any]]:
+def plug_agent_loop_claude_sdk(loop_type: str) -> Optional[Type[_plugins.SupportsAgentLoop]]:
     """Contribute the Claude Agent SDK loop."""
     from dlt._workspace.deployment.launchers import LOOP_CLAUDE_AGENT_SDK
 

--- a/dlt/_workspace/_plugins.py
+++ b/dlt/_workspace/_plugins.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, NamedTuple, Optional, Sequence, Set
+from typing import Any, Dict, NamedTuple, Optional, Sequence, Set, Type
 
 from dlt.common.configuration import plugins as _plugins
 from dlt.common.configuration.specs.pluggable_run_context import RunContextBase
@@ -131,6 +131,31 @@ def plug_mcp_context(features: Set[str]) -> Optional[McpFeatures]:
     return McpFeatures(name="context", tools=list(context_tools.__tools__))
 
 
+@_plugins.hookimpl(specname="plug_agent_loop")
+def plug_agent_loop_pydantic_ai(loop_type: str) -> Optional[Type[Any]]:
+    """Contribute the Pydantic AI agent loop."""
+    # the plugin module loads with the run context, so the deployment package stays out of it
+    from dlt._workspace.deployment.launchers import LOOP_PYDANTIC_AI
+
+    if loop_type != LOOP_PYDANTIC_AI:
+        return None
+    from dlt._workspace.deployment.agent.loops.pydantic_ai import PydanticAILoop
+
+    return PydanticAILoop
+
+
+@_plugins.hookimpl(specname="plug_agent_loop")
+def plug_agent_loop_claude_sdk(loop_type: str) -> Optional[Type[Any]]:
+    """Contribute the Claude Agent SDK loop."""
+    from dlt._workspace.deployment.launchers import LOOP_CLAUDE_AGENT_SDK
+
+    if loop_type != LOOP_CLAUDE_AGENT_SDK:
+        return None
+    from dlt._workspace.deployment.agent.loops.claude_sdk import ClaudeAgentSdkLoop
+
+    return ClaudeAgentSdkLoop
+
+
 __all__ = [
     "plug_workspace_context_impl",
     "plug_mcp_pipeline",
@@ -138,4 +163,6 @@ __all__ = [
     "plug_mcp_toolkit",
     "plug_mcp_secrets",
     "plug_mcp_context",
+    "plug_agent_loop_pydantic_ai",
+    "plug_agent_loop_claude_sdk",
 ]

--- a/dlt/_workspace/access.py
+++ b/dlt/_workspace/access.py
@@ -1,0 +1,143 @@
+import dataclasses
+import typing
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+from dlt.common.typing import AnyFun, NotRequired, get_args
+
+from dlt._workspace.typing import (
+    TWorkspaceAccess,
+    TWorkspaceContextVerb,
+    TWorkspaceDataVerb,
+    TWorkspaceLocalVerb,
+)
+
+ACCESS_AXIS_VERBS: Dict[str, Tuple[str, ...]] = {
+    "local": ("read", "write", "execute", "network"),
+    "data": ("read", "write"),
+    "context": ("read",),
+}
+"""Verbs a declaration may carry on each axis. `all` stands for every verb listed here."""
+
+ACCESS_AXIS_VOCABULARY: Dict[str, Tuple[str, ...]] = {
+    "local": get_args(TWorkspaceLocalVerb),
+    "data": get_args(TWorkspaceDataVerb),
+    "context": get_args(TWorkspaceContextVerb),
+}
+"""Every verb each axis carries in the type, implemented or not."""
+
+ACCESS_AXES = tuple(ACCESS_AXIS_VERBS)
+
+FULL_ACCESS: TWorkspaceAccess = typing.cast(
+    TWorkspaceAccess, {axis: list(verbs) for axis, verbs in ACCESS_AXIS_VERBS.items()}
+)
+"""Everything there is to grant."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RequiresAccess:
+    """Access a tool needs, written as `Annotated[T, RequiresAccess(data=["read"])]` on its return."""
+
+    local: Sequence[TWorkspaceLocalVerb] = ()
+    data: Sequence[TWorkspaceDataVerb] = ()
+    context: Sequence[TWorkspaceContextVerb] = ()
+
+    def __post_init__(self) -> None:
+        # verbs are held as tuples: an `Annotated` alias carrying a list is unhashable
+        for axis in ACCESS_AXES:
+            object.__setattr__(self, axis, tuple(getattr(self, axis)))
+
+    def as_access(self) -> TWorkspaceAccess:
+        declared = {axis: list(getattr(self, axis)) for axis in ACCESS_AXES}
+        return typing.cast(
+            TWorkspaceAccess, {axis: verbs for axis, verbs in declared.items() if verbs}
+        )
+
+
+def annotation_metadata(annotation: Any) -> Tuple[Any, ...]:
+    """What an `Annotated` hint carries, read through `NotRequired`."""
+    if typing.get_origin(annotation) is NotRequired:
+        return annotation_metadata(typing.get_args(annotation)[0])
+    # only `Annotated` carries metadata; `Literal` args are values, not annotations
+    return typing.cast(Tuple[Any, ...], getattr(annotation, "__metadata__", ()))
+
+
+def required_access(f: AnyFun) -> TWorkspaceAccess:
+    """Access the function's return annotation asks for.
+
+    A function that declares nothing needs everything; `RequiresAccess()` asks for nothing.
+    """
+    try:
+        hints = typing.get_type_hints(f, include_extras=True)
+    except Exception:
+        return FULL_ACCESS
+    for metadata in annotation_metadata(hints.get("return")):
+        if isinstance(metadata, RequiresAccess):
+            return metadata.as_access()
+    return FULL_ACCESS
+
+
+def granted_verbs(access: Optional[TWorkspaceAccess], axis: str) -> Set[str]:
+    """Verbs granted on one axis, with `all` expanded."""
+    declared: Dict[str, Any] = dict(access or {})
+    verbs = set(declared.get(axis) or [])
+    return set(ACCESS_AXIS_VERBS[axis]) if "all" in verbs else verbs
+
+
+def format_access(access: TWorkspaceAccess) -> str:
+    """`{"data": ["read"], "local": ["read", "write"]}` as `data:read,local:read,local:write`.
+
+    An access granting nothing renders as every axis without a verb, `local:,data:,context:`.
+    """
+    declared: Dict[str, Any] = dict(access or {})
+    tokens = [f"{axis}:{verb}" for axis in ACCESS_AXES for verb in declared.get(axis) or []]
+    return ",".join(tokens or (f"{axis}:" for axis in ACCESS_AXES))
+
+
+def parse_access(text: str) -> TWorkspaceAccess:
+    """`data:read,local:write` back into an access declaration. `data:` grants nothing on `data`.
+
+    Raises:
+        ValueError: The text is empty or a token is not `axis:verb`. Empty text stands for
+            nothing at all; a caller granting everything passes `FULL_ACCESS` itself.
+    """
+    access: Dict[str, Any] = {}
+    declared = False
+    for token in (text or "").split(","):
+        token = token.strip()
+        if not token:
+            continue
+        axis, colon, verb = token.partition(":")
+        if axis not in ACCESS_AXES or not colon:
+            raise ValueError(
+                f"{token!r} is not an access value. Write axis:verb, with axis one of"
+                f" {', '.join(ACCESS_AXES)}"
+            )
+        declared = True
+        if verb:
+            access.setdefault(axis, []).append(verb)
+    if not declared:
+        raise ValueError(f"{text!r} declares no access. Write axis:verb pairs, or axis: for none")
+    return typing.cast(TWorkspaceAccess, access)
+
+
+def missing_access(required: TWorkspaceAccess, granted: TWorkspaceAccess) -> List[str]:
+    """`axis:verb` grants `required` asks for and `granted` does not have."""
+    missing: List[str] = []
+    for axis in ACCESS_AXES:
+        verbs = granted_verbs(required, axis) - granted_verbs(granted, axis)
+        missing += [f"{axis}:{verb}" for verb in sorted(verbs)]
+    return missing
+
+
+__all__ = [
+    "ACCESS_AXES",
+    "format_access",
+    "parse_access",
+    "ACCESS_AXIS_VERBS",
+    "ACCESS_AXIS_VOCABULARY",
+    "RequiresAccess",
+    "annotation_metadata",
+    "granted_verbs",
+    "missing_access",
+    "required_access",
+]

--- a/dlt/_workspace/cli/dlthub/_local_workspace_command.py
+++ b/dlt/_workspace/cli/dlthub/_local_workspace_command.py
@@ -1,6 +1,6 @@
 import argparse
 import sys
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from dlt.common import json
 from dlt.common.configuration.specs.pluggable_run_context import RunContextBase
@@ -164,13 +164,18 @@ def _add_pipeline_name(parser: argparse.ArgumentParser, _op: str) -> None:
     parser.add_argument("pipeline_name", nargs="?", help="Pipeline name")
 
 
-def _parse_config_args(pairs: List[str]) -> Dict[str, str]:
-    config: Dict[str, str] = {}
+def _parse_config_args(pairs: List[str]) -> Dict[str, Any]:
+    """`KEY=VALUE` pairs into a config dict. A dotted key nests, as config sections do."""
+    config: Dict[str, Any] = {}
     for pair in pairs:
         if "=" not in pair:
             raise ValueError(f"config must be KEY=VALUE, got: {pair!r}")
         key, value = pair.split("=", 1)
-        config[key] = value
+        *sections, name = key.split(".")
+        target = config
+        for section in sections:
+            target = target.setdefault(section, {})
+        target[name] = value
     return config
 
 
@@ -216,6 +221,9 @@ def _execute_one(
     from dlt._workspace.deployment.launchers._launcher import exec_process
 
     cli_config = _parse_config_args(getattr(args, "config", None) or [])
+    if verbosity := getattr(args, "verbosity", 0):
+        # the launcher runs in its own process and reads the level from the entry point config
+        cli_config.setdefault("agent", {}).setdefault("verbosity", verbosity + 1)
     info = fetch_run_info(
         selector=getattr(args, "selector_or_job_ref", None),
         selectors=selectors,

--- a/dlt/_workspace/cli/dlthub/ai/agents.py
+++ b/dlt/_workspace/cli/dlthub/ai/agents.py
@@ -9,6 +9,7 @@ from dlt._workspace.cli.dlthub.ai.utils import (
     cap_skill_description,
     ensure_cursor_rule_frontmatter,
     home_dir,
+    load_toolkits_index,
     merge_json_mcp_servers,
     merge_toml_mcp_servers,
     parse_json_mcp,
@@ -19,8 +20,17 @@ from dlt._workspace.cli.dlthub.ai.utils import (
 )
 from dlt._workspace.cli.formatters import merge_agents_md_skills
 
-TComponentType = Literal["skill", "command", "rule", "ignore", "mcp"]
+TComponentType = Literal["skill", "command", "rule", "agent", "ignore", "mcp"]
 TInstallOp = Literal["copytree", "save"]
+
+COMPONENT_MARKERS: Dict[TComponentType, str] = {
+    "skill": "SKILL.md",
+    "agent": "AGENT.md",
+}
+"""File that must exist inside a directory-based component for it to count as one."""
+
+DLTHUB_AGENTS_DIR = "dlthub/agents"
+"""Where dlt agents go inside a host's folder: `<host>/agents` holds the host's own subagents."""
 
 
 class AgentDetectLevel(IntEnum):
@@ -99,6 +109,9 @@ class _AIAgent(ABC):
         if component_type == "skill":
             assert isinstance(content_or_path, Path)
             return self._install_skill(content_or_path, source_name, project_root, overwrite)
+        if component_type == "agent":
+            assert isinstance(content_or_path, Path)
+            return self._install_agent(content_or_path, source_name, project_root, overwrite)
         if component_type == "ignore":
             assert isinstance(content_or_path, str)
             dest = self.component_dir("ignore", project_root) / self.ignore_file_name
@@ -136,6 +149,54 @@ class _AIAgent(ABC):
                 conflict=not overwrite and dest.exists(),
             )
         ]
+
+    def _install_agent(
+        self,
+        content_or_path: Path,
+        source_name: str,
+        project_root: Path,
+        overwrite: bool,
+    ) -> List["InstallAction"]:
+        """Install actions for an agent directory, copied verbatim."""
+        dest = self.component_dir("agent", project_root) / source_name
+        return [
+            InstallAction(
+                kind="agent",
+                source_name=source_name,
+                dest_path=dest,
+                op="copytree",
+                content_or_path=content_or_path,
+                conflict=not overwrite and dest.exists(),
+            )
+        ]
+
+    def component_path(
+        self,
+        component_type: TComponentType,
+        source_name: str,
+        toolkit_name: str,
+        project_root: Path,
+    ) -> Optional[Path]:
+        """Path this agent installs a component to. Inverse of `install_actions`.
+
+        Args:
+            component_type: "skill", "command", "rule", or "agent".
+            source_name: Name in the toolkit, without any prefix or extension.
+            toolkit_name: Toolkit the component came from; rules are prefixed with it.
+            project_root: Target project root.
+
+        Returns:
+            Optional[Path]: Installed path, or `None` when this agent has no place for the type.
+        """
+        if component_type not in self._DIRS:
+            return None
+        base = self.component_dir(component_type, project_root)
+        marker = COMPONENT_MARKERS.get(component_type)
+        if marker:
+            return base / source_name / marker
+        if component_type == "command":
+            return base / (source_name + ".md")
+        return base / (toolkit_name + "-" + source_name + self._RULE_EXT)
 
     def _transform_rule(self, content: str) -> str:
         """Transform rule content before writing. Override for agent-specific formatting."""
@@ -246,6 +307,7 @@ class _ClaudeAgent(_AIAgent):
         "skill": ".claude/skills",
         "command": ".claude/commands",
         "rule": ".claude/rules",
+        "agent": f".claude/{DLTHUB_AGENTS_DIR}",
     }
     _GLOBAL_MARKER: ClassVar[str] = ".claude"
     _LOCAL_PROBES: ClassVar[Tuple[str, ...]] = (".claude", "CLAUDE.md")
@@ -280,6 +342,7 @@ class _CursorAgent(_AIAgent):
         "skill": ".cursor/skills",
         "command": ".cursor/commands",
         "rule": ".cursor/rules",
+        "agent": f".cursor/{DLTHUB_AGENTS_DIR}",
     }
     _GLOBAL_MARKER: ClassVar[str] = ".cursor"
     _LOCAL_PROBES: ClassVar[Tuple[str, ...]] = (".cursor", ".cursorignore", ".cursorrules")
@@ -314,6 +377,7 @@ class _CursorAgent(_AIAgent):
 class _CodexAgent(_AIAgent):
     _DIRS: ClassVar[Dict[TComponentType, str]] = {
         "skill": ".agents/skills",
+        "agent": f".agents/{DLTHUB_AGENTS_DIR}",
     }
     _GLOBAL_MARKER: ClassVar[str] = ".codex"
     _LOCAL_PROBES: ClassVar[Tuple[str, ...]] = (".agents", "AGENTS.md")
@@ -336,6 +400,20 @@ class _CodexAgent(_AIAgent):
         """Path to the AGENTS.md file for skill registration."""
         return project_root / "AGENTS.md"
 
+    def component_path(
+        self,
+        component_type: TComponentType,
+        source_name: str,
+        toolkit_name: str,
+        project_root: Path,
+    ) -> Optional[Path]:
+        skill_dir = self.component_dir("skill", project_root)
+        if component_type == "command":
+            return skill_dir / source_name / COMPONENT_MARKERS["skill"]
+        if component_type == "rule":
+            return skill_dir / (toolkit_name + "-" + source_name) / COMPONENT_MARKERS["skill"]
+        return super().component_path(component_type, source_name, toolkit_name, project_root)
+
     def _install_skill(
         self,
         content_or_path: Path,
@@ -347,7 +425,7 @@ class _CodexAgent(_AIAgent):
         # Codex drops skills whose description exceeds the limit; copytree installs the
         # SKILL.md verbatim, so cap it with a follow-up save
         skill_action = actions[0]
-        skill_md = content_or_path / "SKILL.md"
+        skill_md = content_or_path / COMPONENT_MARKERS["skill"]
         if not skill_action.conflict and skill_md.is_file():
             capped = cap_skill_description(
                 skill_md.read_text(encoding="utf-8"), self._MAX_SKILL_DESCRIPTION
@@ -358,7 +436,7 @@ class _CodexAgent(_AIAgent):
                     InstallAction(
                         kind="skill",
                         source_name=source_name,
-                        dest_path=skill_action.dest_path / "SKILL.md",
+                        dest_path=skill_action.dest_path / COMPONENT_MARKERS["skill"],
                         op="save",
                         content_or_path=capped,
                         conflict=False,
@@ -379,7 +457,9 @@ class _CodexAgent(_AIAgent):
         if component_type == "command":
             wrapped = wrap_as_skill(content, source_name)
             wrapped = cap_skill_description(wrapped, self._MAX_SKILL_DESCRIPTION) or wrapped
-            dest = self.component_dir("skill", project_root) / source_name / "SKILL.md"
+            dest = (
+                self.component_dir("skill", project_root) / source_name / COMPONENT_MARKERS["skill"]
+            )
             return [
                 InstallAction(
                     kind="skill",
@@ -395,7 +475,9 @@ class _CodexAgent(_AIAgent):
         skill_name = toolkit_name + "-" + source_name
         wrapped = wrap_as_skill(content, skill_name, always_apply=True)
         wrapped = cap_skill_description(wrapped, self._MAX_SKILL_DESCRIPTION) or wrapped
-        skill_dest = self.component_dir("skill", project_root) / skill_name / "SKILL.md"
+        skill_dest = (
+            self.component_dir("skill", project_root) / skill_name / COMPONENT_MARKERS["skill"]
+        )
         return [
             InstallAction(
                 kind="skill",
@@ -456,3 +538,25 @@ AI_AGENTS: Dict[str, Type[_AIAgent]] = {
     "cursor": _CursorAgent,
     "codex": _CodexAgent,
 }
+
+
+def resolve_installed_component(
+    toolkit: str, name: str, kind: TComponentType, project_root: Path
+) -> Optional[Path]:
+    """Path of a component `dlthub ai toolkit install` wrote, or `None` when nothing matches.
+
+    An empty `toolkit` searches every installed toolkit; the index says which host installed
+    each, and that host's layout is where the component is looked for.
+    """
+    index = load_toolkits_index()
+    entry = index.get(toolkit) if toolkit else None
+    host = entry.get("agent") if entry else None
+    variants = [AI_AGENTS[host]] if host in AI_AGENTS else list(AI_AGENTS.values())
+
+    toolkits = [toolkit] if toolkit else list(index)
+    for variant_cls in variants:
+        for toolkit_name in toolkits:
+            path = variant_cls().component_path(kind, name, toolkit_name, project_root)
+            if path is not None and path.is_file():
+                return path
+    return None

--- a/dlt/_workspace/cli/dlthub/ai/commands.py
+++ b/dlt/_workspace/cli/dlthub/ai/commands.py
@@ -6,13 +6,20 @@ import tomlkit.exceptions
 import yaml
 
 from dlt.common.runtime import run_context
+from dlt._workspace.access import FULL_ACCESS, format_access, parse_access
 from dlt._workspace.cli import echo as fmt, utils
-from dlt._workspace.cli.utils import DEFAULT_MCP_FEATURES
+from dlt._workspace.cli.utils import DEFAULT_MCP_FEATURES, mcp_stdio_args, resolve_features
 from dlt._workspace.cli.formatters import parse_frontmatter
 from dlt._workspace.cli.exceptions import (
     CliCommandException,
 )
-from dlt._workspace.cli.dlthub.ai.agents import AI_AGENTS, TComponentType, _AIAgent, InstallAction
+from dlt._workspace.cli.dlthub.ai.agents import (
+    AI_AGENTS,
+    COMPONENT_MARKERS,
+    TComponentType,
+    _AIAgent,
+    InstallAction,
+)
 from dlt._workspace.cli.dlthub.ai.typing import TAiStatusInfo, TToolkitInfo
 from dlt._workspace.cli.dlthub.ai.utils import (
     build_toolkits_dependency_map,
@@ -78,6 +85,8 @@ def ai_mcp_run_command(
     stdio: bool = False,
     sse: bool = False,
     features: Optional[List[str]] = None,
+    no_default_features: bool = False,
+    access: Optional[str] = None,
 ) -> None:
     """Start the dlt MCP server for pipeline data inspection."""
     from dlt._workspace.mcp import WorkspaceMCP
@@ -88,15 +97,17 @@ def ai_mcp_run_command(
         transport = "sse"
     else:
         transport = "streamable-http"
-    from dlt._workspace.mcp.server import resolve_features
-
-    resolved = resolve_features(features)
+    resolved = resolve_features(features, set() if no_default_features else None)
     fmt.echo(
         "Starting dlt MCP server with features: %s" % ", ".join(sorted(resolved)),
         err=True,
     )
-    mcp_server = WorkspaceMCP("dlt", port=port, features=resolved)
-    mcp_server.run(transport=transport)
+    # a person at a terminal passes no --access and gets every tool
+    granted = FULL_ACCESS if access is None else parse_access(access)
+    fmt.echo("Access granted to the caller: %s" % format_access(granted), err=True)
+    mcp_server = WorkspaceMCP("dlt", port=port, features=resolved, access=granted)
+    # a stdio server has no console of its own: its banner would land in the client's terminal
+    mcp_server.run(transport=transport, show_banner=not stdio)
 
 
 @utils.track_command("ai", track_before=True, operation="mcp.install")
@@ -107,15 +118,10 @@ def ai_mcp_install_command(
     overwrite: bool = False,
 ) -> None:
     """Install dlt MCP server config into the agent's config file."""
-    from dlt._workspace.mcp.server import resolve_features
-
     project_root = Path(run_context.active().run_dir)
     variant = _resolve_agent(agent, project_root)
 
-    resolved = resolve_features(features)
-    args = ["uv", "run", fmt.get_cli_host_name(), "ai", "mcp", "run", "--stdio"]
-    if resolved != DEFAULT_MCP_FEATURES:
-        args.extend(["--features"] + sorted(resolved))
+    args = ["uv", "run", fmt.get_cli_host_name(), *mcp_stdio_args(features)]
 
     server_config: Dict[str, Any] = {"command": args[0], "args": args[1:], "type": "stdio"}
     new_servers = {name: server_config}
@@ -181,7 +187,7 @@ def _plan_toolkit_install(
     skills_dir = toolkit_dir / "skills"
     if skills_dir.is_dir():
         for skill_path in sorted(skills_dir.iterdir()):
-            if not skill_path.is_dir() or not (skill_path / "SKILL.md").exists():
+            if not skill_path.is_dir() or not (skill_path / COMPONENT_MARKERS["skill"]).exists():
                 continue
             errors = _validate_skill_dir(skill_path)
             if errors:
@@ -191,6 +197,23 @@ def _plan_toolkit_install(
             actions.extend(
                 agent.install_actions(
                     "skill", skill_path, skill_path.name, toolkit_name, project_root, overwrite
+                )
+            )
+
+    # agents (directory-based, each with AGENT.md + optional files), copied verbatim
+    agents_dir = toolkit_dir / "agents"
+    if agents_dir.is_dir():
+        for agent_path in sorted(agents_dir.iterdir()):
+            if not agent_path.is_dir() or not (agent_path / COMPONENT_MARKERS["agent"]).exists():
+                continue
+            errors = _validate_skill_dir(agent_path)
+            if errors:
+                for err in errors:
+                    warnings.append("Skipping agent %s: %s" % (agent_path.name, err))
+                continue
+            actions.extend(
+                agent.install_actions(
+                    "agent", agent_path, agent_path.name, toolkit_name, project_root, overwrite
                 )
             )
 

--- a/dlt/_workspace/cli/dlthub/commands.py
+++ b/dlt/_workspace/cli/dlthub/commands.py
@@ -299,6 +299,8 @@ class AiCommand(SupportsCliCommand):
                     stdio=getattr(args, "stdio", False),
                     sse=getattr(args, "sse", False),
                     features=getattr(args, "features", None),
+                    no_default_features=getattr(args, "no_default_features", False),
+                    access=getattr(args, "access", None),
                 )
         else:
             self.parser.print_usage()

--- a/dlt/_workspace/cli/dlthub/utils.py
+++ b/dlt/_workspace/cli/dlthub/utils.py
@@ -41,7 +41,7 @@ from dlt._workspace.deployment import (
     humanize_trigger,
     manifest_from_module,
 )
-from dlt._workspace.deployment._job_ref import format_job_label
+from dlt._workspace.deployment._job_ref import format_job_label, job_category
 from dlt._workspace.deployment._trigger_helpers import parse_trigger
 from dlt._workspace.deployment.exceptions import InvalidTrigger
 from dlt._workspace.deployment.manifest import expand_triggers
@@ -62,7 +62,7 @@ WORKSPACE_DEPS: List[str] = [
     "ibis-framework>=12.0.0",
     "pyarrow>=16.0.0",
     "marimo>=0.14.5",
-    "fastmcp>=3.0.0",
+    "fastmcp>=3.1.0",
     "mowidgets>=0.2.1 ; python_version >= '3.11'",
     "pathspec>=0.11.2",
     "pydbml>=1.2.0",
@@ -380,14 +380,7 @@ def fetch_deployment_info() -> TDeploymentManifestInfo:
         expose = job_def.get("expose") or {}
         deliver = job_def.get("deliver") or {}
         entry_point = job_def["entry_point"]
-        # category priority: explicit expose.category > delivers to a pipeline > job_type
-        category: str
-        if expose.get("category"):
-            category = expose["category"]
-        elif deliver.get("pipeline_name"):
-            category = "pipeline"
-        else:
-            category = entry_point["job_type"]
+        category = job_category(expose, deliver, entry_point["job_type"])
         counts[category] = counts.get(category, 0) + 1
 
         expanded = expand_triggers(job_def)

--- a/dlt/_workspace/cli/echo.py
+++ b/dlt/_workspace/cli/echo.py
@@ -1,10 +1,13 @@
 """CLI prompting and output helpers."""
 
 import io
+import os
 import sys
 import contextlib
 from typing import Any, Dict, Iterable, Iterator, Optional, Tuple, ContextManager
 import click
+
+from dlt.common import known_env
 
 
 ALWAYS_CHOOSE_DEFAULT = False
@@ -164,6 +167,15 @@ def maybe_no_stdin() -> ContextManager[None]:
 echo = click.echo
 secho = click.secho
 style = click.style
+
+
+def color_output() -> Optional[bool]:
+    """Pass as `color=` to `echo`. `None` leaves the terminal check to click."""
+    if os.environ.get(known_env.DLT_ECHO_NO_COLOR):
+        return False
+    if os.environ.get(known_env.DLT_ECHO_FORCE_COLOR):
+        return True
+    return None
 
 
 def bold(msg: str) -> str:

--- a/dlt/_workspace/cli/utils.py
+++ b/dlt/_workspace/cli/utils.py
@@ -4,6 +4,8 @@ import os
 import platform
 import shutil
 import subprocess
+import sys
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -11,6 +13,7 @@ from typing import (
     FrozenSet,
     List,
     Optional,
+    Set,
     Tuple,
 )
 
@@ -41,11 +44,13 @@ from dlt.reflection.script_visitor import PipelineScriptVisitor
 from dlt._workspace.cli.exceptions import CliCommandInnerException
 from dlt._workspace.cli import echo as fmt
 from dlt._workspace.helpers.dashboard.typing import TPipelineListItem
+from dlt._workspace.access import format_access
 from dlt._workspace.typing import (
     ProviderInfo,
     ProviderLocationInfo,
     TLocationScope,
     TSchemaExport,
+    TWorkspaceAccess,
 )
 from dlt._workspace.profile import is_local_profile
 
@@ -245,7 +250,77 @@ def make_mcp_run_flags(default_port: int = 8000) -> argparse.ArgumentParser:
             % ", ".join(defaults)
         ),
     )
+    flags.add_argument(
+        "--no-default-features",
+        action="store_true",
+        help="Serve only the features named by --features, without the defaults above",
+    )
+    flags.add_argument(
+        "--access",
+        default=None,
+        help=(
+            "Access the caller was granted, as `axis:verb,verb` pairs"
+            " (e.g. data:read,local:read). Tools requiring more are not served."
+            " `axis:` alone grants nothing on that axis. Everything is served when omitted."
+        ),
+    )
     return flags
+
+
+def resolve_features(feature_tokens: Optional[List[str]], defaults: Set[str] = None) -> Set[str]:
+    """Resolve `+name`, `-name`, `name` tokens against defaults into a feature set."""
+    if defaults is None:
+        defaults = set(DEFAULT_MCP_FEATURES)
+    if not feature_tokens:
+        return set(defaults)
+
+    result = set(defaults)
+    for item in feature_tokens:
+        # tokens may be comma-separated: "--features=-secrets,+context"
+        # because argparse treats leading "-" as a flag, use "=" form for removals
+        for token in item.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            if token.startswith("-"):
+                result.discard(token[1:])
+            elif token.startswith("+"):
+                result.add(token[1:])
+            else:
+                result.add(token)
+    return result
+
+
+def mcp_stdio_args(
+    features: Optional[List[str]] = None,
+    with_defaults: bool = True,
+    access: Optional[TWorkspaceAccess] = None,
+) -> List[str]:
+    """`ai mcp run --stdio` arguments serving `features`, limited to what `access` covers.
+
+    Without `with_defaults` the server serves `features` alone, not the interactive defaults.
+    Without `access` the server grants everything.
+    """
+    args = ["ai", "mcp", "run", "--stdio"]
+    if access is not None:
+        args += ["--access", format_access(access)]
+    if not with_defaults:
+        args.append("--no-default-features")
+        resolved = resolve_features(features, set())
+        return args + ["--features", *sorted(resolved)] if resolved else args
+    resolved = resolve_features(features)
+    if resolved != DEFAULT_MCP_FEATURES:
+        args.extend(["--features"] + sorted(resolved))
+    return args
+
+
+def cli_host_command() -> str:
+    """The `dlthub` script next to the running interpreter, or the bare name when there is none.
+
+    Always `dlthub`, not the active host: the `dlt` host has no `ai` command.
+    """
+    script = Path(sys.executable).parent / ("dlthub.exe" if os.name == "nt" else "dlthub")
+    return str(script) if script.is_file() else "dlthub"
 
 
 def add_mcp_arg_parser(subparsers: Any, description: str, help_str: str, default_port: int) -> None:

--- a/dlt/_workspace/deployment/__init__.py
+++ b/dlt/_workspace/deployment/__init__.py
@@ -74,6 +74,7 @@ from dlt._workspace.deployment.typing import (
     TInterfaceType,
     TJobExposeSpec,
     TJobExposeCategory,
+    TJobObjectInput,
     TExposeSpec,
     TRequireSpec,
     TEntryPoint,

--- a/dlt/_workspace/deployment/_job_ref.py
+++ b/dlt/_workspace/deployment/_job_ref.py
@@ -1,9 +1,21 @@
-from typing import List, Optional, Sequence, Tuple
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
 
 from dlt._workspace.deployment.exceptions import AmbiguousJobRef, InvalidJobRef, JobRefNotFound
 from dlt._workspace.deployment.typing import TDeliverSpec, TExposeSpec, TJobRef
 
 JOB_REF_PREFIX = "jobs."
+
+
+def job_category(
+    expose: Optional[Mapping[str, Any]], deliver: Optional[Mapping[str, Any]], job_type: str
+) -> str:
+    """Label a job is grouped under: `expose.category`, else `pipeline` when it delivers to one,
+    else its `job_type`. The CLI summary and a run's result type use the same rule."""
+    if expose and expose.get("category"):
+        return str(expose["category"])
+    if deliver and deliver.get("pipeline_name"):
+        return "pipeline"
+    return job_type
 
 
 def make_job_ref(section: str, name: str) -> TJobRef:

--- a/dlt/_workspace/deployment/_run_helpers.py
+++ b/dlt/_workspace/deployment/_run_helpers.py
@@ -5,8 +5,10 @@ import os
 import os.path
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 from uuid import uuid4
+
+from packaging.version import Version
 
 from dlt.common.time import UTC_NAME, ensure_datetime_in_tz, to_tzinfo
 
@@ -55,6 +57,10 @@ from dlt._workspace.deployment.typing import (
     resolve_refresh_propagation,
 )
 from dlt.version import DLT_PKG_NAME
+
+INCREMENTAL_MODE_DLT_VERSION = Version("1.30.1a0")
+"""First dlt whose launcher reads `incremental_mode` and `auto_refresh_pipeline_mode`. The ones
+before know `allow_external_schedulers` alone."""
 
 
 TCandidate = Tuple[TJobDefinition, TTrigger]
@@ -135,7 +141,9 @@ def select_candidates(
     for job_def in manifest["jobs"]:
         job_type = job_def["entry_point"]["job_type"]
         expanded = expand_triggers(job_def)
-        hits = match_triggers_with_selectors(job_type, expanded, selectors)
+        hits = match_triggers_with_selectors(
+            job_type, expanded, selectors, job_ref=job_def["job_ref"]
+        )
         trigger = pick_trigger(hits, job_def.get("default_trigger"))
         if trigger is None:
             continue
@@ -312,7 +320,7 @@ def resolve_interval(
 
 def build_runtime_entry_point(
     job_def: TJobDefinition,
-    cli_config: Dict[str, str],
+    cli_config: Dict[str, Any],
     profile: Optional[str],
     refresh: bool,
     interval_start: Optional[datetime],
@@ -330,14 +338,17 @@ def build_runtime_entry_point(
         interval_start: UTC-serialized start of the interval, or `None` for point-in-time runs.
         interval_end: UTC-serialized end of the interval, or `None`.
         dlt_version: Target dlt install (version + source) the deployment runs on. The entry
-            point is emitted in a shape that dlt version understands; callers pass the value
-            from the requirements manifest, where engine-1 deployments resolve to 1.28.0 via
-            `migrate_requirements`.
+            point is emitted in the shape that dlt version's launcher understands; callers
+            pass the value from the requirements manifest, where engine-1 deployments resolve
+            to 1.28.0 via `migrate_requirements`.
         tz: IANA timezone carried alongside the interval for the launcher to re-apply;
             defaults to the job's `require.timezone` (or UTC).
 
     Returns:
         TRuntimeEntryPoint: The entry point enriched with runtime launch context.
+
+    Raises:
+        InvalidVersion: `dlt_version` names no valid package version.
     """
     entry_point: TRuntimeEntryPoint = copy.copy(job_def["entry_point"])  # type: ignore[assignment]
     entry_point["job_ref"] = job_def["job_ref"]
@@ -362,12 +373,13 @@ def build_runtime_entry_point(
         entry_point["interval_timezone"] = tz
     # unset jobs get neither key so launcher-side `jobs` configuration may apply
     mode = job_def.get("incremental_mode")
-    # dual-written: launchers of older dlt versions only know `allow_external_schedulers`.
-    if mode is not None:
-        entry_point["incremental_mode"] = mode
+    if Version(dlt_version["version"]) >= INCREMENTAL_MODE_DLT_VERSION:
+        if mode is not None:
+            entry_point["incremental_mode"] = mode
+        if job_def.get("auto_refresh_pipeline_mode"):
+            entry_point["auto_refresh_pipeline_mode"] = job_def["auto_refresh_pipeline_mode"]
+    elif mode is not None:
         entry_point["allow_external_schedulers"] = mode == "interval"
-    if job_def.get("auto_refresh_pipeline_mode"):
-        entry_point["auto_refresh_pipeline_mode"] = job_def["auto_refresh_pipeline_mode"]
     if profile:
         entry_point["profile"] = profile
     entry_point["refresh"] = refresh
@@ -394,7 +406,7 @@ def fetch_run_info(
     user_start: Optional[str] = None,
     user_end: Optional[str] = None,
     user_refresh: bool = False,
-    cli_config: Optional[Dict[str, str]] = None,
+    cli_config: Optional[Dict[str, Any]] = None,
     job_ref: Optional[str] = None,
     forbidden_job_type: Optional[str] = None,
     available_selectors: Optional[List[str]] = None,

--- a/dlt/_workspace/deployment/_run_typing.py
+++ b/dlt/_workspace/deployment/_run_typing.py
@@ -7,6 +7,47 @@ from dlt.common.typing import NotRequired, TypedDict
 
 TRunLocation = Literal["local", "remote"]
 
+TAgentEventKind = Literal[
+    "start",
+    "system_prompt",
+    "prompt",
+    "turn",
+    "thinks",
+    "says",
+    "tool_call",
+    "tool_result",
+    "mcp",
+    "finish",
+]
+
+
+class TAgentEvent(TypedDict):
+    """One step of an agent run, as it happens."""
+
+    kind: TAgentEventKind
+    agent: str
+    text: NotRequired[str]
+    """What the agent said, thought, or was asked."""
+    tool: NotRequired[str]
+    server: NotRequired[str]
+    """MCP server the tool belongs to."""
+    detail: NotRequired[Any]
+    """Tool arguments on a call, the returned value on a result."""
+    error: NotRequired[bool]
+    """The tool failed."""
+    turn: NotRequired[int]
+    input_tokens: NotRequired[int]
+    output_tokens: NotRequired[int]
+    model: NotRequired[str]
+    limits: NotRequired[str]
+    status: NotRequired[str]
+    total_tokens: NotRequired[int]
+    cost_usd: NotRequired[float]
+    tools: NotRequired[List[str]]
+    """Distinct builtin tools the run called, on `finish`."""
+    skills: NotRequired[List[str]]
+    mcp_tools: NotRequired[List[str]]
+
 
 class TRunJobInfo(TypedDict):
     """Resolved `workspace run` request — all data needed to launch the job."""

--- a/dlt/_workspace/deployment/_run_views.py
+++ b/dlt/_workspace/deployment/_run_views.py
@@ -1,6 +1,5 @@
 """CLI views for `run` / `serve` orchestration: banner, warnings, plan, picker."""
 
-import os
 import sys
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
 
@@ -91,9 +90,8 @@ TEventLines = Callable[[TAgentEvent, int], List[str]]
 
 
 def _echo(text: str = "") -> None:
-    """Writes a line with its colors, terminal or not. `NO_COLOR` turns them off."""
-    # a runner's log viewer renders ANSI, and click would strip it for anything but a terminal
-    fmt.echo(text, color=not os.environ.get("NO_COLOR"))
+    """Writes a line, styled when the output supports color."""
+    fmt.echo(text, color=fmt.color_output())
 
 
 def _rule(label: str, tail: str = "", **label_style: Any) -> str:
@@ -198,15 +196,10 @@ EVENT_LINES: Dict[TAgentEventKind, TEventLines] = {
 }
 
 
-def print_agent_event(event: TAgentEvent, verbosity: int = 1) -> None:
-    """Render one step of an agent run as a transcript."""
+def emit_agent_event(event: TAgentEvent, verbosity: int = 1) -> None:
+    """Renders one step of an agent run as a transcript on stdout."""
     for line in EVENT_LINES[event["kind"]](event, verbosity):
         _echo(line)
-
-
-def emit_agent_event(event: TAgentEvent, verbosity: int = 1) -> None:
-    """Shows a run step on stdout, whether or not a terminal is attached."""
-    print_agent_event(event, verbosity)
 
 
 def print_run_banner(info: TRunBannerInfo) -> None:

--- a/dlt/_workspace/deployment/_run_views.py
+++ b/dlt/_workspace/deployment/_run_views.py
@@ -1,15 +1,22 @@
 """CLI views for `run` / `serve` orchestration: banner, warnings, plan, picker."""
 
+import os
 import sys
-from typing import List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
 
 from dlt.common import json
 
 from dlt._workspace.cli import echo as fmt
 from dlt._workspace.deployment._job_ref import format_job_label
-from dlt._workspace.deployment._run_typing import TRunBannerInfo, TRunJobInfo
+from dlt._workspace.deployment._run_typing import (
+    TAgentEvent,
+    TAgentEventKind,
+    TRunBannerInfo,
+    TRunJobInfo,
+)
 from dlt._workspace.deployment.exceptions import AmbiguousJobSelector
-from dlt._workspace.deployment.typing import TJobDefinition
+from dlt._workspace.deployment.job_result import parse_result_type
+from dlt._workspace.deployment.typing import TJobDefinition, TJobResult
 
 
 TCandidate = Tuple[TJobDefinition, str]
@@ -32,28 +39,190 @@ def print_run_warnings(
 
 def print_run_plan(info: TRunJobInfo) -> None:
     """Render the resolved run plan (used for `-v` / `--dry-run`)."""
-    fmt.echo("job_ref: %s" % info["job_ref"])
-    fmt.echo("trigger: %s" % info["trigger"])
-    fmt.echo("launcher: %s" % info["launcher"])
-    fmt.echo("run_id:  %s" % info["run_id"])
-    fmt.echo("entry_point:")
-    fmt.echo(json.typed_dumps(info["entry_point"], pretty=True))
+    _echo("job_ref: %s" % info["job_ref"])
+    _echo("trigger: %s" % info["trigger"])
+    _echo("launcher: %s" % info["launcher"])
+    _echo("run_id:  %s" % info["run_id"])
+    _echo("entry_point:")
+    _echo(json.typed_dumps(info["entry_point"], pretty=True))
+
+
+def print_job_result(result: TJobResult) -> None:
+    """Render the structured result a job returned, after its run finished."""
+    fields: Dict[str, Any] = dict(result)
+    category, _ = parse_result_type(result["type"])
+    _echo("")
+    _echo("Result  [%s]" % fmt.style(result["type"], fg="cyan"))
+    # the category says an agent ran, and so that status, summary and trace are there
+    if category == "background_agent":
+        status = fields.get("status", "")
+        _echo("  status:     %s" % fmt.style(status, fg=STATUS_COLORS.get(status, "white")))
+        if summary := fields.get("summary"):
+            _echo("  summary:    %s" % summary)
+    for entity in fields.get("object") or []:
+        _echo("  %s: %s" % (entity["type"], entity["id"]))
+    if trace := fields.get("trace"):
+        _echo(
+            "  loop:       %s on %s, %s turns, %s tokens"
+            % (
+                trace.get("loop_type", "?"),
+                trace.get("model", "?"),
+                trace.get("turn_count", 0),
+                trace.get("total_tokens", 0),
+            )
+        )
+        if (tools := trace.get("local_tools")) is not None:
+            wired = ", ".join(f"{name} ({verb})" for name, verb in tools.items())
+            _echo("  local tools: %s" % (wired or "none"))
+    payload = fields.get("result")
+    if payload is not None:
+        _echo(json.typed_dumps(payload, pretty=True))
+
+
+AGENT_RULE_WIDTH = 74
+RULE_CHAR = "─"
+DOT_SEP = " · "
+DETAIL_CAPS = {0: 80, 1: 200}
+"""How much of a tool argument, result or thought each verbosity shows. 2 shows all of it."""
+STATUS_COLORS = {"succeeded": "green", "failed": "red", "aborted": "yellow"}
+
+TEventLines = Callable[[TAgentEvent, int], List[str]]
+"""Renders one event, at one verbosity, as the lines it prints. An empty string is a blank line."""
+
+
+def _echo(text: str = "") -> None:
+    """Writes a line with its colors, terminal or not. `NO_COLOR` turns them off."""
+    # a runner's log viewer renders ANSI, and click would strip it for anything but a terminal
+    fmt.echo(text, color=not os.environ.get("NO_COLOR"))
+
+
+def _rule(label: str, tail: str = "", **label_style: Any) -> str:
+    """`── label ──────── tail ──` filled to the console width, the label styled."""
+    fill = max(AGENT_RULE_WIDTH - len(label) - (len(tail) + 4 if tail else 0) - 4, 2)
+    rule = fmt.style(f"{RULE_CHAR * 2} ", dim=True) + fmt.style(label, **label_style)
+    rule += fmt.style(f" {RULE_CHAR * fill}", dim=True)
+    if tail:
+        rule += fmt.style(f" {tail} {RULE_CHAR * 2}", dim=True)
+    return rule
+
+
+def _excerpt(value: Any, verbosity: int) -> str:
+    """One-line rendering of a detail, capped for the level."""
+    text = value if isinstance(value, str) else json.dumps(value)
+    text = " ".join(text.split())
+    cap = DETAIL_CAPS.get(verbosity)
+    return text if cap is None or len(text) <= cap else f"{text[:cap]}\u2026"
+
+
+def _indented(text: str, prefix: str = "  ") -> str:
+    return "\n".join(f"{prefix}{line}" for line in text.strip().splitlines())
+
+
+def _start_lines(event: TAgentEvent, verbosity: int) -> List[str]:
+    tail = DOT_SEP.join(filter(None, [event.get("model"), event.get("limits")]))
+    return ["", _rule(event["agent"], tail, bold=True)]
+
+
+def _spoken_lines(label: str) -> TEventLines:
+    """A cyan label over the indented text: the prompt going in, the agent speaking."""
+    return lambda event, _: ["", fmt.style(label, fg="cyan"), _indented(event.get("text", ""))]
+
+
+def _turn_lines(event: TAgentEvent, verbosity: int) -> List[str]:
+    tokens = ""
+    if event.get("input_tokens") is not None:
+        tokens = f"{event['input_tokens']:,} in / {event.get('output_tokens', 0):,} out"
+    label = f"turn {event.get('turn', 0)}"
+    pad = max(AGENT_RULE_WIDTH - len(label) - len(tokens), 1)
+    return ["", fmt.style(f"{label}{' ' * pad}{tokens}", dim=True)]
+
+
+def _system_prompt_lines(event: TAgentEvent, verbosity: int) -> List[str]:
+    # the whole assembled prompt is long; only the most verbose level shows it
+    if verbosity < 2:
+        return []
+    return _spoken_lines("system prompt")(event, verbosity)
+
+
+def _thinks_lines(event: TAgentEvent, verbosity: int) -> List[str]:
+    if verbosity == 0:
+        return []
+    return [fmt.style(f"  thinks  {_excerpt(event.get('text', ''), verbosity)}", dim=True)]
+
+
+def _tool_call_lines(event: TAgentEvent, verbosity: int) -> List[str]:
+    call = f"  {fmt.style(event.get('tool', 'tool'), fg='yellow')}"
+    if event.get("server"):
+        call += fmt.style(f" ({event['server']})", dim=True)
+    if verbosity > 0 and event.get("detail") is not None:
+        call += f"  {fmt.style(_excerpt(event['detail'], verbosity), dim=True)}"
+    return [call]
+
+
+def _tool_result_lines(event: TAgentEvent, verbosity: int) -> List[str]:
+    arrow = fmt.style("\u2192", fg="red" if event.get("error") else "green")
+    return [f"     {arrow} {fmt.style(_excerpt(event.get('detail', ''), verbosity), dim=True)}"]
+
+
+def _finish_lines(event: TAgentEvent, verbosity: int) -> List[str]:
+    status = event.get("status", "finished")
+    facts = [f"{event.get('turn', 0)} turns", f"{event.get('total_tokens', 0):,} tokens"]
+    if event.get("cost_usd") is not None:
+        facts.append(f"${event['cost_usd']:.2f}")
+    lines = ["", _rule(status, DOT_SEP.join(facts), fg=STATUS_COLORS.get(status, "white"))]
+    used = [
+        f"{label}: {', '.join(names)}"
+        for label, names in (
+            ("tools", event.get("tools")),
+            ("skills", event.get("skills")),
+            ("mcp tools", event.get("mcp_tools")),
+        )
+        if names
+    ]
+    if used:
+        lines.append(fmt.style(f"  {DOT_SEP.join(used)}", dim=True))
+    return lines + [""]
+
+
+EVENT_LINES: Dict[TAgentEventKind, TEventLines] = {
+    "start": _start_lines,
+    "system_prompt": _system_prompt_lines,
+    "prompt": _spoken_lines("prompt"),
+    "turn": _turn_lines,
+    "thinks": _thinks_lines,
+    "says": _spoken_lines("says"),
+    "tool_call": _tool_call_lines,
+    "tool_result": _tool_result_lines,
+    "mcp": lambda event, _: [fmt.style(f"  mcp  {event.get('text', '')}", dim=True)],
+    "finish": _finish_lines,
+}
+
+
+def print_agent_event(event: TAgentEvent, verbosity: int = 1) -> None:
+    """Render one step of an agent run as a transcript."""
+    for line in EVENT_LINES[event["kind"]](event, verbosity):
+        _echo(line)
+
+
+def emit_agent_event(event: TAgentEvent, verbosity: int = 1) -> None:
+    """Shows a run step on stdout, whether or not a terminal is attached."""
+    print_agent_event(event, verbosity)
 
 
 def print_run_banner(info: TRunBannerInfo) -> None:
     """Print the unified `Starting <job> [local|remote]` banner."""
     color = "green" if info["location"] == "local" else "cyan"
     chip = fmt.style(info["location"], fg=color)
-    fmt.echo("Starting %s  [%s]" % (fmt.bold(info["display_label"]), chip))
-    fmt.echo("  job_ref:    %s" % info["job_ref"])
-    fmt.echo("  trigger:    %s" % info["trigger_humanized"])
-    fmt.echo("  profile:    %s" % info["profile"])
+    _echo("Starting %s  [%s]" % (fmt.bold(info["display_label"]), chip))
+    _echo("  job_ref:    %s" % info["job_ref"])
+    _echo("  trigger:    %s" % info["trigger_humanized"])
+    _echo("  profile:    %s" % info["profile"])
     if "run_id" in info:
-        fmt.echo("  run_id:     %s" % info["run_id"])
+        _echo("  run_id:     %s" % info["run_id"])
     if "workspace_name" in info:
-        fmt.echo("  workspace:  %s" % info["workspace_name"])
+        _echo("  workspace:  %s" % info["workspace_name"])
     if "port" in info:
-        fmt.echo("Listening on http://localhost:%d" % info["port"])
+        _echo("Listening on http://localhost:%d" % info["port"])
 
 
 def pick_one_job(candidates: Sequence[TCandidate]) -> TCandidate:
@@ -65,10 +234,10 @@ def pick_one_job(candidates: Sequence[TCandidate]) -> TCandidate:
     if not (sys.stdin.isatty() and sys.stdout.isatty()) or not fmt.is_interactive():
         raise AmbiguousJobSelector(candidates)
 
-    fmt.echo("%d jobs match:" % len(candidates))
+    _echo("%d jobs match:" % len(candidates))
     for i, (jd, t) in enumerate(candidates, 1):
         label = format_job_label(jd["job_ref"], jd.get("expose"), jd.get("deliver"))
-        fmt.echo("  %d. %s  (trigger: %s)" % (i, label, t))
+        _echo("  %d. %s  (trigger: %s)" % (i, label, t))
     choice = fmt.prompt(
         "Pick a job",
         choices=[str(i) for i in range(1, len(candidates) + 1)],

--- a/dlt/_workspace/deployment/_trigger_helpers.py
+++ b/dlt/_workspace/deployment/_trigger_helpers.py
@@ -1,5 +1,5 @@
 from datetime import timezone
-from fnmatch import fnmatch
+from fnmatch import fnmatchcase
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 from urllib.parse import urlparse
 
@@ -9,7 +9,7 @@ from dlt.common.interval import is_cron_expression
 from dlt.common.time import ensure_datetime_in_tz, parse_period_seconds
 from dlt.common.typing import TAnyDateTime
 from dlt._workspace.deployment._job_ref import resolve_job_ref, short_name as _job_short_name
-from dlt._workspace.deployment.exceptions import InvalidTrigger
+from dlt._workspace.deployment.exceptions import InvalidJobRef, InvalidTrigger
 from dlt._workspace.deployment.typing import (
     HttpTriggerInfo,
     TJobDefinition,
@@ -115,20 +115,23 @@ def _parse_manual(expr: str) -> TParsedTrigger:
     return TParsedTrigger(type="manual", expr=expr or None, raw=TTrigger(f"manual:{expr}"))
 
 
-def _parse_job_success(expr: str) -> TParsedTrigger:
+def _parse_job_event(event: TTriggerType, expr: str) -> TParsedTrigger:
+    """Parses `job.success:` / `job.fail:`, which take a `jobs.` ref or a selector."""
     if not expr:
-        raise InvalidTrigger("job.success:", "requires a job_ref")
-    if not expr.startswith("jobs."):
-        raise InvalidTrigger(f"job.success:{expr}", "expression must start with 'jobs.'")
-    return TParsedTrigger(type="job.success", expr=expr, raw=TTrigger(f"job.success:{expr}"))
+        raise InvalidTrigger(f"{event}:", "requires a job_ref or selector")
+    if not expr.startswith("jobs.") and not is_selector(expr):
+        raise InvalidTrigger(
+            f"{event}:{expr}", "expression must start with 'jobs.' or be a selector"
+        )
+    return TParsedTrigger(type=event, expr=expr, raw=TTrigger(f"{event}:{expr}"))
+
+
+def _parse_job_success(expr: str) -> TParsedTrigger:
+    return _parse_job_event("job.success", expr)
 
 
 def _parse_job_fail(expr: str) -> TParsedTrigger:
-    if not expr:
-        raise InvalidTrigger("job.fail:", "requires a job_ref")
-    if not expr.startswith("jobs."):
-        raise InvalidTrigger(f"job.fail:{expr}", "expression must start with 'jobs.'")
-    return TParsedTrigger(type="job.fail", expr=expr, raw=TTrigger(f"job.fail:{expr}"))
+    return _parse_job_event("job.fail", expr)
 
 
 def _parse_pipeline_name(expr: str) -> TParsedTrigger:
@@ -150,6 +153,22 @@ PARSERS: Dict[str, Callable[[str], TParsedTrigger]] = {
     "job.fail": _parse_job_fail,
     "pipeline_name": _parse_pipeline_name,
 }
+
+
+_JOB_EVENT_TYPES = ("job.success", "job.fail")
+_GLOB_CHARS = "*?["
+
+
+def _normalize_job_event_ref(trigger: str, expr: str) -> str:
+    """Resolve a job event expression: a selector stands, a bare ref becomes `jobs.` form."""
+    if not expr:
+        raise InvalidTrigger(trigger, "requires a job_ref or selector")
+    if is_selector(expr):
+        return expr
+    try:
+        return resolve_job_ref(expr)
+    except InvalidJobRef as e:
+        raise InvalidTrigger(trigger, str(e)) from e
 
 
 def parse_trigger(trigger: TTrigger) -> TParsedTrigger:
@@ -180,6 +199,11 @@ def normalize_trigger(trigger: Union[str, TTrigger]) -> TTrigger:
         trigger_type = s.split(":", 1)[0]
         if trigger_type in _SYNTHETIC_TYPES:
             raise InvalidTrigger(s, f"{trigger_type}: triggers are added automatically")
+        if trigger_type in _JOB_EVENT_TYPES:
+            expr = s.split(":", 1)[1]
+            return parse_trigger(
+                TTrigger(f"{trigger_type}:{_normalize_job_event_ref(s, expr)}")
+            ).raw
         if trigger_type in PARSERS:
             return parse_trigger(TTrigger(s)).raw
         raise InvalidTrigger(s, f"unknown type {trigger_type!r}")
@@ -225,7 +249,8 @@ _SELECTOR_KEYWORDS = _JOB_TYPE_SELECTORS | set(PARSERS.keys())
 
 def is_selector(s: str) -> bool:
     """Check if string looks like a trigger selector vs a bare job ref."""
-    if ":" in s:
+    if ":" in s or any(c in s for c in _GLOB_CHARS):
+        # a job ref never contains glob characters, so a globbed expression selects
         return True
     return s in _SELECTOR_KEYWORDS
 
@@ -243,22 +268,29 @@ def match_triggers_with_selectors(
     job_type: str,
     triggers: List[TTrigger],
     selectors: List[str],
+    job_ref: Optional[str] = None,
 ) -> List[TTrigger]:
     """Return triggers that match any selector.
 
-    Job-type selectors (batch, interactive, stream, job) match ALL triggers.
+    A selector matches a job by any of the three things a job is: its type
+    (`batch`, `interactive`, `stream`, `job`, with or without a trailing colon), one of its
+    triggers, or its `job_ref` when the caller supplies one. Job-type and ref selectors are
+    about the job rather than one trigger, so they match all of them.
     """
     matched: List[TTrigger] = []
 
     for selector in selectors:
-        if selector in _JOB_TYPE_SELECTORS:
-            if (selector == "job" and job_type == "batch") or job_type == selector:
+        if selector.rstrip(":") in _JOB_TYPE_SELECTORS:
+            job_selector = selector.rstrip(":")
+            if (job_selector == "job" and job_type == "batch") or job_type == job_selector:
                 return list(triggers)
             continue
 
         pattern = _normalize_selector(selector)
+        if job_ref and fnmatchcase(job_ref, pattern):
+            return list(triggers)
         for t in triggers:
-            if t not in matched and fnmatch(t, pattern):
+            if t not in matched and fnmatchcase(t, pattern):
                 matched.append(t)
 
     return matched

--- a/dlt/_workspace/deployment/agent/configuration.py
+++ b/dlt/_workspace/deployment/agent/configuration.py
@@ -1,0 +1,54 @@
+"""Job configuration synthesized from an agent's declared inputs."""
+
+import inspect
+from typing import List, Type
+
+from dlt.common import logger
+from dlt.common.configuration.specs.base_configuration import BaseConfiguration
+from dlt.common.typing import AnyFun
+from dlt.common.utils import get_callable_name
+
+from dlt._workspace.deployment.agent.manifest import declared_placeholders
+from dlt._workspace.deployment.agent.typing import TAgentSpec
+from dlt._workspace.deployment.reflection import spec_from_inputs_schema
+
+
+def spec_from_agent_inputs(agent_spec: TAgentSpec) -> Type[BaseConfiguration]:
+    """Configuration spec with one field per input the agent declares."""
+    return spec_from_inputs_schema(agent_spec["name"], agent_spec["inputs"])
+
+
+def warn_unreferenced_inputs(agent_spec: TAgentSpec) -> List[str]:
+    """Declared inputs no placeholder in the system prompt uses. Warns, never raises."""
+    referenced = {
+        name.partition(".")[0] for name in declared_placeholders(agent_spec["system_prompt"])
+    }
+    unreferenced = [
+        name for name in (agent_spec["inputs"].get("properties") or {}) if name not in referenced
+    ]
+    if unreferenced:
+        logger.warning(
+            f"Agent {agent_spec['name']!r} declares inputs"
+            f" {', '.join(map(repr, unreferenced))} that its system prompt never mentions."
+            " Add {{ name }} where each belongs, or drop it."
+        )
+    return unreferenced
+
+
+def warn_unbound_inputs(agent_spec: TAgentSpec, f: AnyFun) -> List[str]:
+    """Declared inputs the decorated function cannot receive. Warns, never raises."""
+    try:
+        parameters = inspect.signature(f).parameters
+    except (ValueError, TypeError):
+        return []
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values()):
+        return []
+    unbound = [
+        name for name in (agent_spec["inputs"].get("properties") or {}) if name not in parameters
+    ]
+    if unbound:
+        logger.warning(
+            f"Agent {agent_spec['name']!r} declares inputs {', '.join(map(repr, unbound))} that"
+            f" {get_callable_name(f)}() does not accept. Nothing will pass them."
+        )
+    return unbound

--- a/dlt/_workspace/deployment/agent/exceptions.py
+++ b/dlt/_workspace/deployment/agent/exceptions.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Sequence
 
-from dlt._workspace.deployment.exceptions import DeploymentException
+from dlt._workspace.deployment.exceptions import DeploymentException, DeploymentValidationError
 
 
 class AgentException(DeploymentException):
@@ -20,13 +20,13 @@ class UnknownAgentLoop(AgentException, KeyError):
         )
 
 
-class InvalidAgentSpec(AgentException, ValueError):
+class InvalidAgentSpec(AgentException, DeploymentValidationError):
     def __init__(self, path: str, reason: str) -> None:
         self.path = path
-        super().__init__(f"Invalid agent file {path!r}: {reason}")
+        super().__init__(f"Invalid agent file {path!r}: {reason}", errors=[reason], subject=path)
 
 
-class AgentComponentNotFound(AgentException, FileNotFoundError):
+class AgentComponentNotFound(AgentException, DeploymentValidationError):
     def __init__(
         self,
         ref: str,
@@ -72,7 +72,7 @@ class AgentComponentNotFound(AgentException, FileNotFoundError):
             lines.append("`dlthub ai toolkit list` shows what is available.")
         if toolkit is not None and searched:
             lines.append(f"It must leave {searched[0]} in place.")
-        super().__init__("\n".join(line for line in lines if line))
+        super().__init__("\n".join(line for line in lines if line), subject=ref)
 
 
 class UnsupportedAgentModel(AgentException, ValueError):

--- a/dlt/_workspace/deployment/agent/exceptions.py
+++ b/dlt/_workspace/deployment/agent/exceptions.py
@@ -1,0 +1,106 @@
+from typing import List, Optional, Sequence
+
+from dlt._workspace.deployment.exceptions import DeploymentException
+
+
+class AgentException(DeploymentException):
+    pass
+
+
+class LocalToolError(AgentException):
+    """A local tool could not do what it was asked. The message is what the model reads."""
+
+
+class UnknownAgentLoop(AgentException, KeyError):
+    def __init__(self, loop_type: str, known: Sequence[str]) -> None:
+        self.loop_type = loop_type
+        super().__init__(
+            f"No plugin implements agent loop {loop_type!r}. dlt ships {', '.join(known)};"
+            " a third-party loop must register a `plug_agent_loop` hook."
+        )
+
+
+class InvalidAgentSpec(AgentException, ValueError):
+    def __init__(self, path: str, reason: str) -> None:
+        self.path = path
+        super().__init__(f"Invalid agent file {path!r}: {reason}")
+
+
+class AgentComponentNotFound(AgentException, FileNotFoundError):
+    def __init__(
+        self,
+        ref: str,
+        kind: str,
+        searched: List[str],
+        toolkit: Optional[str] = None,
+        installed: bool = False,
+    ) -> None:
+        """A skill, rule or agent the manifest names is not in the workspace.
+
+        Args:
+            ref (str): The reference as written.
+            kind (str): `agent`, `skill` or `rule`.
+            searched (List[str]): Files that would have answered the reference.
+            toolkit (Optional[str]): Toolkit the ref names. `None` when the ref is a path,
+                empty when it names no toolkit at all.
+            installed (bool): Whether that toolkit is installed in this workspace.
+        """
+        self.ref = ref
+        self.kind = kind
+        self.searched = searched
+        self.toolkit = toolkit
+        lines = [f"Cannot resolve {kind} {ref!r}."]
+        if toolkit is None:
+            lines.append(f"Make sure {searched[0]} is present." if searched else "")
+        elif not toolkit:
+            lines.append(
+                f"The reference names no toolkit. Write it as `<toolkit>:{ref}` and install that"
+                " toolkit, or point at a file inside the workspace."
+            )
+            lines.append("`dlthub ai toolkit list` shows what is available.")
+        elif installed:
+            lines.append(
+                f"Toolkit {toolkit!r} is installed but has no {kind} {ref.rpartition(':')[2]!r}."
+                f" Update it with `dlthub ai toolkit install {toolkit} --overwrite`,"
+                f" or see what it carries with `dlthub ai toolkit info {toolkit}`."
+            )
+        else:
+            lines.append(
+                f"Toolkit {toolkit!r} is not installed in this workspace."
+                f" Install it with `dlthub ai toolkit install {toolkit}`."
+            )
+            lines.append("`dlthub ai toolkit list` shows what is available.")
+        if toolkit is not None and searched:
+            lines.append(f"It must leave {searched[0]} in place.")
+        super().__init__("\n".join(line for line in lines if line))
+
+
+class UnsupportedAgentModel(AgentException, ValueError):
+    def __init__(self, loop_type: str, model: str, reason: str) -> None:
+        self.loop_type = loop_type
+        self.model = model
+        super().__init__(f"Loop {loop_type!r} cannot run model {model!r}: {reason}")
+
+
+class AgentTraceNotAvailable(AgentException):
+    def __init__(self, loop_type: str) -> None:
+        super().__init__(f"Loop {loop_type!r} has no trace: it has not completed a run.")
+
+
+class AgentRunFailed(AgentException):
+    def __init__(self, loop_type: str, agent_ref: str, reason: str) -> None:
+        self.loop_type = loop_type
+        self.agent_ref = agent_ref
+        super().__init__(f"Agent {agent_ref!r} on {loop_type!r} failed: {reason}")
+
+
+class AgentTokenLimitExceeded(AgentRunFailed):
+    def __init__(self, loop_type: str, agent_ref: str, used: int, limit: int) -> None:
+        self.used = used
+        self.limit = limit
+        super().__init__(
+            loop_type,
+            agent_ref,
+            f"used {used:,} tokens, over its limit of {limit:,}. Raise `limits.max_tokens` on"
+            " the agent or `agent.max_tokens` in configuration, or narrow the task",
+        )

--- a/dlt/_workspace/deployment/agent/loop.py
+++ b/dlt/_workspace/deployment/agent/loop.py
@@ -1,0 +1,367 @@
+"""The agent loop abstraction and the settings one run is assembled from."""
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Tuple, Type, cast
+
+from dlt.common import json, logger
+from dlt.common.configuration import plugins
+from dlt.common.utils import clone_dict_nested, map_nested_values_in_place
+
+from dlt._workspace.deployment.agent.exceptions import (
+    AgentTokenLimitExceeded,
+    AgentTraceNotAvailable,
+    UnknownAgentLoop,
+)
+from dlt._workspace.deployment.agent.manifest import render_placeholders
+from dlt._workspace.deployment.agent.typing import (
+    AGENT_MODEL_ALIASES,
+    TAgentLimits,
+    TAgentSettings,
+    TAgentSpec,
+    TAgentTrace,
+    TAgentTurn,
+)
+from dlt._workspace.deployment._run_typing import TAgentEvent, TAgentEventKind
+from dlt._workspace.deployment._run_views import emit_agent_event
+from dlt._workspace.deployment.configuration import AgentConfiguration
+from dlt._workspace.deployment.launchers import BUILTIN_AGENT_LOOPS, DEFAULT_AGENT_LOOP
+from dlt._workspace.deployment.typing import TWorkspaceAccess
+from dlt._workspace.typing import TWorkspaceLocalVerb
+
+
+DEFAULT_VERBOSITY = 1
+"""Thoughts in one line, tool arguments and results capped. 0 shows less, 2 everything."""
+
+DEFAULT_USER_TURN = "Go ahead"
+"""What a run opens with when nobody gave instructions: the task is in the system prompt."""
+
+
+def distinct_tools_used(turns: List[TAgentTurn]) -> Tuple[List[str], List[str], List[str]]:
+    """Distinct builtin, skill and MCP names across every turn, in first-seen order."""
+    seen: Dict[str, List[str]] = {"builtin": [], "skill": [], "mcp": []}
+    for turn in turns:
+        for use in turn["tools"]:
+            bucket = seen[use["kind"]]
+            if use["name"] not in bucket:
+                bucket.append(use["name"])
+    return seen["builtin"], seen["skill"], seen["mcp"]
+
+
+def _serializable(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    """A copy of `inputs` whose leaves json cannot encode became their `repr`."""
+
+    def coerce(value: Any) -> Any:
+        try:
+            json.dumps(value)
+            return value
+        except (TypeError, ValueError):
+            # the beacon client swallows serialization errors, so replace the leaf here
+            return repr(value)
+
+    return map_nested_values_in_place(coerce, clone_dict_nested(inputs))
+
+
+class AgentLoop(ABC):
+    """Runs one agent spec on one agent framework."""
+
+    LOOP_TYPE: ClassVar[str]
+    DEFAULT_MODEL: ClassVar[str] = "sonnet"
+    DEFAULT_PROVIDER: ClassVar[str] = ""
+    """Provider a bare model name belongs to. Empty when a loop names its models its own way."""
+    DEFAULT_MAX_TURNS: ClassVar[Optional[int]] = None
+    DEFAULT_MAX_TOKENS: ClassVar[Optional[int]] = None
+
+    def __init__(self, settings: TAgentSettings) -> None:
+        self.settings = settings
+        self.spec: TAgentSpec = None
+        self.agent_ref: str = ""
+        self.agent_file: str = ""
+        self._trace: TAgentTrace = None
+        self._ignored_run_args: List[str] = []
+        self._native_skills: List[str] = []
+        self._inlined_skills: List[str] = []
+        self._unresolved_placeholders: List[str] = []
+        self._input_tokens: int = 0
+        self._output_tokens: int = 0
+        self._system_prompt: str = ""
+        """Body plus whatever the loop inlines, assembled in `init` and still a template."""
+
+    @property
+    def loop_type(self) -> str:
+        return self.LOOP_TYPE
+
+    @property
+    def user_turn(self) -> str:
+        """What the run says to the agent. Every framework needs a first message."""
+        return self.settings["instructions"] or DEFAULT_USER_TURN
+
+    @abstractmethod
+    def init(self, agent_spec: TAgentSpec) -> None:
+        """Prepares the loop from the agent declaration."""
+
+    @abstractmethod
+    async def run(
+        self,
+        instructions: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        model: Optional[str] = None,
+        limits: Optional[TAgentLimits] = None,
+        run_args: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Builds the native agent from the runtime arguments, runs it, returns the output.
+
+        Args:
+            instructions (Optional[str]): The user turn, overriding the resolved settings.
+            inputs (Optional[Dict[str, Any]]): Declared inputs plus the implicit run context.
+            model (Optional[str]): Model for this run, overriding the declaration.
+            limits (Optional[TAgentLimits]): Budget for this run, overriding the declaration.
+            run_args (Optional[Dict[str, Any]]): Arguments passed to the native loop.
+        """
+
+    @property
+    @abstractmethod
+    def native(self) -> Any:
+        """The underlying framework object."""
+
+    @property
+    def trace(self) -> TAgentTrace:
+        if self._trace is None:
+            raise AgentTraceNotAvailable(self.LOOP_TYPE)
+        return self._trace
+
+    def resolve_run(
+        self,
+        model: Optional[str] = None,
+        limits: Optional[TAgentLimits] = None,
+        instructions: Optional[str] = None,
+    ) -> None:
+        """Folds this run's arguments over the resolved settings. Called first in `run`."""
+        # a loop may run more than once, and each run counts its tokens from zero
+        self._input_tokens = self._output_tokens = 0
+        if model:
+            self.settings["model"] = model
+        if limits:
+            if limits.get("max_turns") is not None:
+                self.settings["max_turns"] = limits["max_turns"]
+            if limits.get("max_tokens") is not None:
+                self.settings["max_tokens"] = limits["max_tokens"]
+        if instructions:
+            self.settings["instructions"] = instructions
+        logger.info(
+            f"Agent {self.log_name} runs {self.model_id()} on the"
+            f" {self.settings['endpoint_source']} endpoint."
+        )
+
+    def model_id(self) -> str:
+        """Settings model as `provider:model`: aliases expanded, a bare name qualified."""
+        model = self.settings["model"]
+        model = AGENT_MODEL_ALIASES.get(model, model)
+        if ":" in model or not self.DEFAULT_PROVIDER:
+            return model
+        return f"{self.DEFAULT_PROVIDER}:{model}"
+
+    def local_tools(self) -> Dict[str, TWorkspaceLocalVerb]:
+        """Local tools this loop wired, by the access mode that bought each."""
+        return {}
+
+    @property
+    def log_name(self) -> str:
+        return self.agent_ref or (self.spec["name"] if self.spec else "agent")
+
+    def emit(self, kind: TAgentEventKind, **fields: Any) -> None:
+        """Reports one step of the run to stdio"""
+        event = cast(TAgentEvent, {"kind": kind, "agent": self.log_name, **fields})
+        emit_agent_event(event, self.settings["verbosity"])
+
+    def render_system_prompt(self, inputs: Mapping[str, Any]) -> str:
+        """The assembled system prompt with this run's inputs substituted into its placeholders."""
+        prompt, unresolved = render_placeholders(self._system_prompt, inputs)
+        self._unresolved_placeholders = unresolved
+        if unresolved:
+            logger.warning(
+                f"Agent {self.spec['name']!r} system prompt has unresolved placeholders:"
+                f" {', '.join(sorted(set(unresolved)))}"
+            )
+        self.emit("system_prompt", text=prompt)
+        return prompt
+
+    def emit_run_start(self, prompt: str) -> None:
+        limits = [f"max {self.settings['max_turns']} turns"] if self.settings["max_turns"] else []
+        if self.settings["max_tokens"]:
+            limits.append(f"{self.settings['max_tokens']:,} tokens")
+        self.emit("start", model=self.model_id(), limits=" \u00b7 ".join(limits))
+        self.emit("prompt", text=prompt)
+
+    def emit_run_finished(self, status: str = None) -> None:
+        trace = self.trace
+        self.emit(
+            "finish",
+            status=status or "finished",
+            turn=trace["turn_count"],
+            total_tokens=trace["total_tokens"],
+            cost_usd=trace.get("cost_usd"),
+            tools=trace["tools_used"],
+            skills=trace["skills_used"],
+            mcp_tools=trace["mcp_tools_used"],
+        )
+        used = [
+            f"{label}: {', '.join(names)}"
+            for label, names in (
+                ("tools", trace["tools_used"]),
+                ("skills", trace["skills_used"]),
+                ("mcp tools", trace["mcp_tools_used"]),
+            )
+            if names
+        ]
+        logger.info(
+            f"Agent {self.log_name} finished in {trace['turn_count']} turns and"
+            f" {trace['total_tokens']:,} tokens, using {'; '.join(used) or 'no tools'}."
+        )
+
+    @property
+    def tokens_used(self) -> int:
+        """Tokens the loop has counted so far, input and output together."""
+        return self._input_tokens + self._output_tokens
+
+    def count_tokens(self, input_tokens: int, output_tokens: int) -> None:
+        """Adds one turn's tokens to the run and stops it once `max_tokens` is passed.
+
+        Every loop reports its turns here, so the limit means the same thing on all of them.
+
+        Raises:
+            AgentTokenLimitExceeded: The run has used more tokens than it was given.
+        """
+        self._input_tokens += input_tokens
+        self._output_tokens += output_tokens
+        limit = self.settings["max_tokens"]
+        if limit is not None and self.tokens_used > limit:
+            raise AgentTokenLimitExceeded(self.LOOP_TYPE, self.agent_ref, self.tokens_used, limit)
+
+    def _base_trace(self, inputs: Dict[str, Any]) -> TAgentTrace:
+        """Everything the loop ran with, before the counters are filled in."""
+        trace: TAgentTrace = {
+            "agent": self.agent_ref,
+            "agent_file": self.agent_file,
+            "loop_type": self.LOOP_TYPE,
+            "model": self.model_id(),
+            "limits": TAgentLimits(
+                max_turns=self.settings["max_turns"], max_tokens=self.settings["max_tokens"]
+            ),
+            "loop_run_args": dict(self.settings["loop_run_args"]),
+            "inputs": _serializable(inputs),
+            "access": self.spec.get("access") or {},
+            "local_tools": self.local_tools(),
+            "mcp_features": list(self.spec.get("tools") or []),
+            "native_skills": list(self._native_skills),
+            "inlined_skills": list(self._inlined_skills),
+            "unresolved_placeholders": list(self._unresolved_placeholders),
+            "turn_count": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "turns": [],
+            "tools_used": [],
+            "skills_used": [],
+            "mcp_tools_used": [],
+            "instructions": self.user_turn,
+        }
+        return trace
+
+
+def resolve_agent_loop(loop_type: str) -> Type[AgentLoop]:
+    """Asks plugins for a loop class answering to `loop_type`.
+
+    Raises:
+        UnknownAgentLoop: No plugin implements the requested loop.
+    """
+    claimed = [c for c in plugins.manager().hook.plug_agent_loop(loop_type=loop_type) if c]
+    if not claimed:
+        raise UnknownAgentLoop(loop_type, list(BUILTIN_AGENT_LOOPS))
+    if len(claimed) > 1:
+        logger.warning(
+            f"{len(claimed)} plugins claim agent loop {loop_type!r}. Using"
+            f" {claimed[0].__module__}.{claimed[0].__name__}"
+        )
+    return claimed[0]  # type: ignore[no-any-return]
+
+
+def split_model_id(model: str) -> Tuple[str, str]:
+    """`(provider, name)` of a model id. The provider is empty when the id carries none."""
+    provider, separator, name = model.partition(":")
+    return (provider, name) if separator else ("", provider)
+
+
+def resolve_agent_settings(
+    spec: TAgentSpec,
+    config: AgentConfiguration,
+    decorator_args: Mapping[str, Any],
+    loop_cls: Type[AgentLoop],
+    workspace_root: str,
+) -> TAgentSettings:
+    """Merges loop defaults, spec `defaults`, decorator arguments and config into one setting set.
+
+    Precedence: loop class < agent spec < decorator argument < resolved config.
+    """
+    defaults = spec.get("defaults") or {}
+    spec_limits = defaults.get("limits") or {}
+    deco_limits = decorator_args.get("limits") or {}
+
+    # `None` means "not supplied" at every layer, so overriding one limit leaves the other
+    def pick(*values: Any) -> Any:
+        for value in reversed(values):
+            if value is not None:
+                return value
+        return None
+
+    loop_run_args: Dict[str, Any] = dict(defaults.get("loop_run_args") or {})
+    loop_run_args.update(decorator_args.get("loop_run_args") or {})
+    loop_run_args.update(config.loop_run_args or {})
+
+    return {
+        "loop_type": loop_cls.LOOP_TYPE,
+        "model": pick(
+            loop_cls.DEFAULT_MODEL,
+            defaults.get("model"),
+            decorator_args.get("model"),
+            config.effective_model,
+        ),
+        "instructions": pick(decorator_args.get("instructions"), config.instructions),
+        "max_turns": pick(
+            loop_cls.DEFAULT_MAX_TURNS,
+            spec_limits.get("max_turns"),
+            deco_limits.get("max_turns"),
+            config.max_turns,
+        ),
+        "max_tokens": pick(
+            loop_cls.DEFAULT_MAX_TOKENS,
+            spec_limits.get("max_tokens"),
+            deco_limits.get("max_tokens"),
+            config.max_tokens,
+        ),
+        "loop_run_args": loop_run_args,
+        "verbosity": pick(
+            DEFAULT_VERBOSITY, None, decorator_args.get("verbosity"), config.verbosity
+        ),
+        "api_key": config.effective_api_key,
+        "api_url": config.effective_api_url,
+        "api_version": config.effective_api_version,
+        "endpoint_source": config.endpoint_source,
+        "trace_url": config.trace_url,
+        "trace_key": config.trace_key,
+        "workspace_root": workspace_root,
+    }
+
+
+def resolve_loop_type(decorator_loop: Optional[str], config: AgentConfiguration) -> str:
+    """Loop type: config wins, then the decorator, then the built-in default."""
+    return config.loop or decorator_loop or DEFAULT_AGENT_LOOP
+
+
+__all__ = [
+    "AgentLoop",
+    "distinct_tools_used",
+    "resolve_agent_loop",
+    "resolve_agent_settings",
+    "resolve_loop_type",
+    "split_model_id",
+]

--- a/dlt/_workspace/deployment/agent/loops/claude_sdk.py
+++ b/dlt/_workspace/deployment/agent/loops/claude_sdk.py
@@ -1,0 +1,372 @@
+"""Agent loop on the Claude Agent SDK."""
+
+import dataclasses
+from collections import deque
+from pathlib import Path
+from typing import Any, ClassVar, Deque, Dict, List, Optional, Tuple, cast
+
+from dlt.common import json, logger
+from dlt.common.exceptions import MissingDependencyException
+
+from dlt._workspace.deployment.agent.loop import AgentLoop, distinct_tools_used, split_model_id
+from dlt._workspace.deployment.agent.loops.tools import (
+    LOCAL_TOOL_VERBS,
+    LOCAL_TOOLS,
+    MCP_SERVER_ID,
+    mcp_server_command,
+    secret_deny_rules,
+    temp_dir,
+    workspace_note,
+)
+from dlt._workspace.deployment.agent.manifest import (
+    granted,
+    inline_components,
+    resolve_component_ref,
+)
+from dlt._workspace.deployment.agent.exceptions import (
+    AgentComponentNotFound,
+    AgentRunFailed,
+    UnsupportedAgentModel,
+)
+from dlt._workspace.deployment.agent.typing import (
+    TAgentLimits,
+    TAgentSpec,
+    TAgentToolUse,
+    TAgentTurn,
+)
+from dlt._workspace.deployment.launchers import LOOP_CLAUDE_AGENT_SDK, LOOP_PYDANTIC_AI
+from dlt._workspace.deployment.reflection import model_schema
+from dlt._workspace.typing import TWorkspaceAccess, TWorkspaceLocalVerb
+
+try:
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeAgentOptions,
+        ClaudeSDKClient,
+        ClaudeSDKError,
+        ResultMessage,
+        SystemMessage,
+        UserMessage,
+    )
+    from claude_agent_sdk.types import TextBlock, ThinkingBlock, ToolResultBlock, ToolUseBlock
+except ModuleNotFoundError as ex:
+    raise MissingDependencyException(
+        "dlthub background agents on claude-agent-sdk",
+        ["claude-agent-sdk"],
+    ) from ex
+
+
+AI_LOOP_TOOLS: Dict[str, Tuple[str, ...]] = {
+    "Read": ("Read", "NotebookRead"),
+    "Glob": ("Glob",),
+    "Grep": ("Grep",),
+    "Write": ("Write",),
+    "Edit": ("Edit", "MultiEdit", "NotebookEdit"),
+    # the last two only read and stop a shell the agent left running in the background
+    "Bash": ("Bash", "BashOutput", "KillShell"),
+    "PowerShell": ("PowerShell",),
+    "RunPython": (),
+    "WebFetch": ("WebFetch",),
+    "WebSearch": ("WebSearch",),
+}
+"""CLI tools behind each name in `LOCAL_TOOLS`. Python runs through `Bash` here."""
+CLI_STDERR_KEPT = 20
+"""CLI stderr lines held back, to explain a run that ends without a result."""
+
+MCP_TOOL_PREFIX = "mcp__"
+MCP_TOOL_PATTERN = f"{MCP_TOOL_PREFIX}{MCP_SERVER_ID}__*"
+SKILL_TOOL_NAME = "Skill"
+RULES_EXCLUDES = ["**/.claude/rules/**"]
+"""Project rules the CLI loads with the project settings. An agent gets the rules it declares;
+`CLAUDE.md` and `CLAUDE.local.md` still load."""
+
+
+def cli_settings(given: Optional[str] = None) -> str:
+    """The CLI `--settings` layer: the run args' settings, if any, with the project rules kept out."""
+    settings: Dict[str, Any] = {}
+    if given:
+        # the CLI takes the flag as inline JSON or as a path to a JSON file
+        text = given if given.lstrip().startswith("{") else Path(given).read_text(encoding="utf-8")
+        settings = json.loads(text)
+    settings["claudeMdExcludes"] = [*RULES_EXCLUDES, *settings.get("claudeMdExcludes", [])]
+    return json.dumps(settings)
+
+
+def classify_tool(name: str, tool_input: Optional[Dict[str, Any]] = None) -> TAgentToolUse:
+    """Sorts a tool call into an MCP tool, a skill, or a CLI builtin."""
+    if name.startswith(MCP_TOOL_PREFIX):
+        parts = name[len(MCP_TOOL_PREFIX) :].split("__", 1)
+        use: TAgentToolUse = {"name": parts[-1], "kind": "mcp"}
+        if len(parts) == 2:
+            use["server"] = parts[0]
+        return use
+    if name == SKILL_TOOL_NAME:
+        # the CLI names the invoked skill in the tool input, under one of these keys
+        named = tool_input or {}
+        skill = named.get("skill") or named.get("name") or named.get("command") or name
+        return {"name": str(skill), "kind": "skill"}
+    return {"name": name, "kind": "builtin"}
+
+
+class ClaudeAgentSdkLoop(AgentLoop):
+    """The loop runs the Claude Code CLI, with a shell, a filesystem and native skills."""
+
+    LOOP_TYPE: ClassVar[str] = LOOP_CLAUDE_AGENT_SDK
+    DEFAULT_MODEL: ClassVar[str] = "sonnet"
+    DEFAULT_PROVIDER: ClassVar[str] = "anthropic"
+    DEFAULT_MAX_TURNS: ClassVar[Optional[int]] = 30
+    DEFAULT_MAX_TOKENS: ClassVar[Optional[int]] = None
+
+    def __init__(self, settings: Any) -> None:
+        super().__init__(settings)
+        self._client: Any = None
+        self._options: Any = None
+        self._tool_names: Dict[str, str] = {}
+        self._ai_loop_tools: List[str] = []
+        self._cli_stderr: Deque[str] = deque(maxlen=CLI_STDERR_KEPT)
+
+    @property
+    def native(self) -> Any:
+        return self._client
+
+    def init(self, agent_spec: TAgentSpec) -> None:
+        self.spec = agent_spec
+        workspace_root = self.settings["workspace_root"]
+        verbs = granted(agent_spec, "local")
+        self._ai_loop_tools = [
+            tool
+            for verb, names in LOCAL_TOOLS.items()
+            if verb in verbs
+            for name in names
+            for tool in AI_LOOP_TOOLS[name]
+        ]
+
+        # rules have no equivalent in any framework; the CLI lists an installed skill by name
+        # and loads it when the agent invokes it
+        parts = [
+            agent_spec["system_prompt"],
+            *inline_components(agent_spec.get("rules") or [], "rule", workspace_root),
+        ]
+        for ref in agent_spec.get("skills") or []:
+            try:
+                resolve_component_ref(ref, "skill", workspace_root)
+            except AgentComponentNotFound as ex:
+                logger.warning(f"Skipping skill {ref!r}: {ex}")
+                continue
+            self._native_skills.append(ref)
+        # the harness names its own file tools, so the prompt is where the model learns this
+        parts.append(workspace_note(workspace_root, temp_dir()))
+        self._system_prompt = "\n\n".join(parts)
+
+    def local_tools(self) -> Dict[str, TWorkspaceLocalVerb]:
+        """The CLI tools on the allowlist, each under the verb of the name it extends."""
+        by_cli_tool = {
+            cli_tool: LOCAL_TOOL_VERBS[name]
+            for name, cli_tools in AI_LOOP_TOOLS.items()
+            if name in LOCAL_TOOL_VERBS
+            for cli_tool in cli_tools
+        }
+        return {tool: by_cli_tool[tool] for tool in self._ai_loop_tools}
+
+    def _ai_loop_model(self) -> str:
+        """The bare model name the CLI takes. It runs Anthropic models only."""
+        provider, name = split_model_id(self.model_id())
+        if provider != self.DEFAULT_PROVIDER:
+            raise UnsupportedAgentModel(
+                self.LOOP_TYPE,
+                self.model_id(),
+                f"the Claude Code CLI runs {self.DEFAULT_PROVIDER} models. Run this one on"
+                f" {LOOP_PYDANTIC_AI!r}",
+            )
+        return name
+
+    def _build_options(self, system_prompt: str) -> Any:
+        # the CLI subprocess inherits os.environ, where the launcher put the workspace profile
+        env: Dict[str, str] = {}
+        if self.settings.get("api_key"):
+            env["ANTHROPIC_API_KEY"] = self.settings["api_key"]
+        if self.settings.get("api_url"):
+            env["ANTHROPIC_BASE_URL"] = self.settings["api_url"]
+
+        known = {f.name for f in dataclasses.fields(ClaudeAgentOptions)}
+        extra = {k: v for k, v in self.settings["loop_run_args"].items() if k in known}
+        self._ignored_run_args = sorted(k for k in self.settings["loop_run_args"] if k not in known)
+
+        servers: Dict[str, Any] = {}
+        tools = list(self.spec.get("tools") or [])
+        if tools:
+            servers[MCP_SERVER_ID] = mcp_server_command(tools, self.spec.get("access") or {})
+        # `tools` is what exists at all; `allowed_tools` only says what runs unprompted
+        tools = list(self._ai_loop_tools)
+        allowed = list(self._ai_loop_tools)
+        if servers:
+            allowed.append(MCP_TOOL_PATTERN)
+        if self._native_skills:
+            # `skills` allows the Skill tool but cannot add it to a base set that left it out
+            tools.append(SKILL_TOOL_NAME)
+        return ClaudeAgentOptions(
+            system_prompt=system_prompt,
+            model=self._ai_loop_model(),
+            tools=tools,
+            allowed_tools=allowed,
+            # the CLI owns its file tools, so credential files are kept out by rule
+            disallowed_tools=secret_deny_rules(),
+            permission_mode="dontAsk",
+            # an empty list hides every skill the CLI would otherwise offer on its own
+            skills=[r.rpartition(":")[2] for r in self._native_skills],
+            output_format={"type": "json_schema", "schema": model_schema(self.spec["output"])},
+            max_turns=self.settings["max_turns"],
+            # the project settings are where the CLI discovers the installed skills
+            setting_sources=["project"],
+            # they also bring every project rule, and the rules name every skill of the workspace
+            settings=cli_settings(extra.pop("settings", None)),
+            stderr=self._log_cli_stderr,
+            # the workspace server is ours to spawn; the project's own `.mcp.json` stays out
+            mcp_servers=servers,
+            strict_mcp_config=True,
+            env=env,
+            cwd=self.settings["workspace_root"],
+            # the CLI's file tools stop at the working directory unless a folder is added to it
+            add_dirs=[str(temp_dir()), *extra.pop("add_dirs", [])],
+            **extra,
+        )
+
+    async def run(
+        self,
+        instructions: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        model: Optional[str] = None,
+        limits: Optional[TAgentLimits] = None,
+        run_args: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        inputs = inputs or {}
+        self.resolve_run(model, limits, instructions)
+        if run_args:
+            self.settings["loop_run_args"] = {**self.settings["loop_run_args"], **run_args}
+        self._cli_stderr.clear()
+        self._options = self._build_options(self.render_system_prompt(inputs))
+        self._client = ClaudeSDKClient(options=self._options)
+
+        self.emit_run_start(self.user_turn)
+        turns: List[TAgentTurn] = []
+        result: Any = None
+        try:
+            async with self._client:
+                await self._client.query(self.user_turn)
+                async for message in self._client.receive_response():
+                    if isinstance(message, SystemMessage):
+                        self._emit_servers(message)
+                    elif isinstance(message, AssistantMessage):
+                        self._emit_message(message, len(turns) + 1)
+                        turns.append(_turn_from_message(message))
+                        # over the limit this raises, and leaving the client block ends the CLI
+                        self.count_tokens(turns[-1]["input_tokens"], turns[-1]["output_tokens"])
+                    elif isinstance(message, UserMessage):
+                        self._emit_tool_results(message)
+                    elif isinstance(message, ResultMessage):
+                        result = message
+        except ClaudeSDKError as ex:
+            # the CLI's stderr went to our callback, so the SDK's message says only "check stderr"
+            raise AgentRunFailed(self.LOOP_TYPE, self.agent_ref, self._cli_failure(str(ex))) from ex
+        if result is None:
+            raise AgentRunFailed(self.LOOP_TYPE, self.agent_ref, self._cli_failure())
+        self._trace = self._build_trace(inputs, result, turns)
+        self.emit_run_finished((result.structured_output or {}).get("status"))
+        if result.is_error:
+            raise AgentRunFailed(
+                self.LOOP_TYPE, self.agent_ref, str(result.errors or result.terminal_reason)
+            )
+        return result.structured_output  # type: ignore[no-any-return]
+
+    def _cli_failure(self, message: str = "no result message was returned") -> str:
+        """Why the CLI died: what it wrote on the way out, after the framework's own message."""
+        return "; ".join([message, *self._cli_stderr])
+
+    def _log_cli_stderr(self, line: str) -> None:
+        """The CLI writes its own notices to our stderr. They belong in the log instead."""
+        self._cli_stderr.append(line)
+        logger.debug(f"[{self.log_name}] {line}")
+
+    def _emit_servers(self, message: Any) -> None:
+        """Reports the MCP servers the CLI connected, as its init message lists them."""
+        if message.subtype != "init":
+            return
+        for server in message.data.get("mcp_servers") or []:
+            self.emit("mcp", text=f"{server.get('name')} {server.get('status')}")
+
+    def _emit_message(self, message: Any, turn: int) -> None:
+        """Reports what the model said, thought and called in one assistant message."""
+        try:
+            usage = message.usage or {}
+            self.emit(
+                "turn",
+                turn=turn,
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+            )
+            for block in message.content:
+                if isinstance(block, ThinkingBlock):
+                    self.emit("thinks", text=block.thinking)
+                elif isinstance(block, TextBlock):
+                    self.emit("says", text=block.text)
+                elif isinstance(block, ToolUseBlock):
+                    self._tool_names[block.id] = block.name
+                    used = classify_tool(block.name, block.input)
+                    self.emit(
+                        "tool_call",
+                        tool=used["name"],
+                        server=used.get("server"),
+                        detail=block.input,
+                    )
+        except Exception as ex:
+            # a run must never fail because it could not be reported
+            logger.debug(f"Could not report an assistant message: {ex}")
+
+    def _emit_tool_results(self, message: Any) -> None:
+        """Reports what each tool handed back, named after the call it answers."""
+        try:
+            if isinstance(message.content, str):
+                return
+            for block in message.content:
+                if isinstance(block, ToolResultBlock):
+                    name = self._tool_names.get(block.tool_use_id, "tool")
+                    self.emit(
+                        "tool_result",
+                        tool=classify_tool(name)["name"],
+                        detail=block.content,
+                        error=bool(block.is_error),
+                    )
+        except Exception as ex:
+            # a run must never fail because it could not be reported
+            logger.debug(f"Could not report a tool result: {ex}")
+
+    def _build_trace(self, inputs: Dict[str, Any], result: Any, turns: List[TAgentTurn]) -> Any:
+        trace = self._base_trace(inputs)
+        usage = result.usage or {}
+        # num_turns counts sub-agent turns too, so it can exceed the assistant messages seen
+        trace["turn_count"] = result.num_turns or len(turns)
+        trace["input_tokens"] = usage.get("input_tokens", 0)
+        trace["output_tokens"] = usage.get("output_tokens", 0)
+        trace["total_tokens"] = trace["input_tokens"] + trace["output_tokens"]
+        trace["turns"] = turns
+        trace["tools_used"], trace["skills_used"], trace["mcp_tools_used"] = distinct_tools_used(
+            turns
+        )
+        if result.total_cost_usd is not None:
+            trace["cost_usd"] = result.total_cost_usd
+        if result.terminal_reason:
+            trace["stop_reason"] = result.terminal_reason
+        if self._ignored_run_args:
+            trace["ignored_loop_run_args"] = self._ignored_run_args
+        return trace
+
+
+def _turn_from_message(message: Any) -> TAgentTurn:
+    usage = message.usage or {}
+    return {
+        "tools": [
+            classify_tool(b.name, b.input) for b in message.content if isinstance(b, ToolUseBlock)
+        ],
+        "input_tokens": usage.get("input_tokens", 0),
+        "output_tokens": usage.get("output_tokens", 0),
+    }

--- a/dlt/_workspace/deployment/agent/loops/pydantic_ai.py
+++ b/dlt/_workspace/deployment/agent/loops/pydantic_ai.py
@@ -1,0 +1,453 @@
+"""Agent loop on Pydantic AI."""
+
+import functools
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Set, Tuple, cast
+
+from dlt.common import logger
+from dlt.common.exceptions import MissingDependencyException
+
+from dlt._workspace.deployment.agent.loops.tools import (
+    LOCAL_TOOL_VERBS,
+    LOCAL_TOOLS,
+    MCP_SERVER_ID,
+    LocalTools,
+    mcp_server_command,
+    workspace_note,
+)
+from dlt._workspace.deployment.agent.exceptions import (
+    AgentRunFailed,
+    LocalToolError,
+    UnsupportedAgentModel,
+)
+from dlt._workspace.deployment.agent.loop import AgentLoop, distinct_tools_used
+from dlt._workspace.deployment.agent.manifest import granted, inline_components, inputs_schema
+from dlt._workspace.deployment.agent.typing import (
+    TAgentLimits,
+    TAgentSpec,
+    TAgentToolUse,
+    TAgentTurn,
+)
+from dlt._workspace.deployment.launchers import LOOP_PYDANTIC_AI
+from dlt._workspace.deployment.reflection import model_schema
+from dlt._workspace.typing import (
+    TWorkspaceAccess,
+    TWorkspaceDataVerb,
+    TWorkspaceLocalVerb,
+    TWorkspaceContextVerb,
+)
+
+try:
+    from fastmcp.client.transports import StdioTransport
+    from pydantic_ai import Agent, ModelRetry, Tool, ToolFailed
+    from pydantic_ai.mcp import MCPToolset
+    from pydantic_ai.models import infer_model
+    from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
+    from pydantic_ai.providers import infer_provider, infer_provider_class
+    from pydantic_ai.messages import (
+        ModelResponse,
+        PartEndEvent,
+        RetryPromptPart,
+        TextPart,
+        ToolResultEvent,
+        ThinkingPart,
+        ToolCallPart,
+    )
+    from pydantic_ai.exceptions import UnexpectedModelBehavior
+    from pydantic_ai.usage import UsageLimits
+except ModuleNotFoundError as ex:
+    raise MissingDependencyException(
+        "dlthub background agents on pydantic-ai",
+        ["pydantic-ai-slim[anthropic,openai,google,mcp,spec]"],
+    ) from ex
+
+
+OUTPUT_TOOL_NAME = "final_result"
+"""How pydantic-ai names the tool that carries the answer."""
+
+GATEWAY_PREFIX = "gateway/"
+
+DEFAULT_URL_ARG = "base_url"
+DEFAULT_KEY_ARG = "api_key"
+
+PROVIDER_URL_ARG: Dict[str, Optional[str]] = {
+    "azure": "azure_endpoint",
+    "azure-responses": "azure_endpoint",
+    "litellm": "api_base",
+    "xai": "api_host",
+    # these reach one endpoint of their own and take no url; `openrouter` has `app_url`,
+    # which is the attribution header and not the endpoint
+    "cerebras": None,
+    "cohere": None,
+    "crusoe": None,
+    "deepseek": None,
+    "fireworks": None,
+    "github": None,
+    "moonshotai": None,
+    "nebius": None,
+    "openrouter": None,
+    "ovhcloud": None,
+    "together": None,
+    "vercel": None,
+    "voyageai": None,
+    "zai": None,
+}
+"""What each provider calls `api_url` in its constructor. `base_url` where it is not listed"""
+
+PROVIDER_KEY_ARG: Dict[str, str] = {"snowflake": "token"}
+"""What each provider calls `api_key` in its constructor. `api_key` where it is not listed."""
+
+PROVIDER_VERSION_ARG: Dict[str, str] = {"azure": "api_version", "azure-responses": "api_version"}
+"""Providers that version their API. Azure is the only one pydantic-ai gives the argument to."""
+
+NATIVE_CAPABILITIES: Dict[str, Dict[str, Any]] = {
+    "network": {"WebSearch": WebSearchTool, "WebFetch": WebFetchTool},
+}
+"""Verbs the provider serves itself: web access. `execute` stays in the workspace, on the
+platform's shell tool and `RunPython`."""
+
+NATIVE_CAPABILITY_SPECS: Dict[str, Dict[str, Any]] = {
+    "WebSearch": {"WebSearch": {}},
+    "WebFetch": {"WebFetch": {}},
+}
+"""How each native tool is written in an `AgentSpec` `capabilities` list."""
+
+
+def _as_tool_function(fn: Callable[..., str], retries: int) -> Callable[..., str]:
+    """A local tool whose errors pydantic-ai either retries within a budget or hands over as failed."""
+    error_cls = ModelRetry if retries else ToolFailed
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> str:
+        try:
+            return fn(*args, **kwargs)
+        except LocalToolError as ex:
+            raise error_cls(str(ex)) from ex
+
+    return wrapper
+
+
+def _answer_text(answer: Dict[str, Any]) -> str:
+    """What the agent said when it answered: its summary, or the whole answer."""
+    return str(answer.get("summary") or answer)
+
+
+def _failure_reason(ex: Exception) -> str:
+    """The framework's reason, plus where the limit lives when it names one."""
+    reason = str(ex)
+    if "retries" in reason:
+        reason += " In dlt that limit is `loop_run_args.retries` in the agent defaults."
+    return reason
+
+
+def make_local_tools(tools: LocalTools, verbs: Set[str], retries: int = 0) -> List[Any]:
+    """pydantic-ai `Tool`s for the local verbs the agent declared. No verb, no tool.
+
+    With `retries` at 0 a tool error is a failed call the model sees and moves on from; above
+    it, pydantic-ai asks the model to correct the call, that many times per tool.
+    """
+    served = tools.by_name()
+    return [
+        Tool(_as_tool_function(served[name], retries), name=name)
+        for verb, names in LOCAL_TOOLS.items()
+        if verb in verbs
+        for name in names
+        if name in served
+    ]
+
+
+class PydanticAILoop(AgentLoop):
+    """Pydantic AI has no shell, so it enforces access at the tool surface, not the process."""
+
+    LOOP_TYPE: ClassVar[str] = LOOP_PYDANTIC_AI
+    DEFAULT_MODEL: ClassVar[str] = "sonnet"
+    DEFAULT_PROVIDER: ClassVar[str] = "anthropic"
+    DEFAULT_MAX_TURNS: ClassVar[Optional[int]] = 50
+    DEFAULT_MAX_TOKENS: ClassVar[Optional[int]] = None
+
+    def __init__(self, settings: Any) -> None:
+        super().__init__(settings)
+        self._agent: Any = None
+        self._tools: LocalTools = None
+        self._local_tools: Set[str] = set()
+        self._native_tools: Set[str] = set()
+        self._turn: int = 0
+        self._input_seen: int = 0
+        self._output_seen: int = 0
+
+    @property
+    def native(self) -> Any:
+        return self._agent
+
+    @property
+    def tool_retries(self) -> int:
+        """`loop_run_args.retries`: how often the model may correct a failing tool call.
+
+        0, the default, hands every tool error to the model as a failed call instead: the run
+        goes on, and `max_turns` is what bounds it.
+        """
+        return int(self.settings["loop_run_args"].get("retries") or 0)
+
+    def init(self, agent_spec: TAgentSpec) -> None:
+        self.spec = agent_spec
+        workspace_root = self.settings["workspace_root"]
+        # neither rules nor skills exist here, so both are inlined into the system prompt
+        self._inlined_skills = list(agent_spec.get("skills") or [])
+        self._tools = LocalTools(workspace_root)
+        self._system_prompt = "\n\n".join(
+            [
+                agent_spec["system_prompt"],
+                *inline_components(agent_spec.get("rules") or [], "rule", workspace_root),
+                *inline_components(self._inlined_skills, "skill", workspace_root),
+                workspace_note(self._tools.root, self._tools.scratch),
+            ]
+        )
+
+    def _build_agent(self, system_prompt: str) -> Any:
+        model = self._build_model()
+        agent = Agent.from_spec(
+            self._agent_spec_dict(model),
+            model=model,
+            tools=self._build_tools(),
+            toolsets=self._build_toolsets(),
+        )
+        # `AgentSpec.instructions` is a handlebars template whenever `deps_schema` is set, and
+        # dlt has already rendered the prompt: a `{{ }}` left in a rule, a skill or an example
+        # would be silently dropped. A function is taken verbatim.
+        agent.instructions(lambda ctx: system_prompt)
+        return agent
+
+    def _agent_spec_dict(self, model: Any) -> Dict[str, Any]:
+        """The manifest as an `AgentSpec`. The system prompt is attached to the agent itself."""
+        spec_dict: Dict[str, Any] = {
+            "name": self.spec["name"],
+            "deps_schema": model_schema(inputs_schema(self.spec)),
+            "output_schema": model_schema(self.spec["output"]),
+        }
+        if description := self.spec.get("description"):
+            spec_dict["description"] = description
+        # loop_run_args is already AgentSpec vocabulary, so it merges without translation
+        spec_dict.update(self.settings["loop_run_args"])
+        if not self.tool_retries:
+            # tool errors bypass the budget then; pydantic-ai keeps its own default for the
+            # rest of it (output validation, protocol errors), which 0 would end at first sight
+            spec_dict.pop("retries", None)
+        verbs = granted(self.spec, "local")
+        served = type(model).supported_native_tools()
+        native_names = [
+            name
+            for verb, tools in NATIVE_CAPABILITIES.items()
+            if verb in verbs
+            for name, tool in tools.items()
+            if tool in served
+        ]
+        self._native_tools = set(native_names)
+        native: List[Any] = [NATIVE_CAPABILITY_SPECS[name] for name in native_names]
+        if native:
+            capabilities: List[Any] = list(spec_dict.get("capabilities") or [])
+            spec_dict["capabilities"] = capabilities + native
+        return spec_dict
+
+    def _build_tools(self) -> List[Any]:
+        """Local tools the declaration permits."""
+        tools = make_local_tools(self._tools, granted(self.spec, "local"), self.tool_retries)
+        self._local_tools = {tool.name for tool in tools}
+        return tools
+
+    def _build_toolsets(self) -> List[Any]:
+        """The workspace MCP server, limited to the tools the granted access covers."""
+        tools = list(self.spec.get("tools") or [])
+        if not tools:
+            # an agent that asks for no feature group gets no server to ask
+            return []
+        server = mcp_server_command(tools, self.spec.get("access") or {})
+        transport = StdioTransport(
+            command=server["command"],
+            args=server["args"],
+            env=server["env"],
+            cwd=self.settings["workspace_root"],
+        )
+        return [
+            MCPToolset(
+                transport,
+                id=MCP_SERVER_ID,
+                tool_error_behavior="retry" if self.tool_retries else "failed",
+            )
+        ]
+
+    def local_tools(self) -> Dict[str, TWorkspaceLocalVerb]:
+        """The function tools built for the declaration, and the provider's own the model serves."""
+        wired = self._local_tools | self._native_tools
+        verbs = {
+            **LOCAL_TOOL_VERBS,
+            **{name: verb for verb, tools in NATIVE_CAPABILITIES.items() for name in tools},
+        }
+        return {name: cast(TWorkspaceLocalVerb, verbs[name]) for name in verbs if name in wired}
+
+    def _build_model(self) -> Any:
+        """The model this run names, on a provider carrying the configured key and url."""
+        return infer_model(self.model_id(), provider_factory=self._build_provider)
+
+    def _build_provider(self, name: str) -> Any:
+        """The named provider, carrying the configured key and url. Its env vars fill the rest."""
+        try:
+            provider_cls = infer_provider_class(name)
+        except ImportError as ex:
+            raise MissingDependencyException(
+                f"dlt background agents on {name} models", [f"pydantic-ai-slim[{name}]"], str(ex)
+            ) from ex
+        except ValueError as ex:
+            raise UnsupportedAgentModel(self.LOOP_TYPE, self.model_id(), str(ex)) from ex
+
+        args: Dict[str, Any] = {}
+        if key := self.settings.get("api_key"):
+            args[PROVIDER_KEY_ARG.get(name, DEFAULT_KEY_ARG)] = key
+        if url := self.settings.get("api_url"):
+            url_arg = PROVIDER_URL_ARG.get(name, DEFAULT_URL_ARG)
+            if url_arg is None:
+                raise UnsupportedAgentModel(
+                    self.LOOP_TYPE,
+                    self.model_id(),
+                    f"provider {name!r} calls its own endpoint and takes no api_url. Drop"
+                    " `agent.api_url`, or name a provider that takes one, such as `openai`",
+                )
+            args[url_arg] = url
+        if version := self.settings.get("api_version"):
+            version_arg = PROVIDER_VERSION_ARG.get(name)
+            if version_arg is None:
+                # an unused version is harmless, unlike a url that sends the run elsewhere
+                logger.warning(f"Provider {name!r} takes no api_version; {version!r} is ignored.")
+            else:
+                args[version_arg] = version
+        if not args:
+            return infer_provider(name)
+        if name.startswith(GATEWAY_PREFIX):
+            # the gateway routes to an upstream provider, so it is built by name, not by class
+            from pydantic_ai.providers.gateway import gateway_provider
+
+            return gateway_provider(name[len(GATEWAY_PREFIX) :], **args)
+        return provider_cls(**args)
+
+    async def run(
+        self,
+        instructions: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        model: Optional[str] = None,
+        limits: Optional[TAgentLimits] = None,
+        run_args: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        inputs = inputs or {}
+        self.resolve_run(model, limits, instructions)
+        # the usage offsets belong to one run, like the counters `resolve_run` starts over
+        self._input_seen = self._output_seen = 0
+        if run_args:
+            self.settings["loop_run_args"] = {**self.settings["loop_run_args"], **run_args}
+        self._agent = self._build_agent(self.render_system_prompt(inputs))
+
+        # tokens are counted by the loop, turn by turn, the same way on every framework
+        usage_limits = UsageLimits(request_limit=self.settings["max_turns"])
+        self.emit_run_start(self.user_turn)
+        self._turn = 0
+        async with self._agent:
+            if self.spec.get("tools"):
+                self.emit("mcp", text=f"{MCP_SERVER_ID} connected")
+            try:
+                result = await self._agent.run(
+                    self.user_turn,
+                    deps=inputs,
+                    usage_limits=usage_limits,
+                    event_stream_handler=self._emit_events,
+                )
+            except UnexpectedModelBehavior as ex:
+                raise AgentRunFailed(self.LOOP_TYPE, self.agent_ref, _failure_reason(ex)) from ex
+        self._trace = self._build_trace(inputs, result)
+        self.emit_run_finished(result.output.get("status"))
+        return result.output  # type: ignore[no-any-return]
+
+    async def _emit_events(self, ctx: Any, events: Any) -> None:
+        """Reports what the model says, thinks and calls while it runs. One call, one turn."""
+        self._turn += 1
+        # the run context's usage is cumulative through the previous turn, so this is where
+        # that turn's tokens are known; over the limit, the raise ends the run before this one
+        usage = ctx.usage
+        self.count_tokens(
+            usage.input_tokens - self._input_seen, usage.output_tokens - self._output_seen
+        )
+        self._input_seen, self._output_seen = usage.input_tokens, usage.output_tokens
+        self.emit("turn", turn=self._turn)
+        async for event in events:
+            try:
+                if isinstance(event, PartEndEvent):
+                    part = event.part
+                    if isinstance(part, ThinkingPart):
+                        self.emit("thinks", text=part.content)
+                    elif isinstance(part, TextPart):
+                        self.emit("says", text=part.content)
+                    elif isinstance(part, ToolCallPart):
+                        if part.tool_name == OUTPUT_TOOL_NAME:
+                            self.emit("says", text=_answer_text(part.args_as_dict()))
+                        else:
+                            self.emit(
+                                "tool_call",
+                                tool=part.tool_name,
+                                server=(
+                                    None if part.tool_name in self._local_tools else MCP_SERVER_ID
+                                ),
+                                detail=part.args_as_dict(),
+                            )
+                elif isinstance(event, ToolResultEvent):
+                    if event.part.tool_name == OUTPUT_TOOL_NAME:
+                        continue
+                    self.emit(
+                        "tool_result",
+                        tool=event.part.tool_name,
+                        detail=event.part.content,
+                        error=(
+                            isinstance(event.part, RetryPromptPart)
+                            or getattr(event.part, "outcome", None) == "failed"
+                        ),
+                    )
+            except Exception as ex:
+                # a run must never fail because it could not be reported
+                logger.debug(f"Could not report agent event {type(event).__name__}: {ex}")
+
+    def _build_trace(self, inputs: Dict[str, Any], result: Any) -> Any:
+        trace = self._base_trace(inputs)
+        # `usage` was a method before pydantic-ai 2.36 and is a property from it on
+        usage = result.usage
+        if callable(usage):
+            usage = usage()
+        trace["turn_count"] = usage.requests
+        trace["input_tokens"] = usage.input_tokens
+        trace["output_tokens"] = usage.output_tokens
+        trace["total_tokens"] = usage.total_tokens
+        turns: List[TAgentTurn] = []
+        for message in result.all_messages():
+            if not isinstance(message, ModelResponse):
+                continue
+            turns.append(
+                {
+                    "tools": [
+                        self._tool_use(p.tool_name)
+                        for p in message.parts
+                        if isinstance(p, ToolCallPart) and p.tool_name != OUTPUT_TOOL_NAME
+                    ],
+                    "input_tokens": message.usage.input_tokens,
+                    "output_tokens": message.usage.output_tokens,
+                }
+            )
+        trace["turns"] = turns
+        trace["tools_used"], trace["skills_used"], trace["mcp_tools_used"] = distinct_tools_used(
+            turns
+        )
+        return trace
+
+    def _tool_use(self, name: str) -> TAgentToolUse:
+        """A function tool is the loop's own; every other name the model called is the server's."""
+        if name in self._local_tools:
+            return {"name": name, "kind": "builtin"}
+        return {"name": name, "kind": "mcp", "server": MCP_SERVER_ID}

--- a/dlt/_workspace/deployment/agent/loops/tools.py
+++ b/dlt/_workspace/deployment/agent/loops/tools.py
@@ -1,0 +1,311 @@
+"""What a loop needs to run tools: the local tools, their environment and the workspace MCP server."""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+
+from dlt._workspace.cli.utils import cli_host_command, mcp_stdio_args
+from dlt._workspace.deployment.agent.exceptions import LocalToolError
+from dlt._workspace.typing import TWorkspaceAccess, TWorkspaceLocalVerb
+
+MAX_TOOL_OUTPUT = 20_000
+SUBPROCESS_TIMEOUT = 120
+
+MCP_SERVER_ID = "dlt-workspace-mcp"
+"""Name the loops give the workspace MCP server, also used by `dlthub ai mcp install`."""
+
+SECRET_FILE_PATTERNS = ("*secrets.toml", ".env", ".env.*")
+"""Credential files no file tool opens: dlt's `[<profile>.]secrets.toml` and dotenv files."""
+
+FILE_TOOLS = (
+    "Read",
+    "NotebookRead",
+    "Glob",
+    "Grep",
+    "Write",
+    "Edit",
+    "MultiEdit",
+    "NotebookEdit",
+)
+"""Tools that access the filesystem by path, and so take a deny rule each."""
+
+SHELL_TOOL = "PowerShell" if os.name == "nt" else "Bash"
+"""The shell of this platform, named as the Claude Code CLI names it. One shell per platform, so
+the model is never told `bash` and handed PowerShell."""
+
+LOCAL_TOOLS: Dict[str, Tuple[str, ...]] = {
+    "read": ("Read", "Glob", "Grep"),
+    "write": ("Write", "Edit"),
+    "execute": (SHELL_TOOL, "RunPython"),
+    "network": ("WebFetch", "WebSearch"),
+}
+"""What each `access.local` verb buys, named as the Claude Code CLI names its tools."""
+
+LOCAL_TOOL_VERBS: Dict[str, TWorkspaceLocalVerb] = {
+    name: cast(TWorkspaceLocalVerb, verb) for verb, names in LOCAL_TOOLS.items() for name in names
+}
+"""The verb each local tool belongs to."""
+
+
+def is_secret_file(path: str) -> bool:
+    """True when a path names a credential file, wherever in the workspace it sits."""
+    name = os.path.basename(path)
+    return any(fnmatchcase(name, pattern) for pattern in SECRET_FILE_PATTERNS)
+
+
+def secret_deny_rules() -> List[str]:
+    """CLI rules that keep its file tools out of credential files."""
+    return [f"{tool}(**/{pattern})" for tool in FILE_TOOLS for pattern in SECRET_FILE_PATTERNS]
+
+
+def tool_env() -> Dict[str, str]:
+    """Child environment with the job's virtualenv on PATH, so `dlthub`, `dlt` and `python` resolve."""
+    bin_dir = Path(sys.executable).parent
+    env = dict(os.environ)
+    if str(bin_dir) not in env.get("PATH", "").split(os.pathsep):
+        env["PATH"] = os.pathsep.join(filter(None, [str(bin_dir), env.get("PATH", "")]))
+    if (bin_dir.parent / "pyvenv.cfg").is_file():
+        env["VIRTUAL_ENV"] = str(bin_dir.parent)
+    # the MCP server we spawn writes to our stderr, so it keeps quiet
+    env["FASTMCP_SHOW_SERVER_BANNER"] = "false"
+    env["FASTMCP_LOG_LEVEL"] = "WARNING"
+    # tool output is decoded as UTF-8, and a Windows console would otherwise write its code page
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONUTF8"] = "1"
+    return env
+
+
+def shell_executable() -> str:
+    """The shell behind `SHELL_TOOL`: `pwsh` or `powershell` on Windows, `bash` elsewhere."""
+    if os.name != "nt":
+        return "bash"
+    # `bash` on a Windows PATH is usually the WSL launcher, so it is never a fallback here
+    return shutil.which("pwsh") or shutil.which("powershell") or "powershell"
+
+
+def temp_dir() -> Path:
+    """The system temp folder, where an agent may keep scratch files outside the workspace."""
+    return Path(tempfile.gettempdir()).resolve()
+
+
+def workspace_note(root: Any, scratch: Any) -> str:
+    """One sentence for the system prompt naming the workspace and where scratch files go."""
+    # every path the model sees is posix, whatever the platform
+    root, scratch = Path(root).as_posix(), Path(scratch).as_posix()
+    return f"The workspace is `{root}`. Scratch files belong in the temp folder `{scratch}`."
+
+
+class LocalTools:
+    """File, search and execution tools confined to the workspace root and a scratch folder.
+
+    Each method is one tool as the model sees it, and its docstring is the tool description.
+    Nothing here is a sandbox: the shell and `python` run in the job's own process tree and
+    virtualenv, and the runner the job already runs in is what contains them.
+    """
+
+    def __init__(self, workspace_root: str, scratch_dir: Optional[str] = None) -> None:
+        self.root = Path(workspace_root).resolve()
+        self.scratch = Path(scratch_dir).resolve() if scratch_dir else temp_dir()
+
+    def by_name(self) -> Dict[str, Callable[..., str]]:
+        """The tools under the names in `LOCAL_TOOLS`."""
+        return {
+            "Read": self.read,
+            "Glob": self.glob,
+            "Grep": self.grep,
+            "Write": self.write,
+            "Edit": self.edit,
+            SHELL_TOOL: self.powershell if os.name == "nt" else self.bash,
+            "RunPython": self.python,
+        }
+
+    def resolve(self, path: str) -> Path:
+        """Resolves `path` against the workspace, refusing what escapes it and the scratch folder."""
+        # an absolute path replaces `root` in the join, which is how a scratch file is named
+        target = (self.root / path).resolve()
+        if not (target.is_relative_to(self.root) or target.is_relative_to(self.scratch)):
+            raise LocalToolError(
+                f"{path!r} is outside the workspace and the temp folder {str(self.scratch)!r}"
+            )
+        if is_secret_file(target.name):
+            raise LocalToolError(f"{path!r} holds credentials and cannot be opened")
+        return target
+
+    def read(self, path: str, offset: int = None, limit: int = None) -> str:
+        """Read a UTF-8 text file, whole or a range of lines.
+
+        Args:
+            path: Path relative to the workspace root, or an absolute path inside the temp folder.
+            offset: First line to return, 1-based. Reads from the start when omitted.
+            limit: How many lines to return. Reads to the end when omitted.
+        """
+        target = self.resolve(path)
+        if not target.is_file():
+            raise LocalToolError(f"{path!r} does not exist")
+        text = target.read_text(encoding="utf-8", errors="replace")
+        if offset is None and limit is None:
+            return text[:MAX_TOOL_OUTPUT]
+        start = max((offset or 1) - 1, 0)
+        lines = text.splitlines(keepends=True)[start : None if limit is None else start + limit]
+        return "".join(lines)[:MAX_TOOL_OUTPUT]
+
+    def glob(self, pattern: str = "*") -> str:
+        """List workspace files matching a glob, one relative path per line.
+
+        Args:
+            pattern: Glob relative to the workspace root, e.g. `"**/*.py"`.
+        """
+        matches = sorted(
+            path.relative_to(self.root).as_posix()
+            for path in self.root.glob(pattern)
+            if path.is_file() and not is_secret_file(path.name)
+        )
+        return "\n".join(matches)[:MAX_TOOL_OUTPUT] or f"(nothing matches {pattern!r})"
+
+    def grep(self, pattern: str, glob: str = "**/*") -> str:
+        """Search workspace file contents, returning `path:line:text` for each hit.
+
+        Args:
+            pattern: Regular expression matched against each line.
+            glob: Which files to search, relative to the workspace root.
+        """
+        try:
+            expression = re.compile(pattern)
+        except re.error as ex:
+            raise LocalToolError(f"{pattern!r} is not a valid regular expression: {ex}") from ex
+        hits: List[str] = []
+        for path in sorted(self.root.glob(glob)):
+            if not path.is_file() or is_secret_file(path.name):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            relative = path.relative_to(self.root).as_posix()
+            hits += [
+                f"{relative}:{number}:{line}"
+                for number, line in enumerate(text.splitlines(), start=1)
+                if expression.search(line)
+            ]
+        return "\n".join(hits)[:MAX_TOOL_OUTPUT] or f"(no line matches {pattern!r})"
+
+    def write(self, path: str, content: str) -> str:
+        """Write a UTF-8 text file, creating parent folders.
+
+        Args:
+            path: Path relative to the workspace root, or an absolute path inside the temp folder.
+            content: Full new contents of the file. Replaces what is there.
+        """
+        target = self.resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        return f"wrote {len(content)} characters to {path}"
+
+    def edit(self, path: str, old_text: str, new_text: str) -> str:
+        """Replace one fragment of a file, leaving the rest untouched.
+
+        Args:
+            path: Path relative to the workspace root, or an absolute path inside the temp folder.
+            old_text: Text to replace. Must appear exactly once in the file.
+            new_text: Text to put in its place.
+        """
+        target = self.resolve(path)
+        if not target.is_file():
+            raise LocalToolError(f"{path!r} does not exist")
+        text = target.read_text(encoding="utf-8", errors="replace")
+        found = text.count(old_text)
+        if found != 1:
+            raise LocalToolError(
+                f"{old_text[:80]!r} appears {found} times in {path!r}."
+                " Include more context, so it appears exactly once"
+            )
+        target.write_text(text.replace(old_text, new_text), encoding="utf-8")
+        return f"replaced {len(old_text)} characters in {path}"
+
+    def bash(self, command: str) -> str:
+        """Run a bash command and return its stdout and stderr.
+
+        Every call starts a fresh shell in the workspace root. Nothing carries over between
+        calls, so `cd` in one call does not affect the next: use paths relative to the
+        workspace root, or change directory inside the same command (`cd subdir && ls`). The
+        job's virtualenv is first on PATH, so `dlthub`, `dlt` and `python` are the workspace's own.
+
+        Args:
+            command: Command line, run through `bash -c`.
+        """
+        return self._capture([shell_executable(), "-c", command])
+
+    def powershell(self, command: str) -> str:
+        """Run a PowerShell command and return its stdout and stderr.
+
+        Every call starts a fresh shell in the workspace root. Nothing carries over between
+        calls, so `cd` in one call does not affect the next: use paths relative to the
+        workspace root, or change directory inside the same command (`cd subdir; ls`). The
+        job's virtualenv is first on PATH, so `dlthub`, `dlt` and `python` are the workspace's own.
+
+        Args:
+            command: PowerShell command line, run non-interactively without a profile.
+        """
+        # the console code page is not UTF-8 on Windows, and the output is decoded as UTF-8
+        script = f"[Console]::OutputEncoding = [Text.UTF8Encoding]::new(); {command}"
+        return self._capture(
+            [
+                shell_executable(),
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                script,
+            ]
+        )
+
+    def python(self, code: str) -> str:
+        """Run Python in the workspace environment and return its stdout and stderr.
+
+        The interpreter is the workspace's own virtualenv, running in the workspace root: `dlt`,
+        the workspace pipelines and every configured destination import exactly as they do in
+        the job itself, under the same profile and credentials. Each call is a fresh process, so
+        nothing carries over between calls and only what you print comes back.
+
+        Args:
+            code: Python source to execute.
+        """
+        return self._capture([sys.executable, "-"], stdin=code)
+
+    def _capture(self, argv: List[str], stdin: str = None) -> str:
+        """Runs a child process in the workspace and returns its combined, capped output."""
+        try:
+            done = subprocess.run(  # noqa: S603
+                argv,
+                input=stdin,
+                cwd=str(self.root),
+                env=tool_env(),
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=SUBPROCESS_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            return f"(timed out after {SUBPROCESS_TIMEOUT}s)"
+        except OSError as ex:
+            raise LocalToolError(f"could not run {argv[0]!r}: {ex}") from ex
+        output = (done.stdout + done.stderr).strip()
+        return output[:MAX_TOOL_OUTPUT] or f"(no output, exit {done.returncode})"
+
+
+def mcp_server_command(tools: List[str], access: TWorkspaceAccess) -> Dict[str, Any]:
+    """Stdio server config serving the feature groups an agent declared, limited to its access."""
+
+    return {
+        "type": "stdio",
+        "command": cli_host_command(),
+        "args": mcp_stdio_args(tools, with_defaults=False, access=access or {}),
+        "env": tool_env(),
+    }

--- a/dlt/_workspace/deployment/agent/manifest.py
+++ b/dlt/_workspace/deployment/agent/manifest.py
@@ -1,0 +1,283 @@
+"""Loads an `AGENT.md` and resolves the components it references."""
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, cast
+
+from dlt.common import logger
+
+from dlt._workspace.cli.dlthub.ai.agents import (
+    COMPONENT_MARKERS,
+    TComponentType,
+    resolve_installed_component,
+)
+from dlt._workspace.cli.dlthub.ai.utils import load_toolkits_index
+from dlt._workspace.cli.formatters import parse_frontmatter
+from dlt._workspace.deployment.agent.exceptions import (
+    AgentComponentNotFound,
+    InvalidAgentSpec,
+)
+from dlt._workspace.access import (
+    ACCESS_AXES,
+    ACCESS_AXIS_VERBS,
+    ACCESS_AXIS_VOCABULARY,
+    granted_verbs,
+    missing_access,
+)
+from dlt._workspace.deployment.agent.typing import TAgentSpec
+from dlt._workspace.deployment.typing import AGENT_DEFINITION_ENGINE_VERSION, TAgentDefinition
+from dlt._workspace.typing import TWorkspaceAccess
+
+
+_PLACEHOLDER = re.compile(r"\{\{\s*([\w.]+)\s*\}\}")
+
+
+def agent_manifest_path(agent_dir: str) -> str:
+    """`AGENT.md` inside an agent folder."""
+    return os.path.join(agent_dir, COMPONENT_MARKERS["agent"])
+
+
+def load_agent_spec(agent_dir: str) -> TAgentSpec:
+    """Reads `AGENT.md` from an agent folder into a spec, body included.
+
+    The body is the only thing an agent cannot do without. Frontmatter is optional, and so is
+    every field in it: the name falls back to the folder.
+
+    Args:
+        agent_dir (str): Folder holding `AGENT.md`.
+
+    Returns:
+        TAgentSpec: Frontmatter plus the markdown body as `system_prompt`.
+
+    Raises:
+        InvalidAgentSpec: The body is empty, or a declared field breaks the contract.
+    """
+    path = agent_manifest_path(agent_dir)
+    if not os.path.isfile(path):
+        raise InvalidAgentSpec(path, "file does not exist")
+    frontmatter, body = parse_frontmatter(open(path, "r", encoding="utf-8").read())
+    if not body.strip():
+        raise InvalidAgentSpec(path, "body is empty. The body is the system prompt")
+
+    raw_spec: Dict[str, Any] = dict(frontmatter)
+    raw_spec["system_prompt"] = body.strip()
+    if not raw_spec.get("name"):
+        raw_spec["name"] = os.path.basename(os.path.normpath(agent_dir))
+    return validate_agent_spec(cast(TAgentSpec, raw_spec), path)
+
+
+def validate_agent_spec(spec: TAgentSpec, source: str) -> TAgentSpec:
+    """Holds a spec to the contract, wherever it was declared. Returns it unchanged.
+
+    Args:
+        spec (TAgentSpec): Spec read from `AGENT.md` or synthesized from a function.
+        source (str): What to name in the error: a file path, or `<file>:<function>`.
+
+    Raises:
+        InvalidAgentSpec: The name or the system prompt is missing, or a field breaks the contract.
+    """
+    # reflection imports this module, so the output generator can only be reached from here
+    from dlt._workspace.deployment.agent.reflection import with_standard_output
+
+    declared: Dict[str, Any] = dict(spec)
+    for required_key in ("name", "system_prompt"):
+        if not declared.get(required_key):
+            raise InvalidAgentSpec(source, f"must declare {required_key!r}")
+
+    if not declared.get("description"):
+        # a bare `description:` reads as null in YAML, and no description is not an empty one
+        spec.pop("description", None)
+    spec["output"] = with_standard_output(declared.get("output"))
+    spec["inputs"] = declared.get("inputs") or {}
+    if "prompt" in spec["inputs"]:
+        raise InvalidAgentSpec(source, "inputs must not declare 'prompt'. Put the task in the body")
+    access: Dict[str, Any] = dict(declared.get("access") or {})
+    if unknown := sorted(set(access) - set(ACCESS_AXES)):
+        raise InvalidAgentSpec(
+            source, f"access takes {', '.join(ACCESS_AXES)}. Got {', '.join(unknown)}"
+        )
+    for axis in ACCESS_AXES:
+        if isinstance(access.get(axis), str):
+            access[axis] = [access[axis]]
+        allowed = ACCESS_AXIS_VERBS[axis] + ("all",)
+        refused = sorted({verb for verb in access.get(axis) or [] if verb not in allowed})
+        if refused:
+            unserved = sorted(set(ACCESS_AXIS_VOCABULARY[axis]) - set(allowed))
+            reason = f"access.{axis} takes {', '.join(allowed)}"
+            if set(unserved) & set(refused):
+                reason += f", and no runtime serves {', '.join(unserved)} yet"
+            raise InvalidAgentSpec(source, f"{reason}. Got {', '.join(refused)}")
+    if access:
+        spec["access"] = cast(TWorkspaceAccess, access)
+    return spec
+
+
+def declared_placeholders(system_prompt: str) -> Set[str]:
+    """Names the system prompt refers to, `run_context.trigger` included."""
+    return {match.group(1) for match in _PLACEHOLDER.finditer(system_prompt)}
+
+
+def to_agent_definition(
+    spec: TAgentSpec,
+    agent_file: Optional[str] = None,
+    instructions: Optional[str] = None,
+    model: Optional[str] = None,
+) -> TAgentDefinition:
+    """Manifest subset of a spec: no `defaults`, no system prompt, plus decorator overrides.
+
+    `inputs` and `output` are not here either: the job definition carries them, as it does for
+    every other job.
+    """
+    definition: TAgentDefinition = {
+        "engine_version": AGENT_DEFINITION_ENGINE_VERSION,
+        "name": spec["name"],
+    }
+    if description := spec.get("description"):
+        definition["description"] = description
+    if agent_file:
+        definition["agent_file"] = agent_file
+    raw: Dict[str, Any] = dict(spec)
+    for key in ("tools", "skills", "rules"):
+        value = raw.get(key)
+        if value:
+            definition[key] = list(value)
+    if instructions:
+        definition["instructions"] = instructions
+    if model:
+        definition["model"] = model
+    return definition
+
+
+def inputs_schema(spec: TAgentSpec) -> Dict[str, Any]:
+    """`inputs` as JSON Schema."""
+    schema: Dict[str, Any] = dict(spec["inputs"])
+    # `required: {}` is how "nothing is required" was written. JSON Schema wants an array
+    required = schema.get("required")
+    if isinstance(required, dict):
+        schema["required"] = sorted(required)
+    return schema
+
+
+def granted(spec: TAgentSpec, axis: str) -> Set[str]:
+    """Verbs the agent declared on one `access` axis, with `all` expanded."""
+    return granted_verbs(spec.get("access"), axis)
+
+
+def render_placeholders(template: str, values: Mapping[str, Any]) -> Tuple[str, List[str]]:
+    """Substitutes `{{ name }}` and `{{ a.b }}`, blanking what is absent.
+
+    Returns:
+        Tuple[str, List[str]]: Rendered text, and the placeholders that did not resolve.
+    """
+    unresolved: List[str] = []
+
+    def lookup(match: "re.Match[str]") -> str:
+        value: Any = values
+        for part in match.group(1).split("."):
+            if not isinstance(value, Mapping) or part not in value:
+                unresolved.append(match.group(1))
+                return ""
+            value = value[part]
+        return "" if value is None else str(value)
+
+    return _PLACEHOLDER.sub(lookup, template), unresolved
+
+
+def _workspace_path(ref: str, kind: "TComponentType", workspace_root: str) -> str:
+    """Resolve a workspace-relative component ref, refusing anything outside the workspace."""
+    candidate = os.path.realpath(os.path.join(workspace_root, ref))
+    root = os.path.realpath(workspace_root)
+    if os.path.commonpath([candidate, root]) != root:
+        raise AgentComponentNotFound(ref, kind, [f"{candidate} (outside the workspace)"])
+    return candidate
+
+
+def _is_path_ref(ref: str) -> bool:
+    return os.sep in ref or "/" in ref or ref.endswith((".md", ".mdc"))
+
+
+def resolve_agent_dir(agent_ref: str, workspace_root: str) -> str:
+    """Resolves `<toolkit>:<agent>` or a workspace-relative path to an agent folder.
+
+    Args:
+        agent_ref (str): `"<toolkit>:<agent>"` reference, or a path under the workspace.
+        workspace_root (str): Workspace directory the reference is resolved against.
+
+    Returns:
+        str: Absolute path of the agent folder.
+
+    Raises:
+        AgentComponentNotFound: The reference does not name an installed agent.
+    """
+    if _is_path_ref(agent_ref):
+        candidate = _workspace_path(agent_ref, "agent", workspace_root)
+        # the ref may point at the agent folder or at the `AGENT.md` inside it
+        if os.path.basename(candidate) == COMPONENT_MARKERS["agent"]:
+            candidate = os.path.dirname(candidate)
+        if os.path.isfile(agent_manifest_path(candidate)):
+            return candidate
+        raise AgentComponentNotFound(agent_ref, "agent", [agent_manifest_path(candidate)])
+
+    toolkit, _, name = agent_ref.rpartition(":")
+    path = resolve_installed_component(toolkit, name, "agent", Path(workspace_root))
+    if path is None:
+        raise AgentComponentNotFound(
+            agent_ref,
+            "agent",
+            _component_destination("agent", toolkit, name, workspace_root),
+            toolkit=toolkit,
+            installed=toolkit in load_toolkits_index(),
+        )
+    return str(path.parent)
+
+
+def resolve_component_ref(ref: str, kind: "TComponentType", workspace_root: str) -> str:
+    """Resolves a skill or rule ref to the file installed in the project."""
+    if _is_path_ref(ref):
+        candidate = _workspace_path(ref, kind, workspace_root)
+        if os.path.isfile(candidate):
+            return candidate
+        raise AgentComponentNotFound(ref, kind, [candidate])
+
+    toolkit, _, name = ref.rpartition(":")
+    path = resolve_installed_component(toolkit, name, kind, Path(workspace_root))
+    if path is None:
+        raise AgentComponentNotFound(
+            ref,
+            kind,
+            _component_destination(kind, toolkit, name, workspace_root),
+            toolkit=toolkit,
+            installed=toolkit in load_toolkits_index(),
+        )
+    return str(path)
+
+
+def _component_destination(
+    kind: "TComponentType", toolkit: str, name: str, workspace_root: str
+) -> List[str]:
+    """Where installing the toolkit would put the component, for the agent that installed it."""
+    from dlt._workspace.cli.dlthub.ai.agents import AI_AGENTS
+
+    entry = load_toolkits_index().get(toolkit)
+    host = entry.get("agent") if entry else None
+    variants = [AI_AGENTS[host]] if host in AI_AGENTS else list(AI_AGENTS.values())
+    paths = [
+        variant().component_path(kind, name, toolkit, Path(workspace_root)) for variant in variants
+    ]
+    return [str(path) for path in paths if path is not None]
+
+
+def inline_components(refs: List[str], kind: TComponentType, workspace_root: str) -> List[str]:
+    """Reads each ref and wraps it in a labelled block for the system prompt."""
+    blocks: List[str] = []
+    for ref in refs or []:
+        try:
+            path = resolve_component_ref(ref, kind, workspace_root)
+        except AgentComponentNotFound as e:
+            # an agent with less access is weaker, not broken
+            logger.warning(f"Skipping {kind} {ref!r} for the agent prompt: {e}")
+            continue
+        text = open(path, "r", encoding="utf-8").read().strip()
+        blocks.append(f'<{kind} ref="{ref}">\n{text}\n</{kind}>')
+    return blocks

--- a/dlt/_workspace/deployment/agent/reflection.py
+++ b/dlt/_workspace/deployment/agent/reflection.py
@@ -1,0 +1,121 @@
+"""An agent declared as a Python function: its signature, return type and docstring."""
+
+import inspect
+from copy import deepcopy
+from functools import lru_cache
+from typing import Any, Dict, Optional, cast
+
+from dlt.common.typing import AnyFun
+from dlt.common.utils import get_callable_name
+
+from dlt._workspace.deployment.agent.exceptions import InvalidAgentSpec
+from dlt._workspace.deployment.agent.manifest import validate_agent_spec
+from dlt._workspace.deployment.agent.typing import TAgentDefaults, TAgentOutput, TAgentSpec
+from dlt._workspace.deployment.reflection import derives_from, inputs_from_function, output_schema
+
+SPEC_KEYS = ("access", "tools", "skills", "rules")
+DEFAULTS_KEYS = ("model", "limits", "loop_run_args", "trigger")
+
+
+def output_from_return(f: AnyFun, source: str) -> Dict[str, Any]:
+    """JSON Schema of the agent's own output, taken from the return type."""
+    hint = inspect.signature(f).return_annotation
+    if hint in (inspect.Signature.empty, None, Any):
+        # nothing declared: the agent reports the base outcome, `status` and `summary`
+        hint = TAgentOutput
+    if not derives_from(hint, TAgentOutput):
+        raise InvalidAgentSpec(
+            source,
+            "must return TAgentOutput or a TypedDict deriving from it, got"
+            f" {getattr(hint, '__name__', hint)!r}",
+        )
+    return output_schema(hint, source)
+
+
+@lru_cache(maxsize=1)
+def _standard_output() -> Dict[str, Any]:
+    return output_schema(TAgentOutput, "TAgentOutput")
+
+
+def with_standard_output(declared: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Declared output plus `status` and `summary`, which `TAgentOutput` alone defines.
+
+    Args:
+        declared (Optional[Dict[str, Any]]): Output JSON Schema an `AGENT.md` carries, if any.
+
+    Returns:
+        Dict[str, Any]: The declaration with the standard fields written over it.
+    """
+    standard = deepcopy(_standard_output())
+    if not declared:
+        return standard
+    schema = deepcopy(dict(declared))
+    schema["type"] = "object"
+    schema["properties"] = {**(schema.get("properties") or {}), **standard["properties"]}
+    required = schema.get("required")
+    # `required: {}` is how "nothing is required" is written in YAML, as it is for inputs
+    declared_required = sorted(required) if isinstance(required, dict) else list(required or [])
+    schema["required"] = sorted({*declared_required, *standard["required"]})
+    return schema
+
+
+def agent_spec_from_function(
+    f: AnyFun,
+    source: str,
+    declared: Dict[str, Any],
+    base: Optional[TAgentSpec] = None,
+) -> TAgentSpec:
+    """Assembles the agent a function declares.
+
+    The `agent` reference, when given, is the base; decorator arguments override it, and the
+    function's own signature, return type and docstring override those in turn.
+
+    Args:
+        f (AnyFun): The decorated function.
+        source (str): `<file>:<name>`, named in errors and carried as the agent folder.
+        declared (Dict[str, Any]): Decorator arguments, `AGENT.md` field names.
+        base (Optional[TAgentSpec]): Spec of the agent the decorator referenced.
+    """
+    spec: Dict[str, Any] = dict(base) if base else {}
+    docstring = inspect.cleandoc(f.__doc__ or "")
+
+    spec["name"] = declared.get("name") or get_callable_name(f)
+    if docstring:
+        spec["description"] = docstring.split("\n", 1)[0]
+        spec["system_prompt"] = docstring
+    for key in SPEC_KEYS:
+        if declared.get(key) is not None:
+            spec[key] = declared[key]
+
+    defaults: TAgentDefaults = dict(spec.get("defaults") or {})  # type: ignore[assignment]
+    for key in DEFAULTS_KEYS:
+        if declared.get(key) is not None:
+            defaults[key] = declared[key]  # type: ignore[literal-required]
+    if defaults:
+        spec["defaults"] = defaults
+
+    inputs: Dict[str, Any] = dict(spec.get("inputs") or {})
+    signature_inputs = inputs_from_function(f, source)
+    if signature_inputs.get("properties") or not inputs:
+        inputs.update(signature_inputs)
+    spec["inputs"] = inputs
+
+    # a function driving a referenced agent may return anything; then that agent's output stands
+    return_hint = inspect.signature(f).return_annotation
+    if derives_from(return_hint, TAgentOutput) or not spec.get("output"):
+        spec["output"] = output_from_return(f, source)
+
+    return validate_agent_spec(cast(TAgentSpec, spec), source)
+
+
+def agent_source(f: AnyFun, name: str) -> str:
+    """Where a function-declared agent lives: `<module file>:<name>`."""
+    return f"{inspect.getfile(f)}:{name}"
+
+
+__all__ = [
+    "agent_source",
+    "agent_spec_from_function",
+    "output_from_return",
+    "with_standard_output",
+]

--- a/dlt/_workspace/deployment/agent/typing.py
+++ b/dlt/_workspace/deployment/agent/typing.py
@@ -1,0 +1,157 @@
+from typing import Any, Dict, List, Literal, Optional
+
+from dlt.common.typing import Annotated, Doc, NotRequired, TypedDict
+
+from dlt._workspace.deployment.typing import TJobResult
+from dlt._workspace.typing import TWorkspaceAccess, TWorkspaceLocalVerb
+
+
+AGENT_MODEL_ALIASES: Dict[str, str] = {
+    "sonnet": "anthropic:claude-sonnet-5",
+    "opus": "anthropic:claude-opus-5",
+    "haiku": "anthropic:claude-haiku-4-5",
+    "fable": "anthropic:claude-fable-5",
+    "gpt": "openai:gpt-5.5",
+    "gpt-mini": "openai:gpt-5.4-mini",
+    "gpt-nano": "openai:gpt-5.4-nano",
+    "gemini": "google:gemini-3.5-flash",
+    "gemini-pro": "google:gemini-3.1-pro-preview",
+}
+"""Shorthands for `provider:model`, the naming pydantic-ai uses and dlt follows."""
+
+TAgentJobStatus = Literal["succeeded", "failed", "aborted"]
+"""Outcome an agent reports. `aborted` means it could not start the task at all."""
+
+
+class TAgentLimits(TypedDict, total=False):
+    """Loop budget. The manifest declares it, and the runtime supplies the limit that applies."""
+
+    max_turns: int
+    max_tokens: int
+
+
+class TAgentDefaults(TypedDict, total=False):
+    """Settings the manifest suggests and the runtime may override."""
+
+    trigger: List[str]
+    model: str
+    limits: TAgentLimits
+    loop_run_args: Dict[str, Any]
+
+
+class TAgentSpec(TypedDict):
+    """An `AGENT.md` in full: frontmatter plus the body that is the system prompt."""
+
+    name: str
+    description: NotRequired[str]
+    access: NotRequired[TWorkspaceAccess]
+    """What the agent asks to touch. The job definition carries it to the runtime, which grants
+    it or does not."""
+    inputs: Dict[str, Any]
+    """JSON Schema of the inputs, substituted into the system prompt placeholders."""
+    output: Dict[str, Any]
+    system_prompt: str
+    """The body, `{{ }}` placeholders included. Rendered against the inputs at run time."""
+    tools: NotRequired[List[str]]
+    skills: NotRequired[List[str]]
+    rules: NotRequired[List[str]]
+    defaults: NotRequired[TAgentDefaults]
+
+
+class TAgentSettings(TypedDict):
+    """What the runtime decided for one run."""
+
+    loop_type: str
+    model: str
+    instructions: Optional[str]
+    """The user turn. Absent, the loop sends a bare go-signal and the system prompt speaks alone."""
+    max_turns: Optional[int]
+    max_tokens: Optional[int]
+    loop_run_args: Dict[str, Any]
+    verbosity: int
+    api_key: Optional[str]
+    api_url: Optional[str]
+    api_version: Optional[str]
+    endpoint_source: str
+    """Whose model and credentials the run uses: `"user"` or `"runtime"`."""
+    trace_url: Optional[str]
+    trace_key: Optional[str]
+    workspace_root: str
+
+
+class TAgentToolUse(TypedDict):
+    """One tool call the model made."""
+
+    name: str
+    """Tool name as the model called it."""
+    kind: Literal["builtin", "mcp", "skill"]
+    server: NotRequired[str]
+    """MCP server the tool belongs to."""
+
+
+class TAgentTurn(TypedDict):
+    tools: List[TAgentToolUse]
+    input_tokens: int
+    output_tokens: int
+
+
+class TAgentTrace(TypedDict):
+    """Everything the loop ran with, and what it did, read after the loop completes."""
+
+    agent: str
+    """Agent definition reference: `<toolkit>:<agent>`, a workspace path, or `<module>:<function>`
+    for a function with no `AGENT.md` behind it."""
+    agent_file: str
+    loop_type: str
+    model: str
+    limits: TAgentLimits
+    loop_run_args: Dict[str, Any]
+    instructions: str
+    """The user turn this run sent."""
+    inputs: Dict[str, Any]
+    access: TWorkspaceAccess
+    local_tools: Dict[str, TWorkspaceLocalVerb]
+    """Local tools the loop wired, by the verb that bought each: `Grep` under `read`."""
+    mcp_features: List[str]
+    native_skills: List[str]
+    inlined_skills: List[str]
+    unresolved_placeholders: List[str]
+    turn_count: int
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    turns: List[TAgentTurn]
+    tools_used: List[str]
+    skills_used: List[str]
+    mcp_tools_used: List[str]
+    cost_usd: NotRequired[float]
+    stop_reason: NotRequired[str]
+    ignored_loop_run_args: NotRequired[List[str]]
+
+
+class TAgentOutput(TypedDict):
+    """What an agent returns: `status`, `summary` and whatever its own output declares."""
+
+    status: Annotated[
+        TAgentJobStatus,
+        Doc(
+            "Outcome of your task. `succeeded` and `failed` mean what your system prompt says"
+            " they mean. `aborted`: you hit something that prevents doing the task at all, and"
+            " the runner raises an exception carrying `summary`."
+        ),
+    ]
+    summary: Annotated[
+        str,
+        Doc(
+            "Markdown. What you accomplished. When `status` is `aborted` this becomes the"
+            " exception text, so say what blocked you."
+        ),
+    ]
+
+
+class TAgentJobResult(TJobResult):
+    """Job result of an agent run: the outcome lifted out of `result`, plus the loop's trace."""
+
+    status: TAgentJobStatus
+    summary: str
+    trace: NotRequired[TAgentTrace]

--- a/dlt/_workspace/deployment/configuration.py
+++ b/dlt/_workspace/deployment/configuration.py
@@ -1,14 +1,16 @@
-"""Framework-specific configuration specs for interactive job launchers.
+"""Framework-specific configuration specs for job launchers.
 
 Each spec resolves in sections (JOBS, section, name, __section__) so users
 can override per-job via env vars like JOBS__MY_MODULE__MY_JOB__MCP__HOST.
 """
 
-from typing import Literal, Optional
+import dataclasses
+from typing import Any, Dict, Literal, Optional
 
 from dlt.common.configuration import configspec
 from dlt.common.configuration.specs.base_configuration import BaseConfiguration
 from dlt.common.pipeline import TRefreshMode
+from dlt.common.typing import TSecretStrValue
 
 from dlt._workspace.deployment.typing import TIncrementalSource
 
@@ -68,3 +70,67 @@ class McpConfiguration(BaseConfiguration):
     """Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL."""
     stateless_http: bool = False
     """Stateless mode for horizontal scaling (no session affinity)."""
+
+
+USER_ENDPOINT_FIELDS = ("model", "api_key", "api_url", "api_version")
+"""The model and the credentials that reach it. A run takes all four from the user or all four
+from the runtime, and never one from each: a runtime model id means nothing to another endpoint."""
+
+
+@configspec
+class AgentConfiguration(BaseConfiguration):
+    """Configuration for the background agent launcher."""
+
+    __section__ = "agent"
+
+    loop: Optional[str] = None
+    """Loop implementation, e.g. "pydantic-ai" or "claude-agent-sdk"."""
+    instructions: Optional[str] = None
+    """What to tell the agent to do: the user turn, sent as the run's first message."""
+    model: Optional[str] = None
+    """`provider:model` id, or an alias (sonnet, opus, haiku, fable, gpt, gemini)."""
+    api_key: Optional[TSecretStrValue] = None
+    """Key for the provider the model names. Its own env var is used when unset."""
+    api_url: Optional[str] = None
+    """Base URL of the model API, for a proxy or a private deployment."""
+    api_version: Optional[str] = None
+    """API version the provider requires. Azure needs one; no other provider takes it."""
+    runtime_model: Optional[str] = None
+    """Model supplied by the runtime. Both live side by side; see `USER_ENDPOINT_FIELDS`."""
+    runtime_api_key: Optional[TSecretStrValue] = None
+    """Key supplied by the runtime. Both live side by side; see `USER_ENDPOINT_FIELDS`."""
+    runtime_api_url: Optional[str] = None
+    """Base URL supplied by the runtime. Both live side by side; see `USER_ENDPOINT_FIELDS`."""
+    runtime_api_version: Optional[str] = None
+    """Version supplied by the runtime. Both live side by side; see `USER_ENDPOINT_FIELDS`."""
+    max_turns: Optional[int] = None
+    max_tokens: Optional[int] = None
+    loop_run_args: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    """Arguments passed to the native loop, merged over the agent's own defaults."""
+    verbosity: Optional[int] = None
+    """How much of the run to show: 0 quiet, 1 thoughts and tool detail, 2 everything."""
+    trace_url: Optional[str] = None
+    """OTLP endpoint the loop exports its spans to."""
+    trace_key: Optional[TSecretStrValue] = None
+
+    @property
+    def endpoint_source(self) -> str:
+        """Whose endpoint a run uses: `"user"` when it set any field of one, else `"runtime"`."""
+        return "user" if any(getattr(self, f) for f in USER_ENDPOINT_FIELDS) else "runtime"
+
+    @property
+    def effective_model(self) -> Optional[str]:
+        # None here means the agent's own model applies, never the runtime's
+        return self.model if self.endpoint_source == "user" else self.runtime_model
+
+    @property
+    def effective_api_key(self) -> Optional[str]:
+        return self.api_key if self.endpoint_source == "user" else self.runtime_api_key
+
+    @property
+    def effective_api_url(self) -> Optional[str]:
+        return self.api_url if self.endpoint_source == "user" else self.runtime_api_url
+
+    @property
+    def effective_api_version(self) -> Optional[str]:
+        return self.api_version if self.endpoint_source == "user" else self.runtime_api_version

--- a/dlt/_workspace/deployment/decorators.py
+++ b/dlt/_workspace/deployment/decorators.py
@@ -1,13 +1,30 @@
 import inspect
+import os
+import sys
+import warnings
 from functools import update_wrapper, wraps
-from typing import Any, Callable, List, Optional, Sequence, Type, Union, overload
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+    cast,
+    overload,
+)
 
 from typing_extensions import TypeVar
 
+from dlt.common import logger
 from dlt.common.configuration import get_fun_spec, with_config
 from dlt.common.configuration.specs.base_configuration import BaseConfiguration
 from dlt.common.pipeline import SupportsPipeline, TRefreshMode
 from dlt.common.reflection.inspect import iscoroutinefunction
+from dlt.common.runtime.run_context import active
 from dlt.common.typing import AnyFun, Generic, ParamSpec, Unpack
 from dlt.common.utils import get_callable_name, get_module_name
 from dlt.common.warnings import TNoExtraKwargs, apply_deprecations
@@ -24,10 +41,42 @@ from dlt.extract.reference import SourceFactory as AnySourceFactory
 from dlt.extract.resource import DltResource
 from dlt.extract.source import DltSource
 
-from dlt._workspace.deployment._job_ref import make_job_ref
-from dlt._workspace.deployment.exceptions import InvalidJobName, InvalidJobSection
-from dlt._workspace.deployment.launchers import LAUNCHER_JOB
+from dlt._workspace.deployment._job_ref import job_category, make_job_ref
+from dlt._workspace.deployment.exceptions import (
+    InvalidJobName,
+    InvalidJobSchema,
+    InvalidJobSection,
+)
+from dlt._workspace.deployment.reflection import (
+    entity_properties,
+    injectable_fields,
+    inputs_from_function,
+    job_result_from_return,
+)
+from dlt._workspace.deployment.agent.configuration import (
+    spec_from_agent_inputs,
+    warn_unbound_inputs,
+    warn_unreferenced_inputs,
+)
+from dlt._workspace.deployment.agent.manifest import (
+    load_agent_spec,
+    agent_manifest_path,
+    resolve_agent_dir,
+    to_agent_definition,
+)
+from dlt._workspace.deployment.agent.reflection import agent_source, agent_spec_from_function
+from dlt._workspace.deployment.agent.typing import TAgentJobResult, TAgentLimits, TAgentSpec
+from dlt._workspace.deployment.job_result import running_job
+from dlt._workspace.deployment.launchers import (
+    DEFAULT_AGENT_LOOP,
+    LAUNCHER_AGENT,
+    LAUNCHER_JOB,
+    agent_loop_group,
+)
 from dlt._workspace.deployment.typing import (
+    MANIFEST_ENGINE_VERSION,
+    TWorkspaceAccess,
+    TAgentDefinition,
     TDeliverSpec,
     TEntryPoint,
     TExecuteSpec,
@@ -39,6 +88,7 @@ from dlt._workspace.deployment.typing import (
     TJobDefinition,
     TJobDefinitionDeprecated,
     TJobExposeSpec,
+    TJobObjectInput,
     TJobRef,
     TJobType,
     TRefreshPolicy,
@@ -132,6 +182,13 @@ class JobFactory(Generic[TJobFunParams, TJobResult]):
         self.incremental_mode: Optional[TIncrementalSource] = None
         self.refresh_propagation: TRefreshPolicy = "auto"
         self.auto_refresh_pipeline_mode: Optional[TRefreshMode] = None
+        self.launcher: str = LAUNCHER_JOB
+        self.access: Optional[TWorkspaceAccess] = None
+        """What the job may touch. Only an agent sets it today."""
+        self.inputs: Optional[Dict[str, Any]] = None
+        """JSON Schema of the arguments. Read from the function when the manifest is built."""
+        self.output: Optional[Dict[str, Any]] = None
+        """JSON Schema of the result, when the job returns a `TJobResult`."""
 
     @property
     def job_ref(self) -> TJobRef:
@@ -180,13 +237,17 @@ class JobFactory(Generic[TJobFunParams, TJobResult]):
         conf_f = with_config(f, spec=self._user_spec, sections=job_sections)
         self._spec = get_fun_spec(conf_f)
 
+        # the stack is pushed inside the coroutine, not around it: `__call__` returns the
+        # coroutine and the launcher awaits it later, so an outer scope would pop too early
         @wraps(conf_f)
         def _call(*args: Any, **kwargs: Any) -> Any:
-            return conf_f(*args, **kwargs)
+            with running_job(self.job_ref):
+                return conf_f(*args, **kwargs)
 
         @wraps(conf_f)
         async def _call_coro(*args: Any, **kwargs: Any) -> Any:
-            return await conf_f(*args, **kwargs)
+            with running_job(self.job_ref):
+                return await conf_f(*args, **kwargs)
 
         self._deco_f = _call_coro if iscoroutinefunction(f) else _call
 
@@ -197,16 +258,46 @@ class JobFactory(Generic[TJobFunParams, TJobResult]):
         update_wrapper(self, self._f)
         self.__signature__ = inspect.signature(self._f)
 
-    def to_job_definition(self) -> TJobDefinition:
-        """Builds a TJobDefinition manifest dict from this wrapper's metadata."""
-        entry_point: TEntryPoint = {
+    def _entry_point(self) -> TEntryPoint:
+        return {
             "module": self._f.__module__,
             "function": get_callable_name(self._f),
             "job_type": self.job_type,
-            "launcher": LAUNCHER_JOB,
+            "launcher": self.launcher,
         }
 
+    def _description(self) -> str:
+        return (self._f.__doc__ or "").strip()
+
+    def config_fields(self) -> Dict[str, Any]:
+        """Job arguments configuration injects, name to hint. `config_keys` and `inputs` are these."""
+        return injectable_fields(self._spec)
+
+    @property
+    def category(self) -> str:
+        """Label the job is grouped under, and the middle segment of its result type."""
+        deliver = self.deliver if isinstance(self.deliver, dict) else None
+        return job_category(self.expose, deliver, self.job_type)
+
+    def _reflect_schemas(self) -> None:
+        """Inputs and output of the job, read from the function. Set already, they stand."""
+        if self._f is None:
+            return
+        if self.inputs is None:
+            try:
+                self.inputs = inputs_from_function(self._f, self.job_ref, self.config_fields())
+            except InvalidJobSchema as ex:
+                # a job dlt cannot describe still deploys and still runs
+                logger.warning(f"Job {self.job_ref} declares no inputs in the manifest: {ex}")
+        if self.output is None:
+            self.output = job_result_from_return(self._f, self.job_ref)
+
+    def to_job_definition(self) -> TJobDefinition:
+        """Builds a TJobDefinition manifest dict from this wrapper's metadata."""
+        entry_point = self._entry_point()
+
         job_def: TJobDefinition = {
+            "engine_version": MANIFEST_ENGINE_VERSION,
             "job_ref": self.job_ref,
             "entry_point": entry_point,
             "triggers": list(self.trigger),
@@ -216,14 +307,31 @@ class JobFactory(Generic[TJobFunParams, TJobResult]):
         if self.expose:
             job_def["expose"] = self.expose  # type: ignore[typeddict-item]
 
-        description = (self._f.__doc__ or "").strip()
+        description = self._description()
         if description:
             job_def["description"] = description
 
-        if self._spec is not None:
-            config_keys = list(self._spec.get_resolvable_fields().keys())
-            if config_keys:
-                job_def["config_keys"] = config_keys
+        if self.access is not None:
+            job_def["access"] = self.access
+
+        config_keys = list(self.config_fields())
+        if config_keys:
+            job_def["config_keys"] = config_keys
+
+        self._reflect_schemas()
+        if (self.inputs or {}).get("properties"):
+            job_def["inputs"] = self.inputs
+        if self.output:
+            job_def["output"] = self.output
+        # an unknown entity_type fails here, at manifest time, for inputs and output alike
+        entity_properties(self.output, self.job_ref)
+        if entities := entity_properties(self.inputs, self.job_ref):
+            name, entity_type = next(iter(entities.items()))
+            expose = dict(job_def.get("expose") or {})
+            expose["object_input"] = TJobObjectInput(
+                entity_type=entity_type, input=f"{self.job_ref}.{name}"
+            )
+            job_def["expose"] = expose  # type: ignore[typeddict-item]
 
         if self.interval is not None:
             job_def["interval"] = self.interval
@@ -248,9 +356,9 @@ class JobFactory(Generic[TJobFunParams, TJobResult]):
         return job_def
 
 
-def _job(
-    func: Optional[AnyFun] = None,
-    /,
+def _make_job_factory(
+    *,
+    factory_cls: Type[JobFactory[Any, Any]] = JobFactory,
     name: str = None,
     section: str = None,
     job_type: TJobType = "batch",
@@ -269,8 +377,8 @@ def _job(
     spec: Type[BaseConfiguration] = None,
     deco_name: str = "@job",
     **kwargs: Any,
-) -> Any:
-    """Common decorator implementation for all job types."""
+) -> JobFactory[Any, Any]:
+    """Builds an unbound job factory with all metadata normalized."""
     # accept deprecated arg names (including nested `require`), convert, warn
     if require is not None:
         kwargs["require"] = dict(require)
@@ -296,7 +404,7 @@ def _job(
         )
     _validate_job_name(name)
     _validate_job_section(section)
-    wrapper: JobFactory[Any, Any] = JobFactory()
+    wrapper: JobFactory[Any, Any] = factory_cls()
     wrapper.name = name
     wrapper.section = section
     wrapper.job_type = job_type
@@ -317,7 +425,16 @@ def _job(
     wrapper.refresh_propagation = refresh_propagation or "auto"
     wrapper.auto_refresh_pipeline_mode = auto_refresh_pipeline_mode
     wrapper._user_spec = spec
+    return wrapper
 
+
+def _job(
+    func: Optional[AnyFun] = None,
+    /,
+    **kwargs: Any,
+) -> Any:
+    """Common decorator implementation for all job types."""
+    wrapper = _make_job_factory(**kwargs)
     if func is None:
         return wrapper.bind
     return wrapper.bind(func)
@@ -641,7 +758,7 @@ def pipeline_run(
             execute=execute,
             expose=full_expose,
             require=require,
-            deliver=deliver,  # type: ignore[arg-type]
+            deliver=deliver,
             interval=interval,
             freshness=freshness,
             incremental_mode=incremental_mode,
@@ -652,3 +769,474 @@ def pipeline_run(
         )
 
     return decorator
+
+
+def _job_name_from_agent(agent: Union[str, TAgentSpec]) -> str:
+    """Job name derived from the agent name: the part after `:`, dashes turned into underscores."""
+    name = agent if isinstance(agent, str) else agent["name"]
+    return name.rpartition(":")[2].replace("-", "_")
+
+
+def _workspace_relative(source: str, workspace_root: str) -> str:
+    """`<file>:<name>` with the file made relative to the workspace when it sits inside it."""
+    path, _, name = source.rpartition(":")
+    try:
+        return f"{os.path.relpath(path, workspace_root)}:{name}"
+    except ValueError:
+        return source
+
+
+def _set_agent(wrapper: "AgentJobFactory[Any, Any]", agent: Union[None, str, TAgentSpec]) -> None:
+    """Stores the agent on the factory, by reference or in full."""
+    if agent is None:
+        return
+    if isinstance(agent, str):
+        wrapper.agent_ref = agent
+    else:
+        wrapper.agent_spec = agent
+        wrapper.agent_ref = agent["name"]
+
+
+class AgentJobFactory(JobFactory[TJobFunParams, TJobResult]):
+    """Job whose body is an agent loop.
+
+    Declared either by decorating a function that drives the loop from
+    `run_context["ai_loop"]`, or by naming an agent, in which case the launcher drives it.
+    Either form names the agent with a `"<toolkit>:<agent>"` reference or a `TAgentSpec`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.launcher = LAUNCHER_AGENT
+        self.agent_ref: str = None
+        self.agent_spec: Optional[TAgentSpec] = None
+        """Agent declared inline, instead of referenced by name."""
+        self.agent_file: Optional[str] = None
+        """Folder the referenced agent was read from, relative to the workspace root."""
+        self.loop: str = DEFAULT_AGENT_LOOP
+        self.model: str = None
+        self.instructions: str = None
+        """The user turn opening every run of this job, until configuration says otherwise."""
+        self.limits: Optional[TAgentLimits] = None
+        self.loop_run_args: Optional[Dict[str, Any]] = None
+        self.verbosity: Optional[int] = None
+        self.inputs_validator: Optional[AnyFun] = None
+        self.outputs_validator: Optional[AnyFun] = None
+        self.agent_declaration: Dict[str, Any] = {}
+        """`AGENT.md` fields the decorator carried, overriding the agent it referenced."""
+        self.agent_definition: Optional[TAgentDefinition] = None
+        """Manifest subset of the agent, resolved when the job definition is generated."""
+        self._declared_module: str = None
+        self._declared_attr: str = None
+
+    @property
+    def is_declared(self) -> bool:
+        """True when the agent was named instead of decorating a function."""
+        return self._f is None
+
+    @property
+    def has_agent(self) -> bool:
+        """True when the job has an agent: named, given, or declared by the function itself."""
+        return bool(self.agent_ref or self.agent_spec or not self.is_declared)
+
+    def resolve_agent_spec(self, workspace_root: str) -> TAgentSpec:
+        """The agent in full: declared by the decorated function, given inline, or named."""
+        if self.agent_spec is None:
+            base: Optional[TAgentSpec] = None
+            if self.agent_ref:
+                agent_dir = resolve_agent_dir(self.agent_ref, workspace_root)
+                base = load_agent_spec(agent_dir)
+                self.agent_file = os.path.relpath(agent_manifest_path(agent_dir), workspace_root)
+
+            if self.is_declared:
+                self.agent_spec = base
+            else:
+                source = agent_source(self._f, self.name)
+                self.agent_spec = agent_spec_from_function(
+                    self._f, source, self.agent_declaration, base
+                )
+                # a function-declared agent has no AGENT.md: it is the module it lives in
+                self.agent_file = _workspace_relative(source, workspace_root)
+                if not self.agent_ref:
+                    self.agent_ref = f"{self._f.__module__}:{get_callable_name(self._f)}"
+        # the agent declares the result. A declared job's inputs are the agent's too; a
+        # decorated one takes them from its signature, which is what configuration can inject
+        self.output = self.agent_spec["output"]
+        if self.is_declared:
+            self.inputs = self.agent_spec["inputs"]
+        return self.agent_spec
+
+    def declare(self, module_name: str, attr_name: str) -> None:
+        """Names the module attribute holding a declared agent, so the launcher can resolve it."""
+        self._declared_module = self._declared_module or module_name
+        self._declared_attr = self._declared_attr or attr_name
+        self.section = self.section or get_module_name(sys.modules[module_name])
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if not self.is_declared:
+            return super().__call__(*args, **kwargs)
+        # the launcher imports this module, so it can only be reached from inside the call
+        from dlt._workspace.deployment.launchers.agent import run_declared_agent
+
+        return run_declared_agent(self, *args, **kwargs)
+
+    def _entry_point(self) -> TEntryPoint:
+        if not self.is_declared:
+            return super()._entry_point()
+        return {
+            "module": self._declared_module,
+            "function": self._declared_attr,
+            "job_type": self.job_type,
+            "launcher": self.launcher,
+        }
+
+    def _description(self) -> str:
+        if not self.is_declared:
+            return super()._description()
+        # a declared job has no function to describe it, so the agent speaks for it
+        return self.agent_spec.get("description", "") if self.agent_spec else ""
+
+    @property
+    def category(self) -> str:
+        return "background_agent"
+
+    def input_spec(self, agent_spec: TAgentSpec) -> Type[BaseConfiguration]:
+        """Job configuration of a declared agent: its inputs, synthesized once."""
+        if self._spec is None:
+            # no function to inject config into, so the declared inputs are the job config
+            self._spec = spec_from_agent_inputs(agent_spec)
+        return self._spec
+
+    def _resolve_agent(self) -> None:
+        """Reads the agent and takes its job configuration from the inputs it declares."""
+        spec = self.resolve_agent_spec(active().run_dir)
+        self.agent_definition = to_agent_definition(
+            spec, self.agent_file, self.instructions, self.model
+        )
+        self.access = spec.get("access") or {}
+        warn_unreferenced_inputs(spec)
+        if self.is_declared:
+            self.input_spec(spec)
+        else:
+            warn_unbound_inputs(spec, self._f)
+
+    def to_job_definition(self) -> TJobDefinition:
+        if self.has_agent:
+            self._resolve_agent()
+        job_def = super().to_job_definition()
+        expose: TExposeSpec = dict(job_def.get("expose") or {})  # type: ignore[assignment]
+        expose["category"] = self.category  # type: ignore[typeddict-item]
+        job_def["expose"] = expose
+        if self.agent_definition is not None:
+            job_def["agent"] = self.agent_definition
+        require: TRequireSpec = dict(job_def.get("require") or {})  # type: ignore[assignment]
+        groups = list(require.get("dependency_groups") or [])
+        loop_group = agent_loop_group(self.loop)
+        if loop_group not in groups:
+            groups.append(loop_group)
+        require["dependency_groups"] = groups
+        job_def["require"] = require
+        return job_def
+
+
+@overload
+def agent(
+    func: Callable[TJobFunParams, TJobResult],
+    /,
+    *,
+    agent: Union[str, TAgentSpec] = None,
+    instructions: str = None,
+    access: Optional[TWorkspaceAccess] = None,
+    tools: Optional[List[str]] = None,
+    skills: Optional[List[str]] = None,
+    rules: Optional[List[str]] = None,
+    name: str = None,
+    section: str = None,
+    loop: str = DEFAULT_AGENT_LOOP,
+    model: str = None,
+    identity: str = None,
+    limits: Optional[TAgentLimits] = None,
+    loop_run_args: Optional[Dict[str, Any]] = None,
+    verbosity: Optional[int] = None,
+    trigger: Union[str, TTrigger, Sequence[Union[str, TTrigger]]] = None,
+    execute: Optional[TExecuteSpec] = None,
+    expose: Optional[TJobExposeSpec] = None,
+    require: Optional[TRequireSpec] = None,
+    spec: Type[BaseConfiguration] = None,
+) -> AgentJobFactory[TJobFunParams, TJobResult]: ...
+
+
+@overload
+def agent(
+    func: None = ...,
+    /,
+    *,
+    agent: Union[str, TAgentSpec] = None,
+    instructions: str = None,
+    access: Optional[TWorkspaceAccess] = None,
+    tools: Optional[List[str]] = None,
+    skills: Optional[List[str]] = None,
+    rules: Optional[List[str]] = None,
+    name: str = None,
+    section: str = None,
+    loop: str = DEFAULT_AGENT_LOOP,
+    model: str = None,
+    identity: str = None,
+    limits: Optional[TAgentLimits] = None,
+    loop_run_args: Optional[Dict[str, Any]] = None,
+    verbosity: Optional[int] = None,
+    trigger: Union[str, TTrigger, Sequence[Union[str, TTrigger]]] = None,
+    execute: Optional[TExecuteSpec] = None,
+    expose: Optional[TJobExposeSpec] = None,
+    require: Optional[TRequireSpec] = None,
+    spec: Type[BaseConfiguration] = None,
+) -> Callable[
+    [Callable[TJobFunParams, TJobResult]], AgentJobFactory[TJobFunParams, TJobResult]
+]: ...
+
+
+@overload
+def agent(
+    agent_ref: Union[str, TAgentSpec],
+    /,
+    *,
+    name: str = None,
+    section: str = None,
+    loop: str = DEFAULT_AGENT_LOOP,
+    model: str = None,
+    instructions: str = None,
+    identity: str = None,
+    limits: Optional[TAgentLimits] = None,
+    loop_run_args: Optional[Dict[str, Any]] = None,
+    verbosity: Optional[int] = None,
+    inputs_validator: Optional[AnyFun] = None,
+    outputs_validator: Optional[AnyFun] = None,
+    trigger: Union[str, TTrigger, Sequence[Union[str, TTrigger]]] = None,
+    execute: Optional[TExecuteSpec] = None,
+    expose: Optional[TJobExposeSpec] = None,
+    require: Optional[TRequireSpec] = None,
+    spec: Type[BaseConfiguration] = None,
+) -> AgentJobFactory[..., TAgentJobResult]: ...
+
+
+def agent(
+    func_or_ref: Union[Optional[AnyFun], str, TAgentSpec] = None,
+    /,
+    *,
+    agent: Union[str, TAgentSpec] = None,
+    instructions: str = None,
+    access: Optional[TWorkspaceAccess] = None,
+    tools: Optional[List[str]] = None,
+    skills: Optional[List[str]] = None,
+    rules: Optional[List[str]] = None,
+    name: str = None,
+    section: str = None,
+    loop: str = DEFAULT_AGENT_LOOP,
+    model: str = None,
+    identity: str = None,
+    limits: Optional[TAgentLimits] = None,
+    loop_run_args: Optional[Dict[str, Any]] = None,
+    verbosity: Optional[int] = None,
+    inputs_validator: Optional[AnyFun] = None,
+    outputs_validator: Optional[AnyFun] = None,
+    trigger: Union[str, TTrigger, Sequence[Union[str, TTrigger]]] = None,
+    execute: Optional[TExecuteSpec] = None,
+    expose: Optional[TJobExposeSpec] = None,
+    require: Optional[TRequireSpec] = None,
+    spec: Type[BaseConfiguration] = None,
+) -> Any:
+    """Declares a background agent job: an agent loop that dlthub runs as a job.
+
+    Decorate a function, and the function is the agent: its docstring is the system prompt,
+    its parameters are the inputs, its return type is the output, and its body drives the loop
+    it finds in `run_context["ai_loop"]`. Or name an installed agent, and dlthub drives the
+    loop and reports the agent's output as the job result.
+
+    Example: a function agent that explains a failed job run
+
+        >>> from typing import Annotated, Literal
+        >>> from dlt.hub import run
+        >>>
+        >>> class Diagnosis(run.TAgentOutput):
+        ...     classification: Annotated[
+        ...         Literal["config", "code", "upstream_data"],
+        ...         run.Doc("What kind of failure it was"),
+        ...     ]
+        >>>
+        >>> @run.agent(
+        ...     access={"local": ["read"], "data": ["read"], "context": ["read"]},
+        ...     tools=["jobs", "logs", "telemetry"],
+        ...     skills=["dlthub-platform:debug-deployment"],
+        ...     rules=["dlthub-platform:job-resources"],
+        ...     loop="claude-agent-sdk",
+        ...     limits={"max_turns": 20},
+        ... )
+        ... async def inspect_failure(
+        ...     failed_run_id: str, run_context: run.TJobRunContext
+        ... ) -> Diagnosis:
+        ...     '''Explain why job run {{ failed_run_id }} failed. Do not repair anything.
+        ...
+        ...     Read the run record and its logs, classify the failure and propose a fix.
+        ...     '''
+        ...     return await run_context["ai_loop"].run(inputs={"failed_run_id": failed_run_id})
+
+    Run it with `dlthub local run inspect_failure`. The system prompt refers to inputs as
+    `{{ name }}` and to the run as `{{ run_context.trigger }}`; an input comes from the job's
+    configuration first, then from the trigger's run arguments, then from the call. The loop
+    returns the output as a dict; a `status` of `aborted` raises `JobAbortedException` with
+    the agent's `summary`.
+
+    The same agent installed by a toolkit as `.claude/dlthub/agents/job-inspector/AGENT.md`
+    needs no function, and runs from Python too:
+
+        >>> inspector = run.agent(
+        ...     "dlthub-platform:job-inspector", instructions="explain, do not fix"
+        ... )
+        >>> result = inspector(failed_run_id="run-42")
+
+    Configuration in the job's section overrides the decorator: `[jobs.<module>.<job>.agent]`
+    takes `loop`, `model`, `instructions`, `max_turns`, `max_tokens`, `loop_run_args`,
+    `verbosity`, `api_key`, `api_url` and `api_version`. Inputs are set one level up, in
+    `[jobs.<module>.<job>]`.
+
+    Args:
+        func_or_ref (Union[Optional[AnyFun], str, TAgentSpec]): The function to decorate, or the
+            agent to run. An agent is a `"<toolkit>:<agent>"` reference to an installed one, a
+            workspace-relative path to a folder holding `AGENT.md`, or a `TAgentSpec` declared
+            inline.
+        agent (Union[str, TAgentSpec]): Agent the decorated function starts from, as a
+            `"<toolkit>:<agent>"` reference, a path to its folder, or a `TAgentSpec`. The
+            decorator arguments override its fields, and the function's docstring, parameters
+            and return type override those.
+        instructions (str): The first user message of every run: the task for this time, where
+            the system prompt says who the agent is. Optional; without it the run opens with a
+            bare go-ahead. `agent.instructions` in the job's configuration replaces it.
+        access (Optional[TWorkspaceAccess]): What the agent may touch, per axis, as one verb or
+            a list of verbs. `local` (`read`, `write`, `execute`, `network`, `all`) buys the
+            loop's built-in tools: `read` file reading and search, `write` file writing,
+            `execute` a shell and Python in the workspace, `network` web access; credential
+            files stay out of reach whatever is granted. `data` (`read`, `write`) is workspace
+            data, enforced by the dlt profile of the run. `context` (`read`) is telemetry, runs
+            and job definitions on dlthub. Nothing granted, no tools of that kind.
+        tools (Optional[List[str]]): Feature groups of the dlthub MCP server, which the loop
+            spawns for the run with exactly these features: `workspace`, `pipeline`, `toolkit`,
+            `secrets`, `context`, and on dlthub `jobs`, `logs`, `telemetry`. Without `tools`
+            no server is started.
+        skills (Optional[List[str]]): Skills the agent may invoke. Refer to a skill of an
+            installed toolkit as `"<toolkit>:<skill>"`, e.g. `"dlthub-platform:debug-deployment"`,
+            or by a workspace-relative path to its file, e.g. `".claude/skills/my-skill/SKILL.md"`.
+            On `claude-agent-sdk` the CLI lists them by name and loads one when invoked, the
+            way Claude Code does; on `pydantic-ai` their text is inlined into the system
+            prompt. Only the listed skills reach the agent, none of the others installed in the
+            workspace. A reference that does not resolve is skipped with a warning.
+        rules (Optional[List[str]]): Rules inlined into the system prompt on every loop. Refer
+            to a rule of an installed toolkit as `"<toolkit>:<rule>"`, e.g.
+            `"dlthub-platform:job-resources"`, or by a workspace-relative path to its file,
+            e.g. `".claude/rules/my-rule.md"`. The workspace's own `.claude/rules` are not
+            loaded; an agent gets the rules it declares. A reference that does not resolve is
+            skipped with a warning.
+        name (str): Job name. Defaults to the function name, or to the agent's name.
+        section (str): Configuration section. Defaults to the name of the declaring module.
+        loop (str): Framework that runs the agent. `"pydantic-ai"` (default) runs any
+            provider's model on dlt's own file, search and execution tools. `"claude-agent-sdk"`
+            runs Anthropic models on Claude Code, with its tools and native skills; the SDK
+            ships the CLI it needs. `agent.loop` in configuration replaces it.
+        model (str): `provider:model` id, e.g. `"anthropic:claude-sonnet-5"`, or an alias:
+            `sonnet`, `opus`, `haiku`, `fable`, `gpt`, `gpt-mini`, `gpt-nano`, `gemini`,
+            `gemini-pro`. Overrides the agent's declared default; `agent.model` in configuration
+            replaces both.
+        identity (str): Reserved for future use.
+        limits (Optional[TAgentLimits]): `max_turns` and `max_tokens` for one run. The loop
+            ends the run when either is spent. Overrides the agent's declared defaults;
+            `agent.max_turns` and `agent.max_tokens` in configuration replace them.
+        loop_run_args (Optional[Dict[str, Any]]): Arguments handed to the native loop, merged
+            over the agent's declared defaults. `retries` is how often pydantic-ai lets the
+            model correct a failing tool call, 0 by default. Other keys are the framework's
+            own: pydantic-ai `Agent` spec fields, or `ClaudeAgentOptions` fields such as
+            `settings`. Keys a loop does not know are ignored and listed in the run's trace.
+        verbosity (Optional[int]): How much of the run is printed to stdout: 0 the outcome
+            only, 1 turns, thoughts and tool calls, 2 everything, the system prompt included.
+        inputs_validator (Optional[AnyFun]): Called with the resolved inputs before the run;
+            whatever it returns is merged into them. Use it to check or derive inputs, e.g. look
+            up a run id from a job ref.
+        outputs_validator (Optional[AnyFun]): Called with the agent's output after the run;
+            whatever it returns replaces it.
+        trigger (Union[str, TTrigger, Sequence[Union[str, TTrigger]]]): One or more trigger
+            strings or `TTrigger` values.
+        execute (Optional[TExecuteSpec]): Execution constraints: `timeout`, `concurrency`.
+        expose (Optional[TJobExposeSpec]): UI presentation: `tags`, `starred`, `manual`.
+        require (Optional[TRequireSpec]): Runtime resource requirements.
+        spec (Type[BaseConfiguration]): Optional configuration spec class.
+
+    Returns:
+        AgentJobFactory: The job. In the function form it keeps the function's signature and
+        return type; in the reference form it is called with the inputs as keyword arguments.
+
+    Raises:
+        TypeError: An argument was passed that the chosen form does not accept.
+    """
+    is_agent_ref = isinstance(func_or_ref, (str, Mapping))
+    if not is_agent_ref:
+        # the launcher applies these two only when it drives the loop itself
+        for arg_name, value in (
+            ("inputs_validator", inputs_validator),
+            ("outputs_validator", outputs_validator),
+        ):
+            if value is not None:
+                raise TypeError(
+                    f"run.agent on a function does not accept {arg_name!r}. Pass it to"
+                    " `loop.run()`, or name an agent: run.agent('<toolkit>:<agent>')."
+                )
+
+    if is_agent_ref and agent is not None:
+        raise TypeError("run.agent takes the agent positionally here. Drop the 'agent' argument.")
+
+    def _new_factory() -> AgentJobFactory[Any, Any]:
+        wrapper: AgentJobFactory[Any, Any] = _make_job_factory(  # type: ignore[assignment]
+            factory_cls=AgentJobFactory,
+            name=name,
+            section=section,
+            job_type="batch",
+            trigger=trigger,
+            execute=execute,
+            expose=expose,
+            require=require,
+            spec=spec,
+            deco_name="@agent",
+        )
+        wrapper.loop = loop
+        wrapper.model = model
+        wrapper.instructions = instructions
+        wrapper.limits = limits
+        wrapper.loop_run_args = loop_run_args
+        wrapper.verbosity = verbosity
+        wrapper.inputs_validator = inputs_validator
+        wrapper.outputs_validator = outputs_validator
+        wrapper.agent_declaration = {
+            "name": name,
+            "access": access,
+            "tools": tools,
+            "skills": skills,
+            "rules": rules,
+            "model": model,
+            "limits": limits,
+            "loop_run_args": loop_run_args,
+            "trigger": wrapper.trigger or None,
+        }
+        _set_agent(wrapper, agent)
+        return wrapper
+
+    if func_or_ref is None:
+        # called with parens
+        return lambda f: _new_factory().bind(f)
+    if not is_agent_ref:
+        # called as @run.agent, without parens
+        return _new_factory().bind(cast(AnyFun, func_or_ref))
+
+    # an agent was given: there is no function, the launcher drives the loop
+    declared = cast(Union[str, TAgentSpec], func_or_ref)
+    wrapper = _new_factory()
+    _set_agent(wrapper, declared)
+    wrapper.name = wrapper.name or _job_name_from_agent(declared)
+    _validate_job_name(wrapper.name)
+    return wrapper

--- a/dlt/_workspace/deployment/detectors.py
+++ b/dlt/_workspace/deployment/detectors.py
@@ -23,6 +23,7 @@ from dlt._workspace.deployment._trigger_helpers import normalize_triggers
 from dlt._workspace.deployment.launchers import LAUNCHER_MODULE, get_launcher_for_framework
 from dlt._workspace.deployment import trigger as _triggers
 from dlt._workspace.deployment.typing import (
+    MANIFEST_ENGINE_VERSION,
     TEntryPoint,
     TExecuteSpec,
     TExposeSpec,
@@ -134,6 +135,7 @@ def _detect_marimo(module: ModuleType) -> Optional[TJobDefinition]:
         "launcher": get_launcher_for_framework("marimo"),
     }
     job_def: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": _module_job_ref(module),
         "entry_point": entry_point,
         "expose": TExposeSpec(interface="gui", category="notebook"),
@@ -171,6 +173,7 @@ def _detect_mcp(module: ModuleType) -> Optional[TJobDefinition]:
         "launcher": get_launcher_for_framework("fastmcp"),
     }
     job_def: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": _module_job_ref(module),
         "entry_point": entry_point,
         "expose": TExposeSpec(interface="mcp", category="mcp"),
@@ -204,6 +207,7 @@ def _detect_streamlit(module: ModuleType) -> Optional[TJobDefinition]:
         "launcher": get_launcher_for_framework("streamlit"),
     }
     job_def: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": _module_job_ref(module),
         "entry_point": entry_point,
         "expose": TExposeSpec(interface="gui", category="dashboard"),
@@ -263,6 +267,7 @@ def detect_local_module(module: ModuleType, parent_module: ModuleType) -> Option
         "launcher": LAUNCHER_MODULE,
     }
     job_def: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": _module_job_ref(module),
         "entry_point": entry_point,
         "triggers": [],

--- a/dlt/_workspace/deployment/entity.py
+++ b/dlt/_workspace/deployment/entity.py
@@ -1,0 +1,45 @@
+"""Workspace entities a job acts on, addressed relative to the workspace."""
+
+from typing import Any, Dict, List, Mapping, Optional
+
+from dlt._workspace.deployment.reflection import entity_properties
+from dlt._workspace.deployment.typing import THubEntity, THubEntityType
+
+
+def hub_entity(entity_type: THubEntityType, unique_id: str) -> THubEntity:
+    """An entity in shorthand: `{type}/{unique id}`."""
+    return {"type": entity_type, "id": f"{entity_type}/{unique_id}"}
+
+
+def hub_objects(
+    inputs: Optional[Dict[str, Any]],
+    input_values: Mapping[str, Any],
+    output: Optional[Dict[str, Any]],
+    result: Any,
+    source: str,
+) -> List[THubEntity]:
+    """Entities a run acted on. Inputs first; an output of the same name overwrites it.
+
+    Args:
+        inputs (Optional[Dict[str, Any]]): The job's `inputs` JSON Schema.
+        input_values (Mapping[str, Any]): Resolved input values of the run.
+        output (Optional[Dict[str, Any]]): The job's `output` JSON Schema.
+        result (Any): The payload the run produced.
+        source (str): What to name in an error, usually the job ref.
+
+    Returns:
+        List[THubEntity]: Distinct entities, in declaration order.
+    """
+    by_name: Dict[str, THubEntity] = {}
+    for name, entity_type in entity_properties(inputs, source).items():
+        if value := input_values.get(name):
+            by_name[name] = hub_entity(entity_type, str(value))
+    if isinstance(result, Mapping):
+        for name, entity_type in entity_properties(output, source).items():
+            if value := result.get(name):
+                by_name[name] = hub_entity(entity_type, str(value))
+    objects: List[THubEntity] = []
+    for entity in by_name.values():
+        if entity not in objects:
+            objects.append(entity)
+    return objects

--- a/dlt/_workspace/deployment/exceptions.py
+++ b/dlt/_workspace/deployment/exceptions.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Dict, List, NamedTuple, Sequence, Tuple
 from dlt._workspace.exceptions import WorkspaceException
 
 if TYPE_CHECKING:
-    from dlt._workspace.deployment.typing import TJobDefinition
+    from dlt._workspace.deployment.typing import TJobDefinition, TJobResult
 
 
 class DeploymentException(WorkspaceException):
@@ -13,6 +13,12 @@ class DeploymentException(WorkspaceException):
 class JobValidationResult(NamedTuple):
     errors: List[str]
     warnings: List[str]
+
+
+class InvalidJobSchema(DeploymentException, ValueError):
+    def __init__(self, source: str, reason: str) -> None:
+        self.source = source
+        super().__init__(f"Cannot read the schema of {source!r}: {reason}")
 
 
 class InvalidJobDefinition(ValueError, DeploymentException):
@@ -116,6 +122,24 @@ class JobResolutionError(DeploymentException):
     def __init__(self, ref: str, reason: str) -> None:
         self.ref = ref
         super().__init__(f"Cannot resolve job {ref!r}: {reason}")
+
+
+class InvalidJobResultType(DeploymentException, ValueError):
+    def __init__(self, result_type: str) -> None:
+        self.result_type = result_type
+        super().__init__(
+            f"Job result type {result_type!r} is not `job.<category>.<name>`. The launcher"
+            " builds it; a job passes only the name to `run.result(..., type=)`."
+        )
+
+
+class JobAbortedException(DeploymentException):
+    """A job ended its run deliberately without completing its task."""
+
+    def __init__(self, summary: str, result: "TJobResult") -> None:
+        self.summary = summary
+        self.result = result
+        super().__init__(f"Job aborted: {summary}")
 
 
 class ManifestImportError(DeploymentException):

--- a/dlt/_workspace/deployment/exceptions.py
+++ b/dlt/_workspace/deployment/exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Sequence, Tuple
+from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Sequence, Tuple, cast
 
 from dlt._workspace.exceptions import WorkspaceException
 
@@ -10,18 +10,48 @@ class DeploymentException(WorkspaceException):
     pass
 
 
+class DeploymentValidationError(DeploymentException, ValueError):
+    """Deployment input dlt refuses: a manifest, job definition, trigger, ref or agent definition.
+
+    Every subclass reports through `errors`, `warnings` and `subject`, so one handler answers
+    for all of them.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        errors: Optional[Sequence[str]] = None,
+        warnings: Optional[Sequence[str]] = None,
+        subject: Optional[str] = None,
+    ) -> None:
+        self.errors = list(errors) if errors else [message]
+        self.warnings = list(warnings or [])
+        self.subject = subject
+        """What was invalid, when it is one thing: a job ref, a trigger, a path."""
+        super().__init__(message)
+
+    @classmethod
+    def from_message(cls, message: str) -> "DeploymentValidationError":
+        """Rebuilds an instance from its message alone, as a worker process reports it."""
+        exc = cls.__new__(cls)
+        DeploymentValidationError.__init__(exc, message)
+        return exc
+
+
 class JobValidationResult(NamedTuple):
     errors: List[str]
     warnings: List[str]
 
 
-class InvalidJobSchema(DeploymentException, ValueError):
+class InvalidJobSchema(DeploymentValidationError):
     def __init__(self, source: str, reason: str) -> None:
         self.source = source
-        super().__init__(f"Cannot read the schema of {source!r}: {reason}")
+        super().__init__(
+            f"Cannot read the schema of {source!r}: {reason}", errors=[reason], subject=source
+        )
 
 
-class InvalidJobDefinition(ValueError, DeploymentException):
+class InvalidJobDefinition(DeploymentValidationError):
     def __init__(self, job_ref: str, validation: JobValidationResult) -> None:
         self.job_ref = job_ref
         self.validation = validation
@@ -29,7 +59,9 @@ class InvalidJobDefinition(ValueError, DeploymentException):
         msg += "\n".join(f"  - {e}" for e in validation.errors)
         if validation.warnings:
             msg += "\nWarnings:\n" + "\n".join(f"  - {w}" for w in validation.warnings)
-        super().__init__(msg)
+        super().__init__(
+            msg, errors=validation.errors, warnings=validation.warnings, subject=job_ref
+        )
 
 
 class ManifestValidationResult(NamedTuple):
@@ -40,37 +72,39 @@ class ManifestValidationResult(NamedTuple):
     """Maps job_ref -> list of unresolved upstream job refs from triggers."""
 
 
-class InvalidManifest(DeploymentException):
+class InvalidManifest(DeploymentValidationError):
     def __init__(self, validation: ManifestValidationResult) -> None:
         self.validation = validation
         msg = "Invalid deployment manifest:\n" + "\n".join(f"  - {e}" for e in validation.errors)
-        super().__init__(msg)
+        super().__init__(msg, errors=validation.errors, warnings=validation.warnings)
 
     @classmethod
     def from_message(cls, message: str) -> "InvalidManifest":
-        result = ManifestValidationResult(
+        exc = cast("InvalidManifest", super().from_message(message))
+        exc.validation = ManifestValidationResult(
             is_valid=False, errors=[message], warnings=[], unresolved_triggers={}
         )
-        return cls(result)
+        return exc
 
 
-class ManifestEngineNoUpgradePath(DeploymentException, ValueError):
+class ManifestEngineNoUpgradePath(DeploymentValidationError):
     def __init__(self, subject: str, from_engine: int, to_engine: int) -> None:
         self.from_engine = from_engine
         self.to_engine = to_engine
         super().__init__(
             f"No {subject} migration path from engine {from_engine} to {to_engine}. A manifest"
-            " written by a newer dlt cannot be downgraded — upgrade dlt to read it."
+            " written by a newer dlt cannot be downgraded — upgrade dlt to read it.",
+            subject=subject,
         )
 
 
-class InvalidJobRef(DeploymentException, ValueError):
+class InvalidJobRef(DeploymentValidationError):
     def __init__(self, ref: str, reason: str) -> None:
         self.ref = ref
-        super().__init__(f"Invalid job ref {ref!r}: {reason}")
+        super().__init__(f"Invalid job ref {ref!r}: {reason}", errors=[reason], subject=ref)
 
 
-class InvalidJobName(DeploymentException, ValueError):
+class InvalidJobName(DeploymentValidationError):
     def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(
@@ -78,18 +112,20 @@ class InvalidJobName(DeploymentException, ValueError):
             " parts of job references and configuration sections, so they must use"
             " only letters, digits and underscores and may not start with a digit."
             " If you want a human-friendly label for the UI, set it via"
-            " `expose={'display_name': '...'}` and keep `name` a Python identifier."
+            " `expose={'display_name': '...'}` and keep `name` a Python identifier.",
+            subject=name,
         )
 
 
-class InvalidJobSection(DeploymentException, ValueError):
+class InvalidJobSection(DeploymentValidationError):
     def __init__(self, section: str) -> None:
         self.section = section
         super().__init__(
             f"Job section {section!r} is not a valid Python identifier. Sections"
             " become parts of job references and configuration sections, so they"
             " must use only letters, digits and underscores and may not start with"
-            " a digit. Sections default to the module name when not provided."
+            " a digit. Sections default to the module name when not provided.",
+            subject=section,
         )
 
 
@@ -106,16 +142,20 @@ class AmbiguousJobRef(DeploymentException):
         super().__init__(f"ambiguous job name {name!r}, matches: {', '.join(matches)}")
 
 
-class InvalidTrigger(DeploymentException, ValueError):
+class InvalidTrigger(DeploymentValidationError):
     def __init__(self, trigger: str, reason: str) -> None:
         self.trigger = trigger
-        super().__init__(f"Invalid trigger {trigger!r}: {reason}")
+        super().__init__(f"Invalid trigger {trigger!r}: {reason}", errors=[reason], subject=trigger)
 
 
-class InvalidFreshnessConstraint(DeploymentException, ValueError):
+class InvalidFreshnessConstraint(DeploymentValidationError):
     def __init__(self, constraint: str, reason: str) -> None:
         self.constraint = constraint
-        super().__init__(f"Invalid freshness constraint {constraint!r}: {reason}")
+        super().__init__(
+            f"Invalid freshness constraint {constraint!r}: {reason}",
+            errors=[reason],
+            subject=constraint,
+        )
 
 
 class JobResolutionError(DeploymentException):

--- a/dlt/_workspace/deployment/file_selector.py
+++ b/dlt/_workspace/deployment/file_selector.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 
 from dlt._workspace._workspace_context import WorkspaceRunContext
+from dlt._workspace.cli.dlthub.ai.utils import TOOLKITS_INDEX_FILE
 from dlt._workspace.profile import LOCAL_PROFILES
 
 
@@ -28,6 +29,9 @@ DEFAULT_IGNORES: List[str] = [
     ".DS_Store",
     ".env",
 ]
+
+SETTINGS_INCLUDES: List[str] = [TOOLKITS_INDEX_FILE]
+"""Settings-dir files that ship with the code. Never anything holding secrets."""
 
 
 class BaseFileSelector(Iterable[Tuple[Path, Path]]):
@@ -62,7 +66,13 @@ class WorkspaceFileSelector(BaseFileSelector):
         """Build PathSpec from ignore file + defaults + additional excludes"""
         from pathspec import PathSpec
 
-        patterns: List[str] = [f"{self.settings_dir.relative_to(self.root_path)}/"]
+        settings_rel = self.settings_dir.relative_to(self.root_path)
+        # the settings dir stays out, except the toolkit index: the agent launcher reads it
+        # on the runner to resolve `<toolkit>:<agent>` refs
+        patterns: List[str] = [
+            f"{settings_rel}/",
+            *(f"!{settings_rel}/{name}" for name in SETTINGS_INCLUDES),
+        ]
 
         # load ignore file if exists, otherwise fall back to default ignores
         ignore_path = self.root_path / self.ignore_file

--- a/dlt/_workspace/deployment/job_result.py
+++ b/dlt/_workspace/deployment/job_result.py
@@ -1,0 +1,131 @@
+"""Structured job results and their delivery to the dlthub beacon."""
+
+from contextlib import contextmanager
+from typing import Any, ClassVar, Dict, Iterator, List, Mapping, Optional, Tuple
+
+from dlt.common.configuration.container import Container
+from dlt.common.configuration.specs.base_configuration import (
+    ContainerInjectableContext,
+    configspec,
+)
+
+from dlt._workspace.deployment.exceptions import InvalidJobResultType
+from dlt._workspace.deployment.typing import (
+    JOB_RESULT_ENGINE_VERSION,
+    JOB_RESULT_PAYLOAD_TYPE,
+    TJobRef,
+    TJobResult,
+)
+
+
+RESULT_TYPE_PREFIX = "job"
+"""First segment of every result type: `job.{category}.{name}`."""
+
+
+@configspec
+class JobRunContext(ContainerInjectableContext):
+    """Job call stack of the current thread and the result declared by its top-level job."""
+
+    can_create_default: ClassVar[bool] = True
+    global_affinity: ClassVar[bool] = False
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.job_stack: List[TJobRef] = []
+        self.result: Optional[TJobResult] = None
+        self.inputs: Optional[Dict[str, Any]] = None
+
+
+@contextmanager
+def running_job(job_ref: TJobRef) -> Iterator[None]:
+    """Marks `job_ref` as running. The outermost job on the stack owns the run result."""
+    ctx = Container()[JobRunContext]
+    ctx.job_stack.append(job_ref)
+    try:
+        yield
+    finally:
+        ctx.job_stack.pop()
+
+
+def result_type(category: str, name: str) -> str:
+    """`job.{category}.{name}`: the category names the envelope, the name the payload."""
+    return f"{RESULT_TYPE_PREFIX}.{category}.{name}"
+
+
+def parse_result_type(type_: str) -> Tuple[str, str]:
+    """Splits `job.{category}.{name}` into category and name. The name may contain dots.
+
+    Raises:
+        InvalidJobResultType: The string does not start with `job.` or lacks a name.
+    """
+    parts = type_.split(".", 2)
+    if len(parts) != 3 or parts[0] != RESULT_TYPE_PREFIX or not parts[1] or not parts[2]:
+        raise InvalidJobResultType(type_)
+    return parts[1], parts[2]
+
+
+def job_result(
+    result: Any = None,
+    /,
+    *,
+    type: str,  # noqa: A002
+    engine_version: int = JOB_RESULT_ENGINE_VERSION,
+) -> Any:
+    """Declares the structured result of the current job run and returns `result` unchanged.
+
+    Ignored unless the calling job is the one the launcher invoked. A job that calls another
+    job as a plain function does not overwrite the run's result. A second call replaces the
+    first declaration.
+
+    Args:
+        result (Any): JSON-serializable payload.
+        type (str): Name of the payload shape, e.g. `"etl_summary"`. The launcher prefixes it
+            with `job.{category}.` when the run finishes.
+        engine_version (int): Version of that shape.
+
+    Returns:
+        Any: `result`, unchanged.
+    """
+    ctx = Container()[JobRunContext]
+    if len(ctx.job_stack) == 1:
+        ctx.result = {"type": type, "engine_version": engine_version, "result": result}
+    return result
+
+
+def set_job_result(result: TJobResult) -> None:
+    """Declares a fully-formed result for the current top-level job. Its `type` is the bare name."""
+    ctx = Container()[JobRunContext]
+    if len(ctx.job_stack) <= 1:
+        ctx.result = result
+
+
+def set_job_inputs(inputs: Mapping[str, Any]) -> None:
+    """Records the inputs the run received, so `object` can be derived from them at the end."""
+    Container()[JobRunContext].inputs = dict(inputs)
+
+
+def job_inputs() -> Optional[Dict[str, Any]]:
+    """The inputs the run recorded, if any."""
+    return Container()[JobRunContext].inputs
+
+
+def take_job_result(job_ref: TJobRef, category: str) -> Optional[TJobResult]:
+    """Returns and clears the declared result, with `type` and `job_ref` filled in.
+
+    This is the one place the result type is built, so the category is always the launcher's.
+    """
+    ctx = Container()[JobRunContext]
+    result = ctx.result
+    ctx.result = None
+    if result is None:
+        return None
+    result["type"] = result_type(category, result["type"])
+    result["job_ref"] = job_ref
+    return result
+
+
+def send_job_result(result: TJobResult, wait: bool = False) -> None:
+    """Delivers a job result to the dlthub beacon. Does nothing when it is not configured."""
+    from dlt.pipeline.platform import send_payload
+
+    send_payload(JOB_RESULT_PAYLOAD_TYPE, result, wait=wait)

--- a/dlt/_workspace/deployment/launchers/__init__.py
+++ b/dlt/_workspace/deployment/launchers/__init__.py
@@ -6,6 +6,22 @@ LAUNCHER_MCP = "dlt._workspace.deployment.launchers.mcp"
 LAUNCHER_STREAMLIT = "dlt._workspace.deployment.launchers.streamlit"
 LAUNCHER_JOB = "dlt._workspace.deployment.launchers.job"
 LAUNCHER_MODULE = "dlt._workspace.deployment.launchers.module"
+LAUNCHER_AGENT = "dlt._workspace.deployment.launchers.agent"
+
+LOOP_PYDANTIC_AI = "pydantic-ai"
+LOOP_CLAUDE_AGENT_SDK = "claude-agent-sdk"
+DEFAULT_AGENT_LOOP = LOOP_PYDANTIC_AI
+BUILTIN_AGENT_LOOPS = (LOOP_PYDANTIC_AI, LOOP_CLAUDE_AGENT_SDK)
+"""Loop types dlt ships. Plugins may answer to any other name."""
+
+AGENT_LOOP_GROUP_PREFIX = "agent-loop-"
+"""Requirements group carrying a loop's packages, selected per job via `require.dependency_groups`."""
+
+
+def agent_loop_group(loop: str) -> str:
+    """Requirements group name for an agent loop."""
+    return f"{AGENT_LOOP_GROUP_PREFIX}{loop}"
+
 
 _FRAMEWORK_LAUNCHERS = {
     "marimo": LAUNCHER_MARIMO,

--- a/dlt/_workspace/deployment/launchers/agent.py
+++ b/dlt/_workspace/deployment/launchers/agent.py
@@ -1,0 +1,230 @@
+"""Launcher for background agent jobs."""
+
+import asyncio
+import inspect
+from typing import Any, Dict, Optional, cast
+
+from dlt.common.configuration import resolve_configuration
+from dlt.common.configuration.container import Container
+from dlt.common.reflection.ref import object_from_ref
+from dlt.common.runtime.run_context import active
+
+from dlt._workspace.deployment.agent.loop import (
+    AgentLoop,
+    resolve_agent_loop,
+    resolve_agent_settings,
+    resolve_loop_type,
+)
+from dlt._workspace.deployment.agent.manifest import to_agent_definition
+from dlt._workspace.deployment.agent.typing import TAgentJobResult, TAgentSpec
+from dlt._workspace.deployment.decorators import AgentJobFactory
+from dlt._workspace.deployment._run_views import print_job_result
+from dlt._workspace.deployment.configuration import AgentConfiguration
+from dlt._workspace.deployment.exceptions import JobAbortedException, JobResolutionError
+from dlt._workspace.deployment.job_result import JobRunContext, set_job_inputs, set_job_result
+from dlt._workspace.deployment.launchers._launcher import (
+    apply_job_configuration,
+    parse_launcher_args,
+    prepare_run_env,
+)
+from dlt._workspace.deployment.launchers.job import (
+    TJobInvoke,
+    _wants_run_context,
+    configured_inputs,
+    deliver_job_result,
+    job_sections,
+    run as run_job,
+)
+from dlt._workspace.deployment.typing import (
+    JOB_RESULT_ENGINE_VERSION,
+    TJobResult,
+    TJobRunContext,
+    TRuntimeEntryPoint,
+    TTrigger,
+)
+
+
+def _resolve_agent_job(entry_point: TRuntimeEntryPoint) -> AgentJobFactory[Any, Any]:
+    """Import the module and resolve the AgentJobFactory named by the entry point."""
+    function = entry_point.get("function")
+    if not function:
+        raise JobResolutionError(entry_point["module"], "entry_point.function must be set")
+    ref = f"{entry_point['module']}.{function}"
+
+    def _typechecker(obj: Any) -> AgentJobFactory[Any, Any]:
+        if isinstance(obj, AgentJobFactory):
+            return obj
+        raise JobResolutionError(ref, f"expected AgentJobFactory, got {type(obj).__name__}")
+
+    result, trace = object_from_ref(ref, _typechecker, raise_exec_errors=True)
+    if result is None:
+        raise JobResolutionError(ref, f"{trace.reason}" + (f" ({trace.exc})" if trace.exc else ""))
+    if result.is_declared:
+        # stamp the module the manifest found it in, so job_ref and config sections match
+        result.declare(entry_point["module"], function)
+    return result  # type: ignore[no-any-return]
+
+
+def build_agent_loop(job: AgentJobFactory[Any, Any], workspace_root: str) -> AgentLoop:
+    """Resolves the agent spec and builds an initialized loop for it."""
+    sections = job_sections(job)
+    config = resolve_configuration(AgentConfiguration(), sections=sections)
+    spec = job.resolve_agent_spec(workspace_root)
+
+    loop_cls = resolve_agent_loop(resolve_loop_type(job.loop, config))
+    decorator_args: Dict[str, Any] = {
+        "model": job.model,
+        "instructions": job.instructions,
+        "limits": job.limits,
+        "loop_run_args": job.loop_run_args,
+        "verbosity": job.verbosity,
+    }
+    settings = resolve_agent_settings(spec, config, decorator_args, loop_cls, workspace_root)
+    loop = loop_cls(settings)
+    loop.agent_ref = job.agent_ref
+    loop.agent_file = job.agent_file or ""
+    if job.agent_definition is None:
+        job.agent_definition = to_agent_definition(
+            spec, job.agent_file, job.instructions, job.model
+        )
+    loop.init(spec)
+    return loop
+
+
+def _agent_inputs(
+    job: AgentJobFactory[Any, Any],
+    spec: TAgentSpec,
+    run_context: TJobRunContext,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Declared inputs plus the implicit run context, extended by the inputs validator.
+
+    A declared input is taken from configuration first, then from the trigger's run
+    arguments, then from an explicit call argument.
+    """
+    # inputs go into the system prompt and the agent trace, where the loop handle is meaningless
+    context = {k: v for k, v in run_context.items() if k != "ai_loop"}
+    inputs: Dict[str, Any] = {"run_context": context}
+    inputs.update(configured_inputs(job, job.input_spec(spec)))
+    inputs.update(run_context.get("run_args") or {})
+    inputs.update(kwargs)
+    if job.inputs_validator is not None:
+        extended = job.inputs_validator(inputs)
+        if extended:
+            inputs.update(extended)
+    set_job_inputs(inputs)
+    return inputs
+
+
+def _finish(
+    job: AgentJobFactory[Any, Any], output: Dict[str, Any], loop: AgentLoop
+) -> TAgentJobResult:
+    """Wraps a loop result in a job result and declares it; the job launcher delivers it."""
+    if job.outputs_validator is not None:
+        validated = job.outputs_validator(output)
+        if validated:
+            output = validated
+    status = output.get("status", "succeeded")
+    job_result: TAgentJobResult = {
+        "type": job.agent_ref or job.name,
+        "engine_version": JOB_RESULT_ENGINE_VERSION,
+        "status": status,
+        "summary": output.get("summary", ""),
+        "result": output,
+        "trace": loop.trace,
+    }
+    set_job_result(job_result)
+    if status == "aborted":
+        raise JobAbortedException(job_result["summary"] or "agent aborted", job_result)
+    return job_result
+
+
+def run_declared_agent(job: AgentJobFactory[Any, Any], **kwargs: Any) -> TAgentJobResult:
+    """Runs an agent declared by reference, outside a launcher."""
+    context = active()
+    run_context: TJobRunContext = {
+        "run_id": getattr(context.runtime_config, "run_id", None) or "local",
+        "trigger": TTrigger("manual:"),
+        "refresh": False,
+    }
+    loop = build_agent_loop(job, context.run_dir)
+    run_context["ai_loop"] = loop
+    with Container().injectable_context(JobRunContext()):
+        inputs = _agent_inputs(job, loop.spec, run_context, **kwargs)
+        output = asyncio.run(loop.run(inputs=inputs))
+        try:
+            _finish(job, output, loop)
+        finally:
+            # outside a launcher nothing is delivered, but the result is finished all the same
+            finished = deliver_job_result(job, send=False)
+    return cast(TAgentJobResult, finished)
+
+
+def _function_kwargs(job: AgentJobFactory[Any, Any], run_context: TJobRunContext) -> Dict[str, Any]:
+    """Run arguments for the inputs the function declares, plus the run context when it asks."""
+    parameters = inspect.signature(job._f).parameters
+    kwargs: Dict[str, Any] = {
+        name: value
+        for name, value in (run_context.get("run_args") or {}).items()
+        if name in parameters
+    }
+    if _wants_run_context(job._f):
+        kwargs["run_context"] = run_context
+    return kwargs
+
+
+def _invoke_agent(job: AgentJobFactory[Any, Any], run_context: TJobRunContext) -> Any:
+    """Builds the loop and drives it. A decorated function drives it itself."""
+    loop: Optional[AgentLoop] = None
+    if job.has_agent:
+        loop = build_agent_loop(job, active().run_dir)
+        run_context["ai_loop"] = loop
+    if job.is_declared:
+        inputs = _agent_inputs(job, loop.spec, run_context)
+        output = asyncio.run(loop.run(inputs=inputs))
+        return _finish(job, output, loop)
+
+    kwargs = _function_kwargs(job, run_context)
+    set_job_inputs(kwargs)
+    result = job(**kwargs)
+    if asyncio.iscoroutine(result):
+        result = asyncio.run(result)
+    if isinstance(result, dict) and loop is not None and "status" in result:
+        return _finish(job, result, loop)
+    return result
+
+
+def run(entry_point: TRuntimeEntryPoint, run_id: str, trigger: str) -> Any:
+    """Runs an agent job: builds its loop, drives it, and delivers the structured output.
+
+    Args:
+        entry_point (TRuntimeEntryPoint): What to run (module + factory attribute).
+        run_id (str): Unique run identifier.
+        trigger (str): Trigger string that fired this run.
+
+    Returns:
+        Any: The agent job output, or the decorated function's return value.
+
+    Raises:
+        JobAbortedException: The agent reported `status: aborted`.
+    """
+    # the agent module is imported here, before run_job, so its config env must be set first
+    apply_job_configuration(entry_point)
+    prepare_run_env(entry_point)
+    # the job launcher owns config env vars, profile, interval and signals; only the call differs
+    return run_job(
+        entry_point,
+        run_id,
+        trigger,
+        job=_resolve_agent_job(entry_point),
+        invoke=cast(TJobInvoke, _invoke_agent),
+    )
+
+
+if __name__ == "__main__":
+    args = parse_launcher_args()
+    result = run(entry_point=args.entry_point, run_id=args.run_id, trigger=args.trigger)
+    if isinstance(result, dict) and "type" in result:
+        print_job_result(cast(TJobResult, result))
+    elif result is not None:
+        print(result)  # noqa: T201

--- a/dlt/_workspace/deployment/launchers/job.py
+++ b/dlt/_workspace/deployment/launchers/job.py
@@ -4,10 +4,12 @@ from datetime import timezone
 import asyncio
 import inspect
 from contextlib import nullcontext
-from typing import Any, ContextManager, Dict, List, Optional
+from typing import Any, Callable, ContextManager, Dict, List, Optional, Tuple, Type, cast
 
+from dlt.common.configuration import resolve_configuration
 from dlt.common.configuration.container import Container
 from dlt.common.configuration.specs import TimezoneContext
+from dlt.common.configuration.specs.base_configuration import BaseConfiguration
 from dlt.common.time import to_tzinfo
 from dlt.common.libs import is_instance_lib
 from dlt.common.reflection.ref import object_from_ref
@@ -17,8 +19,19 @@ from dlt.common.typing import TTimeInterval
 
 from dlt._workspace import known_sections as ws_known_sections
 from dlt._workspace.deployment.decorators import JobFactory
-from dlt._workspace.deployment.exceptions import JobResolutionError
+from dlt._workspace.deployment.entity import hub_objects
+from dlt._workspace.deployment.exceptions import JobAbortedException, JobResolutionError
+from dlt._workspace.deployment._run_views import print_job_result
+from dlt._workspace.deployment.job_result import (
+    JobRunContext,
+    job_inputs,
+    send_job_result,
+    take_job_result,
+)
 from dlt._workspace.deployment.typing import (
+    RUN_CONTEXT_INPUT,
+    THubEntity,
+    TJobResult,
     TJobRunContext,
     TRuntimeEntryPoint,
     TTrigger,
@@ -133,18 +146,65 @@ def _get_param_names(func: Any) -> Optional[List[str]]:
     ]
 
 
+TJobInvoke = Callable[[JobFactory[Any, Any], TJobRunContext], Any]
+"""Replaces the plain job call: everything around it stays the launcher's."""
+
+
 def _wants_run_context(f: Any) -> bool:
     """Check if a function declares a `run_context` parameter."""
     try:
-        return "run_context" in inspect.signature(f).parameters
+        return RUN_CONTEXT_INPUT in inspect.signature(f).parameters
     except (ValueError, TypeError):
         return False
+
+
+def job_sections(job: JobFactory[Any, Any]) -> Tuple[str, ...]:
+    """Config sections of the job. A job declared outside a module has no section."""
+    return tuple(p for p in (ws_known_sections.JOBS, job.section, job.name) if p)
+
+
+def configured_inputs(job: JobFactory[Any, Any], spec: Type[BaseConfiguration]) -> Dict[str, Any]:
+    """The job's inputs resolved as job config, so `-c`, env vars and toml all fill them."""
+    config = resolve_configuration(spec(), sections=job_sections(job))
+    # an input nobody supplied stays out, so a system prompt reports it as unresolved
+    return {k: v for k, v in dict(config).items() if v is not None}
+
+
+def _objects(job: JobFactory[Any, Any], payload: Any, values: Dict[str, Any]) -> List[THubEntity]:
+    """Entities the run acted on, from the inputs it received and the payload it returned."""
+    job._reflect_schemas()
+    if not job.inputs and not job.output:
+        return []
+    return hub_objects(job.inputs, values, job.output, payload, job.job_ref)
+
+
+def deliver_job_result(
+    job: JobFactory[Any, Any], send: bool = True, wait: bool = False
+) -> Optional[TJobResult]:
+    """Finishes the run's result: type, `job_ref` and `object` filled in, then delivered.
+
+    The one place every job kind ends up, whatever launcher ran it. `object` comes from the
+    inputs the invoker recorded, or from the job's own configuration when it recorded none.
+    """
+    result = take_job_result(job.job_ref, job.category)
+    if result is None:
+        return None
+    recorded = job_inputs()
+    if recorded is None:
+        recorded = configured_inputs(job, job._spec) if job._spec is not None else {}
+    if objects := _objects(job, result.get("result"), recorded):
+        result["object"] = objects
+    if send:
+        send_job_result(result, wait=wait)
+    return result
 
 
 def run(
     entry_point: TRuntimeEntryPoint,
     run_id: str,
     trigger: str,
+    job: Optional[JobFactory[Any, Any]] = None,
+    invoke: Optional[TJobInvoke] = None,
 ) -> Any:
     """Execute a function job from its entry point definition.
 
@@ -152,9 +212,13 @@ def run(
         entry_point (TRuntimeEntryPoint): What to run (module + function + run_args).
         run_id (str): Unique run identifier.
         trigger (str): Trigger string that fired this run.
+        job (Optional[JobFactory]): Already resolved factory, else resolved from `entry_point`.
+        invoke (Optional[TJobInvoke]): Called with the job and the run context instead of
+            calling the job directly.
 
     Returns:
-        Any: The return value of the job function.
+        Any: The job's `TJobResult` when it declared one with `run.result`, otherwise the
+        return value of the job function.
     """
     # fill unset job settings from config, then set env vars - both before user module
     # import so pipelines created at import time pick them up
@@ -163,7 +227,7 @@ def run(
     # entered below scope the same settings in-process
     prepare_run_env(entry_point)
 
-    job = _resolve_job(entry_point)
+    job = job or _resolve_job(entry_point)
     sections = (ws_known_sections.JOBS, job.section, job.name)
     set_config_env_vars(sections, entry_point.get("config", {}))
 
@@ -180,21 +244,25 @@ def run(
             ensure_datetime_in_tz(iv_end_str, timezone.utc).astimezone(target_tz),
         )
 
+    ctx: TJobRunContext = {
+        "run_id": run_id,
+        "trigger": TTrigger(trigger),
+        "refresh": entry_point.get("refresh", False),
+    }
+    run_args = entry_point.get("run_args")
+    if run_args:
+        ctx["run_args"] = run_args
+    if iv is not None:
+        ctx["interval_start"] = iv[0]
+        ctx["interval_end"] = iv[1]
     # inject run_context if the function signature declares it
-    kwargs: Dict[str, Any] = {}
-    if _wants_run_context(job._f):
-        ctx: TJobRunContext = {
-            "run_id": run_id,
-            "trigger": TTrigger(trigger),
-            "refresh": entry_point.get("refresh", False),
-        }
-        run_args = entry_point.get("run_args")
-        if run_args:
-            ctx["run_args"] = run_args
-        if iv is not None:
-            ctx["interval_start"] = iv[0]
-            ctx["interval_end"] = iv[1]
-        kwargs["run_context"] = ctx
+    kwargs: Dict[str, Any] = {"run_context": ctx} if _wants_run_context(job._f) else {}
+
+    def _call() -> Any:
+        called = invoke(job, ctx) if invoke else job(**kwargs)
+        if asyncio.iscoroutine(called):
+            called = asyncio.run(called)
+        return called
 
     # default to intercepting — callers opt out with `intercept_signals=False`
     signal_ctx = (
@@ -220,13 +288,19 @@ def run(
 
     # TODO: job (JobFactory) should have a method that returns pipeline name on the factory
     #       then if refresh flag is set, we refresh ONLY this pipeline
-    with signal_ctx, tz_ctx, iv_ctx:
-        result = job(**kwargs)
-        if asyncio.iscoroutine(result):
-            result = asyncio.run(result)
+    # the result context lives exactly as long as the run
+    with Container().injectable_context(JobRunContext()):
+        try:
+            with signal_ctx, tz_ctx, iv_ctx:
+                result = _call()
+        except JobAbortedException:
+            # an abort ends the process, so the result must be on the wire before it does
+            deliver_job_result(job, wait=True)
+            raise
 
-    _check_return_value(result, job, entry_point)
-    return result
+        _check_return_value(result, job, entry_point)
+        job_result = deliver_job_result(job)
+    return result if job_result is None else job_result
 
 
 if __name__ == "__main__":
@@ -237,5 +311,7 @@ if __name__ == "__main__":
         run_id=args.run_id,
         trigger=args.trigger,
     )
-    if result is not None:
+    if isinstance(result, dict) and "type" in result:
+        print_job_result(cast(TJobResult, result))
+    elif result is not None:
         print(result)  # noqa: T201

--- a/dlt/_workspace/deployment/manifest.py
+++ b/dlt/_workspace/deployment/manifest.py
@@ -20,7 +20,7 @@ from dlt.common.validation import validate_dict
 from dlt.common.warnings import apply_deprecations
 from dlt.reflection.script_inspector import no_pipeline_execution
 
-from dlt._workspace.deployment.decorators import JobFactory
+from dlt._workspace.deployment.decorators import AgentJobFactory, JobFactory
 from dlt._workspace.deployment.detectors import (
     detect_local_module,
     detect_module_job,
@@ -40,6 +40,8 @@ from dlt._workspace.deployment._job_ref import parse_job_ref
 from dlt._workspace.profile import LOCAL_PROFILES, is_local_profile
 from dlt._workspace.deployment import trigger as _triggers
 from dlt._workspace.deployment._trigger_helpers import (
+    is_selector,
+    match_triggers_with_selectors,
     maybe_parse_schedule,
     parse_trigger,
 )
@@ -63,6 +65,8 @@ from dlt._workspace.deployment.typing import (
 
 DEPLOYMENT_ENGINE_VERSION = 1
 """Engine version of package files manifests (`TFilesManifest`), independent of job definitions."""
+
+_JOB_EVENT_TRIGGERS = ("job.success", "job.fail")
 
 _HASH_EXCLUDE_KEYS = ("version", "version_hash", "previous_hashes", "created_at")
 _MAX_PREVIOUS_HASHES = 10
@@ -122,8 +126,6 @@ def migrate_job_definition(
     WARNING: if you add new migration you MUST make sure that build_runtime_entry_point has downgrade
     path for previous dlt versions.
     """
-    if from_engine == to_engine:
-        return job_dict  # type: ignore[return-value]
     if from_engine == 1 and to_engine > 1:
         # engine 2: allow_external_schedulers -> incremental_mode, refresh -> refresh_propagation
         apply_deprecations(
@@ -137,6 +139,7 @@ def migrate_job_definition(
 
     if from_engine != to_engine:
         raise ManifestEngineNoUpgradePath("job definition", from_engine, to_engine)
+    job_dict["engine_version"] = to_engine
     return job_dict  # type: ignore[return-value]
 
 
@@ -220,6 +223,60 @@ def _newtype_validator(path: str, pk: str, pv: Any, t: Any) -> bool:
     return False
 
 
+def selects_job(job_def: TJobDefinition, selector: str) -> bool:
+    """Whether a selector picks this job: by its type, one of its triggers, or its ref."""
+    return bool(
+        match_triggers_with_selectors(
+            job_def["entry_point"].get("job_type", "batch"),
+            expand_triggers(job_def),
+            [selector],
+            job_ref=job_def["job_ref"],
+        )
+    )
+
+
+def expand_trigger_selectors(jobs: List[TJobDefinition]) -> List[str]:
+    """Replaces selector `job.success:` / `job.fail:` triggers with one trigger per matching job.
+
+    The runtime looks a completion trigger up by exact string, so a selector has to become
+    concrete refs here. A selector never expands onto the job that declares it, and an
+    interactive job is never a target: it has no completion to report.
+
+    Returns:
+        List[str]: Warnings for selectors that matched no job.
+    """
+    warnings: List[str] = []
+    candidates = [
+        job_def for job_def in jobs if job_def["entry_point"].get("job_type") != "interactive"
+    ]
+
+    for job_def in jobs:
+        own_ref = job_def["job_ref"]
+        expanded: List[TTrigger] = []
+        changed = False
+        for trigger in job_def.get("triggers", []):
+            trigger_type, _, expr = trigger.partition(":")
+            if trigger_type not in _JOB_EVENT_TRIGGERS or not is_selector(expr):
+                if trigger not in expanded:
+                    expanded.append(trigger)
+                continue
+            changed = True
+            matched = [
+                candidate["job_ref"]
+                for candidate in candidates
+                if candidate["job_ref"] != own_ref and selects_job(candidate, expr)
+            ]
+            if not matched:
+                warnings.append(f"job {own_ref!r}: trigger {trigger!r} matched no job")
+            for ref in matched:
+                concrete = TTrigger(f"{trigger_type}:{ref}")
+                if concrete not in expanded:
+                    expanded.append(concrete)
+        if changed:
+            job_def["triggers"] = expanded
+    return warnings
+
+
 def expand_triggers(job_def: TJobDefinition) -> List[TTrigger]:
     """Expand triggers with synthetic triggers from expose and deliver specs.
 
@@ -244,17 +301,22 @@ def expand_triggers(job_def: TJobDefinition) -> List[TTrigger]:
     return triggers
 
 
-def compute_default_trigger(job_def: TJobDefinition) -> Optional[TTrigger]:
-    """Pick the default trigger for a job: prefer schedule/every, else first eligible trigger.
+NO_DEFAULT_TRIGGER_TYPES = ("manual", "deployment", "job.success", "job.fail")
+"""Trigger types that never become a job's default.
 
-    `manual` and `deployment` triggers are never selected as the default.
-    """
+A job event names the upstream run that fired it, so standing in for a manual run would tell
+the job a job failed when none did.
+"""
+
+
+def compute_default_trigger(job_def: TJobDefinition) -> Optional[TTrigger]:
+    """Pick the default trigger for a job: prefer schedule/every, else first eligible trigger."""
     default: Optional[TTrigger] = None
     for t in job_def.get("triggers", []):
         parsed = parse_trigger(t)
         if parsed.type in ("schedule", "every"):
             return t
-        if default is None and parsed.type not in ("manual", "deployment"):
+        if default is None and parsed.type not in NO_DEFAULT_TRIGGER_TYPES:
             default = t
     return default
 
@@ -298,6 +360,11 @@ def validate_job_definition(
         try:
             parsed = parse_trigger(t)
             trigger_types.add(parsed.type)
+            if parsed.type in _JOB_EVENT_TRIGGERS and parsed.expr == ref:
+                errors.append(
+                    f"job {ref!r}: trigger {t!r} makes the job trigger itself, which never"
+                    " terminates"
+                )
         except InvalidTrigger as e:
             errors.append(f"job {ref!r}: {e}")
 
@@ -411,6 +478,11 @@ def validate_manifest(manifest: TJobsDeploymentManifest) -> ManifestValidationRe
         result = validate_job_definition(job_def)
         errors.extend(result.errors)
         warnings.extend(result.warnings)
+        if job_def["engine_version"] != manifest["engine_version"]:
+            errors.append(
+                f"job {job_def['job_ref']!r} is written for engine {job_def['engine_version']},"
+                f" the manifest for engine {manifest['engine_version']}"
+            )
 
     # duplicate job refs
     seen_refs: Set[str] = set()
@@ -509,6 +581,7 @@ def import_deployment_module(module_name: str) -> ModuleType:
 def default_dashboard_job() -> TJobDefinition:
     """Default workspace dashboard job definition."""
     return {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": DASHBOARD_JOB_REF,
         "entry_point": TEntryPoint(
             module="dlt._workspace.helpers.dashboard.dlt_dashboard",
@@ -583,6 +656,9 @@ def generate_manifest(
                 continue
 
             if isinstance(obj, JobFactory):
+                # a declared agent has no function to take its module and section from
+                if isinstance(obj, AgentJobFactory) and obj.is_declared:
+                    obj.declare(deployment_module.__name__, name)
                 jobs.append(obj.to_job_definition())
             elif isinstance(obj, ModuleType):
                 # __all__: trust the user; __dir__ scan: filter to local modules
@@ -613,6 +689,10 @@ def generate_manifest(
     )
     if is_workspace_deployment and not any(j["job_ref"] == DASHBOARD_JOB_REF for j in jobs):
         jobs.append(default_dashboard_job())
+
+    # selectors are a source-level concept: a stored manifest is always fully expanded,
+    # so this must run before default_trigger and before validation
+    warnings.extend(expand_trigger_selectors(jobs))
 
     # set expose.manual default and compute default_trigger
     for job_def in jobs:

--- a/dlt/_workspace/deployment/manifest.py
+++ b/dlt/_workspace/deployment/manifest.py
@@ -9,14 +9,14 @@ from datetime import datetime, timezone
 from contextlib import contextmanager
 from copy import copy
 from importlib import import_module
-from typing import Any, BinaryIO, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple
+from typing import Any, BinaryIO, Dict, Iterator, List, NamedTuple, Optional, Set, Tuple, Type
 from types import ModuleType
 
 from dlt.common import json
 from dlt.common.exceptions import DictValidationException
 from dlt.common.time import ensure_datetime_in_tz
 from dlt.common.typing import DictStrAny
-from dlt.common.validation import validate_dict
+from dlt.common import validation
 from dlt.common.warnings import apply_deprecations
 from dlt.reflection.script_inspector import no_pipeline_execution
 
@@ -27,6 +27,7 @@ from dlt._workspace.deployment.detectors import (
     is_local_module,
 )
 from dlt._workspace.deployment.exceptions import (
+    DeploymentValidationError,
     InvalidFreshnessConstraint,
     InvalidJobDefinition,
     InvalidJobRef,
@@ -188,11 +189,7 @@ def load_manifest(f: BinaryIO) -> TJobsDeploymentManifest:
     manifest_dict: DictStrAny = json.loadb(data)
     engine_version = manifest_dict.get("engine_version", 1)
     manifest = migrate_manifest(manifest_dict, engine_version, MANIFEST_ENGINE_VERSION)
-
-    result = validate_manifest(manifest)
-    if not result.is_valid:
-        raise InvalidManifest(result)
-
+    validate_manifest(manifest, raise_on_error=True)
     return manifest
 
 
@@ -324,6 +321,7 @@ def compute_default_trigger(job_def: TJobDefinition) -> Optional[TTrigger]:
 def validate_job_definition(
     job_def: TJobDefinition,
     raise_on_error: bool = False,
+    validate_dict: bool = False,
 ) -> JobValidationResult:
     """Validate a single job definition (self-contained checks only).
 
@@ -333,10 +331,21 @@ def validate_job_definition(
     Args:
         job_def: The job definition to validate.
         raise_on_error: If True, raise InvalidJobDefinition when errors found.
+        validate_dict: If True, check that `job_def` conforms to `TJobDefinition` before
+            anything else. A structural error is then the only error reported.
 
     Raises:
         InvalidJobDefinition: When raise_on_error is True and validation fails.
     """
+    if validate_dict:
+        try:
+            validation.validate_dict(TJobDefinition, job_def, ".", validator_f=_newtype_validator)
+        except DictValidationException as e:
+            result = JobValidationResult(errors=[str(e)], warnings=[])
+            if raise_on_error:
+                raise InvalidJobDefinition(job_def.get("job_ref", ""), result) from e
+            return result
+
     errors: List[str] = []
     warnings: List[str] = []
     ref = job_def["job_ref"]
@@ -457,27 +466,42 @@ def validate_job_definition(
     return result
 
 
-def validate_manifest(manifest: TJobsDeploymentManifest) -> ManifestValidationResult:
-    """Validate a deployment manifest structurally and for consistency."""
+def validate_manifest(
+    manifest: TJobsDeploymentManifest, raise_on_error: bool = False
+) -> ManifestValidationResult:
+    """Validate a deployment manifest structurally and for consistency.
+
+    Args:
+        manifest: The manifest to validate.
+        raise_on_error: If True, raise InvalidManifest when errors found.
+
+    Raises:
+        InvalidManifest: When raise_on_error is True and validation fails.
+    """
     errors: List[str] = []
     warnings: List[str] = []
     unresolved: Dict[str, List[str]] = {}
 
     try:
-        validate_dict(TJobsDeploymentManifest, manifest, ".", validator_f=_newtype_validator)
+        validation.validate_dict(
+            TJobsDeploymentManifest, manifest, ".", validator_f=_newtype_validator
+        )
     except DictValidationException as e:
         errors.append(str(e))
-        return ManifestValidationResult(
+        result = ManifestValidationResult(
             is_valid=False, errors=errors, warnings=warnings, unresolved_triggers=unresolved
         )
+        if raise_on_error:
+            raise InvalidManifest(result) from e
+        return result
 
     jobs = manifest.get("jobs", [])
 
     # per-job validation
     for job_def in jobs:
-        result = validate_job_definition(job_def)
-        errors.extend(result.errors)
-        warnings.extend(result.warnings)
+        job_result = validate_job_definition(job_def)
+        errors.extend(job_result.errors)
+        warnings.extend(job_result.warnings)
         if job_def["engine_version"] != manifest["engine_version"]:
             errors.append(
                 f"job {job_def['job_ref']!r} is written for engine {job_def['engine_version']},"
@@ -556,12 +580,15 @@ def validate_manifest(manifest: TJobsDeploymentManifest) -> ManifestValidationRe
                         " but upstream is an interactive job"
                     )
 
-    return ManifestValidationResult(
+    result = ManifestValidationResult(
         is_valid=len(errors) == 0,
         errors=errors,
         warnings=warnings,
         unresolved_triggers=unresolved,
     )
+    if raise_on_error and not result.is_valid:
+        raise InvalidManifest(result)
+    return result
 
 
 @contextmanager
@@ -771,20 +798,29 @@ _WORKER_ERROR_TYPES: Dict[str, type] = {
     "ModuleNotFoundError": ModuleNotFoundError,
     "ImportError": ImportError,
     "SyntaxError": SyntaxError,
-    "InvalidManifest": InvalidManifest,
-    "InvalidTrigger": InvalidTrigger,
-    "InvalidFreshnessConstraint": InvalidFreshnessConstraint,
-    "InvalidJobDefinition": InvalidJobDefinition,
-    "InvalidJobRef": InvalidJobRef,
 }
+"""Import failures the worker reports, rebuilt from the message alone."""
+
+
+def _validation_error_types() -> Dict[str, Type[DeploymentValidationError]]:
+    """Every `DeploymentValidationError` subclass loaded so far, by name."""
+    found: Dict[str, Type[DeploymentValidationError]] = {}
+    pending = [DeploymentValidationError]
+    while pending:
+        cls = pending.pop()
+        for sub in cls.__subclasses__():
+            if sub.__name__ not in found:
+                found[sub.__name__] = sub
+                pending.append(sub)
+    return found
 
 
 def _raise_from_worker_payload(payload: Dict[str, Any]) -> None:
     msg = payload.get("error", "unknown error")
-    exc_cls = _WORKER_ERROR_TYPES.get(payload.get("error_type", ""))
-    if exc_cls is InvalidManifest:
-        raise InvalidManifest.from_message(msg)
-    if exc_cls is not None:
+    error_type = payload.get("error_type", "")
+    if validation_cls := _validation_error_types().get(error_type):
+        raise validation_cls.from_message(msg)
+    if exc_cls := _WORKER_ERROR_TYPES.get(error_type):
         raise exc_cls(msg)
     raise InvalidManifest.from_message(msg)
 
@@ -793,10 +829,13 @@ def _parse_worker_result(
     stdout: str, stderr: str, returncode: int
 ) -> Tuple[TJobsDeploymentManifest, List[str]]:
     if returncode != 0:
+        # only a decode failure means the worker died without a payload
         try:
-            _raise_from_worker_payload(json.typed_loads(stdout.strip()))
-        except (ValueError, KeyError):
-            pass
+            payload = json.typed_loads(stdout.strip())
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict) and "error" in payload:
+            _raise_from_worker_payload(payload)
         raise InvalidManifest.from_message(
             stderr.strip() or stdout.strip() or f"worker exited with code {returncode}"
         )
@@ -823,10 +862,5 @@ def _manifest_from_module_inprocess(
             sys.path.insert(0, cwd)
         mod = import_deployment_module(module_name)
     manifest, gen_warnings = generate_manifest(mod, use_all=use_all)
-
-    result = validate_manifest(manifest)
-    all_warnings = gen_warnings + result.warnings
-    if not result.is_valid:
-        raise InvalidManifest(result)
-
-    return manifest, all_warnings
+    result = validate_manifest(manifest, raise_on_error=True)
+    return manifest, gen_warnings + result.warnings

--- a/dlt/_workspace/deployment/reflection.py
+++ b/dlt/_workspace/deployment/reflection.py
@@ -1,0 +1,282 @@
+"""What a job takes and what it returns, as JSON Schema.
+
+A job's inputs are the arguments configuration can inject, so the schema holds the fields of the
+configspec `with_config` synthesizes and nothing else.
+"""
+
+import inspect
+import re
+import warnings
+from typing import Any, Collection, Dict, List, Mapping, Optional, Tuple, Type, cast
+
+from dlt.common.configuration.specs.base_configuration import BaseConfiguration, configspec
+from dlt.common.json import json
+from dlt.common.reflection.spec import spec_from_signature
+from dlt.common.typing import (
+    AnyFun,
+    ConfigValueSentinel,
+    NotRequired,
+    extract_union_types,
+    get_args,
+    get_origin,
+    get_type_hints,
+    is_optional_type,
+    is_typeddict,
+)
+
+from dlt._workspace.deployment.exceptions import InvalidJobSchema
+from dlt._workspace.deployment.typing import RUN_CONTEXT_INPUT, THubEntityType
+
+ENTITY_TYPE_KEY = "entity_type"
+"""Schema keyword on a property whose value is the unique id of a workspace entity of that type."""
+
+
+JSON_SCHEMA_TYPES: Dict[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": List[Any],
+    "object": Dict[str, Any],
+}
+
+
+def injectable_fields(spec: Optional[Type[BaseConfiguration]]) -> Dict[str, Any]:
+    """Fields of a job configspec that configuration fills. The launcher passes the run context."""
+    fields = spec.get_resolvable_fields() if spec is not None else {}
+    return {name: hint for name, hint in fields.items() if name != RUN_CONTEXT_INPUT}
+
+
+def config_field_names(f: AnyFun) -> Collection[str]:
+    """Fields of the configspec `f` gets, as `with_config` synthesizes it."""
+    return injectable_fields(spec_from_signature(f, inspect.signature(f))[0])
+
+
+def inputs_from_function(
+    f: AnyFun, source: str, fields: Optional[Collection[str]] = None
+) -> Dict[str, Any]:
+    """Arguments JSON Schema of `f`, holding exactly what configuration can inject.
+
+    Args:
+        f (AnyFun): Function the job runs.
+        source (str): What to name in the error, usually the job ref.
+        fields (Optional[Collection[str]]): Resolvable fields of the job's configspec. Read from
+            the signature when absent.
+
+    Returns:
+        Dict[str, Any]: JSON Schema of the arguments, `required` following `dlt.config.value`.
+    """
+    # pydantic is optional and this module is imported with every workspace, so it stays here
+    from dlt.common.libs.pydantic import PydanticJsonSchemaWarning, TypeAdapter
+
+    if fields is None:
+        fields = config_field_names(f)
+    try:
+        with warnings.catch_warnings():
+            # `dlt.config.value` is not serializable, and is dropped from the schema below
+            warnings.simplefilter("ignore", PydanticJsonSchemaWarning)
+            schema: Dict[str, Any] = TypeAdapter(f).json_schema()
+    except Exception as ex:
+        raise InvalidJobSchema(source, f"inputs cannot be read from the signature: {ex}") from ex
+    properties: Dict[str, Any] = {
+        name: prop for name, prop in (schema.get("properties") or {}).items() if name in fields
+    }
+    schema["properties"] = properties
+    required = [name for name in schema.get("required") or [] if name in properties]
+    # `dlt.config.value` is dlt's "required, resolved from config". pydantic sees only a default
+    for name, parameter in inspect.signature(f).parameters.items():
+        if isinstance(parameter.default, ConfigValueSentinel) and name in properties:
+            properties[name].pop("default", None)
+            required.append(name)
+    if required:
+        schema["required"] = required
+    else:
+        schema.pop("required", None)
+    describe_properties(properties, get_type_hints(f, include_extras=True))
+    prune_unreferenced_defs(schema)
+    return schema
+
+
+def job_result_from_return(f: AnyFun, source: str) -> Optional[Dict[str, Any]]:
+    """Output JSON Schema of `f`, or `None` unless it returns a TypedDict."""
+    hint = inspect.signature(f).return_annotation
+    if not is_typeddict(hint):
+        return None
+    return output_schema(hint, source)
+
+
+def output_schema(hint: Any, source: str) -> Dict[str, Any]:
+    """JSON Schema of a TypedDict, with what `Annotated` says about each field written in."""
+    from dlt.common.libs.pydantic import TypeAdapter
+
+    try:
+        schema: Dict[str, Any] = TypeAdapter(hint).json_schema()
+    except Exception as ex:
+        raise InvalidJobSchema(source, f"output cannot be read from {hint!r}: {ex}") from ex
+    properties: Dict[str, Any] = schema.get("properties") or {}
+    describe_properties(properties, get_type_hints(hint, include_extras=True))
+    prune_unreferenced_defs(schema)
+    return schema
+
+
+def derives_from(hint: Any, base: Any) -> bool:
+    """True for `base` itself and for any TypedDict deriving from it."""
+    if hint is base:
+        return True
+    return any(derives_from(parent, base) for parent in getattr(hint, "__orig_bases__", ()))
+
+
+def spec_from_inputs_schema(name: str, inputs: Dict[str, Any]) -> Type[BaseConfiguration]:
+    """Configuration spec with one field per declared input.
+
+    Inputs are to a declared job what parameters are to a function job, so they resolve the same
+    way. They come from the job's config section, through every provider, with the declared type.
+    """
+    # `required` is a list, or the `{}` mapping form an `AGENT.md` may carry
+    required = set(inputs.get("required") or ())
+    annotations: Dict[str, Any] = {}
+    fields: Dict[str, Any] = {"__module__": __name__}
+    for field, schema in (inputs.get("properties") or {}).items():
+        hint = JSON_SCHEMA_TYPES.get(schema.get("type"), Any)
+        # a non-optional hint left unresolved raises, exactly as a required job argument does
+        annotations[field] = hint if field in required else Optional[hint]
+        fields[field] = None
+    fields["__annotations__"] = annotations
+
+    spec_name = "".join(part.capitalize() for part in re.split(r"[\W_]+", name))
+    return configspec()(type(f"{spec_name}InputsConfiguration", (BaseConfiguration,), fields))
+
+
+def prune_unreferenced_defs(schema: Dict[str, Any]) -> None:
+    """Drops the `$defs` nothing points at, following the references between those kept."""
+    defs = schema.get("$defs")
+    if not defs:
+        return
+    kept: Dict[str, Any] = {}
+    referenced = json.dumps({k: v for k, v in schema.items() if k != "$defs"})
+    while found := {
+        k: v for k, v in defs.items() if k not in kept and f'#/$defs/{k}"' in referenced
+    }:
+        kept.update(found)
+        referenced = json.dumps(found)
+    if kept:
+        schema["$defs"] = kept
+    else:
+        schema.pop("$defs")
+
+
+def annotation_metadata(annotation: Any) -> Tuple[Any, ...]:
+    """What an `Annotated` hint carries, read through `NotRequired` and `Optional`."""
+    if get_origin(annotation) is NotRequired:
+        return annotation_metadata(get_args(annotation)[0])
+    # Python below 3.11 wraps the hint of a `None`-defaulted argument in `Optional`
+    if is_optional_type(annotation):
+        inner = extract_union_types(annotation, no_none=True)
+        if len(inner) == 1:
+            return annotation_metadata(inner[0])
+    # only `Annotated` carries metadata; `Literal` args are values, not annotations
+    return cast(Tuple[Any, ...], getattr(annotation, "__metadata__", ()))
+
+
+def annotated_description(annotation: Any) -> Optional[str]:
+    """Description an `Annotated` hint carries: a `Doc` marker, or a plain string."""
+    for metadata in annotation_metadata(annotation):
+        if isinstance(metadata, str):
+            return metadata
+        # typing_extensions.Doc, as PEP 727 defines it. pydantic ignores it, we do not
+        documentation = getattr(metadata, "documentation", None)
+        if isinstance(documentation, str):
+            return documentation
+    return None
+
+
+class Entity:
+    """`Annotated[str, Entity("job-run")]`: the value is the unique id of a workspace entity."""
+
+    def __init__(self, type: THubEntityType) -> None:  # noqa: A002
+        self.type = type
+
+
+def annotated_entity(annotation: Any) -> Optional[Entity]:
+    """The `Entity` marker an `Annotated` hint carries, if any."""
+    for metadata in annotation_metadata(annotation):
+        if isinstance(metadata, Entity):
+            return metadata
+    return None
+
+
+def describe_properties(properties: Dict[str, Any], hints: Mapping[str, Any]) -> None:
+    """Writes what `Annotated` says about each field into the schema its reader gets."""
+    for name, annotation in hints.items():
+        if name not in properties:
+            continue
+        if described := annotated_description(annotation):
+            properties[name].setdefault("description", described)
+        if entity := annotated_entity(annotation):
+            properties[name].setdefault(ENTITY_TYPE_KEY, entity.type)
+
+
+def model_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """The schema as a model gets it: `entity_type` moved into `$comment`, nothing else changed.
+
+    Strict validators such as the Claude CLI's refuse keywords they do not know, and `$comment`
+    is the one standard slot for a note that validation ignores and a model still reads.
+    """
+
+    def convert(node: Any) -> Any:
+        if isinstance(node, list):
+            return [convert(item) for item in node]
+        if not isinstance(node, dict):
+            return node
+        entity_type = node.get(ENTITY_TYPE_KEY)
+        # a property that happens to be named `entity_type` maps to a schema, the keyword to a name
+        is_keyword = isinstance(entity_type, str)
+        converted = {
+            k: convert(v) for k, v in node.items() if not (is_keyword and k == ENTITY_TYPE_KEY)
+        }
+        if is_keyword:
+            note = f"{ENTITY_TYPE_KEY}: {entity_type}"
+            comment = converted.get("$comment")
+            converted["$comment"] = f"{comment}; {note}" if comment else note
+        return converted
+
+    return cast(Dict[str, Any], convert(schema))
+
+
+def entity_properties(schema: Optional[Dict[str, Any]], source: str) -> Dict[str, THubEntityType]:
+    """Property name to entity type for every property carrying `entity_type`, in declaration order.
+
+    Raises:
+        InvalidJobSchema: A property names an entity type dlt does not know.
+    """
+    known = get_args(THubEntityType)
+    found: Dict[str, THubEntityType] = {}
+    for name, prop in ((schema or {}).get("properties") or {}).items():
+        entity_type = prop.get(ENTITY_TYPE_KEY)
+        if entity_type is None:
+            continue
+        if entity_type not in known:
+            raise InvalidJobSchema(
+                source,
+                f"{name}: entity_type {entity_type!r} is not one of {', '.join(known)}",
+            )
+        found[name] = entity_type
+    return found
+
+
+__all__ = [
+    "ENTITY_TYPE_KEY",
+    "RUN_CONTEXT_INPUT",
+    "Entity",
+    "annotated_description",
+    "annotated_entity",
+    "config_field_names",
+    "derives_from",
+    "entity_properties",
+    "injectable_fields",
+    "inputs_from_function",
+    "job_result_from_return",
+    "model_schema",
+    "output_schema",
+    "spec_from_inputs_schema",
+]

--- a/dlt/_workspace/deployment/requirements.py
+++ b/dlt/_workspace/deployment/requirements.py
@@ -24,12 +24,17 @@ DLTHUB_PKG_NAME = "dlthub"
 DLTHUB_CLIENT_PKG_NAME = "dlthub-client"
 
 from dlt._workspace.deployment.launchers import (
+    BUILTIN_AGENT_LOOPS,
+    LAUNCHER_AGENT,
     LAUNCHER_DASHBOARD,
     LAUNCHER_JOB,
     LAUNCHER_MARIMO,
     LAUNCHER_MCP,
     LAUNCHER_MODULE,
     LAUNCHER_STREAMLIT,
+    LOOP_CLAUDE_AGENT_SDK,
+    LOOP_PYDANTIC_AI,
+    agent_loop_group,
 )
 from dlt._workspace.deployment.typing import (
     DASHBOARD_JOB_REF,
@@ -245,6 +250,8 @@ def build_launcher_requirements() -> Dict[str, List[str]]:
     per_launcher: Dict[str, List[str]] = {
         LAUNCHER_JOB: ["botocore", "s3fs"],
         LAUNCHER_MODULE: ["botocore", "s3fs"],
+        # loop packages are per-job, so they live in `agent-loop-*` groups instead
+        LAUNCHER_AGENT: ["botocore", "s3fs"],
         LAUNCHER_MARIMO: ["marimo", "uvicorn"],
         LAUNCHER_MCP: ["fastmcp", "uvicorn"],
         LAUNCHER_STREAMLIT: ["streamlit"],
@@ -262,6 +269,24 @@ def build_dashboard_group() -> List[str]:
     return sorted(["ibis-framework", "marimo", "pyarrow", "s3fs"])
 
 
+_AGENT_LOOP_SPECS: Dict[str, List[str]] = {
+    LOOP_PYDANTIC_AI: ["pydantic-ai-slim[anthropic,openai,google,mcp,spec]"],
+    LOOP_CLAUDE_AGENT_SDK: ["claude-agent-sdk"],
+}
+
+
+def build_agent_loop_groups() -> Dict[str, List[str]]:
+    """Specs for each built-in agent loop, keyed by its requirements group name."""
+    return {agent_loop_group(loop): sorted(_AGENT_LOOP_SPECS[loop]) for loop in BUILTIN_AGENT_LOOPS}
+
+
+def _add_agent_loop_groups(groups: Dict[str, List[str]], default_names: Set[str]) -> None:
+    """Adds the built-in loop groups, leaving a group the workspace already declares alone."""
+    for name, specs in build_agent_loop_groups().items():
+        if name not in groups:
+            groups[name] = _prune_specs(specs, default_names)
+
+
 def _inject_dlt_into_launchers(launcher_requirements: Dict[str, List[str]]) -> None:
     dlt_spec = get_dlt_requirement_spec()
     for launcher in launcher_requirements:
@@ -269,15 +294,17 @@ def _inject_dlt_into_launchers(launcher_requirements: Dict[str, List[str]]) -> N
 
 
 def default_requirements_manifest() -> TWorkspaceRequirementsManifest:
-    """Minimal manifest: empty `main`, dashboard group, launcher specs with dlt injected."""
+    """Minimal manifest: empty `main`, dashboard and agent loop groups, launcher specs with dlt."""
     launcher_requirements = build_launcher_requirements()
     _inject_dlt_into_launchers(launcher_requirements)
+    groups: Dict[str, List[str]] = {MAIN_GROUP: [], DASHBOARD_JOB_REF: build_dashboard_group()}
+    groups.update(build_agent_loop_groups())
     return {
         "engine_version": REQUIREMENTS_ENGINE_VERSION,
         "python_version": python_version(),
         "dlt_version": get_pkg_install_spec(DLT_PKG_NAME),
         "default_groups": [MAIN_GROUP],
-        "groups": {MAIN_GROUP: [], DASHBOARD_JOB_REF: build_dashboard_group()},
+        "groups": groups,
         "launcher_requirements": launcher_requirements,
     }
 
@@ -325,6 +352,7 @@ def export_workspace_requirements(
     _expand_implied_names(default_names)
 
     groups[DASHBOARD_JOB_REF] = _prune_specs(build_dashboard_group(), default_names)
+    _add_agent_loop_groups(groups, default_names)
 
     launcher_requirements = build_launcher_requirements()
     for launcher, specs in launcher_requirements.items():

--- a/dlt/_workspace/deployment/trigger.py
+++ b/dlt/_workspace/deployment/trigger.py
@@ -5,6 +5,7 @@ from dlt.common.time import ensure_datetime_in_tz
 from dlt.common.typing import TAnyDateTime
 from dlt._workspace.deployment._job_ref import resolve_job_ref
 from dlt._workspace.deployment._trigger_helpers import (
+    is_selector,
     _parse_deployment,
     _parse_every,
     _parse_http,
@@ -98,17 +99,24 @@ def job_success(job_ref: str) -> TTrigger:
     """Create a job success event trigger.
 
     Args:
-        job_ref: Job reference — accepts `"name"` (2-part), `"section.name"`,
-            or `"jobs.section.name"`.
+        job_ref: Job reference — accepts `"name"` (2-part), `"section.name"` or
+            `"jobs.section.name"` — or a selector such as `"tag:ingest"`, `"batch:"` or
+            `"jobs.section.*"`, which the manifest expands to one trigger per matching job.
     """
-    return _parse_job_success(resolve_job_ref(job_ref)).raw
+    return _parse_job_success(_job_event_expr(job_ref)).raw
 
 
 def job_fail(job_ref: str) -> TTrigger:
     """Create a job failure event trigger.
 
     Args:
-        job_ref: Job reference — accepts `"name"` (2-part), `"section.name"`,
-            or `"jobs.section.name"`.
+        job_ref: Job reference — accepts `"name"` (2-part), `"section.name"` or
+            `"jobs.section.name"` — or a selector such as `"tag:ingest"`, `"batch:"` or
+            `"jobs.section.*"`, which the manifest expands to one trigger per matching job.
     """
-    return _parse_job_fail(resolve_job_ref(job_ref)).raw
+    return _parse_job_fail(_job_event_expr(job_ref)).raw
+
+
+def _job_event_expr(job_ref: str) -> str:
+    """A selector stands as written; a bare ref is resolved to `jobs.` form."""
+    return job_ref if is_selector(job_ref) else resolve_job_ref(job_ref)

--- a/dlt/_workspace/deployment/typing.py
+++ b/dlt/_workspace/deployment/typing.py
@@ -5,11 +5,17 @@ from dlt.common.pipeline import TRefreshMode
 from dlt.common.typing import Annotated, NotRequired, TypedDict
 from dlt.common.warnings import Deprecated
 
+from dlt._workspace.typing import TWorkspaceAccess
+
 
 MANIFEST_ENGINE_VERSION = 2
 WORKSPACE_DEPRECATED_SINCE = "1.29.0"
 """dlt version the job-definition field renames were introduced in."""
 REQUIREMENTS_ENGINE_VERSION = 2
+AGENT_DEFINITION_ENGINE_VERSION = 1
+JOB_RESULT_ENGINE_VERSION = 1
+JOB_RESULT_PAYLOAD_TYPE = "job_result"
+"""Beacon payload type for job results. The endpoint stores it in a 16 character column."""
 MAIN_GROUP = "main"
 """Conventional group name for top-level workspace dependencies."""
 DEFAULT_DEPLOYMENT_MODULE = "__deployment__"
@@ -79,10 +85,13 @@ TJobType = Literal["batch", "interactive", "stream"]
 """Execution model: batch (run to completion), interactive (long-running HTTP), stream (consumer loop)."""
 
 TInterfaceType = Literal["gui", "rest_api", "mcp"]
-"""What an interactive job exposes: web UI, programmatic API, or MCP tool server."""
+"""What a job exposes: web UI, programmatic API, or MCP tool server."""
 
-TJobExposeCategory = Literal["pipeline", "mcp", "dashboard", "notebook"]
+TJobExposeCategory = Literal["pipeline", "mcp", "dashboard", "notebook", "background_agent"]
 """UI category for grouping jobs in the runtime interface."""
+
+THubEntityType = Literal["job-run", "job", "workspace", "pipeline", "dataset"]
+"""Kinds of workspace entity a job can act on. Hyphenated: the values are URI path segments."""
 
 
 class TJobExposeSpec(TypedDict, total=False):
@@ -98,13 +107,23 @@ class TJobExposeSpec(TypedDict, total=False):
     """When `True` (default), runner creates a `manual:` trigger for this job."""
 
 
+class TJobObjectInput(TypedDict):
+    """The input a UI fills with the entity a job is started from."""
+
+    entity_type: THubEntityType
+    input: str  # noqa: A003
+    """Full config key of the input: `jobs.<section>.<job>.<input>`."""
+
+
 class TExposeSpec(TJobExposeSpec):
     """Extends TJobExposeSpec will elements not directly set by users."""
 
     interface: NotRequired[TInterfaceType]
-    """What an interactive job exposes: `"gui"`, `"rest_api"`, or `"mcp"`."""
+    """What the job exposes: `"gui"`, `"rest_api"` or `"mcp"`."""
     category: NotRequired[TJobExposeCategory]
     """UI grouping category (e.g. `"pipeline"`, `"notebook"`)."""
+    object_input: NotRequired[TJobObjectInput]
+    """The job's first entity-typed input. Use to pass object id as specified input to run that job for that object"""
 
 
 class TRequireSpec(TypedDict, total=False):
@@ -182,6 +201,10 @@ class TIntervalSpec(TypedDict):
     """Interval scheduling mode. Defaults to `sequential` when not set."""
 
 
+RUN_CONTEXT_INPUT = "run_context"
+"""Argument a job declares to get the run context. The launcher fills it, config never does."""
+
+
 class TJobRunContext(TypedDict):
     """Job run context injected into job functions that declare a `run_context` argument."""
 
@@ -197,6 +220,9 @@ class TJobRunContext(TypedDict):
     """End of the interval being processed."""
     refresh: bool
     """Refresh signal with request to refresh (reload) the data"""
+    ai_loop: NotRequired[Any]
+    """Agent loop created by the agent launcher. `SupportsAgentLoop`, untyped here to keep
+    this module free of imports."""
 
 
 class TRuntimeEntryPoint(TEntryPoint):
@@ -211,10 +237,9 @@ class TRuntimeEntryPoint(TEntryPoint):
     interval_timezone: NotRequired[str]
     """IANA timezone name (from `require.timezone`); applied to the interval by the launcher."""
     incremental_mode: NotRequired[TIncrementalSource]
-    """Incremental mode of the job, takes precedence over `allow_external_schedulers`."""
+    """Incremental mode of the job, read by launchers from dlt 1.30.1 on."""
     allow_external_schedulers: NotRequired[bool]
-    """Always written alongside `incremental_mode` so launchers of older dlt versions,
-    which do not know the newer field, still see the join decision."""
+    """The join decision as launchers before dlt 1.30.1 read it. Written for those alone."""
     profile: NotRequired[str]
     """Active workspace profile, resolved from require.profile."""
     config: NotRequired[Dict[str, Any]]
@@ -260,9 +285,29 @@ class TDeliverSpec(TypedDict, total=False):
     """Human-readable delivery deadline, e.g. `"8am on Mondays"`."""
 
 
+class TAgentDefinition(TypedDict):
+    """Agent declaration carried in the job manifest."""
+
+    engine_version: int
+    agent_file: NotRequired[str]
+    """`AGENT.md` the definition was read from, or `<module>.py:<name>` for an agent a function
+    declares. Absent when the agent was given inline."""
+    name: str
+    description: NotRequired[str]
+    tools: NotRequired[List[str]]
+    """MCP feature groups requested from the dlthub MCP server."""
+    skills: NotRequired[List[str]]
+    rules: NotRequired[List[str]]
+    instructions: NotRequired[str]
+    """User prompt supplied on the decorator. Configuration may replace it at run time."""
+    model: NotRequired[str]
+    """Model supplied on the decorator."""
+
+
 class TJobDefinition(TypedDict):
     """A single job in the deployment manifest."""
 
+    engine_version: int
     job_ref: TJobRef
     """Unique job identity: `"jobs.<section>.<name>"` or `"jobs.<name>"` for module-level jobs."""
     description: NotRequired[str]
@@ -274,6 +319,10 @@ class TJobDefinition(TypedDict):
     execute: TExecuteSpec
     config_keys: NotRequired[List[str]]
     """Config keys discovered from function signature (`dlt.config.value` defaults)."""
+    inputs: NotRequired[Dict[str, Any]]
+    """JSON Schema of `config_keys`: the same arguments, typed. Absent when the job takes none."""
+    output: NotRequired[Dict[str, Any]]
+    """JSON Schema of the job's result. Present when the job returns a `TJobResult`."""
     deliver: NotRequired[TDeliverSpec]
     interval: NotRequired[TIntervalSpec]
     """Overall time range for interval-based scheduling."""
@@ -283,12 +332,38 @@ class TJobDefinition(TypedDict):
     """How incrementals obtain their range during a run. Unset falls back to `jobs` configuration."""
     require: NotRequired[TRequireSpec]
     """Runtime resource requirements."""
+    access: NotRequired[TWorkspaceAccess]
+    """What the job may touch. Only background agents declare it today."""
     default_trigger: NotRequired[TTrigger]
     """Primary trigger, computed during manifest generation. Prefers schedule/every triggers."""
     refresh_propagation: NotRequired[TRefreshPolicy]
     """How a refresh signal cascades through the job graph. Defaults to `auto`."""
     auto_refresh_pipeline_mode: NotRequired[TRefreshMode]
     """Refresh mode applied to every pipeline in the job when a refresh run is requested."""
+    agent: NotRequired[TAgentDefinition]
+    """Agent declaration for jobs run by the agent launcher."""
+
+
+class THubEntity(TypedDict):
+    """A workspace entity, addressed relative to its workspace."""
+
+    type: THubEntityType  # noqa: A003
+    id: str  # noqa: A003
+    """`{type}/{unique id}`: `job-run/9ac2…`, `dataset/duckdb_prod/github_events`."""
+
+
+class TJobResult(TypedDict):
+    """Structured result of a job run, delivered to the dlthub beacon. The launcher builds it."""
+
+    type: str  # noqa: A003
+    """`job.{category}.{name}`: the category says which envelope this is, the name which payload."""
+    engine_version: int
+    result: NotRequired[Any]
+    """JSON-serializable payload produced by the job."""
+    object: NotRequired[List[THubEntity]]  # noqa: A003
+    """Entities the run acted on: its entity-typed inputs, overwritten by same-named outputs."""
+    job_ref: NotRequired[TJobRef]
+    """Job that produced the result. The beacon dedups on it."""
 
 
 class TDeploymentFileItem(TypedDict):

--- a/dlt/_workspace/mcp/server.py
+++ b/dlt/_workspace/mcp/server.py
@@ -7,7 +7,9 @@ from fastmcp.prompts import Prompt
 
 from dlt.common import logger
 from dlt.common.configuration.plugins import manager
+from dlt._workspace.access import FULL_ACCESS, missing_access, required_access
 from dlt._workspace.cli.utils import DEFAULT_MCP_FEATURES as _DEFAULT_MCP_FEATURES
+from dlt._workspace.typing import TWorkspaceAccess
 
 
 # large sentinel set used to discover all registered feature names
@@ -38,30 +40,6 @@ def discover_features() -> Tuple[Set[str], Set[str]]:
     return available, extra
 
 
-def resolve_features(feature_tokens: Optional[List[str]], defaults: Set[str] = None) -> Set[str]:
-    """Resolve `+name`, `-name`, `name` tokens against defaults into a feature set."""
-    if defaults is None:
-        defaults = WorkspaceMCP.DEFAULT_FEATURES
-    if not feature_tokens:
-        return set(defaults)
-
-    result = set(defaults)
-    for item in feature_tokens:
-        # tokens may be comma-separated: "--features=-secrets,+context"
-        # because argparse treats leading "-" as a flag, use "=" form for removals
-        for token in item.split(","):
-            token = token.strip()
-            if not token:
-                continue
-            if token.startswith("-"):
-                result.discard(token[1:])
-            elif token.startswith("+"):
-                result.add(token[1:])
-            else:
-                result.add(token)
-    return result
-
-
 def _curry_pipeline_name(fn: Callable[..., Any], pipeline_name: str) -> Callable[..., Any]:
     """Bind pipeline_name as the first argument, hiding it from the MCP schema."""
 
@@ -77,11 +55,19 @@ def _curry_pipeline_name(fn: Callable[..., Any], pipeline_name: str) -> Callable
 
 
 class DltMCP(FastMCP):
-    def __init__(self, name: str, features: Set[str], port: int = 8000, path: str = "/mcp") -> None:
+    def __init__(
+        self,
+        name: str,
+        features: Set[str],
+        port: int = 8000,
+        path: str = "/mcp",
+        access: TWorkspaceAccess = FULL_ACCESS,
+    ) -> None:
         super().__init__(name=name)
         self._port = port
         self._path = path
         self._features = features
+        self._access = access
         self._register_features()
 
     def run(self, transport: str = "streamable-http", **kwargs: Any) -> None:
@@ -108,9 +94,17 @@ class DltMCP(FastMCP):
                 self.add_provider(provider)
         logger.debug("dlt MCP features registered for %s.", self._features)
 
+    def _serves(self, tool: Any) -> bool:
+        """True when the caller's access covers what the tool requires."""
+        shortfall = missing_access(required_access(tool), self._access)
+        if shortfall:
+            logger.debug("Tool %s needs %s.", getattr(tool, "__name__", tool), shortfall)
+        return not shortfall
+
     def _register_tools(self, tools: List[Any]) -> None:
         for tool in tools:
-            self.add_tool(tool)
+            if self._serves(tool):
+                self.add_tool(tool)
 
 
 class WorkspaceMCP(DltMCP):
@@ -125,12 +119,13 @@ class WorkspaceMCP(DltMCP):
         path: str = "/mcp",
         features: Optional[Set[str]] = None,
         extra_features: Optional[Set[str]] = None,
+        access: TWorkspaceAccess = FULL_ACCESS,
     ) -> None:
         if features is not None:
             resolved = features
         else:
             resolved = self.DEFAULT_FEATURES | (extra_features or set())
-        super().__init__(name=name, features=resolved, port=port, path=path)
+        super().__init__(name=name, features=resolved, port=port, path=path, access=access)
 
 
 class PipelineMCP(DltMCP):
@@ -147,4 +142,5 @@ class PipelineMCP(DltMCP):
 
     def _register_tools(self, tools: List[Any]) -> None:
         for tool_fn in tools:
-            self.add_tool(_curry_pipeline_name(tool_fn, self.pipeline_name))
+            if self._serves(tool_fn):
+                self.add_tool(_curry_pipeline_name(tool_fn, self.pipeline_name))

--- a/dlt/_workspace/mcp/tools/context_tools.py
+++ b/dlt/_workspace/mcp/tools/context_tools.py
@@ -5,6 +5,7 @@ from pydantic import Field
 from dlt.common.typing import Annotated
 from dlt._workspace.mcp.tools._ai_context_api_client import search_sources
 from dlt._workspace.cli.exceptions import AiContextApiError
+from dlt._workspace.access import RequiresAccess
 from dlt._workspace.mcp.context import with_mcp_tool_telemetry
 from dlt._workspace.typing import TSourceItem
 
@@ -22,7 +23,7 @@ def search_dlthub_sources(
             )
         ),
     ] = "",
-) -> List[TSourceItem]:
+) -> Annotated[List[TSourceItem], RequiresAccess(context=["read"])]:
     """Search for available dlt sources on dlthub by name or description."""
     try:
         return search_sources(query=query)

--- a/dlt/_workspace/mcp/tools/data_tools.py
+++ b/dlt/_workspace/mcp/tools/data_tools.py
@@ -15,6 +15,7 @@ from dlt.common.typing import Annotated
 from dlt._workspace.cli import formatters
 from dlt._workspace.cli.dlthub.utils import fetch_profiles_list, fetch_workspace_info
 from dlt._workspace.cli.utils import fetch_schema_export, list_local_pipelines
+from dlt._workspace.access import RequiresAccess
 from dlt._workspace.mcp.context import with_mcp_tool_telemetry
 
 TResultFormat = Literal["markdown", "jsonl"]
@@ -41,8 +42,67 @@ def _get_dataset(pipeline_name: str) -> dlt.Dataset:
     return pipeline.dataset(schema=_get_unified_schema(pipeline))
 
 
+MUTATING_STATEMENTS = (
+    sge.Insert,
+    sge.Update,
+    sge.Delete,
+    sge.Merge,
+    sge.Drop,
+    sge.Create,
+    sge.Alter,
+    sge.TruncateTable,
+    sge.Copy,
+    sge.Pragma,
+    sge.Command,
+    sge.Attach,
+    sge.Set,
+    sge.Use,
+)
+"""Statements that change something, wherever in the tree they sit."""
+
+HOST_FUNCTIONS = frozenset(
+    {
+        "read_text",
+        "read_blob",
+        "read_csv",
+        "read_csv_auto",
+        "read_json",
+        "read_json_auto",
+        "read_ndjson",
+        "read_ndjson_auto",
+        "read_parquet",
+        "parquet_scan",
+        "glob",
+        "sniff_csv",
+    }
+)
+"""Destination functions that read the host filesystem or the network from inside a SELECT."""
+
+
+def _ensure_read_only(sql_query: str, dialect: Optional[str]) -> None:
+    """Refuses anything but one read-only query. Raises `ToolError` with what was refused."""
+    try:
+        statements = sqlglot.parse(sql_query, dialect=dialect)
+    except sqlglot.errors.ParseError as e:
+        raise ToolError(f"Query cannot be parsed as {dialect or 'SQL'}: {e}") from e
+    if len(statements) != 1 or statements[0] is None:
+        raise ToolError("Only a single read-only SELECT statement is allowed")
+    root = statements[0]
+    for node in root.walk():
+        if isinstance(node, MUTATING_STATEMENTS):
+            raise ToolError(
+                "Only read-only SELECT statements are allowed."
+                f" {type(node).__name__.upper()} modifies data or schema"
+            )
+        # a host-side function reads files and URLs with the destination's credentials
+        if isinstance(node, sge.Anonymous) and node.name.lower() in HOST_FUNCTIONS:
+            raise ToolError(f"Function {node.name!r} is not allowed in a read-only query")
+    if not isinstance(root, sge.Query):
+        raise ToolError("Only read-only SELECT statements are allowed")
+
+
 @with_mcp_tool_telemetry()
-def list_pipelines() -> List[str]:
+def list_pipelines() -> Annotated[List[str], RequiresAccess(data=["read"])]:
     """List all dlt pipelines available in this workspace"""
     ctx = active_run_context()
     # in OSS context (no profiles), filter to pipelines created in this project
@@ -52,7 +112,7 @@ def list_pipelines() -> List[str]:
 
 
 @with_mcp_tool_telemetry()
-def get_workspace_info() -> Dict[str, Any]:
+def get_workspace_info() -> Annotated[Dict[str, Any], RequiresAccess(local=["read"])]:
     """Get workspace info: name, directories, active profile, and config providers."""
 
     info = fetch_workspace_info()
@@ -63,7 +123,7 @@ def get_workspace_info() -> Dict[str, Any]:
 
 
 @with_mcp_tool_telemetry()
-def list_profiles() -> List[Dict[str, Any]]:
+def list_profiles() -> Annotated[List[Dict[str, Any]], RequiresAccess(local=["read"])]:
     """List all available workspace profiles with status flags (current, pinned, configured)."""
     return fetch_profiles_list()
 
@@ -71,7 +131,7 @@ def list_profiles() -> List[Dict[str, Any]]:
 @with_mcp_tool_telemetry()
 def list_tables(
     pipeline_name: str,
-) -> Dict[str, Any]:
+) -> Annotated[Dict[str, Any], RequiresAccess(data=["read"])]:
     """List all data tables for a pipeline."""
     pipeline = _attach(pipeline_name)
     schema = _get_unified_schema(pipeline)
@@ -82,7 +142,7 @@ def list_tables(
 def get_table_schema(
     pipeline_name: str,
     table_name: str,
-) -> Dict[str, Any]:
+) -> Annotated[Dict[str, Any], RequiresAccess(data=["read"])]:
     """Get table schema with column names, data types, and escaped sql_identifier fields."""
     try:
         dataset = _get_dataset(pipeline_name)
@@ -114,7 +174,7 @@ def get_table_schema(
 def get_table_create_sql(
     pipeline_name: str,
     table_name: str,
-) -> str:
+) -> Annotated[str, RequiresAccess(data=["read"])]:
     """Get CREATE TABLE DDL for the table in the destination's SQL dialect."""
     from dlt.common.libs.sqlglot import to_sqlglot_type
 
@@ -182,7 +242,7 @@ def preview_table(
         TResultFormat,
         Field(description="Output format: 'markdown' or 'jsonl'"),
     ] = "markdown",
-) -> str:
+) -> Annotated[str, RequiresAccess(data=["read"])]:
     """Get the first 10 rows from a table."""
     try:
         relation = _get_dataset(pipeline_name)[table_name].limit(10)
@@ -209,16 +269,10 @@ def execute_sql_query(
         TResultFormat,
         Field(description="Output format: 'markdown' or 'jsonl'"),
     ] = "markdown",
-) -> str:
+) -> Annotated[str, RequiresAccess(data=["read"])]:
     """Execute a read-only SQL query against the pipeline's destination dataset."""
-    parsed = sqlglot.parse(sql_select_query)
-    if any(
-        isinstance(expr, (sqlglot.exp.Insert, sqlglot.exp.Update, sqlglot.exp.Delete))
-        for expr in parsed
-    ):
-        raise ToolError("Data modification statements are not allowed")
-
     dataset = _get_dataset(pipeline_name)
+    _ensure_read_only(sql_select_query, dataset.sql_client.capabilities.sqlglot_dialect)
     relation = dataset(sql_select_query)
     columns = relation.columns
     rows = relation.fetchall()
@@ -234,7 +288,7 @@ def get_row_counts(
         TResultFormat,
         Field(description="Output format: 'markdown' or 'jsonl'"),
     ] = "markdown",
-) -> str:
+) -> Annotated[str, RequiresAccess(data=["read"])]:
     """Get row counts for all data tables in a pipeline."""
     try:
         dataset = _get_dataset(pipeline_name)
@@ -275,7 +329,7 @@ def export_schema(
             )
         ),
     ] = None,
-) -> str:
+) -> Annotated[str, RequiresAccess(data=["read"], local=["write"])]:
     """Export the pipeline schema as a diagram or structured dump."""
     try:
         pipeline = _attach(pipeline_name)
@@ -297,7 +351,7 @@ def export_schema(
 @with_mcp_tool_telemetry()
 def get_local_pipeline_state(
     pipeline_name: str,
-) -> Dict[str, Any]:
+) -> Annotated[Dict[str, Any], RequiresAccess(data=["read"])]:
     """Get pipeline state: incremental cursors, resource state, and source state."""
     try:
         pipeline = _attach(pipeline_name)

--- a/dlt/_workspace/mcp/tools/data_tools.py
+++ b/dlt/_workspace/mcp/tools/data_tools.py
@@ -60,23 +60,8 @@ MUTATING_STATEMENTS = (
 )
 """Statements that change something, wherever in the tree they sit."""
 
-HOST_FUNCTIONS = frozenset(
-    {
-        "read_text",
-        "read_blob",
-        "read_csv",
-        "read_csv_auto",
-        "read_json",
-        "read_json_auto",
-        "read_ndjson",
-        "read_ndjson_auto",
-        "read_parquet",
-        "parquet_scan",
-        "glob",
-        "sniff_csv",
-    }
-)
-"""Destination functions that read the host filesystem or the network from inside a SELECT."""
+MUTATING_FUNCTION_SUFFIXES = ("_execute", "_attach")
+"""Table functions that attach a database or run a statement on one: `postgres_execute`."""
 
 
 def _ensure_read_only(sql_query: str, dialect: Optional[str]) -> None:
@@ -94,8 +79,9 @@ def _ensure_read_only(sql_query: str, dialect: Optional[str]) -> None:
                 "Only read-only SELECT statements are allowed."
                 f" {type(node).__name__.upper()} modifies data or schema"
             )
-        # a host-side function reads files and URLs with the destination's credentials
-        if isinstance(node, sge.Anonymous) and node.name.lower() in HOST_FUNCTIONS:
+        if isinstance(node, sge.Anonymous) and node.name.lower().endswith(
+            MUTATING_FUNCTION_SUFFIXES
+        ):
             raise ToolError(f"Function {node.name!r} is not allowed in a read-only query")
     if not isinstance(root, sge.Query):
         raise ToolError("Only read-only SELECT statements are allowed")

--- a/dlt/_workspace/mcp/tools/secrets_tools.py
+++ b/dlt/_workspace/mcp/tools/secrets_tools.py
@@ -9,11 +9,12 @@ from dlt._workspace.cli.dlthub.ai.utils import (
     fetch_secrets_update_fragment,
     fetch_secrets_view_redacted,
 )
+from dlt._workspace.access import RequiresAccess
 from dlt._workspace.mcp.context import with_mcp_tool_telemetry
 
 
 @with_mcp_tool_telemetry()
-def secrets_list() -> List[Dict[str, Any]]:
+def secrets_list() -> Annotated[List[Dict[str, Any]], RequiresAccess(local=["read"])]:
     """List secret file paths, profiles, and whether each file exists."""
 
     return fetch_secrets_list()  # type: ignore[return-value]
@@ -30,7 +31,7 @@ def secrets_view_redacted(
             )
         ),
     ] = None,
-) -> str:
+) -> Annotated[str, RequiresAccess(local=["read"])]:
     """Show secrets TOML with every value replaced by '***'.
 
     Without path: returns the unified merged view across all project secret files
@@ -55,7 +56,7 @@ def secrets_update_fragment(
         str,
         Field(description="Absolute path to the secrets file to update (from secrets_list)."),
     ],
-) -> str:
+) -> Annotated[str, RequiresAccess(local=["write"])]:
     """Deep-merge a TOML fragment into a secrets file; returns the redacted result. The file is created if it does not exist."""
     try:
         return fetch_secrets_update_fragment(fragment, path)

--- a/dlt/_workspace/mcp/tools/toolkit_tools.py
+++ b/dlt/_workspace/mcp/tools/toolkit_tools.py
@@ -12,11 +12,12 @@ from dlt._workspace.cli.dlthub.ai.utils import (
     fetch_workbench_toolkits,
 )
 from dlt._workspace.cli.dlthub.ai.typing import TToolkitInfo, TWorkbenchToolkitInfo
+from dlt._workspace.access import RequiresAccess
 from dlt._workspace.mcp.context import with_mcp_tool_telemetry
 
 
 @with_mcp_tool_telemetry()
-def list_toolkits() -> Dict[str, TToolkitInfo]:
+def list_toolkits() -> Annotated[Dict[str, TToolkitInfo], RequiresAccess()]:
     """List available dlt AI toolkits with their names and descriptions."""
     try:
         base = fetch_workbench_base(DEFAULT_AI_WORKBENCH_REPO, DEFAULT_AI_WORKBENCH_BRANCH)
@@ -29,7 +30,7 @@ def list_toolkits() -> Dict[str, TToolkitInfo]:
 @with_mcp_tool_telemetry()
 def toolkit_info(
     name: Annotated[str, Field(description="Name of the toolkit to inspect")],
-) -> TWorkbenchToolkitInfo:
+) -> Annotated[TWorkbenchToolkitInfo, RequiresAccess()]:
     """Show detailed contents of a dlt AI toolkit."""
     try:
         info = fetch_workbench_toolkit_info(

--- a/dlt/_workspace/typing.py
+++ b/dlt/_workspace/typing.py
@@ -5,6 +5,22 @@ from dlt.common.storages.configuration import TSchemaFileFormat
 from dlt.common.typing import NotRequired, TypedDict
 
 
+TWorkspaceLocalVerb = Literal["read", "write", "execute", "network", "all"]
+TWorkspaceDataVerb = Literal["read", "write", "all"]
+TWorkspaceContextVerb = Literal["read", "write", "execute", "deploy", "all"]
+
+
+class TWorkspaceAccess(TypedDict, total=False):
+    """What may be touched in a workspace. Declared by an agent, required by a tool."""
+
+    local: List[TWorkspaceLocalVerb]
+    """What may be done on the machine the workspace lives on."""
+    data: List[TWorkspaceDataVerb]
+    """Access to workspace data, governed by the dlt profile in use."""
+    context: List[TWorkspaceContextVerb]
+    """Access to the context graph: telemetry, runs and job definitions. Read-only."""
+
+
 TLocationScope = Literal["project", "global"]
 
 

--- a/dlt/common/configuration/plugins.py
+++ b/dlt/common/configuration/plugins.py
@@ -218,12 +218,12 @@ class SupportsAgentLoop(Protocol):
 
     async def run(
         self,
-        inputs: Dict[str, Any],
-        run_args: Optional[Dict[str, Any]] = None,
+        instructions: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
         model: Optional[str] = None,
         limits: Optional[Any] = None,
-        instructions: Optional[str] = None,
-    ) -> Any:
+        run_args: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Builds the native agent from the runtime arguments and runs it to completion"""
         ...
 

--- a/dlt/common/configuration/plugins.py
+++ b/dlt/common/configuration/plugins.py
@@ -204,3 +204,48 @@ def plug_mcp(features: Set[str]) -> Optional[SupportsMcpFeatures]:
     Args:
         features: set of feature keywords the server requests
     """
+
+
+class SupportsAgentLoop(Protocol):
+    """Protocol for an agent loop implementation returned by the plug_agent_loop hook"""
+
+    LOOP_TYPE: ClassVar[str]
+    """loop type string this class answers to"""
+
+    def init(self, agent_spec: Any) -> None:
+        """Prepares the loop from the agent declaration"""
+        ...
+
+    async def run(
+        self,
+        inputs: Dict[str, Any],
+        run_args: Optional[Dict[str, Any]] = None,
+        model: Optional[str] = None,
+        limits: Optional[Any] = None,
+        instructions: Optional[str] = None,
+    ) -> Any:
+        """Builds the native agent from the runtime arguments and runs it to completion"""
+        ...
+
+    @property
+    def native(self) -> Any:
+        """The underlying framework object, e.g. a Pydantic AI Agent"""
+        ...
+
+    @property
+    def trace(self) -> Any:
+        """Trace of the completed run"""
+        ...
+
+
+@hookspec()
+def plug_agent_loop(loop_type: str) -> Optional[Type[SupportsAgentLoop]]:
+    """Spec for plugin hook that returns an agent loop class for a given loop type.
+
+    Args:
+        loop_type: Loop type requested by the launcher, e.g. `"pydantic-ai"`.
+
+    Returns:
+        Optional[Type[SupportsAgentLoop]]: Loop class to instantiate, or `None` when the
+        plugin does not implement the requested loop.
+    """

--- a/dlt/common/known_env.py
+++ b/dlt/common/known_env.py
@@ -44,3 +44,9 @@ DLT_INTERVAL_TIMEZONE = "DLT_INTERVAL_TIMEZONE"
 
 DLT_ALLOW_EXTERNAL_SCHEDULERS = "DLT_ALLOW_EXTERNAL_SCHEDULERS"
 """`True` lets incrementals that left the flag unset take the interval above, process-wide"""
+
+DLT_ECHO_NO_COLOR = "DLT_ECHO_NO_COLOR"
+"""Set to drop ANSI colors from CLI output, terminal or not"""
+
+DLT_ECHO_FORCE_COLOR = "DLT_ECHO_FORCE_COLOR"
+"""Set to keep ANSI colors in CLI output with no terminal attached, ie. in a runner's log"""

--- a/dlt/common/libs/__init__.py
+++ b/dlt/common/libs/__init__.py
@@ -76,12 +76,14 @@ def is_instance_lib(obj: Any, *, class_ref: str) -> bool:
 
     target_class: Any = sys.modules[module_name]
     for idx, part in enumerate(import_parts[1:], start=1):
-        # packages do not necessarily re-export their submodules: import them on demand
-        if isinstance(target_class, ModuleType) and not hasattr(target_class, part):
-            try:
+        # packages do not necessarily re-export their submodules: import them on demand. a
+        # package that loads the attribute lazily raises ImportError from `hasattr` when its
+        # own dependencies are missing, and such a class is not installed either
+        try:
+            if isinstance(target_class, ModuleType) and not hasattr(target_class, part):
                 importlib.import_module(".".join(import_parts[: idx + 1]))
-            except ImportError:
-                return False
-        target_class = getattr(target_class, part)
+            target_class = getattr(target_class, part)
+        except ImportError:
+            return False
 
     return isinstance(obj, target_class)

--- a/dlt/common/libs/pydantic.py
+++ b/dlt/common/libs/pydantic.py
@@ -49,10 +49,12 @@ try:
         Field,
         ValidationError,
         Json,
+        TypeAdapter,
         create_model,
         RootModel as PydanticRootModel,
     )
     from pydantic.fields import FieldInfo
+    from pydantic.json_schema import PydanticJsonSchemaWarning
     from pydantic.warnings import PydanticDeprecationWarning
 
     warnings.filterwarnings("ignore", category=PydanticDeprecationWarning)

--- a/dlt/common/typing.py
+++ b/dlt/common/typing.py
@@ -32,6 +32,7 @@ from typing import (
 from typing_extensions import (
     ForwardRef,
     Annotated,
+    Doc,
     Never,
     NotRequired,
     ParamSpec,

--- a/dlt/helpers/dbt/profiles.yml
+++ b/dlt/helpers/dbt/profiles.yml
@@ -117,7 +117,8 @@ snowflake_pkey:
       account: "{{ env_var('DLT__CREDENTIALS__HOST') }}"
       user: "{{ env_var('DLT__CREDENTIALS__USERNAME') }}"
       database: "{{ env_var('DLT__CREDENTIALS__DATABASE') }}"
-      password: "{{ env_var('DLT__CREDENTIALS__PASSWORD') }}"
+      # a key pair alone is the whole credential, and dbt ignores an empty password
+      password: "{{ env_var('DLT__CREDENTIALS__PASSWORD', '') }}"
       role: "{{ env_var('DLT__CREDENTIALS__ROLE', '') }}"
       schema: "{{ var('destination_dataset_name', var('source_dataset_name')) }}"
       warehouse: "{{ env_var('DLT__CREDENTIALS__WAREHOUSE', '') }}"

--- a/dlt/hub/run.py
+++ b/dlt/hub/run.py
@@ -1,5 +1,32 @@
-from dlt._workspace.deployment.decorators import job, pipeline_run as pipeline, interactive
+from dlt._workspace.deployment.decorators import (
+    agent,
+    interactive,
+    job,
+    pipeline_run as pipeline,
+)
 from dlt._workspace.deployment import TJobRunContext
 from dlt._workspace.deployment import trigger
+from dlt._workspace.deployment.exceptions import JobAbortedException
+from dlt._workspace.deployment.job_result import job_result as result
+from dlt._workspace.deployment.reflection import Entity
+from dlt._workspace.deployment.agent.typing import TAgentJobResult, TAgentOutput, TAgentSpec
+from dlt._workspace.deployment.typing import THubEntity, THubEntityType
+from dlt.common.typing import Doc
 
-__all__ = ["job", "pipeline", "interactive", "TJobRunContext", "trigger"]
+__all__ = [
+    "agent",
+    "Doc",
+    "Entity",
+    "job",
+    "pipeline",
+    "interactive",
+    "result",
+    "trigger",
+    "TJobRunContext",
+    "THubEntity",
+    "THubEntityType",
+    "TAgentSpec",
+    "TAgentOutput",
+    "TAgentJobResult",
+    "JobAbortedException",
+]

--- a/dlt/pipeline/platform.py
+++ b/dlt/pipeline/platform.py
@@ -1,5 +1,5 @@
-"""Implements SupportsTracking"""
-from typing import Any, cast, List, TYPE_CHECKING
+"""dlthub beacon client. Also implements SupportsTracking for pipeline traces."""
+from typing import Any, cast, List, Optional, TYPE_CHECKING
 
 from dlt.common import logger
 from dlt.common.json import json
@@ -14,8 +14,10 @@ if TYPE_CHECKING:
     from requests import Session
 
 _THREAD_POOL: ManagedThreadPool = None
-TRACE_URL_SUFFIX = "/trace"
-STATE_URL_SUFFIX = "/state"
+TRACE_PAYLOAD_TYPE = "trace"
+STATE_PAYLOAD_TYPE = "state"
+TRACE_URL_SUFFIX = f"/{TRACE_PAYLOAD_TYPE}"
+STATE_URL_SUFFIX = f"/{STATE_PAYLOAD_TYPE}"
 requests: "Session" = None
 
 
@@ -50,35 +52,59 @@ def disable_platform_tracker() -> None:
     _THREAD_POOL = None
 
 
+def send_payload(
+    payload_type: str, payload: Any, dsn: Optional[str] = None, wait: bool = False
+) -> None:
+    """Sends a JSON payload to the dlthub beacon. Does nothing when the beacon is not configured.
+
+    The beacon derives the run identity from the token embedded in the DSN, so `payload` must
+    not carry one.
+
+    Args:
+        payload_type (str): Beacon payload type, appended to the DSN as a path segment.
+        payload (Any): JSON-serializable body.
+        dsn (str): Beacon DSN. Read from the active run context when not given.
+        wait (bool): Block until the request completes. Use when the process is about to exit.
+    """
+    if dsn is None:
+        from dlt.common.runtime.run_context import active
+
+        dsn = active().runtime_config.dlthub_dsn
+    if not dsn or _THREAD_POOL is None:
+        return
+
+    url = f"{dsn}/{payload_type}"
+
+    def _future_send() -> None:
+        try:
+            response = requests.put(url, data=json.dumps(payload))
+            if response.status_code != 200:
+                logger.debug(
+                    f"Failed to send {payload_type} to platform, response code:"
+                    f" {response.status_code}"
+                )
+        except Exception as e:
+            logger.debug(f"Exception while sending {payload_type} to platform: {e}")
+
+    future = _THREAD_POOL.thread_pool.submit(_future_send)
+    if wait:
+        future.result()
+
+
 def _send_trace_to_platform(trace: PipelineTrace, pipeline: SupportsPipeline) -> None:
     """
     Send the full trace after a run operation to the platform
     TODO: Migrate this to open telemetry in the next iteration
     """
-    if not pipeline.run_context.runtime_config.dlthub_dsn:
+    dsn = pipeline.run_context.runtime_config.dlthub_dsn
+    if not dsn:
         return
-
-    def _future_send() -> None:
-        try:
-            trace_dump = json.dumps(trace.asdict())
-            url = pipeline.run_context.runtime_config.dlthub_dsn + TRACE_URL_SUFFIX
-            response = requests.put(url, data=trace_dump)
-            if response.status_code != 200:
-                logger.debug(
-                    f"Failed to send trace to platform, response code: {response.status_code}"
-                )
-        except Exception as e:
-            logger.debug(f"Exception while sending trace to platform: {e}")
-
-    _THREAD_POOL.thread_pool.submit(_future_send)
-
-    # trace_dump = json.dumps(trace.asdict(), pretty=True)
-    # with open(f"trace.json", "w") as f:
-    #     f.write(trace_dump)
+    send_payload(TRACE_PAYLOAD_TYPE, trace.asdict(), dsn=dsn)
 
 
 def _sync_schemas_to_platform(trace: PipelineTrace, pipeline: SupportsPipeline) -> None:
-    if not pipeline.run_context.runtime_config.dlthub_dsn:
+    dsn = pipeline.run_context.runtime_config.dlthub_dsn
+    if not dsn:
         return
 
     # sync only if load step was processed
@@ -104,18 +130,7 @@ def _sync_schemas_to_platform(trace: PipelineTrace, pipeline: SupportsPipeline) 
         schema = pipeline.schemas[schema_name]
         payload["schemas"].append(schema.to_dict())
 
-    def _future_send() -> None:
-        try:
-            url = pipeline.run_context.runtime_config.dlthub_dsn + STATE_URL_SUFFIX
-            response = requests.put(url, data=json.dumps(payload))
-            if response.status_code != 200:
-                logger.debug(
-                    f"Failed to send state to platform, response code: {response.status_code}"
-                )
-        except Exception as e:
-            logger.debug(f"Exception while sending state to platform: {e}")
-
-    _THREAD_POOL.thread_pool.submit(_future_send)
+    send_payload(STATE_PAYLOAD_TYPE, payload, dsn=dsn)
 
 
 def on_start_trace(trace: PipelineTrace, step: TPipelineStep, pipeline: SupportsPipeline) -> None:

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "dlt"
-version = "1.30.0"
+version = "1.30.1a0"
 source = { editable = "../" }
 dependencies = [
     { name = "click" },
@@ -912,6 +912,7 @@ duckdb = [
 hub = [
     { name = "dlthub" },
     { name = "dlthub-client" },
+    { name = "pydantic" },
 ]
 lancedb = [
     { name = "duckdb" },
@@ -958,8 +959,8 @@ requires-dist = [
     { name = "db-dtypes", marker = "extra == 'bigquery'", specifier = ">=1.2.0" },
     { name = "db-dtypes", marker = "extra == 'gcp'", specifier = ">=1.2.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=0.25.1" },
-    { name = "dlthub", marker = "extra == 'hub'", specifier = ">=0.30.0a1,<0.31" },
-    { name = "dlthub-client", marker = "extra == 'hub'", specifier = ">=0.28.1" },
+    { name = "dlthub", marker = "extra == 'hub'", specifier = ">=0.30.0a1,<0.32" },
+    { name = "dlthub-client", marker = "extra == 'hub'", specifier = ">=0.28.3" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
     { name = "duckdb", marker = "extra == 'ducklake'", specifier = ">=1.2.0" },
     { name = "duckdb", marker = "extra == 'lance'", specifier = ">=1.4.3" },
@@ -1013,6 +1014,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'pyiceberg'", specifier = ">=16.0.0" },
     { name = "pyarrow", marker = "extra == 'synapse'", specifier = ">=16.0.0" },
     { name = "pyathena", marker = "extra == 'athena'", specifier = ">=2.9.6" },
+    { name = "pydantic", marker = "extra == 'hub'", specifier = ">=2.10" },
     { name = "pydbml", marker = "extra == 'dbml'" },
     { name = "pyiceberg", marker = "extra == 'pyiceberg'", specifier = ">=0.9.1" },
     { name = "pyiceberg-core", marker = "extra == 'pyiceberg'", specifier = ">=0.6.0" },
@@ -1055,15 +1057,19 @@ adbc = [
     { name = "adbc-driver-manager", specifier = ">=1.8.0" },
     { name = "dbc", specifier = ">=0.1.0" },
 ]
+agent = [
+    { name = "aiohttp", specifier = ">=3.14.3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "openai", "google", "mcp", "spec"], specifier = ">=2.35.0" },
+]
+agent-claude = [{ name = "claude-agent-sdk", specifier = ">=0.2.144" }]
 airflow = [{ name = "apache-airflow", marker = "python_full_version < '3.13'", specifier = ">=2.8.0,<3" }]
 dashboard-tests = [
     { name = "playwright", specifier = ">=1.58.0,<2" },
     { name = "pytest-playwright", specifier = ">=0.7.1,<1" },
 ]
 dbt = [
-    { name = "dbt-athena-community", marker = "python_full_version < '3.14'", specifier = ">=1.7.0" },
     { name = "dbt-bigquery", specifier = ">=1.7.0" },
-    { name = "dbt-core", specifier = ">=1.7.0" },
+    { name = "dbt-core", specifier = ">=1.12.0" },
     { name = "dbt-duckdb", specifier = ">=1.7.0" },
     { name = "dbt-fabric", marker = "python_full_version < '3.13'", specifier = ">=1.7.0" },
     { name = "dbt-redshift", marker = "python_full_version < '3.14'", specifier = ">=1.7.0" },
@@ -1151,7 +1157,7 @@ sources = [
 streamlit = [{ name = "streamlit", specifier = ">1.50" }]
 workspace-deps = [
     { name = "duckdb", specifier = ">=0.9" },
-    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "fastmcp", specifier = ">=3.1.0" },
     { name = "ibis-framework", specifier = ">=12.0.0" },
     { name = "marimo", specifier = ">=0.14.5" },
     { name = "mowidgets", marker = "python_full_version >= '3.11'", specifier = ">=0.2.1" },
@@ -1266,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "dlthub-client"
-version = "0.28.2"
+version = "0.28.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1275,11 +1281,13 @@ dependencies = [
     { name = "httpx" },
     { name = "pathspec" },
     { name = "pyjwt" },
+    { name = "regex" },
     { name = "tabulate" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/02/97cac28340139106ba4b15f4402152d96ac2b3e30a70b0b903d1f4d3c90e/dlthub_client-0.28.2.tar.gz", hash = "sha256:2505c2f598e0528923d1275520df4a69a48825276b3e1be151568d992340c82c", size = 172345, upload-time = "2026-08-07T20:21:55.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ce/e8822974df965645a159fce5a4abca37164ef9ca6d5cc2fbd697978b1bc0/dlthub_client-0.28.4.tar.gz", hash = "sha256:f0a38268cc8690bb97d733ee5e1981c60521d14bc737472287e01d2c18b1666a", size = 303781, upload-time = "2026-09-10T12:19:38.372Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/34/ed305801559f7927abde53fe39d1fa3f72c262e96466907c602d3e12f550/dlthub_client-0.28.2-py3-none-any.whl", hash = "sha256:fd1a2fb1f44b50ad7aeb0167b27c7a1ada61ab142b298cc4bec00c790b4f9a72", size = 415388, upload-time = "2026-08-07T20:21:54.652Z" },
+    { url = "https://files.pythonhosted.org/packages/80/05/409b5539a5e46cd3e32e2f3d037ae7457f5c60a1f294ff68fae9553dec70/dlthub_client-0.28.4-py3-none-any.whl", hash = "sha256:2bab5cb34d9ff692f0789be639aa2d5f21ffd80139109440db2a04f17ce9bb31", size = 678866, upload-time = "2026-09-10T12:19:36.98Z" },
 ]
 
 [[package]]

--- a/docs/website/docs/reference/command-line-interface.md
+++ b/docs/website/docs/reference/command-line-interface.md
@@ -534,7 +534,7 @@ Launch MCP server attached to this pipeline.
 **Usage**
 ```sh
 dlt pipeline [pipeline_name] mcp [-h] [--stdio] [--sse] [--port PORT]
-    [--features [FEATURES ...]]
+    [--features [FEATURES ...]] [--no-default-features] [--access ACCESS]
 ```
 
 **Description**
@@ -553,6 +553,8 @@ Inherits arguments from [`dlt pipeline`](#dlt-pipeline).
 * `--sse` - Use legacy sse transport instead of streamable-http
 * `--port PORT` - Port for the mcp server (default: 43656)
 * `--features [FEATURES ...]` - Mcp features to enable/disable. default: context, pipeline, secrets, toolkit, workspace. use +name to add, -name to remove (e.g. --features=-secrets,+context)
+* `--no-default-features` - Serve only the features named by --features, without the defaults above
+* `--access ACCESS` - Access the caller was granted, as `axis:verb,verb` pairs (e.g. data:read,local:read). tools requiring more are not served. `axis:` alone grants nothing on that axis. everything is served when omitted.
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dlt"
-version = "1.30.0"
+version = "1.30.1a0"
 description = "dlt is an open-source python-first scalable data loading library that does not require any backend to run."
 authors = [{ name = "dltHub Inc.", email = "services@dlthub.com" }]
 requires-python = ">=3.10, <3.15"
@@ -63,8 +63,9 @@ dependencies = [
 
 [project.optional-dependencies]
 hub = [
-    "dlthub>=0.30.0a1, <0.31",
-    "dlthub-client>=0.28.1",
+    "dlthub>=0.30.0a1, <0.32",
+    "dlthub-client>=0.28.3",
+    "pydantic>=2.10",
 ]
 gcp = [
     "grpcio>=1.50.0",
@@ -228,6 +229,13 @@ dlt = "dlt._workspace.cli._dlt:_main"
 dlthub = "dlt._workspace.cli._dlt:_main_dlthub"
 
 [dependency-groups]
+agent = [
+    "pydantic-ai-slim[anthropic,openai,google,mcp,spec]>=2.35.0",
+    "aiohttp>=3.14.3",
+]
+agent-claude = [
+    "claude-agent-sdk>=0.2.144",
+]
 # NOTE: add only dependencies used for linting, type checking etc. anything else goes to pipeline group
 # we use those deps in common tests to make sure they work without extra dependencies so if you add them
 # here you'll break everything
@@ -322,12 +330,11 @@ providers = ["google-api-python-client>=2.86.0,<3"]
 sentry-sdk = ["sentry-sdk>=2.0.0,<3"]
 streamlit = ["streamlit>1.50"]
 dbt = [
-    "dbt-core>=1.7.0",
+    "dbt-core>=1.12.0",
     "dbt-redshift>=1.7.0; python_version < '3.14'",
     "dbt-bigquery>=1.7.0",
     "dbt-duckdb>=1.7.0",
-    "dbt-snowflake>=1.7.0",
-    "dbt-athena-community>=1.7.0; python_version < '3.14'",
+    "dbt-snowflake>=1.7.0",    
     "dbt-sqlserver>=1.7.0 ; python_version < '3.13'",
     "dbt-fabric>=1.7.0 ; python_version < '3.13'",
 ]
@@ -341,7 +348,7 @@ workspace-deps = [
     "ibis-framework>=12.0.0",
     "pyarrow>=16.0.0",
     "marimo>=0.14.5",
-    "fastmcp>=3.0.0",
+    "fastmcp>=3.1.0",
     "mowidgets>=0.2.1 ; python_version >= '3.11'",
     "pathspec>=0.11.2",
     "pydbml>=1.2.0",
@@ -453,6 +460,8 @@ exclude = [
     "tests/workspace/deployment/cases/local_workspace/*",
     "tests/workspace/cases/workspaces/launcher_flat/*",
     "tests/workspace/cases/workspaces/launcher_package/*",
+    "tests/workspace/cases/workspaces/agent_workspace/*",
+    "tests/workspace/cases/workspaces/agent_e2e_workspace/*",
 ]
 
 [[tool.mypy.overrides]]
@@ -526,6 +535,10 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "databricks.*",
+    "claude_agent_sdk",
+    "claude_agent_sdk.*",
+    "pydantic_ai",
+    "pydantic_ai.*",
     "mcp.*",
     "pymongo.*",
     "fastmcp.*",

--- a/tests/helpers/dbt_tests/test_runner_dbt_versions.py
+++ b/tests/helpers/dbt_tests/test_runner_dbt_versions.py
@@ -59,6 +59,9 @@ PACKAGE_IDS = [
     for destination, version in PACKAGE_PARAMS
 ]
 
+SNOWFLAKE_PKEY_DER_B64 = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ=="
+"""Stands in for a base64 DER key: the profile only passes it through, never parses it."""
+
 
 @pytest.fixture(scope="module", params=PACKAGE_PARAMS, ids=PACKAGE_IDS)
 def dbt_package_f(request: Any) -> Iterator[Tuple[str, AnyFun]]:
@@ -95,6 +98,65 @@ def test_default_profile_name() -> None:
     # force them to be present
     bigquery_config.credentials._set_default_credentials({})
     assert _default_profile_name(bigquery_config) == "bigquery_default"
+
+
+def _render_profile(profile_name: str) -> Dict[str, Any]:
+    """One profile of the shipped `profiles.yml`, as dbt renders it against the environment."""
+    import yaml
+    from jinja2 import Environment
+
+    import dlt.helpers.dbt as dbt_helper
+
+    def env_var(name: str, *default: Any) -> Any:
+        # dbt refuses an `env_var` without a default when the variable is unset
+        if default:
+            return os.environ.get(name, default[0])
+        return os.environ[name]
+
+    path = os.path.join(os.path.dirname(dbt_helper.__file__), "profiles.yml")
+    with open(path, "r", encoding="utf-8") as f:
+        # the jinja lives inside quoted scalars, so the file parses as YAML before rendering
+        outputs = yaml.safe_load(f)[profile_name]["outputs"]["analytics"]
+    env = Environment()
+    return {
+        key: (
+            env.from_string(value).render(
+                env_var=env_var, var=lambda name, *default: default[0] if default else name
+            )
+            if isinstance(value, str)
+            else value
+        )
+        for key, value in outputs.items()
+    }
+
+
+@pytest.mark.parametrize("with_password", [True, False], ids=["with-password", "key-only"])
+def test_snowflake_pkey_profile_renders(preserve_environ: Any, with_password: bool) -> None:
+    """A key pair is a whole credential on its own, and dlt exports no password beside it."""
+    from dlt.common.configuration.utils import add_config_to_env
+    from dlt.destinations.impl.snowflake.configuration import (
+        SnowflakeClientConfiguration,
+        SnowflakeCredentials,
+    )
+
+    credentials = SnowflakeCredentials()
+    credentials.host = "acct"
+    credentials.database = "db"
+    credentials.username = "loader"
+    credentials.private_key = SNOWFLAKE_PKEY_DER_B64
+    if with_password:
+        credentials.password = "pwd"
+    credentials.resolve()
+    config = SnowflakeClientConfiguration(credentials=credentials)._bind_dataset_name("ds")
+    assert _default_profile_name(config) == "snowflake_pkey"
+
+    os.environ["DLT__CREDENTIALS__PASSWORD"] = "stale"
+    add_config_to_env(credentials, ("dlt",))
+    assert ("DLT__CREDENTIALS__PASSWORD" in os.environ) is with_password
+
+    output = _render_profile("snowflake_pkey")
+    assert output["private_key"] == SNOWFLAKE_PKEY_DER_B64
+    assert output["password"] == ("pwd" if with_password else "")
 
 
 def test_dbt_configuration() -> None:

--- a/tests/hub/test_manifest_contract.py
+++ b/tests/hub/test_manifest_contract.py
@@ -1,0 +1,21 @@
+"""Manifest values dlt emits must be accepted by the runtime that receives them.
+
+The runtime validates an uploaded manifest against its generated API models, which dlt
+cannot see: `dlthub-client` ships only with the `hub` extra, so `make test-workspace` never
+loads it and a value dlt invents looks valid until `dlthub deploy` rejects it.
+"""
+
+from typing import Set, get_args
+
+import pytest
+
+from dlt._workspace.deployment.typing import TInterfaceType
+
+
+def _runtime_enum_values(name: str) -> Set[str]:
+    models = pytest.importorskip("dlt_runtime.runtime_clients.api.models")
+    return {member.value for member in getattr(models, name)}
+
+
+def test_expose_interface_is_accepted_by_the_runtime() -> None:
+    assert set(get_args(TInterfaceType)) <= _runtime_enum_values("TExposeSpecInterface")

--- a/tests/workspace/cases/runtime_workspace/invalid_trigger_jobs.py
+++ b/tests/workspace/cases/runtime_workspace/invalid_trigger_jobs.py
@@ -1,0 +1,8 @@
+"""A job whose trigger does not parse. Importing this module raises at decoration time."""
+
+from dlt.hub.run import job
+
+
+@job(trigger="every:5x")
+def broken():
+    return "never runs"

--- a/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/dlthub/agents/self-report/AGENT.md
+++ b/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/dlthub/agents/self-report/AGENT.md
@@ -1,0 +1,63 @@
+---
+name: self-report
+description: Reports the tools, skills and rule markers it was given.
+tools:
+  - workspace
+skills:
+  - e2e:visible-skill
+rules:
+  - e2e:visible-rule
+access:
+  local:
+    - read
+output:
+  type: object
+  properties:
+    local_tools:
+      type: array
+      items:
+        type: string
+      description: Name of every tool in your tool list that is not an MCP tool, copied verbatim.
+    mcp_tools:
+      type: array
+      items:
+        type: string
+      description: Name of every MCP tool in your tool list, copied verbatim.
+    skills:
+      type: array
+      items:
+        type: string
+      description: Name of every skill available to you.
+    markers:
+      type: array
+      items:
+        type: string
+      description: Every MARKER-<WORDS> token you were given, copied exactly.
+    workspace_name:
+      type: string
+      description: The `name` field `get_workspace_info` returned.
+  required: [local_tools, mcp_tools, skills, markers, workspace_name]
+defaults:
+  model: haiku
+  limits:
+    max_turns: 12
+---
+
+You are a self-report agent. Describe your own setup in the structured output and do nothing else.
+This prompt carries the token MARKER-PROMPT-CONTROL.
+
+Rules for this task:
+- Use no tool except the MCP tool `get_workspace_info` and the skill loader. Never read, search
+  or list files.
+- Copy names and tokens exactly as you see them. Never invent, guess or rename anything.
+
+Fill the output like this:
+1. `local_tools`: the name of every tool in your tool list that is not an MCP tool, such as file,
+   shell and web tools.
+2. `mcp_tools`: the name of every MCP tool in your tool list.
+3. `skills`: the name of every skill available to you. Load each skill, or read it where its text
+   is already in your instructions, and copy the `MARKER-` token it carries into `markers`.
+4. `markers`: every token of the form `MARKER-<WORDS>` you can see in your instructions, rules,
+   project notes and skills.
+5. `workspace_name`: call `get_workspace_info` and copy the `name` field of its result.
+6. `status`: `succeeded`. `summary`: one sentence on what you found.

--- a/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/rules/e2e-hidden-rule.md
+++ b/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/rules/e2e-hidden-rule.md
@@ -1,0 +1,1 @@
+This rule carries the token MARKER-RULE-HIDDEN. An agent asked for its markers reports it.

--- a/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/rules/e2e-visible-rule.md
+++ b/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/rules/e2e-visible-rule.md
@@ -1,0 +1,1 @@
+This rule carries the token MARKER-RULE-VISIBLE. An agent asked for its markers reports it.

--- a/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/skills/hidden-skill/SKILL.md
+++ b/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/skills/hidden-skill/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: hidden-skill
+description: Carries a marker token. Load it when asked to report the markers of your skills.
+---
+This skill carries the token MARKER-SKILL-HIDDEN. Copy it into `markers`.

--- a/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/skills/visible-skill/SKILL.md
+++ b/tests/workspace/cases/workspaces/agent_e2e_workspace/.claude/skills/visible-skill/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: visible-skill
+description: Carries a marker token. Load it when asked to report the markers of your skills.
+---
+This skill carries the token MARKER-SKILL-VISIBLE. Copy it into `markers`.

--- a/tests/workspace/cases/workspaces/agent_e2e_workspace/.dlt/.toolkits
+++ b/tests/workspace/cases/workspaces/agent_e2e_workspace/.dlt/.toolkits
@@ -1,0 +1,6 @@
+e2e:
+  version: 0.1.0
+  description: Fixtures the end-to-end agent tests run against
+  tags: []
+  installed_at: '2026-09-07T00:00:00+00:00'
+  agent: claude

--- a/tests/workspace/cases/workspaces/agent_e2e_workspace/CLAUDE.md
+++ b/tests/workspace/cases/workspaces/agent_e2e_workspace/CLAUDE.md
@@ -1,0 +1,3 @@
+# Workspace notes
+
+This workspace carries the token MARKER-CLAUDE-MD. An agent asked for its markers reports it.

--- a/tests/workspace/cases/workspaces/agent_e2e_workspace/e2e_agents.py
+++ b/tests/workspace/cases/workspaces/agent_e2e_workspace/e2e_agents.py
@@ -1,0 +1,57 @@
+"""Agent jobs the end-to-end tests run on real loops and real models."""
+
+import asyncio
+from typing import List
+
+from dlt.common.typing import Annotated, Doc
+
+from dlt.hub.run import TAgentOutput, TJobRunContext, agent
+
+self_report_md = agent("e2e:self-report", name="self_report_md")
+
+
+class SelfReport(TAgentOutput):
+    local_tools: Annotated[
+        List[str],
+        Doc("Name of every tool in your tool list that is not an MCP tool, copied verbatim."),
+    ]
+    mcp_tools: Annotated[
+        List[str], Doc("Name of every MCP tool in your tool list, copied verbatim.")
+    ]
+    skills: Annotated[List[str], Doc("Name of every skill available to you.")]
+    markers: Annotated[List[str], Doc("Every MARKER-<WORDS> token you were given, copied exactly.")]
+    workspace_name: Annotated[str, Doc("The `name` field `get_workspace_info` returned.")]
+
+
+@agent(
+    access={"local": ["read"]},
+    tools=["workspace"],
+    skills=["e2e:visible-skill"],
+    rules=["e2e:visible-rule"],
+    model="haiku",
+    limits={"max_turns": 12},
+)
+def self_report_py(run_context: TJobRunContext = None) -> SelfReport:
+    """Reports the tools, skills and rule markers it was given.
+
+    You are a self-report agent. Describe your own setup in the structured output and do nothing
+    else. This prompt carries the token MARKER-PROMPT-CONTROL.
+
+    Rules for this task:
+    - Use no tool except the MCP tool `get_workspace_info` and the skill loader. Never read,
+      search or list files.
+    - Copy names and tokens exactly as you see them. Never invent, guess or rename anything.
+
+    Fill the output like this:
+    1. `local_tools`: the name of every tool in your tool list that is not an MCP tool, such as
+       file, shell and web tools.
+    2. `mcp_tools`: the name of every MCP tool in your tool list.
+    3. `skills`: the name of every skill available to you. Load each skill, or read it where its
+       text is already in your instructions, and copy the `MARKER-` token it carries into
+       `markers`.
+    4. `markers`: every token of the form `MARKER-<WORDS>` you can see in your instructions,
+       rules, project notes and skills.
+    5. `workspace_name`: call `get_workspace_info` and copy the `name` field of its result.
+    6. `status`: `succeeded`. `summary`: one sentence on what you found.
+    """
+    return asyncio.run(run_context["ai_loop"].run())  # type: ignore[no-any-return]

--- a/tests/workspace/cases/workspaces/agent_workspace/.claude/dlthub/agents/job-inspector/AGENT.md
+++ b/tests/workspace/cases/workspaces/agent_workspace/.claude/dlthub/agents/job-inspector/AGENT.md
@@ -1,0 +1,53 @@
+---
+name: job-inspector
+description: Inspects a failed job run and reports a diagnosis.
+tools:
+  - telemetry
+skills:
+  - dlthub-platform:debug-deployment
+rules:
+  - dlthub-platform:job-resources
+access:
+  local:
+    - all
+  data:
+    - read
+  context:
+    - read
+inputs:
+  type: object
+  properties:
+    failed_run_id:
+      type: string
+      description: explicit run id of the job that failed
+      entity_type: job-run
+    failed_job_ref:
+      type: string
+      description: explicit job ref of the failed job
+      entity_type: job
+  required: {}
+output:
+  type: object
+  properties:
+    status:
+      enum: [succeeded, failed, aborted]
+      description: Outcome of the task.
+    summary:
+      type: string
+      description: Markdown describing what was accomplished.
+    classification:
+      enum: [config, code, unknown]
+  required: [status, summary]
+defaults:
+  model: sonnet
+  limits:
+    max_turns: 30
+    max_tokens: 1000000
+  loop_run_args:
+    retries: 1
+---
+
+You are a job inspector. Explain the failure; do not repair it.
+
+Investigate job_ref '{{ failed_job_ref }}' from trigger `{{ run_context.trigger }}`
+with failed run id '{{ failed_run_id }}'.

--- a/tests/workspace/cases/workspaces/agent_workspace/.claude/rules/dlthub-platform-job-resources.md
+++ b/tests/workspace/cases/workspaces/agent_workspace/.claude/rules/dlthub-platform-job-resources.md
@@ -1,0 +1,1 @@
+Resource changes are proposals, never applied automatically.

--- a/tests/workspace/cases/workspaces/agent_workspace/.claude/skills/debug-deployment/SKILL.md
+++ b/tests/workspace/cases/workspaces/agent_workspace/.claude/skills/debug-deployment/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: debug-deployment
+description: Debug a failing deployment.
+---
+Read the run record first.

--- a/tests/workspace/cases/workspaces/agent_workspace/.dlt/.toolkits
+++ b/tests/workspace/cases/workspaces/agent_workspace/.dlt/.toolkits
@@ -1,0 +1,6 @@
+dlthub-platform:
+  version: 0.2.0
+  description: Deploy dlthub workspace and pipelines
+  tags: []
+  installed_at: '2026-08-30T00:00:00+00:00'
+  agent: claude

--- a/tests/workspace/cases/workspaces/agent_workspace/__deployment__.py
+++ b/tests/workspace/cases/workspaces/agent_workspace/__deployment__.py
@@ -1,0 +1,13 @@
+"""Agent workspace deployment."""
+
+from agent_jobs import inspect_crash, inspector, tag_watcher, watcher
+from agent_batch_jobs import daily_ingest, transform
+
+__all__ = [
+    "daily_ingest",
+    "transform",
+    "inspect_crash",
+    "inspector",
+    "watcher",
+    "tag_watcher",
+]

--- a/tests/workspace/cases/workspaces/agent_workspace/agent_batch_jobs.py
+++ b/tests/workspace/cases/workspaces/agent_workspace/agent_batch_jobs.py
@@ -1,0 +1,16 @@
+"""Plain jobs the agent watcher observes."""
+
+from typing import Any, Dict
+
+from dlt.hub.run import job, result
+
+
+@job(trigger="0 8 * * *", expose={"tags": ["ingest"]})
+def daily_ingest() -> Dict[str, Any]:
+    """Ingest yesterday."""
+    return result({"rows": 10}, type="etl_summary")
+
+
+@job
+def transform() -> str:
+    return "transformed"

--- a/tests/workspace/cases/workspaces/agent_workspace/agent_jobs.py
+++ b/tests/workspace/cases/workspaces/agent_workspace/agent_jobs.py
@@ -1,0 +1,55 @@
+"""Agent jobs used by the deployment tests."""
+
+import signal
+from typing import Any, Dict
+
+import dlt
+from dlt.hub.run import TJobRunContext, agent
+
+import mock_loop  # noqa: F401
+from mock_loop import MOCK_LOOP
+
+
+def extend_inputs(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    """Adds an input the trigger did not carry."""
+    return {"failed_job_ref": inputs.get("failed_job_ref") or "jobs.batch.ingest"}
+
+
+@agent(
+    agent="dlthub-platform:job-inspector", loop=MOCK_LOOP, model="haiku", identity="ignored_for_now"
+)
+def inspect_crash(run_context: TJobRunContext = None) -> Dict[str, Any]:
+    """Drives the loop itself."""
+    return {"status": "succeeded", "summary": "drove the loop by hand"}
+
+
+@agent(agent="dlthub-platform:job-inspector", loop=MOCK_LOOP)
+def interval_aware(run_context: TJobRunContext = None) -> Dict[str, Any]:
+    """Reports what the launcher set up around the call."""
+    current = dlt.current.interval()
+    return {
+        "ctx_start": run_context["interval_start"].isoformat(),
+        "current_start": current[0].isoformat(),
+        "sigint_handler": signal.getsignal(signal.SIGINT),
+    }
+
+
+inspector = agent(
+    "dlthub-platform:job-inspector",
+    loop=MOCK_LOOP,
+    instructions="I expect incremental on github actions traces to generate dupes",
+    trigger="0 7 * * *",
+    require={"timezone": "Europe/Berlin"},
+    inputs_validator=extend_inputs,
+)
+
+watcher = agent(
+    "dlthub-platform:job-inspector", loop=MOCK_LOOP, name="watcher", trigger="job.fail:*"
+)
+
+tag_watcher = agent(
+    "dlthub-platform:job-inspector",
+    loop=MOCK_LOOP,
+    name="tag_watcher",
+    trigger="job.fail:tag:ingest",
+)

--- a/tests/workspace/cases/workspaces/agent_workspace/agent_launcher_jobs.py
+++ b/tests/workspace/cases/workspaces/agent_workspace/agent_launcher_jobs.py
@@ -1,0 +1,104 @@
+"""Agent jobs the launcher tests run. Not exported from `__deployment__`."""
+
+import asyncio
+from typing import Any, Dict, List, Literal
+
+import dlt
+from dlt.common.typing import NotRequired
+
+from dlt.hub.run import TAgentOutput, TAgentSpec, TJobRunContext, agent
+
+import mock_loop  # noqa: F401
+from mock_loop import MOCK_LOOP
+
+
+INLINE_AGENT: TAgentSpec = {
+    "name": "inline-inspector",
+    "description": "Declared in the deployment module instead of installed with a toolkit.",
+    "access": {"data": ["read"]},
+    "inputs": {
+        "type": "object",
+        "properties": {
+            "failed_run_id": {"type": "string"},
+            "depth": {"type": "integer"},
+        },
+        "required": ["failed_run_id"],
+    },
+    "output": {
+        "type": "object",
+        "properties": {"status": {"type": "string"}, "summary": {"type": "string"}},
+    },
+    "system_prompt": "You inspect runs. Inspect '{{ failed_run_id }}' at depth {{ depth }}.",
+}
+
+
+AGENT_REF = "dlthub-platform:job-inspector"
+
+inspector = agent(
+    AGENT_REF,
+    name="mock_inspector",
+    loop=MOCK_LOOP,
+    instructions="explain the failure",
+)
+
+
+@agent(agent=AGENT_REF, loop=MOCK_LOOP)
+def context_aware(run_context: TJobRunContext = None) -> Dict[str, Any]:
+    return {
+        "run_id": run_context["run_id"],
+        "trigger": run_context["trigger"],
+        "interval_start": run_context.get("interval_start"),
+        "run_args": run_context.get("run_args"),
+    }
+
+
+@agent(agent=AGENT_REF, loop=MOCK_LOOP)
+def no_context() -> str:
+    return "no_context_ok"
+
+
+@agent(agent=AGENT_REF, loop=MOCK_LOOP)
+async def async_job(run_context: TJobRunContext = None) -> str:
+    return "async_ok"
+
+
+inline = agent(INLINE_AGENT, loop=MOCK_LOOP)
+
+
+@agent(agent=AGENT_REF, loop=MOCK_LOOP)
+def driver(run_context: TJobRunContext = None) -> Dict[str, Any]:
+    """Drives the loop the launcher built for it."""
+    loop = run_context["ai_loop"]
+    return asyncio.run(loop.run(inputs={"failed_run_id": "r-driven"}))  # type: ignore[no-any-return]
+
+
+class CrashReport(TAgentOutput):
+    classification: Literal["config", "code", "upstream_data"]
+    confidence: Literal["high", "medium", "low"]
+    evidence: NotRequired[List[str]]
+
+
+@agent(
+    loop=MOCK_LOOP,
+    access={"data": ["read"], "context": ["read"]},
+    tools=["telemetry"],
+    model="haiku",
+)
+def python_inspector(
+    failed_run_id: str = dlt.config.value, depth: int = 2, run_context: TJobRunContext = None
+) -> CrashReport:
+    """Inspects a failed run without any AGENT.md.
+
+    You run unattended and report a diagnosis with evidence.
+    Investigate run '{{ failed_run_id }}' at depth {{ depth }}.
+    """
+    loop = run_context["ai_loop"]
+    return asyncio.run(  # type: ignore[no-any-return]
+        loop.run(inputs={"failed_run_id": failed_run_id, "depth": depth})
+    )
+
+
+@agent(loop=MOCK_LOOP, access={"data": "read", "context": "read"})
+def sanity_check(run_context: TJobRunContext = None) -> TAgentOutput:
+    """Sanity check agent. Lists the skills, tools and MCP tools it can see."""
+    return asyncio.run(run_context["ai_loop"].run())  # type: ignore[no-any-return]

--- a/tests/workspace/cases/workspaces/agent_workspace/mock_loop.py
+++ b/tests/workspace/cases/workspaces/agent_workspace/mock_loop.py
@@ -1,0 +1,96 @@
+"""Agent loop that records what the launcher gave it instead of calling a model.
+
+Registered on import so a launcher started with `python -m` resolves it too: the launcher
+imports the entry point module, and the job modules import this one.
+"""
+
+import os
+from typing import Any, ClassVar, Dict, Optional
+
+from dlt.common.configuration import plugins
+from dlt.common.configuration.container import Container
+from dlt.common.configuration.plugins import PluginContext
+
+from dlt._workspace._known_env import WORKSPACE__PROFILE
+from dlt._workspace.deployment.agent.loop import AgentLoop
+from dlt._workspace.deployment.agent.typing import TAgentSpec
+from dlt._workspace.deployment.agent.typing import TAgentLimits
+
+MOCK_LOOP = "mock-loop"
+PLUGIN_NAME = "mock-agent-loop"
+
+
+class MockLoop(AgentLoop):
+    LOOP_TYPE: ClassVar[str] = MOCK_LOOP
+    DEFAULT_MODEL: ClassVar[str] = "mock-model"
+    DEFAULT_MAX_TURNS: ClassVar[Optional[int]] = 5
+    DEFAULT_MAX_TOKENS: ClassVar[Optional[int]] = 1000
+    outcome: ClassVar[Dict[str, Any]] = {"status": "succeeded", "summary": "mock run"}
+
+    def __init__(self, settings: Any) -> None:
+        super().__init__(settings)
+        self._native: Optional[str] = None
+
+    @property
+    def native(self) -> Any:
+        return self._native
+
+    def init(self, agent_spec: TAgentSpec) -> None:
+        self.spec = agent_spec
+        self._system_prompt = agent_spec["system_prompt"]
+
+    async def run(
+        self,
+        instructions: Optional[str] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        model: Optional[str] = None,
+        limits: Optional[TAgentLimits] = None,
+        run_args: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        inputs = inputs or {}
+        self.resolve_run(model, limits, instructions)
+        self._native = f"mock-native:{self.model_id()}"
+        system_prompt = self.render_system_prompt(inputs)
+        # three pretend turns, counted through the base so the token limit applies here too
+        for _ in range(3):
+            self.count_tokens(40, 15)
+        self._trace = self._base_trace(inputs)
+        self._trace["turn_count"] = 3
+        self._trace["total_tokens"] = self.tokens_used
+        return {
+            **self.outcome,
+            "ran": {
+                "agent": self.spec["name"],
+                "model": self.model_id(),
+                "profile": os.environ.get(WORKSPACE__PROFILE),
+                "max_turns": self.settings["max_turns"],
+                "verbosity": self.settings["verbosity"],
+                "instructions": self.settings["instructions"],
+                "user_turn": self.user_turn,
+                "system_prompt": system_prompt,
+                "run_args": run_args,
+                "run_context": inputs.get("run_context"),
+            },
+        }
+
+
+class MockLoopPlugin:
+    @plugins.hookimpl(specname="plug_agent_loop")
+    def plug_agent_loop(self, loop_type: str) -> Any:
+        return MockLoop if loop_type == MOCK_LOOP else None
+
+
+def register() -> None:
+    """Adds the loop to the active plugin manager.
+
+    Replaces an earlier registration: each workspace copy imports this module afresh, and a
+    plugin left over from the previous copy would answer with that copy's class.
+    """
+    manager = Container()[PluginContext].manager
+    existing = manager.get_plugin(PLUGIN_NAME)
+    if existing is not None:
+        manager.unregister(existing, name=PLUGIN_NAME)
+    manager.register(MockLoopPlugin(), name=PLUGIN_NAME)
+
+
+register()

--- a/tests/workspace/cli/dlthub/ai/cases/mock_toolkit/agents/find-crash/AGENT.md
+++ b/tests/workspace/cli/dlthub/ai/cases/mock_toolkit/agents/find-crash/AGENT.md
@@ -1,0 +1,25 @@
+---
+name: find-crash
+description: Test agent used by the toolkit install tests.
+access:
+  local:
+    - read
+  data:
+    - read
+inputs:
+  type: object
+  properties: {}
+  required: {}
+output:
+  type: object
+  properties:
+    status:
+      enum: [succeeded, failed, aborted]
+      description: Outcome.
+    summary:
+      type: string
+      description: What happened.
+  required: [status, summary]
+---
+
+You are a test agent.

--- a/tests/workspace/cli/dlthub/ai/cases/mock_toolkit/agents/find-crash/crash_helper.py
+++ b/tests/workspace/cli/dlthub/ai/cases/mock_toolkit/agents/find-crash/crash_helper.py
@@ -1,0 +1,1 @@
+CRASH = "supporting file copied verbatim with the agent"

--- a/tests/workspace/cli/dlthub/ai/test_ai_agent.py
+++ b/tests/workspace/cli/dlthub/ai/test_ai_agent.py
@@ -23,11 +23,11 @@ def no_home_dir(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("variant_name", "expected_skill", "expected_command", "expected_rule"),
+    ("variant_name", "expected_skill", "expected_command", "expected_rule", "expected_agent"),
     [
-        ("claude", ".claude/skills", ".claude/commands", ".claude/rules"),
-        ("cursor", ".cursor/skills", ".cursor/commands", ".cursor/rules"),
-        ("codex", ".agents/skills", None, None),
+        ("claude", ".claude/skills", ".claude/commands", ".claude/rules", ".claude/dlthub/agents"),
+        ("cursor", ".cursor/skills", ".cursor/commands", ".cursor/rules", ".cursor/dlthub/agents"),
+        ("codex", ".agents/skills", None, None, ".agents/dlthub/agents"),
     ],
     ids=["claude", "cursor", "codex"],
 )
@@ -36,11 +36,14 @@ def test_variant_component_dir(
     expected_skill: str,
     expected_command: str,
     expected_rule: str,
+    expected_agent: str,
 ) -> None:
     project = Path("project")
     project.mkdir(exist_ok=True)
     variant = AI_AGENTS[variant_name]()
     assert variant.component_dir("skill", project) == project / expected_skill
+    # dlt agents sit apart from the host's native agents, which live in `<host>/agents`
+    assert variant.component_dir("agent", project) == project / expected_agent
 
     if expected_command is not None:
         assert variant.component_dir("command", project) == project / expected_command

--- a/tests/workspace/cli/dlthub/ai/test_ai_command_helpers.py
+++ b/tests/workspace/cli/dlthub/ai/test_ai_command_helpers.py
@@ -51,21 +51,21 @@ from tests.workspace.cli.dlthub.ai.utils import (
     [
         (
             _ClaudeAgent,
-            {"skill", "command", "rule", "ignore"},
+            {"skill", "command", "rule", "agent", "ignore"},
             ".claude/rules/test-toolkit-coding.md",
             lambda c: "alwaysApply" not in c and "# Coding Style" in c,
             ".claudeignore",
         ),
         (
             _CursorAgent,
-            {"skill", "command", "rule", "ignore"},
+            {"skill", "command", "rule", "agent", "ignore"},
             ".cursor/rules/test-toolkit-coding.mdc",
             lambda c: "alwaysApply: true" in c,
             ".cursorignore",
         ),
         (
             _CodexAgent,
-            {"skill", "ignore", "rule"},
+            {"skill", "agent", "ignore", "rule"},
             ".agents/skills/test-toolkit-coding/SKILL.md",
             lambda c: "Coding Style" in c,
             ".codexignore",
@@ -97,6 +97,15 @@ def test_toolkit_install_all_variants(
     skill_base = variant.component_dir("skill", project_root) / "find-source"
     assert (skill_base / "SKILL.md").exists()
     assert (skill_base / "helper.py").exists()
+
+    # agent dir is copied verbatim, supporting files included
+    agent_base = variant.component_dir("agent", project_root) / "find-crash"
+    assert (agent_base / "AGENT.md").exists()
+    assert (agent_base / "crash_helper.py").exists()
+    assert "You are a test agent." in (agent_base / "AGENT.md").read_text(encoding="utf-8")
+    # the host's own agents folder is left to its native subagents
+    assert agent_base.parent.parent.name == "dlthub"
+    assert not (agent_base.parents[2] / "agents").exists()
 
     # rule/converted-rule written with correct content
     rule_dest = project_root / rule_path
@@ -188,7 +197,8 @@ def test_toolkit_install_skip_existing() -> None:
     assert skill_action.conflict is True
 
     installed = _execute_install(actions)
-    assert installed == 3
+    # everything but the conflicting skill
+    assert installed == len(actions) - 1
     assert (existing_skill / "SKILL.md").read_text(encoding="utf-8") == "custom content"
 
 
@@ -445,7 +455,8 @@ def test_toolkit_install_overwrite() -> None:
     assert rule_action.conflict is False
 
     installed = _execute_install(actions, overwrite=True)
-    assert installed == 4
+    # overwrite clears the conflict, so every planned action runs
+    assert installed == len(actions)
     new_content = (rule_dest / "test-toolkit-coding.md").read_text(encoding="utf-8")
     assert new_content != "old content"
     assert "Coding Style" in new_content

--- a/tests/workspace/cli/dlthub/test_local_workspace_command.py
+++ b/tests/workspace/cli/dlthub/test_local_workspace_command.py
@@ -439,3 +439,35 @@ def test_is_destructive_local_op(
 
     _, _, args = _parse_dlthub(monkeypatch, argv)
     assert _is_destructive_local_op(args) is expected_destructive
+
+
+@pytest.mark.parametrize(
+    "argv,expected",
+    [
+        (["local", "run", "myjob"], None),
+        (["local", "-v", "run", "myjob"], 2),
+        (["local", "-v", "run", "myjob", "-c", "agent.verbosity=0"], "0"),
+    ],
+    ids=["default", "verbose", "explicit-wins"],
+)
+def test_dlthub_local_run_passes_verbosity_to_the_agent(
+    auto_isolated_workspace: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    argv: List[str],
+    expected: Any,
+) -> None:
+    """An agent watched from a terminal shows more of its run; `-c` still has the last word."""
+    from dlt._workspace.cli.dlthub import _local_workspace_command as local_command
+    from dlt._workspace.deployment import _run_helpers
+
+    seen: Dict[str, Any] = {}
+
+    def _fetch_run_info(**kwargs: Any) -> None:
+        seen.update(kwargs["cli_config"])
+        return None
+
+    monkeypatch.setattr(_run_helpers, "fetch_run_info", _fetch_run_info)
+    _, _, args = _parse_dlthub(monkeypatch, argv)
+    local_command.execute_run(args)
+
+    assert seen.get("agent", {}).get("verbosity") == expected

--- a/tests/workspace/cli/dlthub/test_run_views.py
+++ b/tests/workspace/cli/dlthub/test_run_views.py
@@ -1,19 +1,24 @@
-"""Unit tests for the unified run/serve banner, warnings, plan, and picker."""
+"""Unit tests for the unified run/serve banner, warnings, plan, picker and agent transcript."""
 
-from typing import Tuple
+import sys
+from typing import Any, List, Optional, Tuple, cast
 
+import click
 import pytest
 
 from dlt._workspace.cli import echo as fmt
-from dlt._workspace.deployment._run_typing import TRunBannerInfo, TRunJobInfo
+from dlt._workspace.deployment._run_typing import TAgentEvent, TRunBannerInfo, TRunJobInfo
 from dlt._workspace.deployment._run_views import (
+    emit_agent_event,
     pick_one_job,
+    print_agent_event,
     print_run_banner,
     print_run_plan,
     print_run_warnings,
 )
 from dlt._workspace.deployment.exceptions import AmbiguousJobSelector
 from dlt._workspace.deployment.typing import (
+    MANIFEST_ENGINE_VERSION,
     TEntryPoint,
     TExecuteSpec,
     TJobDefinition,
@@ -30,6 +35,7 @@ def _candidate(ref: str) -> Tuple[TJobDefinition, TTrigger]:
         "launcher": "dlt._workspace.deployment.launchers.job",
     }
     jd: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef(ref),
         "entry_point": entry,
         "triggers": [TTrigger(f"manual:{ref}")],
@@ -122,3 +128,91 @@ def test_pick_one_job(monkeypatch: pytest.MonkeyPatch, scenario: str) -> None:
     monkeypatch.setattr(fmt, "ALWAYS_CHOOSE_DEFAULT", True)
     with pytest.raises(AmbiguousJobSelector):
         pick_one_job(cands)
+
+
+def _agent_event(kind: str, **fields: Any) -> TAgentEvent:
+    return cast(TAgentEvent, {"kind": kind, "agent": "job-inspector", **fields})
+
+
+def test_print_agent_event_renders_the_transcript(capsys: pytest.CaptureFixture[str]) -> None:
+    """One assertion per kind: what a person watching the run must see."""
+    for event in [
+        _agent_event("start", model="claude-sonnet-5", limits="max 30 turns"),
+        _agent_event("prompt", text="Investigate run '89826ee6'."),
+        _agent_event("mcp", text="dlt-workspace-mcp connected"),
+        _agent_event("turn", turn=1, input_tokens=1204, output_tokens=340),
+        _agent_event("thinks", text="the run id is there"),
+        _agent_event("tool_call", tool="list_runs", server="dlt-workspace-mcp", detail={"n": 3}),
+        _agent_event("tool_result", tool="list_runs", detail="3 runs"),
+        _agent_event("says", text="The cursor produced duplicates."),
+        _agent_event(
+            "finish",
+            status="succeeded",
+            turn=3,
+            total_tokens=7955,
+            cost_usd=0.04,
+            tools=["Read"],
+            mcp_tools=["list_runs"],
+        ),
+    ]:
+        print_agent_event(event)
+    # colors are always on, so they are stripped to match the text
+    out = click.unstyle(capsys.readouterr().out)
+
+    assert "── job-inspector " in out and "claude-sonnet-5 · max 30 turns" in out
+    assert "prompt\n  Investigate run '89826ee6'." in out
+    assert "mcp  dlt-workspace-mcp connected" in out
+    assert "turn 1" in out and "1,204 in / 340 out" in out
+    assert "thinks  the run id is there" in out
+    assert "list_runs (dlt-workspace-mcp)" in out and '{"n":3}' in out
+    assert "→ 3 runs" in out
+    assert "says\n  The cursor produced duplicates." in out
+    assert "── succeeded " in out and "3 turns · 7,955 tokens · $0.04" in out
+    assert "tools: Read · mcp tools: list_runs" in out
+
+
+@pytest.mark.parametrize(
+    "verbosity,thinking,detail",
+    [(0, False, 80), (1, True, 200), (2, True, None)],
+    ids=["quiet", "default", "everything"],
+)
+def test_agent_verbosity_caps_thinking_and_detail(
+    capsys: pytest.CaptureFixture[str], verbosity: int, thinking: bool, detail: Optional[int]
+) -> None:
+    print_agent_event(_agent_event("thinks", text="t" * 500), verbosity)
+    print_agent_event(_agent_event("tool_result", tool="read", detail="r" * 500), verbosity)
+    out = capsys.readouterr().out
+
+    assert ("t" * 20 in out) is thinking
+    assert ("r" * 500 in out) is (detail is None)
+    if detail is not None:
+        assert f"{'r' * detail}…" in out
+
+
+def test_a_failing_tool_result_is_red(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+    print_agent_event(_agent_event("tool_result", tool="run_bash", detail="boom", error=True))
+    print_agent_event(_agent_event("tool_result", tool="run_bash", detail="fine"))
+    red, green = capsys.readouterr().out.splitlines()
+
+    assert fmt.style("→", fg="red") in red
+    assert fmt.style("→", fg="green") in green
+
+
+def test_agent_events_print_in_color_without_a_terminal(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A runner has no terminal, but its log viewer renders ANSI: the transcript keeps its colors."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
+    emit_agent_event(_agent_event("finish", status="succeeded", turn=3, total_tokens=7955))
+    out = capsys.readouterr().out
+    assert "3 turns · 7,955 tokens" in out
+    assert fmt.style("succeeded", fg="green") in out
+
+    # the one standard way to say no: https://no-color.org
+    monkeypatch.setenv("NO_COLOR", "1")
+    emit_agent_event(_agent_event("finish", status="succeeded", turn=3, total_tokens=7955))
+    assert "\x1b[" not in capsys.readouterr().out

--- a/tests/workspace/cli/dlthub/test_run_views.py
+++ b/tests/workspace/cli/dlthub/test_run_views.py
@@ -1,17 +1,18 @@
 """Unit tests for the unified run/serve banner, warnings, plan, picker and agent transcript."""
 
 import sys
-from typing import Any, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import click
 import pytest
+
+from dlt.common import known_env
 
 from dlt._workspace.cli import echo as fmt
 from dlt._workspace.deployment._run_typing import TAgentEvent, TRunBannerInfo, TRunJobInfo
 from dlt._workspace.deployment._run_views import (
     emit_agent_event,
     pick_one_job,
-    print_agent_event,
     print_run_banner,
     print_run_plan,
     print_run_warnings,
@@ -134,7 +135,7 @@ def _agent_event(kind: str, **fields: Any) -> TAgentEvent:
     return cast(TAgentEvent, {"kind": kind, "agent": "job-inspector", **fields})
 
 
-def test_print_agent_event_renders_the_transcript(capsys: pytest.CaptureFixture[str]) -> None:
+def test_emit_agent_event_renders_the_transcript(capsys: pytest.CaptureFixture[str]) -> None:
     """One assertion per kind: what a person watching the run must see."""
     for event in [
         _agent_event("start", model="claude-sonnet-5", limits="max 30 turns"),
@@ -155,8 +156,8 @@ def test_print_agent_event_renders_the_transcript(capsys: pytest.CaptureFixture[
             mcp_tools=["list_runs"],
         ),
     ]:
-        print_agent_event(event)
-    # colors are always on, so they are stripped to match the text
+        emit_agent_event(event)
+    # unstyled so the assertions hold under DLT_ECHO_FORCE_COLOR too
     out = click.unstyle(capsys.readouterr().out)
 
     assert "── job-inspector " in out and "claude-sonnet-5 · max 30 turns" in out
@@ -179,8 +180,8 @@ def test_print_agent_event_renders_the_transcript(capsys: pytest.CaptureFixture[
 def test_agent_verbosity_caps_thinking_and_detail(
     capsys: pytest.CaptureFixture[str], verbosity: int, thinking: bool, detail: Optional[int]
 ) -> None:
-    print_agent_event(_agent_event("thinks", text="t" * 500), verbosity)
-    print_agent_event(_agent_event("tool_result", tool="read", detail="r" * 500), verbosity)
+    emit_agent_event(_agent_event("thinks", text="t" * 500), verbosity)
+    emit_agent_event(_agent_event("tool_result", tool="read", detail="r" * 500), verbosity)
     out = capsys.readouterr().out
 
     assert ("t" * 20 in out) is thinking
@@ -192,27 +193,11 @@ def test_agent_verbosity_caps_thinking_and_detail(
 def test_a_failing_tool_result_is_red(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    monkeypatch.delenv(known_env.DLT_ECHO_NO_COLOR, raising=False)
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
-    print_agent_event(_agent_event("tool_result", tool="run_bash", detail="boom", error=True))
-    print_agent_event(_agent_event("tool_result", tool="run_bash", detail="fine"))
+    emit_agent_event(_agent_event("tool_result", tool="run_bash", detail="boom", error=True))
+    emit_agent_event(_agent_event("tool_result", tool="run_bash", detail="fine"))
     red, green = capsys.readouterr().out.splitlines()
 
     assert fmt.style("→", fg="red") in red
     assert fmt.style("→", fg="green") in green
-
-
-def test_agent_events_print_in_color_without_a_terminal(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """A runner has no terminal, but its log viewer renders ANSI: the transcript keeps its colors."""
-    monkeypatch.delenv("NO_COLOR", raising=False)
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: False, raising=False)
-    emit_agent_event(_agent_event("finish", status="succeeded", turn=3, total_tokens=7955))
-    out = capsys.readouterr().out
-    assert "3 turns · 7,955 tokens" in out
-    assert fmt.style("succeeded", fg="green") in out
-
-    # the one standard way to say no: https://no-color.org
-    monkeypatch.setenv("NO_COLOR", "1")
-    emit_agent_event(_agent_event("finish", status="succeeded", turn=3, total_tokens=7955))
-    assert "\x1b[" not in capsys.readouterr().out

--- a/tests/workspace/deployment/test_agent_e2e.py
+++ b/tests/workspace/deployment/test_agent_e2e.py
@@ -1,0 +1,148 @@
+"""Agent runs on real loops and real models: four model calls, run by `make test-workspace-agents`.
+
+The agent reports its own setup, and the test holds the report against what dlt wired: the
+local tools the access bought, the MCP tools the server kept, the declared skill, the declared
+rule's marker, and the result of one MCP tool call. Skipped when `jobs.agent.api_key` is not
+configured.
+"""
+
+import re
+from typing import Any, Iterable, Iterator, Set
+
+import pytest
+
+from dlt.common.configuration import resolve_configuration
+from dlt.common.json import json
+from dlt.common.utils import uniq_id
+
+from dlt._workspace.deployment.agent.typing import TAgentJobResult
+from dlt._workspace.deployment.configuration import AgentConfiguration
+from dlt._workspace.deployment.launchers import (
+    LAUNCHER_AGENT,
+    LOOP_CLAUDE_AGENT_SDK,
+    LOOP_PYDANTIC_AI,
+)
+from dlt._workspace.deployment.launchers.agent import run as agent_run
+from dlt._workspace.deployment.typing import TJobRef, TRuntimeEntryPoint
+
+from tests.workspace.utils import TEST_SETTINGS_DIR, importable_workspace
+
+JOBS_MODULE = "e2e_agents"
+READ_TOOLS = {"read", "glob", "grep"}
+SERVED_MCP_TOOLS = {"get_workspace_info", "list_profiles"}
+# what `local: read` does not buy, in the names the loops give the model
+UNGRANTED_TOOLS = {
+    "write",
+    "edit",
+    "multiedit",
+    "notebookedit",
+    "bash",
+    "bashoutput",
+    "killshell",
+    "powershell",
+    "runpython",
+    "webfetch",
+    "websearch",
+    "list_pipelines",
+}
+VISIBLE_MARKERS = {"MARKER-PROMPT-CONTROL", "MARKER-RULE-VISIBLE", "MARKER-SKILL-VISIBLE"}
+HIDDEN_MARKERS = {"MARKER-RULE-HIDDEN", "MARKER-SKILL-HIDDEN"}
+MARKER = re.compile(r"MARKER-[A-Z]+(?:-[A-Z]+)*")
+
+
+@pytest.fixture
+def workspace() -> Iterator[Any]:
+    # the test secrets stand in for `~/.dlt`, so the launcher resolves `jobs.agent.*` on its own
+    with importable_workspace(
+        "agent_e2e_workspace", JOBS_MODULE, global_dir=TEST_SETTINGS_DIR
+    ) as ctx:
+        if not resolve_configuration(AgentConfiguration(), sections=("jobs",)).effective_api_key:
+            pytest.skip("jobs.agent.api_key is not configured")
+        yield ctx
+
+
+def _entry(job: str, loop_type: str) -> TRuntimeEntryPoint:
+    return {
+        "module": JOBS_MODULE,
+        "function": job,
+        "job_type": "batch",
+        "launcher": LAUNCHER_AGENT,
+        "job_ref": TJobRef(f"jobs.{JOBS_MODULE}.{job}"),
+        "config": {"agent": {"loop": loop_type}},
+    }
+
+
+def _names(values: Iterable[str]) -> Set[str]:
+    """Names as the test compares them: lowercase, without an MCP server or toolkit prefix."""
+    return {str(v).strip().lower().rpartition("__")[2].rpartition(":")[2] for v in values}
+
+
+def _markers(values: Iterable[str]) -> Set[str]:
+    """The marker tokens in the report, however the model wrapped them."""
+    return set(MARKER.findall(" ".join(str(v) for v in values)))
+
+
+def _seen(output: TAgentJobResult) -> str:
+    """What the model said and did, for the message of a failing assertion."""
+    trace = output["trace"]
+    return json.dumps(
+        {
+            "summary": output.get("summary"),
+            "result": output.get("result"),
+            "tools_used": trace["tools_used"],
+            "mcp_tools_used": trace["mcp_tools_used"],
+            "turns": trace["turns"],
+        },
+        pretty=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "loop_type", [LOOP_PYDANTIC_AI, LOOP_CLAUDE_AGENT_SDK], ids=["pydantic-ai", "claude"]
+)
+@pytest.mark.parametrize(
+    "job,type_name",
+    [("self_report_md", "e2e:self-report"), ("self_report_py", f"{JOBS_MODULE}:self_report_py")],
+    ids=["md", "py"],
+)
+def test_agent_reports_what_dlt_wired(
+    workspace: Any, loop_type: str, job: str, type_name: str
+) -> None:
+    output = agent_run(_entry(job, loop_type), run_id=uniq_id(), trigger="manual:")
+    seen = _seen(output)
+    trace = output["trace"]
+    on_claude = loop_type == LOOP_CLAUDE_AGENT_SDK
+
+    assert output["status"] == "succeeded", seen
+    assert output["type"] == f"job.background_agent.{type_name}"
+    assert trace["loop_type"] == loop_type
+
+    # dlt's side: what `local: read` bought, and what the server was told to serve
+    read_tools = {"Read", "Glob", "Grep"} | ({"NotebookRead"} if on_claude else set())
+    assert trace["local_tools"] == {tool: "read" for tool in read_tools}
+    assert trace["mcp_features"] == ["workspace"]
+    assert trace["native_skills" if on_claude else "inlined_skills"] == ["e2e:visible-skill"]
+    # the task forbids the file tools: with them the hidden markers are one grep away
+    assert not _names(trace["tools_used"]) & (READ_TOOLS | UNGRANTED_TOOLS), seen
+    assert "get_workspace_info" in _names(trace["mcp_tools_used"]), seen
+    if on_claude:
+        # the skill's marker is behind the `Skill` tool, so reporting it means loading it
+        assert "visible-skill" in _names(trace["skills_used"]), seen
+
+    # the model's side: what it saw. On pydantic-ai nothing in a name tells an MCP tool from a
+    # local one, so the two buckets are read together; a tool the model never needed may go
+    # unlisted, a tool the server pruned must not appear
+    report = output["result"]
+    tools = _names(report["local_tools"]) | _names(report["mcp_tools"])
+    assert READ_TOOLS | {"get_workspace_info"} <= tools, seen
+    assert not UNGRANTED_TOOLS & tools, seen
+    if on_claude:
+        assert SERVED_MCP_TOOLS <= _names(report["mcp_tools"]), seen
+    skills = _names(report["skills"])
+    assert "visible-skill" in skills and "hidden-skill" not in skills, seen
+    markers = _markers(report["markers"])
+    assert VISIBLE_MARKERS <= markers, seen
+    assert not HIDDEN_MARKERS & markers, seen
+    # the CLI loads the project's `CLAUDE.md`; the other loop has no such file
+    assert ("MARKER-CLAUDE-MD" in markers) == on_claude, seen
+    assert report["workspace_name"] == workspace.name, seen

--- a/tests/workspace/deployment/test_agent_jobs.py
+++ b/tests/workspace/deployment/test_agent_jobs.py
@@ -1,0 +1,404 @@
+"""Tests for `run.agent`, agent job definitions, and the agent launcher."""
+
+import json as pyjson
+import os
+import sys
+from contextlib import contextmanager
+from typing import Any, ClassVar, Dict, Iterator, List, Optional, Tuple, cast
+
+import pytest
+
+from dlt.common.configuration import plugins
+from dlt.common.configuration.container import Container
+from dlt.common.configuration.plugins import PluginContext
+
+from dlt._workspace.deployment.agent.loop import AgentLoop
+from dlt._workspace.deployment.agent.typing import TAgentLimits, TAgentSpec
+from dlt._workspace.deployment.decorators import AgentJobFactory, agent
+from dlt._workspace.deployment.exceptions import (
+    InvalidJobName,
+    InvalidJobSchema,
+    JobAbortedException,
+)
+from dlt._workspace.deployment.launchers import (
+    DEFAULT_AGENT_LOOP,
+    LAUNCHER_AGENT,
+    agent_loop_group,
+)
+from dlt._workspace.deployment.launchers.agent import run as agent_run
+from dlt._workspace.deployment.manifest import manifest_from_module, validate_manifest
+from dlt._workspace.deployment.typing import TWorkspaceAccess, TJobRef, TRuntimeEntryPoint
+
+from tests.workspace.utils import beacon as beacon, drain_beacon, importable_workspace
+
+
+MOCK_LOOP = "mock-loop"
+
+
+def agent_workspace() -> Any:
+    """The agent workspace, which registers its mock loop when a job module imports it."""
+    return importable_workspace(
+        "agent_workspace", "__deployment__", "agent_jobs", "agent_batch_jobs", "mock_loop"
+    )
+
+
+def test_agent_decorator_dual_use() -> None:
+    """All three call shapes produce an AgentJobFactory."""
+
+    @agent
+    def bare(run_context: Any = None) -> Dict[str, Any]:
+        return {}
+
+    @agent(loop=MOCK_LOOP, model="haiku", identity="ignored")
+    def with_parens(run_context: Any = None) -> Dict[str, Any]:
+        return {}
+
+    declared = agent("dlthub-platform:job-inspector", loop=MOCK_LOOP)
+
+    for factory in (bare, with_parens, declared):
+        assert isinstance(factory, AgentJobFactory)
+        assert factory.launcher == LAUNCHER_AGENT
+
+    assert bare.loop == DEFAULT_AGENT_LOOP
+    assert (bare.is_declared, with_parens.is_declared, declared.is_declared) == (
+        False,
+        False,
+        True,
+    )
+    # the name comes off the function, or off the agent ref
+    assert (bare.name, with_parens.name, declared.name) == ("bare", "with_parens", "job_inspector")
+
+
+def test_identity_is_accepted_and_not_stored() -> None:
+    with agent_workspace():
+        import agent_jobs  # type: ignore[import-not-found] # noqa: F401
+
+        inspector = agent("dlthub-platform:job-inspector", identity="crash_inspector")
+        inspector.declare("agent_jobs", "inspector")
+        assert "identity" not in inspector.to_job_definition()
+    assert not hasattr(inspector, "identity")
+
+
+@pytest.mark.parametrize(
+    "ref,expected",
+    [
+        ("dlthub-platform:job-inspector", "job_inspector"),
+        ("dq-sentinel", "dq_sentinel"),
+        ("toolkit:multi-word-agent", "multi_word_agent"),
+    ],
+    ids=["toolkit-ref", "bare-name", "multi-word"],
+)
+def test_job_name_derived_from_agent_ref(ref: str, expected: str) -> None:
+    assert agent(ref).name == expected
+
+
+def test_non_identifier_agent_ref_is_rejected() -> None:
+    with pytest.raises(InvalidJobName):
+        agent("toolkit:9lives")
+
+
+def test_declared_agent_job_definition() -> None:
+    with agent_workspace():
+        manifest, _ = manifest_from_module("__deployment__")
+    jobs = {j["job_ref"]: j for j in manifest["jobs"]}
+    definition = jobs[TJobRef("jobs.__deployment__.job_inspector")]
+
+    entry = definition["entry_point"]
+    assert entry["launcher"] == LAUNCHER_AGENT
+    # the declaring module and the attribute name are stamped, so `function` is never None
+    assert entry["function"] == "inspector"
+    assert entry["job_type"] == "batch"
+    assert definition["expose"]["category"] == "background_agent"
+    # the loop reaches the runtime as the group that installs it
+    assert agent_loop_group(MOCK_LOOP) in definition["require"]["dependency_groups"]
+    # a requirement the user declared survives alongside it
+    assert definition["require"]["timezone"] == "Europe/Berlin"
+    # a declared job has no function, so the agent describes it
+    assert definition["description"] == "Inspects a failed job run and reports a diagnosis."
+    # the first entity-typed input tells the UI which entity's menu offers this job, and where
+    # the chosen entity goes
+    assert definition["expose"]["object_input"] == {
+        "entity_type": "job-run",
+        "input": "jobs.__deployment__.job_inspector.failed_run_id",
+    }
+
+
+def test_an_agent_job_declares_what_can_be_injected() -> None:
+    """Every agent job holds to the rule: `inputs` is `config_keys`, typed."""
+    with agent_workspace():
+        manifest, _ = manifest_from_module("__deployment__")
+        import agent_jobs
+
+        agent_jobs.inspect_crash.declare("agent_jobs", "inspect_crash")
+        driver = agent_jobs.inspect_crash.to_job_definition()
+
+    for job_def in manifest["jobs"]:
+        declared = set((job_def.get("inputs") or {}).get("properties") or {})
+        assert declared == set(job_def.get("config_keys") or []), job_def["job_ref"]
+
+    # a function driving a referenced agent takes none of its inputs, so the job offers none:
+    # its `AGENT.md` still declares them for the prompt, and dlt warns that nothing passes them
+    assert "config_keys" not in driver
+    assert "inputs" not in driver
+    assert set(driver["output"]["properties"]) >= {"status", "summary"}
+
+
+def test_agent_block_and_config_keys_reach_the_manifest() -> None:
+    """The declaration is read when the job definition is built, not when the loop runs."""
+    with agent_workspace():
+        import agent_jobs
+
+        agent_jobs.inspector.declare("agent_jobs", "inspector")
+        job_def = agent_jobs.inspector.to_job_definition()
+
+    agent_definition = job_def["agent"]
+    assert agent_definition["name"] == "job-inspector"
+    assert agent_definition["agent_file"].endswith(os.path.join("job-inspector", "AGENT.md"))
+    assert agent_definition["instructions"].startswith("I expect incremental")
+    assert "defaults" not in agent_definition
+    assert "system_prompt" not in agent_definition
+    # what the job may touch belongs to the job, not to the agent it runs
+    assert job_def["access"] == {
+        "local": ["all"],
+        "data": ["read"],
+        "context": ["read"],
+    }
+    assert "access" not in agent_definition
+    # the declared inputs are the job's configuration, and the job declares them
+    assert set(job_def["config_keys"]) == {"failed_run_id", "failed_job_ref"}
+    assert set(job_def["inputs"]["properties"]) == {"failed_run_id", "failed_job_ref"}
+    assert set(job_def["output"]["properties"]) >= {"status", "summary"}
+    assert "inputs" not in agent_definition
+    assert "output" not in agent_definition
+
+
+def test_manifest_with_agents_validates() -> None:
+    with agent_workspace():
+        manifest, _ = manifest_from_module("__deployment__")
+    result = validate_manifest(manifest)
+    assert result.is_valid, result.errors
+    assert result.unresolved_triggers == {}
+
+
+def test_only_an_agent_job_declares_access() -> None:
+    """`access` is a job field, but nothing except an agent fills it yet."""
+    with agent_workspace():
+        manifest, _ = manifest_from_module("__deployment__")
+    jobs = {j["job_ref"]: j for j in manifest["jobs"]}
+
+    assert jobs[TJobRef("jobs.__deployment__.job_inspector")]["access"] == {
+        "local": ["all"],
+        "data": ["read"],
+        "context": ["read"],
+    }
+    assert "access" not in jobs[TJobRef("jobs.agent_batch_jobs.transform")]
+
+
+def test_watcher_selector_expands_to_batch_jobs_only() -> None:
+    with agent_workspace():
+        manifest, _ = manifest_from_module("__deployment__")
+    jobs = {j["job_ref"]: j for j in manifest["jobs"]}
+    triggers = jobs[TJobRef("jobs.__deployment__.watcher")]["triggers"]
+    # every batch job is a target, including agent jobs that are not themselves watchers
+    assert triggers == [
+        "job.fail:jobs.agent_batch_jobs.daily_ingest",
+        "job.fail:jobs.agent_batch_jobs.transform",
+        "job.fail:jobs.agent_jobs.inspect_crash",
+        "job.fail:jobs.__deployment__.job_inspector",
+        "job.fail:jobs.__deployment__.tag_watcher",
+    ]
+    # a watcher never targets itself, so a failure cannot re-trigger the run that reported it
+    assert "job.fail:jobs.__deployment__.watcher" not in triggers
+    # the same grammar selects by tag: only the job carrying it
+    assert jobs[TJobRef("jobs.__deployment__.tag_watcher")]["triggers"] == [
+        "job.fail:jobs.agent_batch_jobs.daily_ingest"
+    ]
+    # nor the interactive dashboard, which has no batch completion to watch
+    assert not any("dashboard" in t for t in triggers)
+
+
+def _entry(function: str) -> TRuntimeEntryPoint:
+    """Entry point as the manifest records it: the deployment module and the attribute."""
+    return {
+        "module": "__deployment__",
+        "function": function,
+        "job_type": "batch",
+        "launcher": LAUNCHER_AGENT,
+        "job_ref": TJobRef(f"jobs.__deployment__.{function}"),
+    }
+
+
+def test_launcher_runs_a_declared_agent(beacon: List[Tuple[str, str]]) -> None:
+    with agent_workspace() as ctx:
+        ctx.runtime_config.dlthub_dsn = "https://beacon.example/token"
+        output = agent_run(_entry("inspector"), run_id="r-1", trigger="job.fail:jobs.b.ingest")
+        drain_beacon()
+
+    assert output["type"] == "job.background_agent.dlthub-platform:job-inspector"
+    assert output["status"] == "succeeded"
+    assert output["trace"]["turn_count"] == 3
+
+    body = pyjson.loads(beacon[-1][1])
+    assert "run_id" not in body
+    assert body["job_ref"] == "jobs.__deployment__.job_inspector"
+
+
+def test_inputs_validator_extends_the_inputs() -> None:
+    with agent_workspace():
+        output = agent_run(_entry("inspector"), run_id="r-2", trigger="manual:")
+    # the validator supplied a job ref the trigger did not carry
+    assert output["trace"]["inputs"]["failed_job_ref"] == "jobs.batch.ingest"
+    # the loop handle never reaches the trace: it is neither useful nor serializable there
+    assert "ai_loop" not in output["trace"]["inputs"]["run_context"]
+
+
+def test_aborted_agent_raises_after_delivering(beacon: List[Tuple[str, str]]) -> None:
+    with agent_workspace() as ctx:
+        import mock_loop  # type: ignore[import-not-found]
+
+        mock_loop.MockLoop.outcome = {
+            "status": "aborted",
+            "summary": "no failed run id could be resolved",
+        }
+        ctx.runtime_config.dlthub_dsn = "https://beacon.example/token"
+        with pytest.raises(JobAbortedException, match="no failed run id") as exc:
+            agent_run(_entry("inspector"), run_id="r-3", trigger="manual:")
+
+    assert exc.value.result["status"] == "aborted"  # type: ignore[typeddict-item]
+    # an abort ends the process, so the trace must already be on the wire
+    assert len(beacon) == 1
+    body = pyjson.loads(beacon[0][1])
+    assert body["status"] == "aborted"
+    assert "trace" in body
+
+
+def test_agent_launcher_shares_the_job_launcher_setup() -> None:
+    """Interval injection and signal interception come from the job launcher, not a copy of it."""
+    import signal
+
+    from dlt.common.runtime import signals
+
+    ep: TRuntimeEntryPoint = {
+        "module": "agent_jobs",
+        "function": "interval_aware",
+        "job_type": "batch",
+        "launcher": LAUNCHER_AGENT,
+        "job_ref": TJobRef("jobs.agent_jobs.interval_aware"),
+        "interval_start": "2024-01-15T00:00:00Z",
+        "interval_end": "2024-01-16T00:00:00Z",
+        "intercept_signals": False,
+    }
+    with agent_workspace():
+        result = agent_run(ep, run_id="iv-1", trigger="schedule:0 0 * * *")
+        assert result["ctx_start"].startswith("2024-01-15")
+        # dlt.current.interval() needs TimeIntervalContext, which only the job launcher injects
+        assert result["current_start"].startswith("2024-01-15")
+        # `intercept_signals=False` was ignored before the launchers were shared
+        assert result["sigint_handler"] is not signals._signal_receiver
+
+        ep["intercept_signals"] = True
+        intercepted = agent_run(ep, run_id="iv-2", trigger="schedule:0 0 * * *")
+        assert intercepted["sigint_handler"] is signals._signal_receiver
+        assert signal.getsignal(signal.SIGINT) is not signals._signal_receiver
+
+
+@pytest.mark.parametrize(
+    "argument,value",
+    [
+        ("inputs_validator", lambda inputs: inputs),
+        ("outputs_validator", lambda output: output),
+    ],
+    ids=["inputs_validator", "outputs_validator"],
+)
+def test_function_form_rejects_declared_agent_arguments(argument: str, value: Any) -> None:
+    """Only the launcher-driven form accepts these. On a function, dlt ignores them."""
+    with pytest.raises(TypeError, match=argument):
+
+        @agent(**{argument: value})
+        def driver(run_context: Any = None) -> Dict[str, Any]:
+            return {}
+
+    # the same arguments are accepted when an agent is named
+    assert agent("toolkit:inspector", **{argument: value}) is not None
+
+
+@pytest.mark.parametrize(
+    "argument,value",
+    [
+        ("interval", {"start": "2024-01-01"}),
+        ("freshness", "is_fresh"),
+        ("allow_external_schedulers", True),
+        ("refresh", "always"),
+    ],
+    ids=["interval", "freshness", "allow-external-schedulers", "refresh"],
+)
+def test_agent_does_not_take_interval_scheduling_arguments(argument: str, value: Any) -> None:
+    with pytest.raises(TypeError, match=argument):
+        agent("toolkit:inspector", **{argument: value})
+
+
+MINIMAL_AGENT: TAgentSpec = {
+    "name": "inline-agent",
+    "description": "d",
+    "access": {},
+    "inputs": {"type": "object", "properties": {"why": {"type": "string"}}},
+    "output": {"type": "object", "properties": {"status": {}, "summary": {}}},
+    "system_prompt": "Explain {{ why }}.",
+}
+
+
+def test_agent_is_named_by_reference_or_given_in_full() -> None:
+    """Both forms take either a `<toolkit>:<agent>` reference or a `TAgentSpec`."""
+    by_ref = agent("dlthub-platform:job-inspector", loop=MOCK_LOOP)
+    in_full = agent(MINIMAL_AGENT, loop=MOCK_LOOP)
+
+    @agent(agent="dlthub-platform:job-inspector", loop=MOCK_LOOP)
+    def driver(run_context: Any = None) -> Dict[str, Any]:
+        return {}
+
+    assert (by_ref.agent_ref, by_ref.agent_spec) == ("dlthub-platform:job-inspector", None)
+    assert in_full.agent_spec is MINIMAL_AGENT
+    # the job name comes off the agent name either way
+    assert (by_ref.name, in_full.name) == ("job_inspector", "inline_agent")
+    # a decorated function keeps its own body, and now has an agent to build a loop from
+    assert (driver.is_declared, driver.has_agent) == (False, True)
+
+
+def test_an_agent_declaring_no_access_still_states_it() -> None:
+    """`{}` is an answer: the job says it may touch nothing, rather than saying nothing."""
+    job = agent(MINIMAL_AGENT, loop=MOCK_LOOP, name="minimal")
+    job.declare(__name__, "minimal")
+    with agent_workspace():
+        assert job.to_job_definition()["access"] == {}
+
+
+def test_an_agent_without_a_description_leaves_the_job_without_one() -> None:
+    """A declared job takes its description from the agent, and an agent needs none."""
+    spec = {key: value for key, value in MINIMAL_AGENT.items() if key != "description"}
+    job = agent(cast(TAgentSpec, spec), loop=MOCK_LOOP, name="quiet")
+    job.declare(__name__, "quiet")
+    with agent_workspace():
+        job_def = job.to_job_definition()
+
+    assert "description" not in job_def
+    assert "description" not in job_def["agent"]
+
+
+def test_unknown_entity_type_fails_at_manifest_time() -> None:
+    """A typo in `entity_type` is refused when the manifest is built, not when a run finishes."""
+    spec = dict(MINIMAL_AGENT)
+    spec["inputs"] = {
+        "type": "object",
+        "properties": {"why": {"type": "string", "entity_type": "pipline"}},
+    }
+    job = agent(cast(TAgentSpec, spec), loop=MOCK_LOOP, name="typo")
+    job.declare(__name__, "typo")
+    with agent_workspace():
+        with pytest.raises(InvalidJobSchema, match="why: entity_type 'pipline'"):
+            job.to_job_definition()
+
+
+def test_agent_given_positionally_rejects_the_keyword() -> None:
+    """The overloads already refuse this; the runtime says so too."""
+    with pytest.raises(TypeError, match="positionally"):
+        agent("dlthub-platform:job-inspector", agent=MINIMAL_AGENT)  # type: ignore[call-overload]

--- a/tests/workspace/deployment/test_agent_launcher.py
+++ b/tests/workspace/deployment/test_agent_launcher.py
@@ -1,0 +1,438 @@
+"""Tests for the agent launcher, mirroring `test_launchers.py` for the job launcher.
+
+Every test selects the loop through configuration, which is how a user switches a job to
+another loop; parametrizing `loop_type` is what adds a real loop to the same coverage.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone  # noqa: I251
+from typing import Any, Dict, Iterator, List
+
+import pytest
+
+from dlt._workspace._known_env import WORKSPACE__PROFILE
+from dlt._workspace.deployment._run_helpers import build_runtime_entry_point
+from dlt._workspace.deployment.agent.loop import DEFAULT_USER_TURN
+from dlt._workspace.deployment.exceptions import JobResolutionError
+from dlt._workspace.deployment.launchers import LAUNCHER_AGENT
+from dlt._workspace.deployment.launchers.agent import run as agent_run
+from dlt._workspace.deployment.typing import TInstallSpec, TJobRef, TRuntimeEntryPoint
+from dlt.version import __version__
+
+from tests.workspace.utils import importable_workspace
+
+WORKSPACE_MODULES = (
+    "__deployment__",
+    "agent_jobs",
+    "agent_batch_jobs",
+    "agent_launcher_jobs",
+    "mock_loop",
+)
+JOBS_MODULE = "agent_launcher_jobs"
+_DLT_SPEC: TInstallSpec = {"name": "dlt", "extras": [], "version": __version__, "mode": "pypi"}
+
+
+@pytest.fixture(params=["mock-loop"], ids=["mock"])
+def loop_type(request: pytest.FixtureRequest) -> str:
+    """Loop the launcher runs the job on."""
+    return request.param
+
+
+@pytest.fixture
+def workspace() -> Iterator[Any]:
+    with importable_workspace("agent_workspace", *WORKSPACE_MODULES) as ctx:
+        yield ctx
+
+
+def _entry(
+    function: str, loop_type: str, agent_config: Dict[str, str] = None, **config: str
+) -> TRuntimeEntryPoint:
+    """Entry point whose `config` carries `-c` values, with the loop in the agent section."""
+    ep: TRuntimeEntryPoint = {
+        "module": JOBS_MODULE,
+        "function": function,
+        "job_type": "batch",
+        "launcher": LAUNCHER_AGENT,
+        "job_ref": TJobRef(f"jobs.{JOBS_MODULE}.{function}"),
+    }
+    ep["config"] = {"agent": {"loop": loop_type, **(agent_config or {})}, **config}
+    return ep
+
+
+def test_agent_launcher_runs_a_declared_agent(workspace: Any, loop_type: str) -> None:
+    """The launcher drives the loop and returns the agent job output."""
+    output = agent_run(_entry("inspector", loop_type), run_id="a-1", trigger="manual:")
+
+    # the category says which envelope this is, the name which agent produced the payload
+    assert output["type"] == "job.background_agent.dlthub-platform:job-inspector"
+    assert "agent" not in output
+    assert output["status"] == "succeeded"
+    assert output["job_ref"] == "jobs.agent_launcher_jobs.mock_inspector"
+    assert output["trace"]["loop_type"] == loop_type
+    # the decorator's instructions open the run as its user turn
+    assert output["result"]["ran"]["user_turn"] == "explain the failure"
+
+
+def test_agent_launcher_run_context_injection(workspace: Any, loop_type: str) -> None:
+    """A decorated function receives run_id and trigger, like any other job."""
+    ep = _entry("context_aware", loop_type)
+    ep["run_args"] = {"depth": 2}  # type: ignore[typeddict-unknown-key]
+    result = agent_run(ep, run_id="a-ctx", trigger="job.fail:jobs.b.ingest")
+
+    assert result["run_id"] == "a-ctx"
+    assert result["trigger"] == "job.fail:jobs.b.ingest"
+    assert result["run_args"] == {"depth": 2}
+
+
+def test_agent_launcher_run_context_not_injected(workspace: Any, loop_type: str) -> None:
+    """A function that does not declare `run_context` is called without it."""
+    assert (
+        agent_run(_entry("no_context", loop_type), run_id="a-2", trigger="manual:")
+        == "no_context_ok"
+    )
+
+
+def test_agent_launcher_awaits_coroutines(workspace: Any, loop_type: str) -> None:
+    assert agent_run(_entry("async_job", loop_type), run_id="a-3", trigger="manual:") == "async_ok"
+
+
+def test_agent_launcher_interval_injection(workspace: Any, loop_type: str) -> None:
+    """Interval parsing is the job launcher's, so an agent job gets it too."""
+    ep = _entry("context_aware", loop_type)
+    ep["interval_start"] = "2024-01-15T00:00:00Z"
+    ep["interval_end"] = "2024-01-16T00:00:00Z"
+    result = agent_run(ep, run_id="a-iv", trigger="schedule:0 0 * * *")
+
+    assert result["interval_start"] == datetime(2024, 1, 15, tzinfo=timezone.utc)
+
+
+def test_agent_launcher_profile_injection(workspace: Any, loop_type: str) -> None:
+    """The profile the runtime picked reaches the loop, which hands it to the agent."""
+    old = os.environ.pop(WORKSPACE__PROFILE, None)
+    try:
+        ep = _entry("inspector", loop_type)
+        ep["profile"] = "access"
+        output = agent_run(ep, run_id="a-prof", trigger="manual:")
+        assert output["result"]["ran"]["profile"] == "access"
+        assert os.environ[WORKSPACE__PROFILE] == "access"
+    finally:
+        if old is not None:
+            os.environ[WORKSPACE__PROFILE] = old
+        else:
+            os.environ.pop(WORKSPACE__PROFILE, None)
+
+
+def test_agent_launcher_with_config(workspace: Any, loop_type: str) -> None:
+    """`entry_point.config` reaches `AgentConfiguration`, which outranks the declaration."""
+    ep = _entry("inspector", loop_type, {"model": "opus", "max_turns": "11"})
+    output = agent_run(ep, run_id="a-cfg", trigger="manual:")
+
+    ran = output["result"]["ran"]
+    assert ran["model"] == "anthropic:claude-opus-5"
+    assert ran["max_turns"] == 11
+    assert output["trace"]["model"] == "anthropic:claude-opus-5"
+
+
+def test_agent_verbosity_comes_from_config(workspace: Any, loop_type: str) -> None:
+    """`-c agent.verbosity=2` decides how much of the run reaches the console."""
+    ep = _entry("inspector", loop_type, {"verbosity": "2"})
+    output = agent_run(ep, run_id="a-verbose", trigger="manual:")
+
+    assert output["result"]["ran"]["verbosity"] == 2
+
+
+def test_agent_launcher_unknown_loop(workspace: Any) -> None:
+    from dlt._workspace.deployment.agent.exceptions import UnknownAgentLoop
+
+    with pytest.raises(UnknownAgentLoop):
+        agent_run(_entry("inspector", "no-such-loop"), run_id="a-4", trigger="manual:")
+
+
+def test_agent_launcher_function_not_found(workspace: Any, loop_type: str) -> None:
+    with pytest.raises(JobResolutionError):
+        agent_run(_entry("nonexistent", loop_type), run_id="a-5", trigger="manual:")
+
+
+def test_agent_launcher_module_not_found(loop_type: str) -> None:
+    ep = _entry("inspector", loop_type)
+    ep["module"] = "no.such.module"
+    with pytest.raises(JobResolutionError):
+        agent_run(ep, run_id="a-6", trigger="manual:")
+
+
+def test_agent_launcher_requires_function(loop_type: str) -> None:
+    ep = _entry("inspector", loop_type)
+    ep["function"] = None
+    with pytest.raises(JobResolutionError, match="entry_point.function"):
+        agent_run(ep, run_id="a-7", trigger="manual:")
+
+
+def test_agent_launcher_rejects_a_plain_job(workspace: Any, loop_type: str) -> None:
+    """The agent launcher is only for `run.agent` jobs."""
+    ep = _entry("transform", loop_type)
+    ep["module"] = "agent_batch_jobs"
+    with pytest.raises(JobResolutionError, match="AgentJobFactory"):
+        agent_run(ep, run_id="a-8", trigger="manual:")
+
+
+def test_agent_launcher_via_cli(workspace: Any, loop_type: str) -> None:
+    """`python -m` on the agent launcher prints the rendered job output."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "dlt._workspace.deployment.launchers.agent",
+            "--run-id",
+            "a-cli",
+            "--trigger",
+            "manual:",
+            "--entry-point",
+            json.dumps(_entry("inspector", loop_type)),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=workspace.run_dir,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "job.background_agent." in result.stdout
+    assert "succeeded" in result.stdout
+    assert "mock run" in result.stdout
+
+
+def test_agent_launcher_cli_error_exit_code(workspace: Any, loop_type: str) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "dlt._workspace.deployment.launchers.agent",
+            "--run-id",
+            "a-cli-err",
+            "--trigger",
+            "manual:",
+            "--entry-point",
+            json.dumps(_entry("nonexistent", loop_type)),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=workspace.run_dir,
+    )
+    assert result.returncode != 0
+
+
+def test_decorator_to_launcher_e2e(workspace: Any, loop_type: str) -> None:
+    """The manifest's own entry point runs: what `dlthub local run` hands the launcher."""
+    import agent_launcher_jobs  # type: ignore[import-not-found]
+
+    # the manifest generator stamps the module a declared agent was found in
+    agent_launcher_jobs.inspector.declare(JOBS_MODULE, "inspector")
+    job_def = agent_launcher_jobs.inspector.to_job_definition()
+    assert job_def["expose"]["category"] == "background_agent"
+
+    ep = build_runtime_entry_point(
+        job_def,
+        cli_config={"agent": {"loop": loop_type}},
+        profile="access",
+        refresh=False,
+        interval_start=datetime(2024, 1, 15, tzinfo=timezone.utc),
+        interval_end=datetime(2024, 1, 16, tzinfo=timezone.utc),
+        dlt_version=_DLT_SPEC,
+        tz="UTC",
+    )
+    output = agent_run(ep, run_id="a-e2e", trigger="manual:")
+
+    assert output["status"] == "succeeded"
+    assert output["result"]["ran"]["profile"] == "access"
+    assert output["trace"]["agent"] == "dlthub-platform:job-inspector"
+
+
+def test_declared_agent_runs_as_a_plain_call(workspace: Any, loop_type: str) -> None:
+    """Calling the factory outside a launcher runs the same agent."""
+    env_key = "JOBS__AGENT_LAUNCHER_JOBS__MOCK_INSPECTOR__AGENT__LOOP"
+    os.environ[env_key] = loop_type
+    try:
+        import agent_launcher_jobs
+
+        output: Dict[str, Any] = agent_launcher_jobs.inspector(failed_job_ref="jobs.b.ingest")
+    finally:
+        os.environ.pop(env_key, None)
+
+    assert output["status"] == "succeeded"
+    assert output["result"]["ran"]["run_context"]["run_id"] == "local"
+
+
+def test_declared_inputs_come_from_config(workspace: Any, loop_type: str) -> None:
+    """`-c failed_run_id=...` fills a declared input, as it fills a function job's argument."""
+    ep = _entry("inspector", loop_type, failed_run_id="r-42")
+    output = agent_run(ep, run_id="a-in", trigger="manual:")
+
+    inputs = output["trace"]["inputs"]
+    assert inputs["failed_run_id"] == "r-42"
+    # a declared input nobody supplied stays absent, and renders blank in the prompt
+    assert "failed_job_ref" not in inputs
+
+
+def test_instructions_are_the_user_turn(workspace: Any, loop_type: str) -> None:
+    """`agent.instructions` is what a person tells the agent to do, and configuration wins."""
+    ep = _entry("inspector", loop_type, {"instructions": "focus on the loader step"})
+    output = agent_run(ep, run_id="a-instr", trigger="manual:")
+
+    ran = output["result"]["ran"]
+    # the decorator declared "explain the failure"; this run says otherwise
+    assert ran["user_turn"] == "focus on the loader step"
+    assert output["trace"]["instructions"] == "focus on the loader step"
+    # and the task itself stays in the system prompt, rendered against the inputs
+    assert "You are a job inspector" in ran["system_prompt"]
+
+
+def test_the_body_carries_the_inputs_to_the_model(workspace: Any, loop_type: str) -> None:
+    """Placeholders in the body are substituted with what configuration and the trigger gave."""
+    ep = _entry("inspector", loop_type, failed_run_id="r-42")
+    output = agent_run(ep, run_id="a-body", trigger="job.fail:jobs.b.ingest")
+
+    system_prompt = output["result"]["ran"]["system_prompt"]
+    assert "with failed run id 'r-42'" in system_prompt
+    assert "from trigger `job.fail:jobs.b.ingest`" in system_prompt
+    # an input nobody supplied renders blank, and the trace says which
+    assert "job_ref ''" in system_prompt
+    assert output["trace"]["unresolved_placeholders"] == ["failed_job_ref"]
+
+
+def test_run_args_fill_declared_inputs(workspace: Any, loop_type: str) -> None:
+    ep = _entry("inspector", loop_type, failed_run_id="r-42")
+    ep["run_args"] = {"failed_run_id": "r-99"}  # type: ignore[typeddict-unknown-key]
+    output = agent_run(ep, run_id="a-in2", trigger="job.fail:jobs.b.ingest")
+
+    assert output["trace"]["inputs"]["failed_run_id"] == "r-99"
+
+
+@pytest.mark.parametrize(
+    "pairs,expected",
+    [
+        (["failed_run_id=r-42"], {"failed_run_id": "r-42"}),
+        # a dotted key addresses a config section, as it does everywhere else in dlt
+        (["agent.model=opus"], {"agent": {"model": "opus"}}),
+        (
+            ["agent.model=opus", "agent.max_turns=11", "failed_run_id=r-42"],
+            {"agent": {"model": "opus", "max_turns": "11"}, "failed_run_id": "r-42"},
+        ),
+        (["url=https://example.com/a=b"], {"url": "https://example.com/a=b"}),
+    ],
+    ids=["flat", "sectioned", "mixed", "value-with-equals"],
+)
+def test_cli_config_args_nest_on_dots(pairs: List[str], expected: Dict[str, Any]) -> None:
+    from dlt._workspace.cli.dlthub._local_workspace_command import _parse_config_args
+
+    assert _parse_config_args(pairs) == expected
+
+
+def test_cli_config_reaches_the_agent_configuration(workspace: Any, loop_type: str) -> None:
+    """`-c agent.model=opus` must land as `JOBS__..__AGENT__MODEL`, not a dotted env name."""
+    from dlt._workspace.cli.dlthub._local_workspace_command import _parse_config_args
+
+    ep = _entry("inspector", loop_type)
+    ep["config"].update(_parse_config_args(["agent.model=opus", "failed_run_id=r-7"]))
+    output = agent_run(ep, run_id="a-cli-cfg", trigger="manual:")
+
+    assert output["result"]["ran"]["model"] == "anthropic:claude-opus-5"
+    assert output["trace"]["inputs"]["failed_run_id"] == "r-7"
+    # the input is declared `entity_type: job-run`, so the run says which run it acted on
+    assert output["object"] == [{"type": "job-run", "id": "job-run/r-7"}]
+
+
+def test_function_form_drives_the_loop_the_launcher_built(workspace: Any, loop_type: str) -> None:
+    """`@run.agent(agent=...)` names the agent, so the function gets a loop in its run context."""
+    output = agent_run(_entry("driver", loop_type), run_id="a-drv", trigger="manual:")
+
+    # the function drives an installed agent definition, so that definition names the result
+    assert output["type"] == "job.background_agent.dlthub-platform:job-inspector"
+    assert output["result"]["ran"]["agent"] == "driver"
+    assert output["trace"]["inputs"] == {"failed_run_id": "r-driven"}
+
+
+def test_agent_declared_inline_runs_like_a_referenced_one(workspace: Any, loop_type: str) -> None:
+    ep = _entry("inline", loop_type, failed_run_id="r-inline", depth="3")
+    output = agent_run(ep, run_id="a-inline", trigger="manual:")
+
+    assert output["type"] == "job.background_agent.inline-inspector"
+    inputs = output["trace"]["inputs"]
+    # the declared type is applied, so `depth` arrives as an int
+    assert (inputs["failed_run_id"], inputs["depth"]) == ("r-inline", 3)
+
+
+def test_required_input_missing_from_config_fails_the_run(workspace: Any, loop_type: str) -> None:
+    """A required input is a required job argument: the run fails instead of prompting blank."""
+    from dlt.common.configuration.exceptions import ConfigFieldMissingException
+
+    with pytest.raises(ConfigFieldMissingException, match="failed_run_id"):
+        agent_run(_entry("inline", loop_type), run_id="a-req", trigger="manual:")
+
+
+def test_agent_declared_by_a_python_function(workspace: Any, loop_type: str) -> None:
+    """The signature is the inputs, the return type the output, the docstring the system prompt."""
+    ep = _entry("python_inspector", loop_type, failed_run_id="r-77")
+    ep["run_args"] = {"depth": 5}  # type: ignore[typeddict-unknown-key]
+    output = agent_run(ep, run_id="a-py", trigger="manual:")
+
+    # no AGENT.md behind it: the function itself is the agent definition, named module:function
+    assert output["type"] == "job.background_agent.agent_launcher_jobs:python_inspector"
+    # config filled the parameter, the trigger's run args filled the other
+    assert output["trace"]["inputs"] == {"failed_run_id": "r-77", "depth": 5}
+    ran = output["result"]["ran"]
+    assert ran["agent"] == "python_inspector"
+    assert ran["model"] == "anthropic:claude-haiku-4-5"
+
+
+def test_python_agent_reaches_the_manifest(workspace: Any) -> None:
+    import agent_launcher_jobs
+
+    agent_launcher_jobs.python_inspector.declare(JOBS_MODULE, "python_inspector")
+    job_def = agent_launcher_jobs.python_inspector.to_job_definition()
+    declaration = job_def["agent"]
+
+    assert declaration["name"] == "python_inspector"
+    assert declaration["description"] == "Inspects a failed run without any AGENT.md."
+    assert declaration["agent_file"] == "agent_launcher_jobs.py:python_inspector"
+    assert declaration["tools"] == ["telemetry"]
+    # what the job may touch belongs to the job, not to the agent it runs
+    assert job_def["access"] == {"data": ["read"], "context": ["read"]}
+    assert "access" not in declaration
+    # the signature is the job configuration, exactly as a function job's parameters are
+    assert {"failed_run_id", "depth"} <= set(job_def["config_keys"])
+
+    # what the job takes and returns belongs to the job too, at the same resolution as config_keys
+    assert "inputs" not in declaration
+    assert "output" not in declaration
+    inputs = job_def["inputs"]
+    assert set(inputs["properties"]) == set(job_def["config_keys"]) == {"failed_run_id", "depth"}
+    assert inputs["required"] == ["failed_run_id"]
+    # the docstring is the system prompt, and the manifest never carries it
+    assert "system_prompt" not in declaration
+
+    output = job_def["output"]
+    # status and summary are inherited; the launcher's own keys never reach the model
+    assert set(output["properties"]) == {
+        "status",
+        "summary",
+        "classification",
+        "confidence",
+        "evidence",
+    }
+    assert output["properties"]["status"]["enum"] == ["succeeded", "failed", "aborted"]
+    assert set(output["required"]) == {"status", "summary", "classification", "confidence"}
+
+
+def test_agent_with_no_inputs(workspace: Any, loop_type: str) -> None:
+    """The minimum an agent needs: a docstring and a result. `loop.run()` takes nothing."""
+    output = agent_run(_entry("sanity_check", loop_type), run_id="a-sanity", trigger="manual:")
+
+    assert output["status"] == "succeeded"
+    # a single verb is accepted where a list is
+    assert output["trace"]["access"] == {"data": ["read"], "context": ["read"]}
+    # nobody gave instructions, so the run opens with the go-signal
+    assert output["trace"]["inputs"] == {}
+    assert output["result"]["ran"]["user_turn"] == DEFAULT_USER_TURN

--- a/tests/workspace/deployment/test_agent_loop.py
+++ b/tests/workspace/deployment/test_agent_loop.py
@@ -1,0 +1,1067 @@
+"""Tests for the agent loop abstraction, its plugin hook, and settings resolution."""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, TypeVar, cast
+
+import click
+import pytest
+from claude_agent_sdk import ProcessError
+from pydantic_ai import ModelRetry, ToolFailed, capture_run_messages
+from pydantic_ai.exceptions import UnexpectedModelBehavior
+from pydantic_ai.messages import (
+    FunctionToolResultEvent,
+    ModelResponse,
+    PartEndEvent,
+    TextPart,
+    ThinkingPart,
+    ToolCallPart,
+    ToolReturnPart,
+)
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from dlt.common import json, logger
+from dlt.common.configuration import resolve_configuration
+from dlt.common.configuration.providers import EnvironProvider
+
+from dlt._workspace.deployment.agent.exceptions import (
+    AgentRunFailed,
+    AgentTokenLimitExceeded,
+    AgentTraceNotAvailable,
+    UnknownAgentLoop,
+    UnsupportedAgentModel,
+)
+from dlt._workspace.deployment.agent.loop import (
+    AgentLoop,
+    DEFAULT_USER_TURN,
+    split_model_id,
+    resolve_agent_loop,
+    resolve_agent_settings,
+    resolve_loop_type,
+)
+from dlt._workspace.deployment.agent.loops import claude_sdk
+from dlt._workspace.deployment.agent.loops.claude_sdk import (
+    AI_LOOP_TOOLS,
+    MCP_TOOL_PATTERN,
+    RULES_EXCLUDES,
+    ClaudeAgentSdkLoop,
+    classify_tool,
+)
+from dlt._workspace.deployment.agent.loops.pydantic_ai import PydanticAILoop, make_local_tools
+from dlt._workspace.deployment.agent.loops.tools import (
+    MCP_SERVER_ID,
+    SHELL_TOOL,
+    LocalTools,
+    temp_dir,
+)
+from dlt._workspace.deployment.agent.manifest import load_agent_spec, resolve_agent_dir
+from dlt._workspace.deployment.agent.typing import TAgentSpec
+from dlt._workspace.deployment.configuration import AgentConfiguration
+from dlt._workspace.deployment.launchers import (
+    DEFAULT_AGENT_LOOP,
+    LOOP_CLAUDE_AGENT_SDK,
+    LOOP_PYDANTIC_AI,
+)
+from dlt._workspace.deployment.typing import TWorkspaceAccess
+
+from tests.utils import init_test_logging, inject_providers
+from tests.workspace.utils import importable_workspace
+
+TLoop = TypeVar("TLoop", bound=AgentLoop)
+
+
+@pytest.fixture
+def dlt_logger_name() -> Iterator[str]:
+    """Name of the initialized dlt logger, made to propagate so `caplog` sees it.
+
+    Inside a workspace the logger is named after the workspace, not `dlt`.
+    """
+    init_test_logging()
+    dlt_logger = logging.getLogger(logger.LOGGER.name)
+    previous = dlt_logger.propagate
+    dlt_logger.propagate = True
+    try:
+        yield dlt_logger.name
+    finally:
+        dlt_logger.propagate = previous
+
+
+@pytest.fixture
+def workspace() -> Iterator[Any]:
+    with importable_workspace("agent_workspace", "mock_loop") as ctx:
+        yield ctx
+
+
+@pytest.fixture
+def loop_cls(workspace: Any) -> Type[AgentLoop]:
+    """The loop the workspace registers on import, as a plugin would."""
+    import mock_loop  # type: ignore[import-not-found]
+
+    return mock_loop.MockLoop
+
+
+def _spec(run_dir: str) -> TAgentSpec:
+    return load_agent_spec(resolve_agent_dir("dlthub-platform:job-inspector", run_dir))
+
+
+def _bare_spec(**extra: Any) -> TAgentSpec:
+    """An agent definition declaring nothing beyond what the contract requires."""
+    spec: TAgentSpec = {
+        "name": "bare",
+        "description": "d",
+        "access": {},
+        "inputs": {"type": "object", "properties": {}, "prompt": ""},
+        "output": {},
+        "system_prompt": "b",
+    }
+    spec.update(cast(Any, extra))
+    return spec
+
+
+def _config(**overrides: Any) -> AgentConfiguration:
+    config = AgentConfiguration()
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _loop(
+    workspace: Any,
+    loop_cls: Type[TLoop],
+    config: Optional[AgentConfiguration] = None,
+    decorator_args: Optional[Dict[str, Any]] = None,
+    **spec_overrides: Any,
+) -> TLoop:
+    """A loop initialized with the job-inspector definition, as the launcher builds one."""
+    spec = _spec(workspace.run_dir)
+    spec.update(cast(Any, spec_overrides))
+    settings = resolve_agent_settings(
+        spec, config or _config(), decorator_args or {}, loop_cls, workspace.run_dir
+    )
+    loop = loop_cls(settings)
+    loop.init(spec)
+    return loop
+
+
+def _resolve_agent_config() -> AgentConfiguration:
+    """The job's agent config from the environment alone, so a developer's own secrets stay out."""
+    with inject_providers([EnvironProvider()]):
+        return resolve_configuration(AgentConfiguration(), sections=("jobs", "ops", "inspector"))
+
+
+def test_resolve_agent_loop_knows_builtins_and_plugins(loop_cls: Type[AgentLoop]) -> None:
+    assert resolve_agent_loop(LOOP_PYDANTIC_AI).LOOP_TYPE == LOOP_PYDANTIC_AI
+    assert resolve_agent_loop(LOOP_CLAUDE_AGENT_SDK).LOOP_TYPE == LOOP_CLAUDE_AGENT_SDK
+    # a plugin answers only for the names it implements, so the builtins still resolve
+    assert resolve_agent_loop(loop_cls.LOOP_TYPE) is loop_cls
+
+
+def test_unknown_loop_names_the_builtins() -> None:
+    with pytest.raises(UnknownAgentLoop, match=LOOP_PYDANTIC_AI):
+        resolve_agent_loop("no-such-loop")
+
+
+@pytest.mark.parametrize(
+    "decorator_loop,config_loop,expected",
+    [
+        (None, None, DEFAULT_AGENT_LOOP),
+        ("mock-loop", None, "mock-loop"),
+        ("mock-loop", LOOP_CLAUDE_AGENT_SDK, LOOP_CLAUDE_AGENT_SDK),
+    ],
+    ids=["default", "decorator", "config-wins"],
+)
+def test_resolve_loop_type(
+    decorator_loop: Optional[str], config_loop: Optional[str], expected: str
+) -> None:
+    assert resolve_loop_type(decorator_loop, _config(loop=config_loop)) == expected
+
+
+def test_settings_precedence_rises_to_config(workspace: Any, loop_cls: Type[AgentLoop]) -> None:
+    """loop default < AGENT.md defaults < decorator argument < resolved config."""
+    # a definition declaring no defaults gets the loop's
+    settings = resolve_agent_settings(_bare_spec(), _config(), {}, loop_cls, "/ws")
+    assert settings["model"] == "mock-model"
+    assert (settings["max_turns"], settings["max_tokens"]) == (5, 1000)
+
+    # nothing supplied: the spec's own defaults beat the loop class defaults
+    spec = _spec(workspace.run_dir)
+    settings = resolve_agent_settings(spec, _config(), {}, loop_cls, workspace.run_dir)
+    assert settings["model"] == "sonnet"
+    assert settings["max_turns"] == 30
+    assert settings["max_tokens"] == 1000000
+    assert settings["verbosity"] == 1
+
+    # a decorator argument beats the spec
+    decorator_args = {"model": "opus", "verbosity": 0}
+    settings = resolve_agent_settings(spec, _config(), decorator_args, loop_cls, workspace.run_dir)
+    assert settings["model"] == "opus"
+    assert settings["verbosity"] == 0
+
+    # config beats the decorator
+    config = _config(model="haiku", verbosity=2)
+    settings = resolve_agent_settings(spec, config, decorator_args, loop_cls, workspace.run_dir)
+    assert settings["model"] == "haiku"
+    assert settings["verbosity"] == 2
+
+    # one limit overridden leaves the other where the spec put it
+    settings = resolve_agent_settings(spec, _config(max_turns=3), {}, loop_cls, workspace.run_dir)
+    assert settings["max_turns"] == 3
+    assert settings["max_tokens"] == 1000000
+
+    # loop run args merge shallowly: the spec default `retries: 1` goes, everything else survives
+    settings = resolve_agent_settings(
+        spec,
+        _config(loop_run_args={"tool_timeout": 30}),
+        {"loop_run_args": {"retries": 5, "extra": 1}},
+        loop_cls,
+        workspace.run_dir,
+    )
+    assert settings["loop_run_args"] == {"retries": 5, "extra": 1, "tool_timeout": 30}
+
+
+def test_instructions_resolve_like_the_model(workspace: Any, loop_cls: Type[AgentLoop]) -> None:
+    """The user turn comes from the decorator, then configuration, then the run itself."""
+    spec = _spec(workspace.run_dir)
+
+    # nobody said anything: the system prompt speaks alone and the run still opens
+    settings = resolve_agent_settings(spec, _config(), {}, loop_cls, workspace.run_dir)
+    assert settings["instructions"] is None
+    assert loop_cls(settings).user_turn == DEFAULT_USER_TURN
+
+    settings = resolve_agent_settings(
+        spec,
+        _config(instructions="focus on the loader step"),
+        {"instructions": "explain the failure"},
+        loop_cls,
+        workspace.run_dir,
+    )
+    assert loop_cls(settings).user_turn == "focus on the loader step"
+
+    # and a direct call overrides both
+    loop = loop_cls(settings)
+    loop.resolve_run(instructions="just list the failed jobs")
+    assert loop.user_turn == "just list the failed jobs"
+
+
+@pytest.mark.parametrize(
+    "model,provider,expected",
+    [
+        ("sonnet", "anthropic", "anthropic:claude-sonnet-5"),
+        ("gpt", "anthropic", "openai:gpt-5.5"),
+        ("claude-opus-5", "anthropic", "anthropic:claude-opus-5"),
+        ("openai:gpt-5.4-mini", "anthropic", "openai:gpt-5.4-mini"),
+        ("gateway/openai:gpt-5.5", "anthropic", "gateway/openai:gpt-5.5"),
+        ("mock-model", "", "mock-model"),
+    ],
+    ids=["alias", "other-provider-alias", "bare", "qualified", "gateway", "no-provider"],
+)
+def test_model_id_is_provider_qualified(
+    workspace: Any, loop_cls: Type[AgentLoop], model: str, provider: str, expected: str
+) -> None:
+    """dlt names models as pydantic-ai does; a loop qualifies a bare name with its own provider."""
+    spec = _spec(workspace.run_dir)
+    settings = resolve_agent_settings(spec, _config(model=model), {}, loop_cls, workspace.run_dir)
+    loop = type("Loop", (loop_cls,), {"DEFAULT_PROVIDER": provider})(settings)
+
+    assert loop.model_id() == expected
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("anthropic:claude-sonnet-5", ("anthropic", "claude-sonnet-5")),
+        ("gateway/openai:gpt-5.5", ("gateway/openai", "gpt-5.5")),
+        ("mock-model", ("", "mock-model")),
+    ],
+    ids=["qualified", "gateway", "bare"],
+)
+def test_split_model_id(model: str, expected: Tuple[str, str]) -> None:
+    assert split_model_id(model) == expected
+
+
+@pytest.mark.parametrize("user_field", ["MODEL", "API_KEY", "API_URL", "API_VERSION"])
+def test_the_endpoint_is_one_set_and_any_user_field_replaces_all_of_it(user_field: str) -> None:
+    """A model id belongs to the endpoint that serves it, so a run never mixes the two sets."""
+    # the runtime set sits on the workspace-wide section, which every job falls back to
+    os.environ["AGENT__RUNTIME_MODEL"] = "runtime-model"
+    os.environ["AGENT__RUNTIME_API_KEY"] = "runtime-key"
+    os.environ["AGENT__RUNTIME_API_URL"] = "https://runtime.example"
+    os.environ["AGENT__RUNTIME_API_VERSION"] = "2024-02-01"
+    config = _resolve_agent_config()
+
+    assert config.endpoint_source == "runtime"
+    assert (
+        config.effective_model,
+        config.effective_api_key,
+        config.effective_api_url,
+        config.effective_api_version,
+    ) == ("runtime-model", "runtime-key", "https://runtime.example", "2024-02-01")
+
+    # one user field on the job's own section takes the whole set with it, the runtime model included
+    os.environ[f"JOBS__OPS__INSPECTOR__AGENT__{user_field}"] = "user-value"
+    config = _resolve_agent_config()
+
+    assert config.endpoint_source == "user"
+    effective = {
+        "MODEL": config.effective_model,
+        "API_KEY": config.effective_api_key,
+        "API_URL": config.effective_api_url,
+        "API_VERSION": config.effective_api_version,
+    }
+    assert effective.pop(user_field) == "user-value"
+    assert set(effective.values()) == {None}
+    # the runtime values stay readable rather than being overwritten
+    assert config.runtime_model == "runtime-model"
+    assert config.runtime_api_key == "runtime-key"
+
+
+def test_a_user_key_leaves_the_runtime_model_out_of_the_run(loop_cls: Type[AgentLoop]) -> None:
+    """The user's endpoint does not serve the runtime's model id, so the agent's own model runs."""
+    spec = _bare_spec(defaults={"model": "declared-model"})
+    runtime = _config(
+        runtime_model="runtime-model",
+        runtime_api_key="runtime-key",
+        runtime_api_version="2024-02-01",
+    )
+    settings = resolve_agent_settings(spec, runtime, {}, loop_cls, "/ws")
+    assert (settings["model"], settings["api_key"]) == ("runtime-model", "runtime-key")
+    assert settings["api_version"] == "2024-02-01"
+
+    with_user_key = _config(
+        runtime_model="runtime-model",
+        runtime_api_key="runtime-key",
+        runtime_api_version="2024-02-01",
+        api_key="user-key",
+        api_version="2024-10-21",
+    )
+    settings = resolve_agent_settings(spec, with_user_key, {}, loop_cls, "/ws")
+    assert (settings["model"], settings["api_key"]) == ("declared-model", "user-key")
+    # the version follows the key, and both values stay readable side by side
+    assert settings["api_version"] == "2024-10-21"
+    assert with_user_key.runtime_api_version == "2024-02-01"
+
+
+def test_a_loop_run_from_settings_to_trace(
+    workspace: Any,
+    loop_cls: Type[AgentLoop],
+    caplog: pytest.LogCaptureFixture,
+    dlt_logger_name: str,
+) -> None:
+    """One loop through its life: built from settings, given the definition, run, and run again."""
+    spec = _spec(workspace.run_dir)
+    settings = resolve_agent_settings(
+        spec, _config(api_key="user-key"), {}, loop_cls, workspace.run_dir
+    )
+    loop = loop_cls(settings)
+    loop.agent_ref = "dlthub-platform:job-inspector"
+    loop.agent_file = ".claude/dlthub/agents/job-inspector/AGENT.md"
+    # nothing is recorded and nothing is built until a run supplies its arguments
+    with pytest.raises(AgentTraceNotAvailable):
+        loop.trace
+    loop.init(spec)
+    assert loop.native is None
+
+    with caplog.at_level(logging.INFO, logger=dlt_logger_name):
+        loop.resolve_run()
+    assert any("on the user endpoint" in r.getMessage() for r in caplog.records)
+
+    asyncio.run(loop.run(inputs={"failed_job_ref": "jobs.batch.ingest"}))
+    assert loop.native == "mock-native:anthropic:claude-sonnet-5"
+    trace = loop.trace
+    assert trace["agent"] == "dlthub-platform:job-inspector"
+    assert trace["agent_file"] == ".claude/dlthub/agents/job-inspector/AGENT.md"
+    assert trace["loop_type"] == loop_cls.LOOP_TYPE
+    assert trace["model"] == "anthropic:claude-sonnet-5"
+    assert trace["limits"] == {"max_turns": 30, "max_tokens": 1000000}
+    assert trace["loop_run_args"] == {"retries": 1}
+    assert trace["inputs"] == {"failed_job_ref": "jobs.batch.ingest"}
+    assert trace["mcp_features"] == ["telemetry"]
+    # the mock wires no local tool, whatever the declaration asks for
+    assert trace["local_tools"] == {}
+
+    # `run` takes the runtime and rebuilds the native object; one limit overridden leaves the
+    # other where the declaration put it
+    asyncio.run(
+        loop.run(inputs={}, model="haiku", limits={"max_turns": 3}, instructions="be brief")
+    )
+    assert loop.native == "mock-native:anthropic:claude-haiku-4-5"
+    assert loop.user_turn == "be brief"
+    assert loop.trace["instructions"] == "be brief"
+    assert loop.trace["limits"] == {"max_turns": 3, "max_tokens": 1000000}
+
+    # the beacon swallows serialization errors, so one exotic input must not drop the run
+    asyncio.run(loop.run(inputs={"handle": object(), "nested": {"fn": lambda: None}}))
+    json.dumps(loop.trace)
+    assert loop.trace["inputs"]["handle"].startswith("<object object")
+
+    # finishing names the tools the run used, in the log and in the console event
+    events: List[Dict[str, Any]] = []
+    native: Any = loop
+    native.emit = lambda kind, **fields: events.append({"kind": kind, **fields})
+    with caplog.at_level(logging.INFO, logger=dlt_logger_name):
+        loop.emit_run_finished("succeeded")
+        loop.trace["tools_used"] = ["read_file"]
+        loop.trace["mcp_tools_used"] = ["list_runs", "get_logs"]
+        loop.emit_run_finished("succeeded")
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("finished in 3 turns and 165 tokens, using no tools" in m for m in messages)
+    assert any("using tools: read_file; mcp tools: list_runs, get_logs" in m for m in messages)
+    assert events[-1]["tools"] == ["read_file"]
+    assert events[-1]["mcp_tools"] == ["list_runs", "get_logs"]
+
+    # the base counts every turn, so `max_tokens` means the same on any framework: the mock
+    # counts three turns of 55 tokens, and the second one passes a limit of 100
+    with pytest.raises(AgentTokenLimitExceeded, match="used 110 tokens, over its limit of 100"):
+        asyncio.run(
+            loop.run(inputs={"failed_job_ref": "jobs.b.ingest"}, limits={"max_tokens": 100})
+        )
+    assert loop.tokens_used == 110
+
+
+def test_loops_wire_only_what_the_agent_declares(workspace: Any) -> None:
+    """No `access`: no file tool, no shell, and a server told in so many words to grant nothing.
+    No `tools`: no server at all."""
+
+    for loop_cls in (PydanticAILoop, ClaudeAgentSdkLoop):
+        loop = _loop(workspace, loop_cls, access={})
+        assert loop.spec["tools"]
+        assert loop.local_tools() == {}, loop_cls.LOOP_TYPE
+        if isinstance(loop, PydanticAILoop):
+            args = loop._build_toolsets()[0].client.transport.args
+        else:
+            options = cast(ClaudeAgentSdkLoop, loop)._build_options("system")
+            args = options.mcp_servers[MCP_SERVER_ID]["args"]
+        # the server still serves the tools that require nothing, such as the toolkit catalogue
+        assert args[args.index("--access") + 1] == "local:,data:,context:", loop_cls.LOOP_TYPE
+
+        # `tools` is the whole request: nothing declared, nothing spawned
+        loop = _loop(workspace, loop_cls, tools=[], access={"local": ["read"]})
+        if isinstance(loop, PydanticAILoop):
+            assert loop._build_toolsets() == []
+        else:
+            options = cast(ClaudeAgentSdkLoop, loop)._build_options("system")
+            assert options.mcp_servers == {}
+            assert MCP_TOOL_PATTERN not in options.allowed_tools
+
+
+def test_loops_serve_the_workspace_mcp_server(workspace: Any) -> None:
+    """Each loop spawns the workspace server itself, for the feature groups the agent declared."""
+
+    for loop_cls in (PydanticAILoop, ClaudeAgentSdkLoop):
+        loop = _loop(workspace, loop_cls, access={"local": ["read"]}, tools=["telemetry"])
+        if isinstance(loop, PydanticAILoop):
+            transport = loop._build_toolsets()[0].client.transport
+            args, env = transport.args, transport.env
+            assert transport.cwd == workspace.run_dir
+        else:
+            options = cast(ClaudeAgentSdkLoop, loop)._build_options("system")
+            server = options.mcp_servers[MCP_SERVER_ID]
+            args, env = server["args"], server["env"]
+        assert args[:4] == ["ai", "mcp", "run", "--stdio"], loop_cls.LOOP_TYPE
+        # the agent gets the feature group it declared and none of the interactive defaults
+        assert "--no-default-features" in args, loop_cls.LOOP_TYPE
+        assert args[-2:] == ["--features", "telemetry"], loop_cls.LOOP_TYPE
+        assert "secrets" not in args, loop_cls.LOOP_TYPE
+        assert env["FASTMCP_SHOW_SERVER_BANNER"] == "false", loop_cls.LOOP_TYPE
+        # the server reads the profile the launcher exported
+        assert "WORKSPACE__PROFILE" in env or os.environ.get("WORKSPACE__PROFILE") is None
+
+    # project settings are read for the skills, never for servers: the project's own `.mcp.json`
+    # stays out, and the workspace server's tools ride along on `allowed_tools`
+    assert options.setting_sources == ["project"]
+    assert options.strict_mcp_config is True
+    assert MCP_TOOL_PATTERN in options.allowed_tools
+
+
+def test_loops_hand_entity_types_to_the_model_as_comments(workspace: Any) -> None:
+    """The Claude CLI validates the output schema strictly, so dlt's keyword travels as `$comment`."""
+
+    output = _spec(workspace.run_dir)["output"]
+    output["properties"]["classification"]["entity_type"] = "job"
+    for loop_cls in (PydanticAILoop, ClaudeAgentSdkLoop):
+        loop = _loop(workspace, loop_cls, config=_config(api_key="sk-test"), output=output)
+        if isinstance(loop, PydanticAILoop):
+            agent_spec = loop._agent_spec_dict(loop._build_model())
+            schemas = [agent_spec["deps_schema"], agent_spec["output_schema"]]
+            assert schemas[0]["properties"]["failed_run_id"]["$comment"] == "entity_type: job-run"
+        else:
+            options = cast(ClaudeAgentSdkLoop, loop)._build_options("system")
+            schemas = [options.output_format["schema"]]
+        assert '"entity_type"' not in json.dumps(schemas), loop_cls.LOOP_TYPE
+        assert schemas[-1]["properties"]["classification"]["$comment"] == "entity_type: job"
+        # the manifest schema keeps the keyword
+        assert loop.spec["inputs"]["properties"]["failed_run_id"]["entity_type"] == "job-run"
+
+
+def test_both_loops_render_the_body_and_keep_the_turn_out_of_it(workspace: Any) -> None:
+    """The system prompt is the rendered body plus what the loop inlines; the turn stays a turn."""
+
+    inputs = {"failed_run_id": "r-77", "run_context": {"trigger": "job.fail:*"}}
+    for loop_cls in (PydanticAILoop, ClaudeAgentSdkLoop):
+        loop = _loop(workspace, loop_cls, config=_config(instructions="focus on the loader step"))
+        rendered = loop.render_system_prompt(inputs)
+
+        assert "with failed run id 'r-77'" in rendered, loop_cls.LOOP_TYPE
+        # the rule the agent declared is inlined next to the body
+        assert "Resource changes are proposals" in rendered, loop_cls.LOOP_TYPE
+        assert "focus on the loader step" not in rendered, loop_cls.LOOP_TYPE
+        assert loop.user_turn == "focus on the loader step", loop_cls.LOOP_TYPE
+        assert loop._unresolved_placeholders == ["failed_job_ref"], loop_cls.LOOP_TYPE
+    # the claude loop hands the framework what it rendered; the pydantic one has its own test
+    assert cast(Any, loop)._build_options(rendered).system_prompt == rendered
+
+
+def test_loops_name_the_workspace_and_the_temp_folder(workspace: Any) -> None:
+    """The tools' descriptions stay generic, so the prompt says which folders they mean."""
+
+    for loop_cls in (PydanticAILoop, ClaudeAgentSdkLoop):
+        loop = _loop(workspace, loop_cls)
+        prompt = loop.render_system_prompt({})
+        # both folders as posix paths, whatever the platform
+        assert Path(workspace.run_dir).resolve().as_posix() in prompt, loop_cls.LOOP_TYPE
+        assert temp_dir().as_posix() in prompt, loop_cls.LOOP_TYPE
+    # the CLI's file tools stop at the working directory unless the temp folder is added
+    assert cast(Any, loop)._build_options("system").add_dirs == [str(temp_dir())]
+
+
+def test_pydantic_loop_stops_at_the_token_limit(workspace: Any) -> None:
+    """A real run: the check sits in the event handler, and its raise ends the agent run."""
+
+    # local read tools give TestModel something to call, so the run takes more than one turn
+    loop = _loop(workspace, PydanticAILoop, access={"local": ["read"]})
+    native: Any = loop
+    native._build_model = lambda: TestModel()
+    native._build_toolsets = lambda: []
+
+    with pytest.raises(AgentTokenLimitExceeded, match="over its limit of 1"):
+        asyncio.run(
+            loop.run(inputs={"failed_run_id": "r-1", "run_context": {}}, limits={"max_tokens": 1})
+        )
+    assert loop.tokens_used > 1
+
+
+class _Usage:
+    requests = 2
+    input_tokens = 10
+    output_tokens = 5
+    total_tokens = 15
+
+
+@pytest.mark.parametrize("usage_is_callable", [False, True], ids=["property", "method"])
+def test_pydantic_loop_reads_usage_either_way(workspace: Any, usage_is_callable: bool) -> None:
+    """`usage` is a property from pydantic-ai 2.36 on; calling it as a method killed the run."""
+
+    class _Result:
+        usage = (lambda self: _Usage()) if usage_is_callable else _Usage()
+
+        def all_messages(self) -> List[Any]:
+            return []
+
+    trace = _loop(workspace, PydanticAILoop)._build_trace({}, _Result())
+
+    assert trace["turn_count"] == 2
+    assert (trace["input_tokens"], trace["output_tokens"], trace["total_tokens"]) == (10, 5, 15)
+
+
+def test_pydantic_trace_tells_mcp_tools_from_local_ones(workspace: Any) -> None:
+    """A tool the loop did not build itself came from the workspace MCP server. The run's tool
+    lists name each tool once, in the order it was first used."""
+
+    class _Result:
+        usage = _Usage()
+
+        def all_messages(self) -> List[Any]:
+            return [
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(tool_name="Read", args={"path": "x"}),
+                        ToolCallPart(tool_name="list_toolkits", args={}),
+                    ]
+                ),
+                ModelResponse(
+                    parts=[
+                        ToolCallPart(tool_name="Grep", args={"pattern": "x"}),
+                        ToolCallPart(tool_name="Read", args={"path": "y"}),
+                        ToolCallPart(tool_name="toolkit_info", args={"name": "t"}),
+                        ToolCallPart(tool_name="list_toolkits", args={}),
+                        # the answer is not a tool the agent used
+                        ToolCallPart(tool_name="final_result", args={}),
+                    ]
+                ),
+            ]
+
+    loop = _loop(workspace, PydanticAILoop, access=TWorkspaceAccess(local=["read"]))
+    loop._build_tools()
+    trace = loop._build_trace({}, _Result())
+
+    assert trace["turns"][0]["tools"] == [
+        {"name": "Read", "kind": "builtin"},
+        {"name": "list_toolkits", "kind": "mcp", "server": "dlt-workspace-mcp"},
+    ]
+    assert [use["name"] for use in trace["turns"][1]["tools"]] == [
+        "Grep",
+        "Read",
+        "toolkit_info",
+        "list_toolkits",
+    ]
+    assert trace["tools_used"] == ["Read", "Grep"]
+    assert trace["mcp_tools_used"] == ["list_toolkits", "toolkit_info"]
+
+
+def test_pydantic_loop_reports_what_the_agent_does(
+    workspace: Any, capsys: pytest.CaptureFixture[str]
+) -> None:
+    loop = _loop(workspace, PydanticAILoop)
+    # the handler reads the run's usage on entry; nothing was used yet
+    ctx = SimpleNamespace(usage=RunUsage())
+
+    async def _drive() -> None:
+        async def events() -> Any:
+            yield PartEndEvent(index=0, part=ThinkingPart(content="weighing the options"))
+            yield PartEndEvent(index=1, part=TextPart(content="here is the answer"))
+            yield PartEndEvent(index=2, part=ToolCallPart(tool_name="list_runs", args={"n": 3}))
+            yield FunctionToolResultEvent(
+                part=ToolReturnPart(tool_name="list_runs", content="r-1 failed", tool_call_id="1")
+            )
+            # the answer arrives as a call to pydantic-ai's output tool
+            yield PartEndEvent(
+                index=3,
+                part=ToolCallPart(
+                    tool_name="final_result", args={"summary": "r-1 ran out of memory"}
+                ),
+            )
+            yield FunctionToolResultEvent(
+                part=ToolReturnPart(
+                    tool_name="final_result", content="Final result processed.", tool_call_id="2"
+                )
+            )
+
+        await loop._emit_events(ctx, events())
+
+    loop.emit_run_start("inspect the failed run")
+    asyncio.run(_drive())
+
+    # the transcript goes to stdout, terminal or not; colors are stripped to match the text
+    out = click.unstyle(capsys.readouterr().out)
+    assert "job-inspector" in out and "anthropic:claude-sonnet-5" in out
+    assert "prompt\n  inspect the failed run" in out
+    assert "thinks  weighing the options" in out
+    assert "says\n  here is the answer" in out
+    assert 'list_runs (dlt-workspace-mcp)  {"n":3}' in out
+    # the result lives on the part; reporting `event.content` showed nothing
+    assert "→ r-1 failed" in out
+    # the answer is the agent speaking, not a tool call to an MCP server it never made
+    assert "says\n  r-1 ran out of memory" in out
+    assert "final_result" not in out
+
+
+def test_pydantic_loop_reports_a_tool_it_could_not_get_past(workspace: Any) -> None:
+    """A tool that keeps failing ends the run: say which one, and where the limit lives."""
+
+    loop = _loop(workspace, PydanticAILoop)
+
+    class _Failing:
+        async def __aenter__(self) -> Any:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def run(self, *args: Any, **kwargs: Any) -> Any:
+            raise UnexpectedModelBehavior("Tool 'list_recent_runs' exceeded max retries count of 1")
+
+    loop._build_agent = lambda *args: _Failing()  # type: ignore[method-assign]
+
+    with pytest.raises(AgentRunFailed) as failed:
+        asyncio.run(loop.run(inputs={}))
+
+    said = str(failed.value)
+    assert "list_recent_runs" in said
+    assert "loop_run_args.retries" in said
+
+
+def test_system_prompt_is_shown_in_full_at_the_top_verbosity(
+    workspace: Any, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The prompt is what the agent actually got: too long for every run, too useful to drop."""
+    loop = _loop(workspace, PydanticAILoop)
+    loop._system_prompt = "RULE " * 400
+
+    loop.settings["verbosity"] = 1
+    loop.render_system_prompt({})
+    assert "system prompt" not in click.unstyle(capsys.readouterr().out)
+
+    loop.settings["verbosity"] = 2
+    loop.render_system_prompt({})
+    out = click.unstyle(capsys.readouterr().out)
+    assert "system prompt\n  RULE RULE" in out
+    assert out.count("RULE") == 400
+
+
+def test_pydantic_loop_hands_the_prompt_over_verbatim(workspace: Any) -> None:
+    """pydantic-ai renders `AgentSpec.instructions` as a template when `deps_schema` is set.
+
+    dlt has already rendered the prompt, so a `{{ }}` left in a rule, a skill or an example
+    would be silently dropped on the way to the model.
+    """
+
+    # dlt blanks its own `{{ name }}`; a call is not its grammar, and must survive untouched
+    body = _spec(workspace.run_dir)["system_prompt"]
+    body += "\n\nAn example the agent must still see: {{helper(x)}}."
+    # native capabilities are anthropic's, and TestModel refuses them
+    loop = _loop(workspace, PydanticAILoop, system_prompt=body, access={"data": ["read"]})
+    rendered = loop.render_system_prompt({"failed_run_id": "r-77", "run_context": {}})
+
+    native: Any = loop
+    native._build_model = lambda: TestModel()
+    native._build_toolsets = lambda: []
+    agent = native._build_agent(rendered)
+    with capture_run_messages() as messages:
+        asyncio.run(agent.run("go", deps={"failed_run_id": "r-77"}))
+
+    assert "{{helper(x)}}" in rendered
+    assert cast(Any, messages[0]).instructions == rendered
+
+
+@pytest.mark.parametrize("retries", [0, 2], ids=["no-budget", "budget"])
+def test_tool_errors_follow_the_retry_budget(workspace: Any, tmp_path: Path, retries: int) -> None:
+    """0 hands a tool error to the model as a failed call; above it pydantic-ai asks for a fix."""
+
+    # the spec's own default is 1, the decorator argument is what the run gets
+    loop = _loop(
+        workspace,
+        PydanticAILoop,
+        config=_config(api_key="sk-test"),
+        decorator_args={"loop_run_args": {"retries": retries}},
+    )
+
+    assert loop.tool_retries == retries
+    assert loop._build_toolsets()[0].tool_error_behavior == ("retry" if retries else "failed")
+    # the agent's own budget is forwarded only when there is one to enforce
+    assert loop._agent_spec_dict(loop._build_model()).get("retries") == (retries or None)
+    # the same tool error reaches pydantic-ai as a retry or as a failed call
+    tools = {t.name: t for t in make_local_tools(LocalTools(str(tmp_path)), {"read"}, retries)}
+    with pytest.raises(ToolFailed if retries == 0 else ModelRetry, match="does not exist"):
+        tools["Read"].function("missing.txt")
+
+
+def test_pydantic_loop_hands_a_failed_tool_call_to_the_model(workspace: Any) -> None:
+    """A real run without a budget: the missing file comes back as a result, and the run goes on."""
+
+    loop = _loop(
+        workspace,
+        PydanticAILoop,
+        decorator_args={"loop_run_args": {"retries": 0}},
+        access={"local": ["read"]},
+    )
+    native: Any = loop
+    native._build_model = lambda: TestModel()
+    native._build_toolsets = lambda: []
+    events: List[Dict[str, Any]] = []
+    emit = loop.emit
+
+    def recording(kind: Any, **fields: Any) -> None:
+        events.append({"kind": kind, **fields})
+        emit(kind, **fields)
+
+    native.emit = recording
+
+    # TestModel calls Read with a made-up path, which is the failure the model must get to see
+    output = asyncio.run(loop.run(inputs={"failed_run_id": "r-1", "run_context": {}}))
+
+    assert isinstance(output, dict)
+    failed = [e for e in events if e["kind"] == "tool_result" and e.get("error")]
+    assert failed and "does not exist" in str(failed[0]["detail"])
+    assert events[-1]["kind"] == "finish"
+
+
+@pytest.mark.parametrize(
+    "local_access,expected",
+    [
+        (["read"], ["Read", "Glob", "Grep"]),
+        (["read", "write"], ["Read", "Glob", "Grep", "Write", "Edit"]),
+        (["execute"], [SHELL_TOOL, "RunPython"]),
+        (["all"], ["Read", "Glob", "Grep", "Write", "Edit", SHELL_TOOL, "RunPython"]),
+        ([], []),
+        # the provider runs the network tools itself, so no function is registered
+        (["network"], []),
+    ],
+    ids=["read", "read-write", "execute", "all", "none", "network"],
+)
+def test_pydantic_loop_local_tools_follow_access(
+    workspace: Any, local_access: List[str], expected: List[str]
+) -> None:
+    """Both loops answer a verb with the same tool names, whatever implements them."""
+    loop = _loop(workspace, PydanticAILoop, access=TWorkspaceAccess(local=cast(Any, local_access)))
+    assert [tool.name for tool in loop._build_tools()] == expected
+
+
+@pytest.mark.parametrize(
+    "model,expected_system",
+    [("sonnet", "anthropic"), ("openai:gpt-5.5", "openai"), ("gemini", "google")],
+    ids=["anthropic", "openai", "google"],
+)
+def test_pydantic_loop_builds_any_provider(
+    workspace: Any, model: str, expected_system: str
+) -> None:
+    """One key and url reach whichever provider the model names."""
+
+    loop = _loop(workspace, PydanticAILoop, config=_config(model=model, api_key="sk-test"))
+    built = loop._build_model()
+
+    assert built.system == expected_system
+    assert built.model_name == split_model_id(loop.model_id())[1]
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["openai", "azure", "litellm", "anthropic", "google"],
+    ids=["base_url", "azure_endpoint", "api_base", "anthropic", "google"],
+)
+def test_api_url_reaches_the_provider_under_its_own_argument(workspace: Any, provider: str) -> None:
+    """Every provider names the endpoint its own way, and dropping it talks to the wrong host."""
+
+    loop = _loop(workspace, PydanticAILoop)
+    loop.settings["api_key"] = "sk-test"
+    loop.settings["api_url"] = "https://gateway.example.com/v1"
+
+    assert (
+        str(loop._build_provider(provider).base_url).rstrip("/") == "https://gateway.example.com/v1"
+    )
+
+
+def test_a_provider_takes_its_own_endpoint_arguments(workspace: Any) -> None:
+    """Azure versions its data plane; deepseek runs on its own platform; nobody knows `nope`."""
+
+    loop = _loop(workspace, PydanticAILoop)
+    loop.settings["api_key"] = "sk-test"
+    loop.settings["api_url"] = "https://my-resource.openai.azure.com"
+    loop.settings["api_version"] = "2024-10-21"
+    assert loop._build_provider("azure").client._custom_query == {"api-version": "2024-10-21"}
+
+    # silently ignoring `api_url` sent the run to the provider's own platform
+    with pytest.raises(UnsupportedAgentModel, match="takes no api_url"):
+        loop._build_provider("deepseek")
+
+    loop = _loop(workspace, PydanticAILoop, config=_config(model="nope:x"))
+    with pytest.raises(UnsupportedAgentModel, match="nope:x"):
+        loop._build_model()
+
+
+def test_pydantic_loop_serves_network_from_the_provider(workspace: Any) -> None:
+    """Pydantic AI ships no web tool of its own; the provider runs both web tools."""
+    loop = _loop(workspace, PydanticAILoop)
+    loop.settings["loop_run_args"] = {"capabilities": [{"Thinking": {"effort": "medium"}}]}
+    loop.settings["api_key"] = "sk-test"
+    model = loop._build_model()
+
+    loop.spec["access"] = TWorkspaceAccess(local=["read"])
+    assert loop._agent_spec_dict(model)["capabilities"] == [{"Thinking": {"effort": "medium"}}]
+
+    loop.spec["access"] = TWorkspaceAccess(local=["read", "network", "execute"])
+    # what the manifest asked for survives; the web tools are added to it, `execute` adds nothing
+    assert loop._agent_spec_dict(model)["capabilities"] == [
+        {"Thinking": {"effort": "medium"}},
+        {"WebSearch": {}},
+        {"WebFetch": {}},
+    ]
+    # the spec must pass pydantic-ai's capability registry; pydantic-ai adds native tools of
+    # its own (tool search), so the two are a subset
+    agent = loop._build_agent("prompt")
+    assert {"WebSearchTool", "WebFetchTool"} <= {type(t).__name__ for t in agent._cap_native_tools}
+    # the function tools and the provider's own, each under its verb
+    loop._build_tools()
+    assert loop.local_tools() == {
+        "Read": "read",
+        "Glob": "read",
+        "Grep": "read",
+        SHELL_TOOL: "execute",
+        "RunPython": "execute",
+        "WebFetch": "network",
+        "WebSearch": "network",
+    }
+
+
+def test_provider_capabilities_are_dropped_when_the_model_cannot_serve_them(
+    workspace: Any,
+) -> None:
+    """OpenAI responses search the web, but fetch no URL of their own."""
+
+    loop = _loop(
+        workspace,
+        PydanticAILoop,
+        config=_config(model="openai:gpt-5.5", api_key="sk-test"),
+        access=TWorkspaceAccess(local=["network", "execute"]),
+    )
+
+    assert loop._agent_spec_dict(loop._build_model())["capabilities"] == [{"WebSearch": {}}]
+
+
+@pytest.mark.parametrize(
+    "name,tool_input,expected",
+    [
+        ("Bash", None, {"name": "Bash", "kind": "builtin"}),
+        (
+            "mcp__dlt-workspace-mcp__list_tables",
+            None,
+            {"name": "list_tables", "kind": "mcp", "server": "dlt-workspace-mcp"},
+        ),
+        # a server name is not guaranteed to be there
+        ("mcp__bare", None, {"name": "bare", "kind": "mcp"}),
+        ("Skill", {"skill": "debug-deployment"}, {"name": "debug-deployment", "kind": "skill"}),
+        # the harness may name the skill under another key, or not at all
+        ("Skill", {"name": "profiling"}, {"name": "profiling", "kind": "skill"}),
+        ("Skill", {}, {"name": "Skill", "kind": "skill"}),
+    ],
+    ids=["builtin", "mcp", "mcp-no-server", "skill", "skill-alt-key", "skill-unnamed"],
+)
+def test_classify_tool(name: str, tool_input: Any, expected: Dict[str, Any]) -> None:
+    assert classify_tool(name, tool_input) == expected
+
+
+@pytest.mark.parametrize(
+    "local_access,expected",
+    [
+        (["read"], ["Read", "NotebookRead", "Glob", "Grep"]),
+        (["write"], ["Write", "Edit", "MultiEdit", "NotebookEdit"]),
+        # one shell per platform, as Claude Code offers it: PowerShell on Windows, bash elsewhere
+        (["execute"], list(AI_LOOP_TOOLS[SHELL_TOOL])),
+        (["network"], ["WebFetch", "WebSearch"]),
+        ([], []),
+    ],
+    ids=["read", "write", "execute", "network", "none"],
+)
+def test_claude_loop_tools_follow_access(
+    workspace: Any, local_access: List[str], expected: List[str]
+) -> None:
+    """`tools` is the availability list: no verb, no built-in, not even a denied one."""
+
+    # the Skill tool follows `skills`, not access
+    loop = _loop(
+        workspace,
+        ClaudeAgentSdkLoop,
+        access=TWorkspaceAccess(local=cast(Any, local_access)),
+        skills=[],
+    )
+    options = loop._build_options("system")
+
+    assert options.tools == expected
+    # what exists may still need approving; the MCP pattern rides along on `allowed_tools`
+    assert options.allowed_tools[: len(expected)] == expected
+    # each allowed CLI tool is listed under the verb that bought it, extensions included
+    assert loop.local_tools() == {tool: verb for verb in local_access for tool in expected}
+
+
+def test_claude_loop_lists_only_the_declared_skills(workspace: Any) -> None:
+    """The installed skill is the CLI's to list and load; an agent declaring none must not see
+    the skills of whoever installed the harness."""
+
+    loop = _loop(workspace, ClaudeAgentSdkLoop)
+    options = loop._build_options("system")
+    assert options.skills == ["debug-deployment"]
+    # the CLI lists skills only where the Skill tool exists, and `tools` is the base set
+    assert "Skill" in options.tools
+    # nothing of the skill is pasted into the prompt
+    assert loop._inlined_skills == []
+    assert "<skill" not in loop.render_system_prompt({})
+
+    loop = _loop(workspace, ClaudeAgentSdkLoop, skills=[])
+    options = loop._build_options("system")
+    # `None` would leave the harness defaults in place, which list every skill it can find
+    assert options.skills == []
+    assert "Skill" not in options.tools
+    assert "Skill" not in options.allowed_tools
+
+
+def test_claude_loop_keeps_the_project_rules_out(workspace: Any, tmp_path: Path) -> None:
+    """The project settings bring every rule file, which name all skills of the workspace.
+    The agent declares its rules, so the CLI must not load any on its own. CLAUDE.md stays."""
+
+    loop = _loop(workspace, ClaudeAgentSdkLoop)
+    assert json.loads(loop._build_options("system").settings) == {
+        "claudeMdExcludes": RULES_EXCLUDES
+    }
+    assert not any("CLAUDE" in glob for glob in RULES_EXCLUDES)
+    # settings given in run args are kept, inline or from a file, and the exclusion stays
+    given = {"claudeMdExcludes": ["**/TEAM.md"], "env": {"X": "1"}}
+    loop.settings["loop_run_args"]["settings"] = json.dumps(given)
+    merged = json.loads(loop._build_options("system").settings)
+    assert merged["env"] == {"X": "1"}
+    assert merged["claudeMdExcludes"] == [*RULES_EXCLUDES, "**/TEAM.md"]
+    settings_file = tmp_path / "settings.json"
+    settings_file.write_text(json.dumps(given), encoding="utf-8")
+    loop.settings["loop_run_args"]["settings"] = str(settings_file)
+    assert json.loads(loop._build_options("system").settings) == merged
+
+
+def test_claude_loop_denies_its_file_tools_the_credentials(workspace: Any) -> None:
+    """The harness owns its file tools, so the only lever is a deny rule per tool."""
+
+    loop = _loop(workspace, ClaudeAgentSdkLoop, access={"local": ["read", "write"]})
+    denied = loop._build_options("system").disallowed_tools
+
+    assert "Read(**/*secrets.toml)" in denied
+    assert "Write(**/*secrets.toml)" in denied
+    assert "Grep(**/.env)" in denied
+
+
+def test_claude_loop_takes_the_bare_anthropic_name(workspace: Any) -> None:
+    """The harness names Anthropic models without the provider prefix, and runs nothing else."""
+
+    loop = _loop(workspace, ClaudeAgentSdkLoop, config=_config(model="opus"))
+    assert loop._ai_loop_model() == "claude-opus-5"
+    assert loop._build_options("system").model == "claude-opus-5"
+
+    loop = _loop(workspace, ClaudeAgentSdkLoop, config=_config(model="claude-haiku-4-5"))
+    assert loop._ai_loop_model() == "claude-haiku-4-5"
+    assert loop._build_options("system").model == "claude-haiku-4-5"
+
+    loop = _loop(workspace, ClaudeAgentSdkLoop, config=_config(model="gpt"))
+    with pytest.raises(UnsupportedAgentModel, match="pydantic-ai"):
+        loop._ai_loop_model()
+
+
+def test_claude_loop_keeps_the_cli_stderr_for_the_failure(
+    workspace: Any,
+    caplog: pytest.LogCaptureFixture,
+    dlt_logger_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI writes notices to stderr, which the transcript must not show. When the CLI dies
+    the SDK says only "check stderr", so the run failure carries what the CLI wrote there."""
+
+    loop = _loop(workspace, ClaudeAgentSdkLoop)
+    options = loop._build_options("system")
+    with caplog.at_level(logging.DEBUG, logger=dlt_logger_name):
+        options.stderr("claude.ai connectors are disabled because ANTHROPIC_API_KEY is set")
+
+    assert any("connectors are disabled" in r.getMessage() for r in caplog.records)
+    # kept for a run that ends without a result, where the harness never says why
+    assert loop._cli_stderr[-1].endswith("ANTHROPIC_API_KEY is set")
+
+    class _DyingClient:
+        def __init__(self, options: Any) -> None:
+            # what the CLI writes before exiting reaches the loop through the stderr callback
+            options.stderr("Error: Invalid API key. Please run /login")
+
+        async def __aenter__(self) -> Any:
+            raise ProcessError(
+                "Command failed with exit code 1",
+                exit_code=1,
+                stderr="Check stderr output for details",
+            )
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+    monkeypatch.setattr(claude_sdk, "ClaudeSDKClient", _DyingClient)
+    with pytest.raises(AgentRunFailed) as failed:
+        asyncio.run(loop.run(inputs={}))
+
+    said = str(failed.value)
+    assert "exit code: 1" in said
+    assert "Invalid API key" in said

--- a/tests/workspace/deployment/test_agent_manifest.py
+++ b/tests/workspace/deployment/test_agent_manifest.py
@@ -1,0 +1,459 @@
+"""Tests for loading `AGENT.md` and resolving the components it references."""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, cast
+
+import pytest
+
+from dlt.common.json import json
+
+from dlt._workspace.deployment.agent.exceptions import (
+    AgentComponentNotFound,
+    InvalidAgentSpec,
+)
+from dlt._workspace.deployment.agent.configuration import (
+    spec_from_agent_inputs,
+    warn_unbound_inputs,
+    warn_unreferenced_inputs,
+)
+from dlt._workspace.deployment.agent.manifest import (
+    declared_placeholders,
+    granted,
+    inline_components,
+    inputs_schema,
+    load_agent_spec,
+    render_placeholders,
+    resolve_agent_dir,
+    resolve_component_ref,
+    to_agent_definition,
+    validate_agent_spec,
+)
+from dlt._workspace.deployment.agent.typing import TAgentSpec
+from dlt._workspace.deployment.typing import AGENT_DEFINITION_ENGINE_VERSION
+
+from tests.workspace.utils import isolated_workspace
+
+
+AGENT_REF = "dlthub-platform:job-inspector"
+
+
+def _spec(run_dir: str) -> Any:
+    return load_agent_spec(resolve_agent_dir(AGENT_REF, run_dir))
+
+
+def test_resolve_agent_dir_from_toolkit_ref() -> None:
+    with isolated_workspace("agent_workspace") as ctx:
+        agent_dir = resolve_agent_dir(AGENT_REF, ctx.run_dir)
+    assert agent_dir.endswith(os.path.join(".claude", "dlthub", "agents", "job-inspector"))
+
+
+def test_resolve_agent_dir_from_path() -> None:
+    with isolated_workspace("agent_workspace") as ctx:
+        agent_dir = resolve_agent_dir(".claude/dlthub/agents/job-inspector", ctx.run_dir)
+    assert Path(agent_dir, "AGENT.md").is_file()
+
+
+@pytest.mark.parametrize(
+    "ref", ["../outside", "dlthub-platform:missing"], ids=["escapes-workspace", "unknown-agent"]
+)
+def test_resolve_agent_dir_rejects(ref: str) -> None:
+    with isolated_workspace("agent_workspace") as ctx:
+        with pytest.raises(AgentComponentNotFound):
+            resolve_agent_dir(ref, ctx.run_dir)
+
+
+def test_a_missing_agent_says_what_to_run_next() -> None:
+    """The manifest names an agent nobody installed: the error is the recovery instruction."""
+    with isolated_workspace("agent_workspace") as ctx:
+        # the workspace has dlthub-platform installed, but no such agent in it
+        with pytest.raises(AgentComponentNotFound) as installed:
+            resolve_agent_dir("dlthub-platform:no-such-agent", ctx.run_dir)
+        with pytest.raises(AgentComponentNotFound) as absent:
+            resolve_agent_dir("not-a-toolkit:no-such-agent", ctx.run_dir)
+        with pytest.raises(AgentComponentNotFound) as bare:
+            resolve_agent_dir("no-such-agent", ctx.run_dir)
+        with pytest.raises(AgentComponentNotFound) as by_path:
+            resolve_agent_dir(".claude/dlthub/agents/mine/AGENT.md", ctx.run_dir)
+
+    said = str(installed.value)
+    assert "is installed but has no agent 'no-such-agent'" in said
+    assert "dlthub ai toolkit install dlthub-platform --overwrite" in said
+    assert "dlthub ai toolkit info dlthub-platform" in said
+
+    said = str(absent.value)
+    assert "'not-a-toolkit' is not installed" in said
+    assert "dlthub ai toolkit install not-a-toolkit" in said
+    assert "dlthub ai toolkit list" in said
+    # and where the install has to land the file
+    assert said.rstrip().endswith(os.path.join("no-such-agent", "AGENT.md") + " in place.")
+
+    assert "names no toolkit" in str(bare.value)
+    assert "dlthub ai toolkit list" in str(bare.value)
+
+    # a path ref is answered by a path, not by a toolkit command
+    said = str(by_path.value)
+    assert said.endswith(os.path.join("mine", "AGENT.md") + " is present.")
+    assert "toolkit" not in said
+
+
+def test_load_agent_spec_keeps_body_as_system_prompt() -> None:
+    with isolated_workspace("agent_workspace") as ctx:
+        spec = _spec(ctx.run_dir)
+    assert spec["name"] == "job-inspector"
+    assert "You are a job inspector" in spec["system_prompt"]
+    # `defaults` stay on the spec; only the manifest subset drops them
+    assert spec["defaults"]["model"] == "sonnet"
+
+
+@pytest.mark.parametrize(
+    "frontmatter,body,reason",
+    [
+        ("name: a\ndescription: b", "", "body is empty"),
+        ("name: a\ndescription: b\ninputs:\n  prompt: p", "b", "must not declare 'prompt'"),
+    ],
+    ids=["empty-body", "prompt-input"],
+)
+def test_load_agent_spec_rejects(tmp_path: Path, frontmatter: str, body: str, reason: str) -> None:
+    agent_dir = tmp_path / "broken"
+    agent_dir.mkdir()
+    text = f"---\n{frontmatter}\n---\n{body}\n" if frontmatter else body
+    (agent_dir / "AGENT.md").write_text(text, encoding="utf-8")
+    with pytest.raises(InvalidAgentSpec, match=reason):
+        load_agent_spec(str(agent_dir))
+
+
+def test_load_agent_spec_needs_only_a_body(tmp_path: Path) -> None:
+    """No frontmatter at all: the folder names the agent and the rest defaults."""
+    agent_dir = tmp_path / "tool-checker"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(
+        "This is sanity check agent. Please list all tools.\n", encoding="utf-8"
+    )
+    spec = load_agent_spec(str(agent_dir))
+
+    assert spec["name"] == "tool-checker"
+    assert "description" not in spec
+    assert spec["inputs"] == {}
+    assert spec["system_prompt"] == "This is sanity check agent. Please list all tools."
+    # `status` and `summary` come from TAgentJobResult, which every agent reports
+    assert set(spec["output"]["properties"]) == {"status", "summary"}
+    assert spec["output"]["required"] == ["status", "summary"]
+    # nothing downstream may assume a description is there
+    assert "description" not in to_agent_definition(spec)
+
+
+@pytest.mark.parametrize(
+    "declared", ["", "description:", "description: null"], ids=["absent", "bare", "null"]
+)
+def test_a_description_that_says_nothing_is_no_description(tmp_path: Path, declared: str) -> None:
+    agent_dir = tmp_path / "quiet"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(
+        f"---\nname: quiet\n{declared}\n---\nbody\n", encoding="utf-8"
+    )
+    assert "description" not in load_agent_spec(str(agent_dir))
+
+
+def test_the_frontmatter_name_wins_over_the_folder(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "folder-name"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text("---\nname: tool checker\n---\nbody\n", encoding="utf-8")
+    assert load_agent_spec(str(agent_dir))["name"] == "tool checker"
+
+
+def _load_output(tmp_path: Path, output: str) -> Dict[str, Any]:
+    """Output schema of an agent whose frontmatter carries the given `output:` block."""
+    agent_dir = tmp_path / "with-output"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(f"---\nname: a\n{output}---\nbody\n", encoding="utf-8")
+    return load_agent_spec(str(agent_dir))["output"]
+
+
+def test_declared_output_gains_the_standard_fields(tmp_path: Path) -> None:
+    """An agent declares what it adds; `status` and `summary` arrive on their own."""
+    output = _load_output(
+        tmp_path,
+        "output:\n"
+        "  type: object\n"
+        "  properties:\n"
+        "    status:\n"
+        "      enum: [succeeded, failed, aborted]\n"
+        "    seen_tools:\n"
+        "      type: array\n",
+    )
+
+    assert output["properties"]["seen_tools"] == {"type": "array"}
+    assert output["properties"]["summary"]["type"] == "string"
+    assert output["required"] == ["status", "summary"]
+    # the declaration named `status` but said nothing about when to use which outcome
+    assert "`aborted`" in output["properties"]["status"]["description"]
+
+
+def test_the_typed_dict_wins_over_the_file(tmp_path: Path) -> None:
+    """`TAgentJobResult` defines the standard fields, so a file cannot retype them."""
+    output = _load_output(
+        tmp_path,
+        "output:\n"
+        "  properties:\n"
+        "    status:\n"
+        "      type: integer\n"
+        "      description: how many tools I found\n"
+        "    summary:\n"
+        "      type: integer\n"
+        "  required: [status]\n",
+    )
+
+    status = output["properties"]["status"]
+    assert status["type"] == "string"
+    assert status["enum"] == ["succeeded", "failed", "aborted"]
+    assert "how many tools" not in status["description"]
+    # all three outcomes are named, so the model knows which one to report
+    for outcome in ("succeeded", "failed", "aborted"):
+        assert f"`{outcome}`" in status["description"]
+    assert output["properties"]["summary"]["type"] == "string"
+    assert output["required"] == ["status", "summary"]
+
+
+def test_a_declared_output_keeps_its_own_shape(tmp_path: Path) -> None:
+    output = _load_output(
+        tmp_path,
+        "output:\n"
+        "  title: Tool report\n"
+        "  description: what the agent saw\n"
+        "  properties:\n"
+        "    finding:\n"
+        "      $ref: '#/$defs/Finding'\n"
+        "  $defs:\n"
+        "    Finding:\n"
+        "      type: object\n",
+    )
+
+    assert output["title"] == "Tool report"
+    assert output["description"] == "what the agent saw"
+    assert output["$defs"]["Finding"] == {"type": "object"}
+    assert output["properties"]["finding"] == {"$ref": "#/$defs/Finding"}
+    # the merge brings the two fields over, not the type they come from
+    assert "TAgentJobResult" not in json.dumps(output)
+
+
+@pytest.mark.parametrize(
+    "access,accepted",
+    [
+        ({"context": ["read"]}, True),
+        ({"context": "read"}, True),
+        ({"context": ["all"]}, True),
+        ({"context": ["write"]}, False),
+        ({"context": ["read", "execute"]}, False),
+        ({"context": ["deploy"]}, False),
+        ({"data": ["deploy"]}, False),
+        ({"local": ["read", "network"]}, True),
+    ],
+    ids=[
+        "read",
+        "read-scalar",
+        "all",
+        "write",
+        "read-and-execute",
+        "deploy",
+        "unknown-data",
+        "local",
+    ],
+)
+def test_access_verbs_are_held_to_the_axis(access: Dict[str, Any], accepted: bool) -> None:
+    """`context` types the whole ladder but serves `read`; the rest is refused at the manifest."""
+    spec = cast(
+        TAgentSpec,
+        {
+            "name": "a",
+            "description": "b",
+            "system_prompt": "p",
+            "output": {"properties": {"status": {}, "summary": {}}},
+            "access": access,
+        },
+    )
+    if accepted:
+        assert validate_agent_spec(spec, "AGENT.md")["access"] == {
+            axis: [verbs] if isinstance(verbs, str) else verbs for axis, verbs in access.items()
+        }
+    else:
+        with pytest.raises(InvalidAgentSpec, match="takes") as refusal:
+            validate_agent_spec(spec, "AGENT.md")
+        # a verb the type carries but nothing implements says so, rather than reading as a typo
+        typed_but_unserved = set(access.get("context") or []) - {"read"}
+        assert ("no runtime serves" in str(refusal.value)) is bool(typed_but_unserved)
+
+
+def test_load_agent_spec_without_inputs(tmp_path: Path) -> None:
+    """An agent that takes nothing needs no `inputs` block."""
+    agent_dir = tmp_path / "sanity"
+    agent_dir.mkdir()
+    (agent_dir / "AGENT.md").write_text(
+        "---\nname: sanity\ndescription: Lists what it can see.\n"
+        "output:\n  properties:\n    status: {}\n    summary: {}\n---\nbody\n",
+        encoding="utf-8",
+    )
+    spec = load_agent_spec(str(agent_dir))
+
+    assert spec["inputs"] == {}
+    assert spec["system_prompt"] == "body"
+
+
+def test_to_agent_definition_is_the_manifest_subset() -> None:
+    with isolated_workspace("agent_workspace") as ctx:
+        spec = _spec(ctx.run_dir)
+    definition = to_agent_definition(
+        spec, ".claude/dlthub/agents/job-inspector/AGENT.md", "extra prompt", "haiku"
+    )
+    assert definition["engine_version"] == AGENT_DEFINITION_ENGINE_VERSION
+    assert definition["agent_file"] == ".claude/dlthub/agents/job-inspector/AGENT.md"
+    assert definition["instructions"] == "extra prompt"
+    assert definition["model"] == "haiku"
+    # the runtime gets the declaration, never the defaults or the prompt, and never what the job
+    # itself carries: its access, its inputs and its output
+    assert "defaults" not in definition
+    assert "system_prompt" not in definition
+    assert "access" not in definition
+    assert "inputs" not in definition
+    assert "output" not in definition
+    assert definition["tools"] == ["telemetry"]
+
+
+def test_inputs_schema_coerces_required() -> None:
+    with isolated_workspace("agent_workspace") as ctx:
+        schema = inputs_schema(_spec(ctx.run_dir))
+    # `required: {}` is how "nothing is required" is written; JSON Schema wants an array
+    assert schema["required"] == []
+    assert set(schema["properties"]) == {"failed_run_id", "failed_job_ref"}
+
+
+def test_granted_expands_all() -> None:
+    with isolated_workspace("agent_workspace") as ctx:
+        spec = _spec(ctx.run_dir)
+    assert granted(spec, "local") == {"read", "write", "execute", "network"}
+    assert granted(spec, "data") == {"read"}
+
+
+@pytest.mark.parametrize(
+    "template,values,expected,unresolved",
+    [
+        ("run {{ a }}", {"a": "x"}, "run x", []),
+        ("run {{ a.b }}", {"a": {"b": "y"}}, "run y", []),
+        ("run {{ missing }}", {}, "run ", ["missing"]),
+        ("run {{ a }}", {"a": None}, "run ", []),
+        ("{{ lookup(x) }} stays", {}, "{{ lookup(x) }} stays", []),
+    ],
+    ids=["flat", "dotted", "missing", "none-value", "function-call-unsupported"],
+)
+def test_render_placeholders(
+    template: str, values: Dict[str, Any], expected: str, unresolved: List[str]
+) -> None:
+    text, missing = render_placeholders(template, values)
+    assert text == expected
+    assert missing == unresolved
+
+
+@pytest.mark.parametrize(
+    "ref,kind",
+    [("dlthub-platform:job-resources", "rule"), ("dlthub-platform:debug-deployment", "skill")],
+    ids=["rule", "skill"],
+)
+def test_resolve_component_ref(ref: str, kind: str) -> None:
+    with isolated_workspace("agent_workspace") as ctx:
+        path = resolve_component_ref(ref, kind, ctx.run_dir)  # type: ignore[arg-type]
+    assert Path(path).is_file()
+
+
+def test_inline_components_skips_what_it_cannot_resolve() -> None:
+    """A narrowed agent is weaker, not broken, so an unresolved ref only warns."""
+    with isolated_workspace("agent_workspace") as ctx:
+        blocks = inline_components(
+            ["dlthub-platform:job-resources", "nope:missing"], "rule", ctx.run_dir
+        )
+    assert len(blocks) == 1
+    assert blocks[0].startswith('<rule ref="dlthub-platform:job-resources">')
+
+
+def _inputs_spec(required: Any) -> Any:
+    return {
+        "name": "job-inspector",
+        "description": "d",
+        "access": {},
+        "inputs": {
+            "type": "object",
+            "properties": {
+                "failed_run_id": {"type": "string"},
+                "depth": {"type": "integer"},
+                "verbose": {"type": "boolean"},
+                "extras": {"type": "object"},
+            },
+            "required": required,
+        },
+        "output": {},
+        "system_prompt": "b",
+    }
+
+
+@pytest.mark.parametrize(
+    "required,expected_run_id_hint",
+    [(["failed_run_id"], str), ({}, Optional[str]), (None, Optional[str])],
+    ids=["required-list", "empty-mapping", "absent"],
+)
+def test_spec_from_agent_inputs(required: Any, expected_run_id_hint: Any) -> None:
+    """Declared inputs become job configuration: one field each, typed by the schema."""
+    spec_cls = spec_from_agent_inputs(_inputs_spec(required))
+    fields = spec_cls.get_resolvable_fields()
+
+    assert set(fields) == {"failed_run_id", "depth", "verbose", "extras"}
+    # a required input keeps a non-optional hint, so resolution enforces it
+    assert fields["failed_run_id"] == expected_run_id_hint
+    assert fields["depth"] == Optional[int]
+    assert fields["verbose"] == Optional[bool]
+    assert fields["extras"] == Optional[Dict[str, Any]]
+    assert spec_cls.__name__ == "JobInspectorInputsConfiguration"
+
+
+def test_the_body_is_a_template_over_the_inputs() -> None:
+    """The task lives in the body, so its placeholders are the inputs the agent is given."""
+    with isolated_workspace("agent_workspace") as ctx:
+        spec = _spec(ctx.run_dir)
+
+    assert declared_placeholders(spec["system_prompt"]) == {
+        "failed_job_ref",
+        "failed_run_id",
+        "run_context.trigger",
+    }
+    prompt, unresolved = render_placeholders(
+        spec["system_prompt"],
+        {"failed_job_ref": "jobs.ingest", "run_context": {"trigger": "job.fail:*"}},
+    )
+    assert "Investigate job_ref 'jobs.ingest' from trigger `job.fail:*`" in prompt
+    assert "You are a job inspector" in prompt
+    # an input nobody supplied renders blank and is reported
+    assert unresolved == ["failed_run_id"]
+
+
+def test_warn_unreferenced_inputs() -> None:
+    """An input no placeholder mentions reaches no model, so the manifest says so."""
+    spec = _inputs_spec(["failed_run_id"])
+    spec["system_prompt"] = "Inspect {{ failed_run_id }} for {{ run_context.trigger }}."
+
+    assert warn_unreferenced_inputs(spec) == ["depth", "verbose", "extras"]
+
+    spec["system_prompt"] += " Depth {{ depth }}, verbose {{ verbose }}, extras {{ extras }}."
+    assert warn_unreferenced_inputs(spec) == []
+
+
+def test_warn_unbound_inputs() -> None:
+    """A decorated function that cannot receive a declared input is reported, not rejected."""
+
+    def takes_one(run_context: Any = None, failed_run_id: str = None) -> None:
+        pass
+
+    def takes_kwargs(**kwargs: Any) -> None:
+        pass
+
+    spec = _inputs_spec(["failed_run_id"])
+    assert warn_unbound_inputs(spec, takes_one) == ["depth", "verbose", "extras"]
+    # a function collecting kwargs can receive anything
+    assert warn_unbound_inputs(spec, takes_kwargs) == []

--- a/tests/workspace/deployment/test_agent_reflection.py
+++ b/tests/workspace/deployment/test_agent_reflection.py
@@ -1,0 +1,251 @@
+"""Tests for reading an agent declaration off a Python function."""
+
+from typing import Any, Dict, List, Literal, Optional
+
+import pytest
+
+import dlt
+from dlt.common.typing import Annotated, Doc, NotRequired, TypedDict
+
+from dlt._workspace.deployment.agent.exceptions import InvalidAgentSpec
+from dlt._workspace.deployment.agent.reflection import (
+    agent_source,
+    agent_spec_from_function,
+    inputs_from_function,
+    output_from_return,
+)
+from dlt._workspace.deployment.agent.typing import TAgentOutput
+from dlt._workspace.deployment.typing import TJobRunContext
+
+SOURCE = "/ws/jobs.py:inspector"
+
+
+class Report(TAgentOutput):
+    classification: Literal["config", "code"]
+    confidence: str
+    evidence: NotRequired[List[str]]
+
+
+class NotAnAgentOutput(TypedDict):
+    status: str
+    summary: str
+
+
+def inspector(
+    failed_run_id: str = dlt.config.value,
+    depth: int = 2,
+    tags: Optional[List[str]] = None,
+    run_context: TJobRunContext = None,
+) -> Report:
+    """Inspects a failed run and reports a diagnosis.
+
+    You run unattended, seconds after a job failed.
+    """
+
+
+def test_inputs_come_from_the_signature() -> None:
+    schema = inputs_from_function(inspector, SOURCE)
+
+    assert set(schema["properties"]) == {"failed_run_id", "depth", "tags"}
+    assert schema["properties"]["depth"] == {"default": 2, "title": "Depth", "type": "integer"}
+    # `dlt.config.value` means required, resolved from configuration
+    assert schema["required"] == ["failed_run_id"]
+    assert "default" not in schema["properties"]["failed_run_id"]
+    # the run context is implicit, and takes its definition with it
+    assert "run_context" not in schema["properties"]
+    assert "$defs" not in schema
+
+
+def test_output_comes_from_the_return_type() -> None:
+    schema = output_from_return(inspector, SOURCE)
+
+    assert set(schema["properties"]) == {
+        "status",
+        "summary",
+        "classification",
+        "confidence",
+        "evidence",
+    }
+    assert schema["properties"]["status"]["enum"] == ["succeeded", "failed", "aborted"]
+    assert set(schema["required"]) == {"status", "summary", "classification", "confidence"}
+
+
+@pytest.mark.parametrize(
+    "annotation", [NotAnAgentOutput, Dict[str, Any]], ids=["plain-typeddict", "dict"]
+)
+def test_output_must_derive_from_the_agent_output(annotation: Any) -> None:
+    def wrong() -> Any:
+        pass
+
+    wrong.__annotations__["return"] = annotation
+    with pytest.raises(InvalidAgentSpec, match="TAgentOutput"):
+        output_from_return(wrong, SOURCE)
+
+
+def test_spec_assembled_from_the_function() -> None:
+    spec = agent_spec_from_function(inspector, SOURCE, {"access": {"data": ["read"]}})
+
+    assert spec["name"] == "inspector"
+    assert spec["description"] == "Inspects a failed run and reports a diagnosis."
+    # the whole docstring is the system prompt, its first line the description
+    assert spec["system_prompt"].endswith("seconds after a job failed.")
+    assert spec["access"] == {"data": ["read"]}
+
+
+def test_decorator_and_function_override_the_referenced_agent() -> None:
+    base: Any = {
+        "name": "job-inspector",
+        "description": "from the toolkit",
+        "system_prompt": "toolkit body",
+        "access": {"data": ["read", "write"]},
+        "tools": ["telemetry"],
+        "inputs": {"type": "object", "properties": {"other": {}}},
+        "output": {"properties": {"status": {}, "summary": {}}},
+        "defaults": {"model": "sonnet", "limits": {"max_turns": 30}},
+    }
+    spec = agent_spec_from_function(inspector, SOURCE, {"access": {"data": ["read"]}}, base)
+
+    # decorator beats the toolkit
+    assert spec["access"] == {"data": ["read"]}
+    # the function beats it too, and what neither touches survives
+    assert set(spec["inputs"]["properties"]) == {"failed_run_id", "depth", "tags"}
+    assert spec["name"] == "inspector"
+    assert spec["tools"] == ["telemetry"]
+    assert spec["defaults"] == {"model": "sonnet", "limits": {"max_turns": 30}}
+
+
+def test_agent_source_names_the_file_and_the_function() -> None:
+    assert agent_source(inspector, "inspector").endswith("test_agent_reflection.py:inspector")
+
+
+class BareOutput(TAgentOutput):
+    pass
+
+
+@pytest.mark.parametrize(
+    "annotation", [None, Any, TAgentOutput, BareOutput], ids=["none", "any", "base", "empty-sub"]
+)
+def test_output_defaults_to_the_job_result(annotation: Any) -> None:
+    """Saying nothing about the result means the agent reports `status` and `summary`."""
+
+    def bare(run_context: TJobRunContext = None) -> Any:
+        pass
+
+    if annotation is None:
+        del bare.__annotations__["return"]
+    else:
+        bare.__annotations__["return"] = annotation
+
+    schema = output_from_return(bare, SOURCE)
+    assert set(schema["properties"]) == {"status", "summary"}
+    assert set(schema["required"]) == {"status", "summary"}
+
+
+def test_the_docstring_is_the_whole_prompt() -> None:
+    """An agent that takes nothing has a system prompt and no inputs."""
+
+    def sanity(run_context: TJobRunContext = None) -> BareOutput:
+        """Lists what it can see.
+
+        Report every skill, tool and MCP tool you are given.
+        """
+
+    spec = agent_spec_from_function(sanity, SOURCE, {})
+    assert spec["inputs"]["properties"] == {}
+    assert spec["description"] == "Lists what it can see."
+    assert spec["system_prompt"].endswith("MCP tool you are given.")
+
+
+@pytest.mark.parametrize(
+    "access,expected",
+    [
+        ({"data": "write"}, {"data": ["write"]}),
+        ({"local": "all", "context": ["read"]}, {"local": ["all"], "context": ["read"]}),
+        ({"data": "read", "context": "read"}, {"data": ["read"], "context": ["read"]}),
+    ],
+    ids=["single-verb", "mixed", "two-axes"],
+)
+def test_access_accepts_a_single_verb(access: Any, expected: Any) -> None:
+    spec = agent_spec_from_function(inspector, SOURCE, {"access": access})
+    assert spec["access"] == expected
+
+
+def test_inputs_schema_passes_manifest_validation() -> None:
+    """The inputs are a JSON Schema, so whatever a generator emits must survive validation."""
+    from dlt._workspace.deployment.agent.manifest import to_agent_definition
+    from dlt._workspace.deployment.manifest import validate_manifest
+
+    spec = agent_spec_from_function(inspector, SOURCE, {})
+    manifest: Any = {
+        "engine_version": 1,
+        "created_at": "2026-01-01T00:00:00Z",
+        "deployment_module": "__deployment__",
+        "jobs": [
+            {
+                "engine_version": 1,
+                "job_ref": "jobs.ops.inspector",
+                "entry_point": {
+                    "module": "m",
+                    "function": "inspector",
+                    "job_type": "batch",
+                    "launcher": "dlt._workspace.deployment.launchers.agent",
+                },
+                "triggers": [],
+                "execute": {"concurrency": 1},
+                "agent": to_agent_definition(spec),
+            }
+        ],
+    }
+    assert "additionalProperties" in spec["inputs"]
+    result = validate_manifest(manifest)
+    assert result.is_valid, result.errors
+
+
+class Described(TAgentOutput):
+    category_tools: Annotated[Dict[str, List[str]], Doc("all detected tools, in your categories")]
+    # a bare string reads as a description too, though flake8 takes it for a forward reference
+    hunch: Annotated[NotRequired[str], "what you suspect, one line"]  # noqa: F722
+    plain: str
+
+
+def test_annotated_describes_what_the_agent_reads() -> None:
+    """`Annotated` is the one place a description can be written without importing pydantic."""
+
+    def inspector(
+        run_id: Annotated[str, Doc("the run to look at")] = dlt.config.value,
+        depth: Annotated[int, Doc("how deep to dig")] = 2,
+        untouched: str = "x",
+    ) -> Described:
+        """Inspects a run."""
+        return None
+
+    output = output_from_return(inspector, SOURCE)["properties"]
+    inputs = inputs_from_function(inspector, SOURCE)["properties"]
+
+    assert output["category_tools"]["description"] == "all detected tools, in your categories"
+    assert output["hunch"]["description"] == "what you suspect, one line"
+    assert "description" not in output["plain"]
+    # the contract fields carry their meaning down from `TAgentOutput`
+    assert "aborted" in output["status"]["description"]
+    assert output["summary"]["description"].startswith("Markdown.")
+    # a Literal is a set of values, never a description
+    assert output["status"]["enum"] == ["succeeded", "failed", "aborted"]
+
+    assert inputs["run_id"]["description"] == "the run to look at"
+    assert inputs["depth"]["description"] == "how deep to dig"
+    assert "description" not in inputs["untouched"]
+
+
+def test_agent_output_is_the_payload_alone() -> None:
+    """The agent returns a payload type, not the envelope, so no launcher field reaches the model."""
+
+    def inspector() -> TAgentOutput:
+        """Inspects a run."""
+        return None
+
+    schema = output_from_return(inspector, SOURCE)
+
+    assert set(schema["properties"]) == {"status", "summary"}
+    for envelope_field in ("type", "engine_version", "result", "object", "job_ref", "trace"):
+        assert envelope_field not in schema["properties"]
+    assert "$defs" not in schema

--- a/tests/workspace/deployment/test_agent_tools.py
+++ b/tests/workspace/deployment/test_agent_tools.py
@@ -1,0 +1,135 @@
+"""Tests for the local tools an agent loop serves: files, search and execution in a workspace."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from dlt._workspace.deployment.agent.exceptions import LocalToolError
+from dlt._workspace.deployment.agent.loops.tools import (
+    LOCAL_TOOLS,
+    SHELL_TOOL,
+    LocalTools,
+    tool_env,
+    workspace_note,
+)
+
+
+def test_every_local_verb_but_network_has_its_tools(tmp_path: Path) -> None:
+    """`network` is the provider's; every other name in `LOCAL_TOOLS` is served here."""
+    served = LocalTools(str(tmp_path)).by_name()
+    for verb, names in LOCAL_TOOLS.items():
+        if verb != "network":
+            assert set(names) <= set(served), verb
+    assert "WebSearch" not in served
+
+
+def test_read_serves_whole_files_fragments_and_search(tmp_path: Path) -> None:
+    """One verb, three ways to look: the file, a range of its lines, and a pattern."""
+    (tmp_path / "jobs").mkdir()
+    (tmp_path / "jobs" / "load.py").write_text("import dlt\nrows = 10\nprint(rows)\n")
+    tools = LocalTools(str(tmp_path))
+
+    assert tools.read("jobs/load.py") == "import dlt\nrows = 10\nprint(rows)\n"
+    assert tools.read("jobs/load.py", offset=2, limit=1) == "rows = 10\n"
+    assert tools.glob("**/*.py") == "jobs/load.py"
+    assert tools.grep("rows") == "jobs/load.py:2:rows = 10\njobs/load.py:3:print(rows)"
+    assert "no line matches" in tools.grep("nothing-here")
+    with pytest.raises(LocalToolError, match="does not exist"):
+        tools.read("jobs/missing.py")
+    with pytest.raises(LocalToolError, match="not a valid regular expression"):
+        tools.grep("(")
+
+
+def test_write_replaces_a_fragment_or_the_whole_file(tmp_path: Path) -> None:
+    (tmp_path / "notes.md").write_text("one\ntwo\n")
+    tools = LocalTools(str(tmp_path))
+
+    tools.edit("notes.md", "two", "three")
+    assert (tmp_path / "notes.md").read_text() == "one\nthree\n"
+    # an ambiguous fragment is refused rather than guessed at
+    (tmp_path / "notes.md").write_text("x\nx\n")
+    with pytest.raises(LocalToolError, match="appears 2 times"):
+        tools.edit("notes.md", "x", "y")
+
+    tools.write("fresh/file.txt", "body")
+    assert (tmp_path / "fresh" / "file.txt").read_text() == "body"
+
+
+def test_file_tools_reach_the_workspace_and_the_scratch_folder(tmp_path: Path) -> None:
+    """Scratch files go to the temp folder; nowhere else is reachable."""
+    root, scratch = tmp_path / "ws", tmp_path / "scratch"
+    root.mkdir()
+    scratch.mkdir()
+    tools = LocalTools(str(root), str(scratch))
+
+    tools.write(str(scratch / "notes" / "draft.md"), "one\ntwo\n")
+    tools.edit(str(scratch / "notes" / "draft.md"), "two", "three")
+    assert tools.read(str(scratch / "notes" / "draft.md")) == "one\nthree\n"
+    # workspace paths stay relative to its root, absolute or not
+    tools.write("out/report.md", "ok")
+    assert tools.read(str(root / "out" / "report.md")) == "ok"
+    # anything else, including a hop out of either folder, is refused
+    with pytest.raises(LocalToolError, match="outside the workspace and the temp folder"):
+        tools.write(str(tmp_path / "elsewhere.txt"), "no")
+    with pytest.raises(LocalToolError, match="outside the workspace and the temp folder"):
+        tools.read("../elsewhere.txt")
+    # credentials are off limits in the temp folder too
+    with pytest.raises(LocalToolError, match="credentials"):
+        tools.write(str(scratch / "secrets.toml"), "api_key = 'x'")
+    # the prompt is where the model learns both folders
+    note = workspace_note(tools.root, tools.scratch)
+    assert root.resolve().as_posix() in note and scratch.resolve().as_posix() in note
+
+
+def test_file_tools_refuse_credential_files(tmp_path: Path) -> None:
+    """`local: [read]` is access to the workspace, not to what unlocks the destinations."""
+    (tmp_path / ".dlt").mkdir()
+    (tmp_path / ".dlt" / "prod.secrets.toml").write_text("[destination]\napi_key = 'live'\n")
+    (tmp_path / ".dlt" / "config.toml").write_text("[runtime]\n")
+    tools = LocalTools(str(tmp_path))
+
+    with pytest.raises(LocalToolError, match="credentials"):
+        tools.read(".dlt/prod.secrets.toml")
+    with pytest.raises(LocalToolError, match="credentials"):
+        tools.write(".dlt/secrets.toml", "api_key = 'stolen'")
+    with pytest.raises(LocalToolError, match="credentials"):
+        tools.edit(".dlt/prod.secrets.toml", "live", "stolen")
+    # neither listing nor search offers it, and the rest of the folder still is
+    assert "secrets.toml" not in tools.glob("**/*")
+    assert tools.grep("api_key").startswith("(no line matches")
+    assert "config.toml" in tools.glob("**/*")
+    assert tools.read(".dlt/config.toml") == "[runtime]\n"
+
+
+def test_execution_runs_in_the_workspace_with_its_virtualenv(tmp_path: Path) -> None:
+    """The launcher may start as `<venv>/bin/python -m ...`, which puts nothing on PATH."""
+    env = tool_env()
+    assert env["PATH"].split(os.pathsep)[0] == str(Path(sys.executable).parent)
+    # the MCP server we spawn shares our stderr, so its banner and info logs would land there
+    assert env["FASTMCP_SHOW_SERVER_BANNER"] == "false"
+    assert env["FASTMCP_LOG_LEVEL"] == "WARNING"
+    assert env["PYTHONIOENCODING"] == "utf-8"
+
+    tools = LocalTools(str(tmp_path))
+    (tmp_path / "marker.txt").write_text("here")
+    # each call is a fresh process in the workspace root, on the workspace interpreter
+    assert tools.python(
+        "import os, sys; print(os.getcwd()); print(sys.executable)"
+    ).splitlines() == [
+        str(tmp_path.resolve()),
+        sys.executable,
+    ]
+    # one shell per platform, PowerShell on Windows and bash elsewhere; `ls`, `cd`, `pwd` and
+    # `echo` are aliases in PowerShell, so the same commands run on both
+    shell = tools.by_name()[SHELL_TOOL]
+    assert "marker.txt" in shell("ls")
+    assert shell("cd /; pwd") != shell("pwd")
+    assert shell("exit 3") == "(no output, exit 3)"
+    # output is UTF-8 on every platform, whatever the console code page
+    assert shell("echo zażółć") == "zażółć"
+    assert tools.python("print('zażółć')") == "zażółć"
+    # the model reads the docstrings, which say how execution behaves
+    assert "fresh shell" in shell.__doc__ and "does not affect the next" in shell.__doc__
+    assert "workspace environment" in tools.python.__doc__

--- a/tests/workspace/deployment/test_decorators.py
+++ b/tests/workspace/deployment/test_decorators.py
@@ -3,14 +3,18 @@
 import asyncio
 import inspect
 from typing import Any, Dict, List, Literal, cast
+from unittest import mock
 
 import pytest
 
 import dlt
+from dlt.common import logger
+from dlt.common.typing import Annotated, TypedDict
 from dlt.common.warnings import DltDeprecationWarning
 from dlt._workspace.deployment.decorators import JobFactory, interactive, job, pipeline_run
 from dlt._workspace.deployment.exceptions import InvalidJobName, InvalidJobSection
-from dlt._workspace.deployment.typing import TTrigger
+from dlt._workspace.deployment.reflection import Entity
+from dlt._workspace.deployment.typing import TJobRunContext, TTrigger
 
 
 # module-level sources and resources for deliver tests
@@ -570,6 +574,115 @@ def test_config_key_discovery() -> None:
     job_def = with_config.to_job_definition()
     assert "api_key" in job_def["config_keys"]
     assert "limit" in job_def["config_keys"]
+
+
+def test_a_job_declares_its_arguments() -> None:
+    """`inputs` is `config_keys` with the types: one list, two resolutions."""
+
+    @job
+    def typed_job(
+        run_context: TJobRunContext = None,
+        since: str = dlt.config.value,
+        depth: int = 3,
+        verbose: bool = False,
+    ):
+        """Reads what configuration gives it."""
+
+    job_def = typed_job.to_job_definition()
+    inputs = job_def["inputs"]
+
+    assert set(inputs["properties"]) == set(job_def["config_keys"]) == {"since", "depth", "verbose"}
+    # `dlt.config.value` is required with no default; a real default is optional and carries it
+    assert inputs["required"] == ["since"]
+    assert inputs["properties"]["depth"] == {"default": 3, "title": "Depth", "type": "integer"}
+    assert inputs["properties"]["verbose"]["type"] == "boolean"
+
+
+def test_the_run_context_is_not_an_argument() -> None:
+    """The launcher passes it, configuration never does, so it is in neither list."""
+
+    @job
+    def needs_context(run_context: TJobRunContext):
+        pass
+
+    @job
+    def optional_context(run_context: TJobRunContext = None):
+        pass
+
+    for job_def in (needs_context.to_job_definition(), optional_context.to_job_definition()):
+        assert "inputs" not in job_def
+        assert "config_keys" not in job_def
+
+
+def test_an_argument_configuration_cannot_fill_is_not_declared() -> None:
+    """No default means nothing can inject it, so the manifest does not offer it."""
+
+    @job
+    def positional(needed: str, optional: int = 1):
+        pass
+
+    job_def = positional.to_job_definition()
+    assert set(job_def["inputs"]["properties"]) == set(job_def["config_keys"]) == {"optional"}
+
+
+class _Report(TypedDict):
+    rows: int
+
+
+@pytest.mark.parametrize(
+    "hint,declares",
+    [(_Report, True), (Dict[str, Any], False), (str, False), (None, False)],
+    ids=["typeddict", "dict", "str", "none"],
+)
+def test_a_job_declares_an_output_only_when_it_returns_one(hint: Any, declares: bool) -> None:
+    """`output` is the result contract, and a TypedDict return type is how a job declares one."""
+
+    def returns() -> Any:
+        pass
+
+    returns.__annotations__["return"] = hint
+    job_def = job(returns).to_job_definition()
+
+    assert ("output" in job_def) is declares
+    if declares:
+        assert job_def["output"]["properties"]["rows"]["type"] == "integer"
+
+
+def test_an_unreadable_signature_warns_and_still_deploys() -> None:
+    """A job dlt cannot describe is still a job."""
+
+    @job
+    def opaque(thing: "NoSuchType" = None):  # type: ignore[name-defined] # noqa: F821
+        pass
+
+    with mock.patch.object(logger, "warning") as warned:
+        job_def = opaque.to_job_definition()
+
+    assert "inputs" not in job_def
+    assert "declares no inputs" in warned.call_args[0][0]
+
+
+def test_entity_annotation_reaches_the_schema() -> None:
+    """`Entity` on an argument is `entity_type` in the schema, and the first one is the job's object."""
+
+    @job
+    def inspect(
+        run_id: Annotated[str, Entity("job-run")] = dlt.config.value,
+        dataset: Annotated[str, Entity("dataset")] = None,
+        depth: int = 3,
+    ):
+        pass
+
+    job_def = inspect.to_job_definition()
+    properties = job_def["inputs"]["properties"]
+
+    assert properties["run_id"]["entity_type"] == "job-run"
+    assert properties["dataset"]["entity_type"] == "dataset"
+    assert "entity_type" not in properties["depth"]
+    assert job_def["expose"]["object_input"] == {
+        "entity_type": "job-run",
+        "input": f"{inspect.job_ref}.run_id",
+    }
 
 
 def test_isinstance_check() -> None:

--- a/tests/workspace/deployment/test_entity.py
+++ b/tests/workspace/deployment/test_entity.py
@@ -1,0 +1,98 @@
+"""Tests for the workspace entities a job result points at."""
+
+from typing import Any, Dict
+
+import pytest
+
+from dlt._workspace.deployment.entity import hub_entity, hub_objects
+from dlt._workspace.deployment.exceptions import InvalidJobSchema
+from dlt._workspace.deployment.reflection import model_schema
+from dlt._workspace.deployment.typing import THubEntityType
+
+
+@pytest.mark.parametrize(
+    "entity_type,unique_id,expected",
+    [
+        ("job-run", "9ac2", "job-run/9ac2"),
+        ("job", "agents.job_inspector", "job/agents.job_inspector"),
+        ("pipeline", "github_actions", "pipeline/github_actions"),
+        ("dataset", "duckdb_prod/github_events", "dataset/duckdb_prod/github_events"),
+        ("workspace", "github_actions", "workspace/github_actions"),
+    ],
+    ids=["job-run", "job", "pipeline", "dataset", "workspace"],
+)
+def test_entity_id_is_type_slash_unique_id(
+    entity_type: THubEntityType, unique_id: str, expected: str
+) -> None:
+    assert hub_entity(entity_type, unique_id) == {"type": entity_type, "id": expected}
+
+
+INPUTS: Dict[str, Any] = {
+    "properties": {
+        "investigated_run_id": {"type": "string", "entity_type": "job-run"},
+        "depth": {"type": "integer"},
+        "dataset": {"type": "string", "entity_type": "dataset"},
+    }
+}
+OUTPUT: Dict[str, Any] = {
+    "properties": {
+        "investigated_run_id": {"type": "string", "entity_type": "job-run"},
+        "produced": {"type": "string", "entity_type": "dataset"},
+        "status": {"type": "string"},
+    }
+}
+
+
+def test_objects_come_from_inputs_and_outputs_overwrite() -> None:
+    """Inputs first, in declaration order; an output of the same name replaces the input's value."""
+    objects = hub_objects(
+        INPUTS,
+        {"investigated_run_id": "9ac2", "depth": 3, "dataset": "duckdb_prod/events"},
+        OUTPUT,
+        {"investigated_run_id": "b7e1", "produced": "duckdb_prod/costs", "status": "succeeded"},
+        "jobs.x.y",
+    )
+    assert objects == [
+        {"type": "job-run", "id": "job-run/b7e1"},
+        {"type": "dataset", "id": "dataset/duckdb_prod/events"},
+        {"type": "dataset", "id": "dataset/duckdb_prod/costs"},
+    ]
+
+
+def test_objects_skip_what_nobody_supplied_and_collapse_duplicates() -> None:
+    # an unset input is not an entity, and a payload that is not a mapping contributes nothing
+    assert hub_objects(INPUTS, {"depth": 3}, OUTPUT, "done", "jobs.x.y") == []
+    # the same entity named twice is one entity
+    twice = {"properties": {"other": {"type": "string", "entity_type": "job-run"}}}
+    objects = hub_objects(INPUTS, {"investigated_run_id": "9ac2"}, twice, {"other": "9ac2"}, "j")
+    assert objects == [{"type": "job-run", "id": "job-run/9ac2"}]
+
+
+def test_model_schema_moves_entity_type_into_a_comment() -> None:
+    """Strict validators refuse dlt's keyword; `$comment` is the standard slot a model still reads."""
+    schema: Dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "run_id": {"type": "string", "entity_type": "job-run", "$comment": "the failed run"},
+            "runs": {"type": "array", "items": {"type": "string", "entity_type": "job-run"}},
+            # a property that happens to be called entity_type is data, not the keyword
+            "entity_type": {"type": "string"},
+        },
+    }
+    converted = model_schema(schema)
+    assert converted["properties"]["run_id"] == {
+        "type": "string",
+        "$comment": "the failed run; entity_type: job-run",
+    }
+    assert converted["properties"]["runs"]["items"] == {
+        "type": "string",
+        "$comment": "entity_type: job-run",
+    }
+    assert converted["properties"]["entity_type"] == {"type": "string"}
+    # the manifest keeps the keyword, only the model's copy changes
+    assert schema["properties"]["run_id"]["entity_type"] == "job-run"
+
+
+def test_an_unknown_entity_type_is_refused() -> None:
+    with pytest.raises(InvalidJobSchema, match="pipline"):
+        hub_objects({"properties": {"x": {"entity_type": "pipline"}}}, {"x": "1"}, None, {}, "j")

--- a/tests/workspace/deployment/test_file_selector.py
+++ b/tests/workspace/deployment/test_file_selector.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from dlt._workspace.cli.dlthub.ai.utils import TOOLKITS_INDEX_FILE
 from dlt._workspace.deployment.file_selector import (
     ConfigurationFileSelector,
     DEFAULT_IGNORES,
@@ -216,3 +217,23 @@ def test_configuration_file_selector() -> None:
             files_custom
         )
         assert {"dev.config.toml", "tests.config.toml"} <= files_custom
+
+
+def test_toolkits_index_ships_but_secrets_do_not() -> None:
+    """The agent launcher resolves `<toolkit>:<agent>` from the index, so it must reach the runner."""
+    with isolated_workspace("default") as ctx:
+        settings = Path(ctx.settings_dir)
+        settings.mkdir(parents=True, exist_ok=True)
+        (settings / TOOLKITS_INDEX_FILE).write_text("dlthub-platform:\n  version: '0.2.0'\n")
+        (settings / "secrets.toml").write_text("[destination]\n")
+        (settings / "config.toml").write_text("[runtime]\n")
+        (settings / "state").mkdir(exist_ok=True)
+        (settings / "state" / "local.duckdb").write_text("x")
+
+        files = {rel.as_posix() for _, rel in WorkspaceFileSelector(ctx, ignore_file=".ignorefile")}
+
+    assert f".dlt/{TOOLKITS_INDEX_FILE}" in files
+    # everything else under the settings dir stays out, secrets above all
+    assert ".dlt/secrets.toml" not in files
+    assert ".dlt/config.toml" not in files
+    assert ".dlt/state/local.duckdb" not in files

--- a/tests/workspace/deployment/test_job_result.py
+++ b/tests/workspace/deployment/test_job_result.py
@@ -1,0 +1,196 @@
+"""Tests for structured job results and their delivery to the dlthub beacon."""
+
+import json as pyjson
+from typing import Any, Dict, List, Mapping, Optional, Tuple, cast
+
+import pytest
+
+from dlt._workspace.deployment._job_ref import job_category
+from dlt._workspace.deployment._run_views import print_job_result
+from dlt._workspace.deployment.exceptions import InvalidJobResultType
+from dlt._workspace.deployment.job_result import (
+    job_result,
+    parse_result_type,
+    result_type,
+    running_job,
+    set_job_result,
+    take_job_result,
+)
+from dlt._workspace.deployment.launchers import LAUNCHER_JOB
+from dlt._workspace.deployment.launchers.job import run as job_run
+from dlt._workspace.deployment.agent.typing import TAgentJobResult, TAgentTrace
+from dlt._workspace.deployment.typing import (
+    JOB_RESULT_ENGINE_VERSION,
+    JOB_RESULT_PAYLOAD_TYPE,
+    TJobRef,
+    TJobResult,
+    TRuntimeEntryPoint,
+)
+
+from tests.workspace.utils import beacon as beacon, drain_beacon, isolated_workspace
+
+WORKSPACE = "tests.workspace.cases.workspaces.agent_workspace"
+
+AGENT_RESULT: TAgentJobResult = {
+    "type": "job.background_agent.dlthub-platform:job-inspector",
+    "engine_version": 1,
+    "status": "succeeded",
+    "summary": "found the cause",
+    "object": [{"type": "job-run", "id": "job-run/r-9"}],
+    # the view reads a handful of trace fields, so a partial one exercises it
+    "trace": cast(
+        TAgentTrace,
+        {
+            "loop_type": "pydantic-ai",
+            "model": "claude-sonnet-5",
+            "turn_count": 3,
+            "total_tokens": 165,
+            "local_tools": {"Grep": "read", "Bash": "execute"},
+        },
+    ),
+    "result": {"classification": "code"},
+}
+
+PLAIN_RESULT: TJobResult = {
+    "type": "job.batch.etl_summary",
+    "engine_version": 1,
+    "result": {"rows": 10},
+}
+
+
+def _entry(function: str) -> TRuntimeEntryPoint:
+    module = f"{WORKSPACE}.agent_batch_jobs"
+    return {
+        "module": module,
+        "function": function,
+        "job_type": "batch",
+        "launcher": LAUNCHER_JOB,
+        "job_ref": TJobRef(f"jobs.agent_batch_jobs.{function}"),
+    }
+
+
+def test_top_level_job_owns_the_run_result() -> None:
+    """`run.result` is a pass-through, recorded once for the job the launcher invoked."""
+    payload = {"from": "outer"}
+    with running_job(TJobRef("jobs.x.outer")):
+        assert job_result(payload, type="outer") is payload
+        # a job called as a plain function by another job does not overwrite the run result
+        with running_job(TJobRef("jobs.x.inner")):
+            assert job_result({"from": "inner"}, type="inner") == {"from": "inner"}
+            set_job_result({"type": "inner", "engine_version": 1})
+        declared = take_job_result(TJobRef("jobs.x.outer"), "batch")
+    # the job named the payload, taking it stamps the launcher's category and the job ref
+    assert declared == {
+        "type": "job.batch.outer",
+        "engine_version": JOB_RESULT_ENGINE_VERSION,
+        "result": payload,
+        "job_ref": "jobs.x.outer",
+    }
+    # a second take finds nothing, so one run delivers at most one result
+    assert take_job_result(TJobRef("jobs.x.outer"), "batch") is None
+    # outside a job the payload still comes back, it is simply not recorded
+    assert job_result(payload, type="outer") is payload
+    assert take_job_result(TJobRef("jobs.x.outer"), "batch") is None
+
+
+@pytest.mark.parametrize(
+    "category,name",
+    [
+        ("background_agent", "dlthub-platform:job-inspector"),
+        ("background_agent", "jobs.agents.check_toolkits"),
+        ("pipeline", "load_info"),
+        ("batch", "etl_summary"),
+    ],
+    ids=["agent-ref", "dotted-job-ref", "pipeline", "batch"],
+)
+def test_parse_result_type_survives_dots_in_the_name(category: str, name: str) -> None:
+    """The first two segments are closed vocabularies, so the name may carry anything."""
+    assert parse_result_type(result_type(category, name)) == (category, name)
+
+
+@pytest.mark.parametrize("bad", ["etl_summary", "job.batch", "run.batch.x", "job..x", "job.batch."])
+def test_parse_result_type_refuses_anything_else(bad: str) -> None:
+    with pytest.raises(InvalidJobResultType):
+        parse_result_type(bad)
+
+
+@pytest.mark.parametrize(
+    "expose,deliver,job_type,expected",
+    [
+        ({"category": "background_agent"}, None, "batch", "background_agent"),
+        ({}, {"pipeline_name": "p"}, "batch", "pipeline"),
+        (None, None, "interactive", "interactive"),
+        ({"category": "dashboard"}, {"pipeline_name": "p"}, "batch", "dashboard"),
+    ],
+    ids=["expose-category", "delivering-job", "job-type", "category-over-pipeline"],
+)
+def test_job_category_is_one_rule(
+    expose: Optional[Mapping[str, Any]],
+    deliver: Optional[Mapping[str, Any]],
+    job_type: str,
+    expected: str,
+) -> None:
+    """`expose.category`, else `pipeline` for a delivering job, else `job_type`."""
+    assert job_category(expose, deliver, job_type) == expected
+
+
+def test_launcher_delivers_the_result_to_the_beacon(beacon: List[Tuple[str, str]]) -> None:
+    """The job names the payload, the launcher names the envelope and sends it once configured."""
+    with isolated_workspace("agent_workspace") as ctx:
+        # without `dlthub_dsn` the result comes back and nothing is sent
+        result = job_run(_entry("daily_ingest"), run_id="r-1", trigger="manual:")
+        assert result["type"] == "job.batch.etl_summary"
+        assert result["result"] == {"rows": 10}
+        assert "object" not in result
+        assert beacon == []
+
+        ctx.runtime_config.dlthub_dsn = "https://beacon.example/token"
+        # a job that declares no result returns what it returned, and sends nothing
+        assert job_run(_entry("transform"), run_id="r-2", trigger="manual:") == "transformed"
+        job_run(_entry("daily_ingest"), run_id="r-3", trigger="manual:")
+        drain_beacon()
+
+    assert len(beacon) == 1
+    url, data = beacon[0]
+    assert url.endswith(f"/{JOB_RESULT_PAYLOAD_TYPE}")
+    body: Dict[str, Any] = pyjson.loads(data)
+    # the beacon derives run identity from the DSN token, so the body must not carry it
+    assert "run_id" not in body
+    # job_ref is what the beacon dedups on
+    assert body["job_ref"] == "jobs.agent_batch_jobs.daily_ingest"
+    assert body["type"] == "job.batch.etl_summary"
+    assert body["result"] == {"rows": 10}
+
+
+@pytest.mark.parametrize(
+    "result,shown,hidden",
+    [
+        (
+            AGENT_RESULT,
+            [
+                "job.background_agent.dlthub-platform:job-inspector",
+                "succeeded",
+                "found the cause",
+                "job-run: job-run/r-9",
+                "pydantic-ai on claude-sonnet-5, 3 turns, 165 tokens",
+                "local tools: Grep (read), Bash (execute)",
+                # the payload is pretty-printed rather than dumped as a repr
+                '"classification": "code"',
+            ],
+            [],
+        ),
+        # nothing agent-specific leaks into a plain job's result
+        (PLAIN_RESULT, ["job.batch.etl_summary", '"rows": 10'], ["status", "loop:"]),
+    ],
+    ids=["agent", "plain"],
+)
+def test_print_job_result(
+    result: TJobResult, shown: List[str], hidden: List[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`dlthub local run` shows the payload; agent runs also show status, summary and loop."""
+    print_job_result(result)
+    out = capsys.readouterr().out
+    for text in shown:
+        assert text in out, text
+    for text in hidden:
+        assert text not in out, text

--- a/tests/workspace/deployment/test_launchers.py
+++ b/tests/workspace/deployment/test_launchers.py
@@ -23,7 +23,12 @@ from dlt._workspace.deployment.launchers._launcher import (
 )
 from dlt._workspace.deployment.exceptions import JobResolutionError
 from dlt._workspace.deployment.launchers.job import run as job_run
-from dlt._workspace.deployment.typing import TInstallSpec, TJobDefinition, TRuntimeEntryPoint
+from dlt._workspace.deployment.typing import (
+    MANIFEST_ENGINE_VERSION,
+    TInstallSpec,
+    TJobDefinition,
+    TRuntimeEntryPoint,
+)
 from dlt.common.exceptions import SignalReceivedException
 from dlt.common.runtime import signals
 from dlt.pipeline.exceptions import PipelineStepFailed
@@ -33,7 +38,7 @@ from tests.workspace.cases.runtime_workspace import batch_jobs
 from tests.workspace.utils import isolated_workspace
 
 WORKSPACE = "tests.workspace.cases.runtime_workspace"
-_DLT_SPEC: TInstallSpec = {"name": "dlt", "extras": [], "version": "1.29.0", "mode": "pypi"}
+_DLT_SPEC: TInstallSpec = {"name": "dlt", "extras": [], "version": dlt.__version__, "mode": "pypi"}
 
 
 def _entry(
@@ -239,7 +244,9 @@ def test_decorator_to_launcher_e2e_incremental_mode() -> None:
         dlt_version=_DLT_SPEC,
         tz="UTC",
     )
-    assert ep["allow_external_schedulers"] is True
+    # this dlt's launcher reads the mode itself; the flag is for launchers before 1.30.1
+    assert ep["incremental_mode"] == "interval"
+    assert "allow_external_schedulers" not in ep
 
     result = job_run(ep, run_id="inc-iv-e2e", trigger="schedule:0 0 * * *")
     # context flag was injected and observed by the job
@@ -1086,6 +1093,7 @@ def test_build_runtime_entry_point_propagates_execute_intercept_signals() -> Non
 
     def _job_def(**extra: Any) -> TJobDefinition:
         jd: Dict[str, Any] = {
+            "engine_version": MANIFEST_ENGINE_VERSION,
             "job_ref": "jobs.test",
             "entry_point": dict(base_ep),
             "triggers": [],

--- a/tests/workspace/deployment/test_manifest_generator.py
+++ b/tests/workspace/deployment/test_manifest_generator.py
@@ -9,7 +9,7 @@ from typing import List
 import pytest
 
 from dlt._workspace.deployment.decorators import job
-from dlt._workspace.deployment.exceptions import InvalidManifest
+from dlt._workspace.deployment.exceptions import InvalidManifest, InvalidTrigger
 from dlt._workspace.deployment.manifest import (
     DASHBOARD_JOB_REF,
     generate_manifest,
@@ -524,6 +524,16 @@ def test_manifest_from_module_invalid_module(isolated: bool) -> None:
     """Both modes raise ModuleNotFoundError for a bad module name."""
     with pytest.raises(ModuleNotFoundError, match="nonexistent_module_xyz_123"):
         manifest_from_module("nonexistent_module_xyz_123", isolated=isolated)
+
+
+@pytest.mark.parametrize("isolated", [False, True], ids=["inprocess", "isolated"])
+def test_manifest_from_module_invalid_trigger(isolated: bool) -> None:
+    """A definition error in the module comes back as itself from both modes."""
+    with pytest.raises(InvalidTrigger, match="period must be like") as exc_info:
+        manifest_from_module(f"{WORKSPACE}.invalid_trigger_jobs", isolated=isolated)
+    exc = exc_info.value
+    # only the message crosses the worker boundary, so the rebuilt error carries it whole
+    assert exc.errors == ([str(exc)] if isolated else ["period must be like '5m', '1h', '1d'"])
 
 
 def test_manifest_from_module_isolated_no_pollution() -> None:

--- a/tests/workspace/deployment/test_manifest_generator.py
+++ b/tests/workspace/deployment/test_manifest_generator.py
@@ -103,11 +103,12 @@ def test_full_deployment_job_details() -> None:
     assert daily["execute"]["timeout"]["timeout"] == 14400.0
     assert daily["default_trigger"] == TTrigger("schedule:0 8 * * *")
 
-    # batch job with chained triggers — first trigger is default
+    # batch job with chained triggers only: a job event names the run that fired it, so it
+    # never stands in for a manual run and the job has no default trigger
     transform = jobs_by_ref[TJobRef("jobs.batch_jobs.transform")]
     assert len(transform["triggers"]) == 2
     assert all("job.success:" in t for t in transform["triggers"])
-    assert transform["default_trigger"] == transform["triggers"][0]
+    assert "default_trigger" not in transform
     assert transform["description"] == "Transform ingested data."
 
     # starred job with config keys
@@ -140,6 +141,31 @@ def test_full_deployment_job_details() -> None:
     assert st_app["expose"]["interface"] == "gui"
     assert st_app["description"] == "Test dashboard."
     assert st_app.get("expose", {}).get("category") == "dashboard"
+
+
+def test_inputs_and_config_keys_are_one_list() -> None:
+    """A job declares the arguments configuration injects, twice: as names and as a schema."""
+    module = ModuleType("__deployment_inputs_test__")
+    from tests.workspace.cases.runtime_workspace import batch_jobs
+
+    names = ["backfill", "maintenance", "context_aware", "context_optional", "interval_aware"]
+    for name in names:
+        setattr(module, name, getattr(batch_jobs, name))
+    module.__all__ = names  # type: ignore[attr-defined]
+    manifest, _ = generate_manifest(module)
+
+    for job_def in manifest["jobs"]:
+        declared = set((job_def.get("inputs") or {}).get("properties") or {})
+        assert declared == set(job_def.get("config_keys") or []), job_def["job_ref"]
+        # neither is written empty: nothing to declare means no key at all
+        assert ("inputs" in job_def) == ("config_keys" in job_def), job_def["job_ref"]
+
+    jobs_by_ref = {j["job_ref"]: j for j in manifest["jobs"]}
+    maintenance = jobs_by_ref[TJobRef("jobs.batch_jobs.maintenance")]
+    assert maintenance["inputs"]["required"] == ["cleanup_days"]
+    # the run context is the launcher's to pass, in either form it is written
+    assert "inputs" not in jobs_by_ref[TJobRef("jobs.batch_jobs.context_optional")]
+    assert "config_keys" not in jobs_by_ref[TJobRef("jobs.batch_jobs.context_optional")]
 
 
 def test_batch_only_deployment() -> None:

--- a/tests/workspace/deployment/test_requirements.py
+++ b/tests/workspace/deployment/test_requirements.py
@@ -11,6 +11,8 @@ import pytest
 from packaging.requirements import Requirement
 
 from dlt._workspace.deployment.launchers import (
+    AGENT_LOOP_GROUP_PREFIX,
+    LAUNCHER_AGENT,
     LAUNCHER_DASHBOARD,
     LAUNCHER_JOB,
     LAUNCHER_MARIMO,
@@ -27,6 +29,7 @@ from dlt._workspace.deployment.requirements import (
     REQUIREMENTS_ENGINE_VERSION,
     WorkspaceRequirementsError,
     _BASE_LAUNCHER_SPECS,
+    build_agent_loop_groups,
     build_dashboard_group,
     build_launcher_requirements,
     default_requirements_manifest,
@@ -103,7 +106,11 @@ def test_pyproject_with_lock_resolves_all_groups() -> None:
         result = export_workspace_requirements(Path(ctx.run_dir))
 
     groups = result["groups"]
-    user_groups = {k: v for k, v in groups.items() if k != DASHBOARD_JOB_REF}
+    user_groups = {
+        k: v
+        for k, v in groups.items()
+        if k != DASHBOARD_JOB_REF and not k.startswith(AGENT_LOOP_GROUP_PREFIX)
+    }
     assert set(user_groups.keys()) == {"main", "dev", "gpu"}
 
     # every user spec must be pinned, and free of hashes / local paths
@@ -145,7 +152,11 @@ def test_requirements_file_resolved_with_uv(fixture_name: str, required_names: S
     with isolated_workspace(fixture_name) as ctx:
         result = export_workspace_requirements(Path(ctx.run_dir))
 
-    user_group_names = [k for k in result["groups"] if k != DASHBOARD_JOB_REF]
+    user_group_names = [
+        k
+        for k in result["groups"]
+        if k != DASHBOARD_JOB_REF and not k.startswith(AGENT_LOOP_GROUP_PREFIX)
+    ]
     assert user_group_names == [MAIN_GROUP]
     specs = result["groups"][MAIN_GROUP]
     assert specs
@@ -306,6 +317,7 @@ def test_launcher_requirements_shape() -> None:
         LAUNCHER_MCP,
         LAUNCHER_STREAMLIT,
         LAUNCHER_DASHBOARD,
+        LAUNCHER_AGENT,
     }
     # every launcher gets the base specs
     for specs in lreq.values():
@@ -316,6 +328,8 @@ def test_launcher_requirements_shape() -> None:
     # by export_workspace_requirements / default_requirements_manifest
     assert lreq[LAUNCHER_JOB] == sorted(set(["botocore", "s3fs"] + _BASE_LAUNCHER_SPECS))
     assert lreq[LAUNCHER_MODULE] == sorted(set(["botocore", "s3fs"] + _BASE_LAUNCHER_SPECS))
+    # loop packages live in agent-loop-* groups, not here
+    assert lreq[LAUNCHER_AGENT] == sorted(set(["botocore", "s3fs"] + _BASE_LAUNCHER_SPECS))
     assert lreq[LAUNCHER_MARIMO] == sorted(set(["marimo", "uvicorn"] + _BASE_LAUNCHER_SPECS))
     assert lreq[LAUNCHER_MCP] == sorted(set(["fastmcp", "uvicorn"] + _BASE_LAUNCHER_SPECS))
     assert lreq[LAUNCHER_STREAMLIT] == sorted(set(["streamlit"] + _BASE_LAUNCHER_SPECS))
@@ -376,10 +390,11 @@ def test_default_requirements_manifest_shape() -> None:
     assert manifest["dlt_version"] == get_pkg_install_spec("dlt")
     assert manifest["dlt_version"]["version"]
     assert manifest["default_groups"] == [MAIN_GROUP]
-    # empty main + dashboard group
+    # empty main + dashboard group + one group per built-in agent loop
     assert manifest["groups"] == {
         MAIN_GROUP: [],
         DASHBOARD_JOB_REF: build_dashboard_group(),
+        **build_agent_loop_groups(),
     }
     # dlt injected into every launcher entry
     dlt_spec = get_dlt_requirement_spec()

--- a/tests/workspace/deployment/test_run_helpers.py
+++ b/tests/workspace/deployment/test_run_helpers.py
@@ -3,9 +3,10 @@
 from datetime import datetime, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional
 
 import pytest
+from packaging.version import InvalidVersion
 
 from dlt._workspace.deployment import _run_helpers as run_helpers
 from dlt._workspace.deployment._run_helpers import (
@@ -31,7 +32,6 @@ from dlt._workspace.deployment.exceptions import (
 )
 from dlt._workspace.deployment.launchers import LAUNCHER_JOB, LAUNCHER_MODULE
 from dlt._workspace.deployment.typing import (
-    TIncrementalSource,
     TInstallSpec,
     TJobDefinition,
     TJobsDeploymentManifest,
@@ -40,12 +40,15 @@ from dlt._workspace.deployment.typing import (
     TTrigger,
 )
 from dlt._workspace.profile import DEFAULT_PROFILE
+from dlt.version import __version__
 
 from tests.workspace.manifest_utils import make_job, make_manifest
 
 
 NOW = datetime(2026, 4, 19, 12, 0, tzinfo=timezone.utc)
-_DLT_SPEC: TInstallSpec = {"name": "dlt", "extras": [], "version": "1.29.0", "mode": "pypi"}
+_DLT_SPEC: TInstallSpec = {"name": "dlt", "extras": [], "version": __version__, "mode": "pypi"}
+# a launcher from before `incremental_mode`, as an engine-1 deployment resolves to
+_OLD_DLT_SPEC: TInstallSpec = {"name": "dlt", "extras": [], "version": "1.28.0", "mode": "pypi"}
 
 
 def _job(
@@ -560,27 +563,44 @@ def test_build_runtime_entry_point_config_merges() -> None:
     assert ep["config"] == {"A": "1", "B": "override", "C": "3"}
 
 
-def test_build_runtime_entry_point_propagates_modes() -> None:
-    """incremental_mode is dual-written with `allow_external_schedulers` for older launchers;
-    auto_refresh_pipeline_mode passes through verbatim."""
-    mode_cases: List[Tuple[Dict[str, Any], bool, Optional[str]]] = [
-        ({"incremental_mode": "interval"}, True, "interval"),
-        ({"incremental_mode": "pipeline"}, False, "pipeline"),
-    ]
-    for jd_kwargs, expected_allow, expected_mode in mode_cases:
-        jd = _job("jobs.a", **jd_kwargs)
-        ep = build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, _DLT_SPEC, "UTC")
-        assert ep["allow_external_schedulers"] is expected_allow, jd_kwargs
-        assert ep.get("incremental_mode") == expected_mode, jd_kwargs
-
-    # auto_refresh_pipeline_mode: unset emits nothing, set passes through
-    jd = _job("jobs.a")
-    ep = build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, _DLT_SPEC, "UTC")
-    assert "auto_refresh_pipeline_mode" not in ep
-
+def test_build_runtime_entry_point_shapes_modes_for_the_target_dlt() -> None:
+    """A launcher from dlt 1.30.1 on reads `incremental_mode` and `auto_refresh_pipeline_mode`;
+    one from before knows `allow_external_schedulers` alone. Each target gets its own keys."""
+    jd = _job("jobs.a", incremental_mode="interval")
     jd["auto_refresh_pipeline_mode"] = "drop_sources"
-    ep = build_runtime_entry_point(jd, {}, "dev", True, NOW, NOW, _DLT_SPEC, "UTC")
+    ep = build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, _DLT_SPEC, "UTC")
+    assert ep["incremental_mode"] == "interval"
     assert ep["auto_refresh_pipeline_mode"] == "drop_sources"
+    assert "allow_external_schedulers" not in ep
+
+    ep = build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, _OLD_DLT_SPEC, "UTC")
+    assert ep["allow_external_schedulers"] is True
+    assert "incremental_mode" not in ep
+    assert "auto_refresh_pipeline_mode" not in ep
+    jd = _job("jobs.a", incremental_mode="pipeline")
+    ep = build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, _OLD_DLT_SPEC, "UTC")
+    assert ep["allow_external_schedulers"] is False
+
+    # the keys came in with a devel pre-release, so it and everything after count as new
+    for version in ("1.30.1a0", "1.30.1", "1.31.0.dev2", "1.30.1+local"):
+        spec: TInstallSpec = {**_DLT_SPEC, "version": version}
+        ep = build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, spec, "UTC")
+        assert ep["incremental_mode"] == "pipeline", version
+    for version in ("1.30.0", "1.29.9rc1"):
+        spec = {**_DLT_SPEC, "version": version}
+        ep = build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, spec, "UTC")
+        assert "incremental_mode" not in ep, version
+    # anything but a package version is refused: a guess would shape the point for the wrong launcher
+    for version in ("", "latest"):
+        spec = {**_DLT_SPEC, "version": version}
+        with pytest.raises(InvalidVersion):
+            build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, spec, "UTC")
+
+    # unset modes emit nothing, whatever the target
+    for spec in (_DLT_SPEC, _OLD_DLT_SPEC):
+        ep = build_runtime_entry_point(_job("jobs.a"), {}, "dev", True, NOW, NOW, spec, "UTC")
+        assert "incremental_mode" not in ep and "allow_external_schedulers" not in ep
+        assert "auto_refresh_pipeline_mode" not in ep
 
 
 def test_build_runtime_entry_point_requires_dlt_version() -> None:
@@ -727,17 +747,3 @@ def test_warn_missing_profiles_returns_empty_when_both_present(
 
     monkeypatch.setattr(run_helpers, "active", lambda: _MockCtx())
     assert warn_missing_profiles() == []
-
-
-@pytest.mark.parametrize("mode", ["interval", "pipeline"])
-def test_entry_point_always_dual_writes_legacy_flag(mode: str) -> None:
-    """The entry point is the compatibility layer, not the job definition.
-
-    Launchers of older dlt versions only read `allow_external_schedulers`, so it must be
-    emitted whenever `incremental_mode` is. Dropping it as redundant silently breaks every
-    already-deployed workspace running an older dlt.
-    """
-    jd = _job("jobs.a", incremental_mode=cast(TIncrementalSource, mode))
-    ep = build_runtime_entry_point(jd, {}, "dev", False, NOW, NOW, _DLT_SPEC, "UTC")
-    assert ep["incremental_mode"] == mode
-    assert ep["allow_external_schedulers"] is (mode == "interval")

--- a/tests/workspace/deployment/test_triggers.py
+++ b/tests/workspace/deployment/test_triggers.py
@@ -1,11 +1,12 @@
 """Tests for trigger parsing, normalization, and selectors."""
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import pytest
 
 from dlt._workspace.deployment.exceptions import InvalidTrigger
 from dlt._workspace.deployment._trigger_helpers import (
+    is_selector,
     humanize_trigger,
     match_triggers_with_selectors,
     normalize_trigger,
@@ -13,7 +14,9 @@ from dlt._workspace.deployment._trigger_helpers import (
     parse_trigger,
     pick_trigger,
 )
+from dlt._workspace.deployment.manifest import expand_trigger_selectors
 from dlt._workspace.deployment.typing import (
+    MANIFEST_ENGINE_VERSION,
     HttpTriggerInfo,
     TEntryPoint,
     TExecuteSpec,
@@ -183,8 +186,9 @@ def test_normalize_trigger_valid(trigger: str) -> None:
         ("http:0", "1-65535"),
         ("http:abc", "port invalid"),
         ("http://localhost:5000", "not a full URL"),
-        ("job.success:not_a_ref", "must start with"),
-        ("job.fail:bad_ref", "must start with"),
+        # a bare name cannot be resolved; `section.name` and `jobs.section.name` both can
+        ("job.success:not_a_ref", "section.name"),
+        ("job.fail:bad_ref", "section.name"),
     ],
     ids=[
         "unknown-type",
@@ -279,6 +283,7 @@ def _job(
     if manual:
         trigger_list.append(TTrigger(f"manual:{ref}"))
     return {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef(ref),
         "entry_point": TEntryPoint(
             module="m",
@@ -551,3 +556,167 @@ def test_pick_trigger(matched: List[str], default: Optional[str], expected: Opti
 )
 def test_humanize_trigger(trigger: str, expected: str) -> None:
     assert humanize_trigger(TTrigger(trigger)) == expected
+
+
+@pytest.mark.parametrize(
+    "trigger,expected",
+    [
+        ("job.fail:jobs.batch.daily", "job.fail:jobs.batch.daily"),
+        ("job.fail:batch.daily", "job.fail:jobs.batch.daily"),
+        # a selector stands as written; only a bare ref is resolved
+        ("job.success:batch.*", "job.success:batch.*"),
+        ("job.success:jobs.*", "job.success:jobs.*"),
+        ("job.fail:*", "job.fail:*"),
+        ("job.success:tag:ingest", "job.success:tag:ingest"),
+        ("job.success:batch:", "job.success:batch:"),
+    ],
+    ids=["qualified", "section-name", "section-glob", "qualified-glob", "bare-star", "tag", "type"],
+)
+def test_normalize_job_event_trigger_refs(trigger: str, expected: str) -> None:
+    assert normalize_trigger(trigger) == expected
+
+
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("tag:ingest", True),
+        ("batch", True),
+        ("batch:", True),
+        ("jobs.batch.*", True),
+        ("jobs.a.b?", True),
+        ("*", True),
+        ("jobs.a.b", False),
+        ("ingest", False),
+    ],
+    ids=["tag", "type", "type-colon", "ref-glob", "question", "star", "ref", "name"],
+)
+def test_is_selector(expr: str, expected: bool) -> None:
+    """A job ref never carries a colon or a glob character, so either one selects."""
+    assert is_selector(expr) is expected
+
+
+def _job_def(job_ref: str, triggers: List[str], job_type: str = "batch") -> TJobDefinition:
+    return {
+        "engine_version": MANIFEST_ENGINE_VERSION,
+        "job_ref": TJobRef(job_ref),
+        "entry_point": TEntryPoint(
+            module="m", function="f", job_type=job_type, launcher="l"  # type: ignore[typeddict-item]
+        ),
+        "triggers": [TTrigger(t) for t in triggers],
+        "execute": TExecuteSpec(),
+    }
+
+
+def test_expand_trigger_selectors() -> None:
+    """A selector expands to every other job; only the declaring job is excluded."""
+    watcher = _job_def("jobs.ops.inspector", ["job.fail:jobs.*"])
+    other_watcher = _job_def("jobs.ops.auditor", ["job.success:jobs.*"])
+    ingest = _job_def("jobs.batch.ingest", ["schedule:0 8 * * *"])
+    transform = _job_def("jobs.batch.transform", [])
+    dashboard = _job_def("jobs.workspace.dashboard", ["http:"], job_type="interactive")
+    jobs = [watcher, other_watcher, ingest, transform, dashboard]
+
+    assert expand_trigger_selectors(jobs) == []
+
+    # never itself, never the interactive job; another watcher is a legitimate target
+    assert watcher["triggers"] == [
+        "job.fail:jobs.ops.auditor",
+        "job.fail:jobs.batch.ingest",
+        "job.fail:jobs.batch.transform",
+    ]
+    assert other_watcher["triggers"] == [
+        "job.success:jobs.ops.inspector",
+        "job.success:jobs.batch.ingest",
+        "job.success:jobs.batch.transform",
+    ]
+    # non-selector triggers pass through untouched
+    assert ingest["triggers"] == ["schedule:0 8 * * *"]
+
+
+def test_expand_trigger_selectors_never_targets_the_declaring_job() -> None:
+    """Self-exclusion is the whole loop guard: a job must not trigger itself."""
+    watcher = _job_def("jobs.ops.only_job", ["job.fail:jobs.*"])
+    jobs = [watcher]
+    warnings = expand_trigger_selectors(jobs)
+    assert watcher["triggers"] == []
+    assert len(warnings) == 1
+
+
+def test_expand_trigger_selectors_keeps_other_triggers_and_warns() -> None:
+    watcher = _job_def("jobs.ops.inspector", ["schedule:0 7 * * *", "job.fail:jobs.nothing.*"])
+    warnings = expand_trigger_selectors([watcher, _job_def("jobs.batch.ingest", [])])
+    assert watcher["triggers"] == ["schedule:0 7 * * *"]
+    assert len(warnings) == 1
+    assert "matched no job" in warnings[0]
+
+
+def test_expand_trigger_selectors_is_case_sensitive() -> None:
+    """Manifests must not differ by platform, so matching never folds case."""
+    watcher = _job_def("jobs.ops.inspector", ["job.fail:jobs.Batch.*"])
+    jobs = [watcher, _job_def("jobs.batch.ingest", [])]
+    warnings = expand_trigger_selectors(jobs)
+    assert watcher["triggers"] == []
+    assert len(warnings) == 1
+
+
+def _tagged(job_ref: str, tags: List[str], job_type: str = "batch") -> TJobDefinition:
+    job_def = _job_def(job_ref, [], job_type=job_type)
+    job_def["expose"] = {"tags": tags}
+    return job_def
+
+
+def test_expand_selects_by_tag() -> None:
+    """`tag:` reaches a job through the trigger its `expose.tags` synthesizes."""
+    watcher = _job_def("jobs.ops.inspector", ["job.fail:tag:ingest"])
+    ingest = _tagged("jobs.batch.ingest", ["ingest"])
+    load = _tagged("jobs.batch.load", ["ingest", "nightly"])
+    report = _tagged("jobs.batch.report", ["nightly"])
+
+    assert expand_trigger_selectors([watcher, ingest, load, report]) == []
+    assert watcher["triggers"] == ["job.fail:jobs.batch.ingest", "job.fail:jobs.batch.load"]
+
+
+@pytest.mark.parametrize("selector", ["batch", "batch:"], ids=["keyword", "trailing-colon"])
+def test_expand_selects_by_job_type(selector: str) -> None:
+    """A job type selects the same way with or without the colon."""
+    watcher = _job_def("jobs.ops.inspector", [f"job.success:{selector}"])
+    ingest = _job_def("jobs.batch.ingest", [])
+    dashboard = _job_def("jobs.ws.dashboard", ["http:"], job_type="interactive")
+
+    assert expand_trigger_selectors([watcher, ingest, dashboard]) == []
+    assert watcher["triggers"] == ["job.success:jobs.batch.ingest"]
+
+
+@pytest.mark.parametrize(
+    "selector", ["jobs.batch.*", "manual:jobs.batch.*"], ids=["ref-glob", "trigger-glob"]
+)
+def test_expand_selects_by_ref_or_by_manual_trigger(selector: str) -> None:
+    """The ref and the synthetic `manual:` trigger reach the same jobs."""
+    watcher = _job_def("jobs.ops.inspector", [f"job.fail:{selector}"])
+    ingest = _job_def("jobs.batch.ingest", [])
+    other = _job_def("jobs.ops.audit", [])
+
+    assert expand_trigger_selectors([watcher, ingest, other]) == []
+    assert watcher["triggers"] == ["job.fail:jobs.batch.ingest"]
+
+
+def test_expand_leaves_an_exact_ref_alone() -> None:
+    """The runtime looks a completion trigger up by exact string, so a ref must survive as one."""
+    watcher = _job_def("jobs.ops.inspector", ["job.fail:jobs.batch.ingest"])
+    expand_trigger_selectors([watcher, _job_def("jobs.batch.ingest", [])])
+    assert watcher["triggers"] == ["job.fail:jobs.batch.ingest"]
+
+
+@pytest.mark.parametrize(
+    "selector,expected",
+    [("batch:", ["jobs.batch.ingest"]), ("jobs.batch.*", ["jobs.batch.ingest"])],
+    ids=["job-type-colon", "ref-glob"],
+)
+def test_cli_select_understands_the_same_selectors(selector: str, expected: List[str]) -> None:
+    """`--select` shares the matcher, so both forms work there too."""
+    from dlt._workspace.deployment._run_helpers import select_candidates
+
+    manifest: Any = {
+        "jobs": [_job_def("jobs.batch.ingest", []), _job_def("jobs.ops.audit", [], "interactive")]
+    }
+    assert [jd["job_ref"] for jd, _ in select_candidates(manifest, [selector])] == expected

--- a/tests/workspace/deployment/test_validation.py
+++ b/tests/workspace/deployment/test_validation.py
@@ -33,7 +33,11 @@ from dlt._workspace.deployment.manifest import (
 )
 from dlt._workspace.deployment.typing import (
     MANIFEST_ENGINE_VERSION,
+    TEntryPoint,
+    TExecuteSpec,
     TJobDefinition,
+    TJobRef,
+    TJobsDeploymentManifest,
     TJobType,
     TTrigger,
 )
@@ -628,6 +632,7 @@ def test_load_manifest_migrates_stored_v1() -> None:
         loaded = load_manifest(f)
     assert loaded["engine_version"] == MANIFEST_ENGINE_VERSION
     jobs: Dict[str, Any] = {j["job_ref"]: j for j in loaded["jobs"]}
+    assert {j["engine_version"] for j in jobs.values()} == {MANIFEST_ENGINE_VERSION}
     assert jobs["jobs.events.hourly_events"]["incremental_mode"] == "interval"
     assert jobs["jobs.events.daily_report"]["refresh_propagation"] == "block"
     assert "refresh" not in jobs["jobs.events.daily_report"]
@@ -997,13 +1002,23 @@ def test_validate_job_definition_no_raise_on_valid() -> None:
         ),
         # no schedule/every — first eligible trigger wins
         (
-            ["job.success:jobs.mod.up", "manual:jobs.mod.a"],
-            "job.success:jobs.mod.up",
+            ["http:8000", "manual:jobs.mod.a"],
+            "http:8000",
         ),
         # manual/deployment skipped, next eligible wins
         (
             ["manual:jobs.mod.a", "deployment:prod", "tag:daily"],
             "tag:daily",
+        ),
+        # a job event names the run that fired it, so it never stands in for a manual run
+        (
+            ["job.success:jobs.mod.up", "job.fail:jobs.mod.up", "manual:jobs.mod.a"],
+            None,
+        ),
+        # ... but a schedule alongside it still wins
+        (
+            ["job.fail:jobs.mod.up", "schedule:0 0 * * *"],
+            "schedule:0 0 * * *",
         ),
         # no triggers — None
         ([], None),
@@ -1020,6 +1035,8 @@ def test_validate_job_definition_no_raise_on_valid() -> None:
         "schedule-over-every",
         "first-eligible-fallback",
         "skip-manual-and-deployment",
+        "job-events-only",
+        "job-event-with-schedule",
         "empty-triggers",
         "manual-only",
         "deployment-only",
@@ -1117,6 +1134,19 @@ def test_migrate_job_definition_field_mapping(
         assert migrated[key] == value  # type: ignore[literal-required]
     assert "allow_external_schedulers" not in migrated
     assert "refresh" not in migrated
+    # the definition says which engine wrote it, for a copy kept away from the manifest
+    assert migrated["engine_version"] == MANIFEST_ENGINE_VERSION
+
+
+def test_validate_manifest_rejects_a_job_from_another_engine() -> None:
+    job = _make_job("jobs.mod.a")
+    job["engine_version"] = MANIFEST_ENGINE_VERSION - 1
+    result = validate_manifest(_make_manifest([job]))
+    assert not result.is_valid
+    assert "written for engine" in result.errors[0]
+    # migrating the job alone stamps the manifest's engine on it
+    migrated = migrate_job_definition(dict(job), MANIFEST_ENGINE_VERSION, MANIFEST_ENGINE_VERSION)
+    assert validate_manifest(_make_manifest([migrated])).is_valid
 
 
 def test_validate_manifest_rejects_unmigrated_engine_1() -> None:
@@ -1171,3 +1201,68 @@ def test_migrated_manifest_round_trips_and_bumps_version() -> None:
     assert stored_hash in reloaded["previous_hashes"]
     # a migrated manifest is stable from then on
     assert generate_manifest_hash(reloaded) == generate_manifest_hash(migrated)
+
+
+def _event_job(job_ref: str, triggers: List[str]) -> TJobDefinition:
+    return {
+        "engine_version": MANIFEST_ENGINE_VERSION,
+        "job_ref": TJobRef(job_ref),
+        "entry_point": TEntryPoint(
+            module="m",
+            function=job_ref.rsplit(".", 1)[-1],
+            job_type="batch",
+            launcher="l",
+        ),
+        "triggers": [TTrigger(t) for t in triggers],
+        "execute": TExecuteSpec(),
+    }
+
+
+def _manifest(jobs: List[TJobDefinition]) -> TJobsDeploymentManifest:
+    return {
+        "engine_version": MANIFEST_ENGINE_VERSION,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "deployment_module": "m",
+        "jobs": jobs,
+    }
+
+
+@pytest.mark.parametrize("event", ["job.success", "job.fail"], ids=["success", "fail"])
+def test_job_cannot_trigger_itself(event: str) -> None:
+    result = validate_manifest(_manifest([_event_job("jobs.ops.a", [f"{event}:jobs.ops.a"])]))
+    assert not result.is_valid
+    assert len(result.errors) == 1
+    assert "trigger itself" in result.errors[0]
+
+
+@pytest.mark.parametrize(
+    "jobs",
+    [
+        [
+            ("jobs.o.ingest", ["schedule:0 8 * * *"]),
+            ("jobs.o.transform", ["job.success:jobs.o.ingest"]),
+            ("jobs.o.report", ["job.success:jobs.o.transform"]),
+        ],
+        [
+            ("jobs.o.a", []),
+            ("jobs.o.b", ["job.success:jobs.o.a"]),
+            ("jobs.o.c", ["job.success:jobs.o.a"]),
+            ("jobs.o.d", ["job.success:jobs.o.b", "job.success:jobs.o.c"]),
+        ],
+    ],
+    ids=["chain", "diamond"],
+)
+def test_job_event_chains_stay_valid(jobs: List[Any]) -> None:
+    """Chains and diamonds of job events are normal, and are never inspected for cycles."""
+    result = validate_manifest(_manifest([_event_job(ref, t) for ref, t in jobs]))
+    assert result.is_valid, result.errors
+
+
+def test_cycles_between_jobs_are_allowed() -> None:
+    """Only self-triggering is rejected; jobs may trigger each other in a cycle."""
+    jobs = [
+        _event_job("jobs.o.b", ["job.fail:jobs.o.c"]),
+        _event_job("jobs.o.c", ["job.fail:jobs.o.b"]),
+    ]
+    result = validate_manifest(_manifest(jobs))
+    assert result.is_valid, result.errors

--- a/tests/workspace/deployment/test_validation.py
+++ b/tests/workspace/deployment/test_validation.py
@@ -12,9 +12,20 @@ import pytest
 
 from dlt._workspace.deployment import interval as interval_mod
 from dlt._workspace.deployment.decorators import job
+from dlt._workspace.deployment.agent.exceptions import AgentComponentNotFound, InvalidAgentSpec
 from dlt._workspace.deployment.exceptions import (
+    DeploymentValidationError,
+    InvalidFreshnessConstraint,
     InvalidJobDefinition,
+    InvalidJobName,
+    InvalidJobRef,
+    InvalidJobSchema,
+    InvalidJobSection,
+    InvalidManifest,
+    InvalidTrigger,
+    JobValidationResult,
     ManifestEngineNoUpgradePath,
+    ManifestValidationResult,
 )
 from dlt._workspace.deployment.manifest import (
     DASHBOARD_JOB_REF,
@@ -980,6 +991,118 @@ def test_validate_job_definition_no_raise_on_valid() -> None:
     job = _make_job("jobs.mod.ok", triggers=["schedule:0 8 * * *"])
     result = validate_job_definition(job, raise_on_error=True)
     assert result.errors == []
+
+
+def test_validate_job_definition_checks_the_structure_first() -> None:
+    """With `validate_dict` a malformed definition reports its shape and nothing else."""
+    job = _make_job("jobs.mod.ok", triggers=["schedule:0 8 * * *"])
+    assert validate_job_definition(job, validate_dict=True).errors == []
+
+    # a missing required key would break every later check
+    missing: Any = dict(job)
+    del missing["entry_point"]
+    result = validate_job_definition(missing, validate_dict=True)
+    assert len(result.errors) == 1
+    assert "entry_point" in result.errors[0]
+    with pytest.raises(InvalidJobDefinition) as exc_info:
+        validate_job_definition(missing, validate_dict=True, raise_on_error=True)
+    assert exc_info.value.job_ref == "jobs.mod.ok"
+    assert "entry_point" in str(exc_info.value)
+
+    # a wrong type is a structural error, not a trigger error
+    mistyped: Any = dict(job)
+    mistyped["triggers"] = "schedule:0 8 * * *"
+    result = validate_job_definition(mistyped, validate_dict=True)
+    assert len(result.errors) == 1
+    assert "triggers" in result.errors[0]
+
+
+def test_validate_manifest_raises_on_request() -> None:
+    """`raise_on_error` turns an invalid result into `InvalidManifest`, a valid one comes back."""
+    ok = make_job("jobs.mod.a", triggers=["schedule:0 8 * * *"])
+    result = validate_manifest(make_manifest([ok]), raise_on_error=True)
+    assert result.is_valid
+
+    duplicated = make_manifest([ok, make_job("jobs.mod.a")])
+    assert not validate_manifest(duplicated).is_valid
+    with pytest.raises(InvalidManifest) as exc_info:
+        validate_manifest(duplicated, raise_on_error=True)
+    assert any("duplicate" in e for e in exc_info.value.validation.errors)
+    assert exc_info.value.errors == exc_info.value.validation.errors
+
+    # a structural failure raises too, and the dict error is its cause
+    broken: Any = make_manifest([ok])
+    del broken["jobs"]
+    with pytest.raises(InvalidManifest, match="jobs") as exc_info:
+        validate_manifest(broken, raise_on_error=True)
+    assert exc_info.value.__cause__ is not None
+
+
+@pytest.mark.parametrize(
+    "exc,subject",
+    [
+        pytest.param(
+            InvalidManifest(
+                ManifestValidationResult(
+                    is_valid=False, errors=["duplicate a"], warnings=["w"], unresolved_triggers={}
+                )
+            ),
+            None,
+            id="InvalidManifest",
+        ),
+        pytest.param(
+            InvalidJobDefinition("jobs.mod.a", JobValidationResult(["bad trigger"], ["w"])),
+            "jobs.mod.a",
+            id="InvalidJobDefinition",
+        ),
+        pytest.param(InvalidJobSchema("mod.f", "no signature"), "mod.f", id="InvalidJobSchema"),
+        pytest.param(InvalidJobRef("x", "must start with 'jobs.'"), "x", id="InvalidJobRef"),
+        pytest.param(InvalidJobName("1bad"), "1bad", id="InvalidJobName"),
+        pytest.param(InvalidJobSection("1bad"), "1bad", id="InvalidJobSection"),
+        pytest.param(
+            InvalidTrigger("every:5x", "period must be like '5m'"), "every:5x", id="InvalidTrigger"
+        ),
+        pytest.param(
+            InvalidFreshnessConstraint("odd", "not a constraint"),
+            "odd",
+            id="InvalidFreshnessConstraint",
+        ),
+        pytest.param(
+            ManifestEngineNoUpgradePath("manifest", 99, 2),
+            "manifest",
+            id="ManifestEngineNoUpgradePath",
+        ),
+        pytest.param(
+            InvalidAgentSpec("AGENT.md", "body is empty"), "AGENT.md", id="InvalidAgentSpec"
+        ),
+        pytest.param(
+            AgentComponentNotFound(
+                "tk:skill", "skill", ["a/SKILL.md"], toolkit="tk", installed=True
+            ),
+            "tk:skill",
+            id="AgentComponentNotFound",
+        ),
+    ],
+)
+def test_validation_errors_share_one_contract(
+    exc: DeploymentValidationError, subject: Optional[str]
+) -> None:
+    """Every validation error reports through `errors`, `warnings` and `subject`."""
+    assert isinstance(exc, DeploymentValidationError)
+    assert isinstance(exc, ValueError)
+    assert exc.errors and all(isinstance(e, str) for e in exc.errors)
+    assert isinstance(exc.warnings, list)
+    assert exc.subject == subject
+    # the message carries every error, so `str()` alone still tells what was wrong
+    assert all(e in str(exc) for e in exc.errors)
+
+    # only the message crosses the worker boundary
+    rebuilt = type(exc).from_message(str(exc))
+    assert type(rebuilt) is type(exc)
+    assert str(rebuilt) == str(exc)
+    assert rebuilt.errors == [str(exc)] and rebuilt.warnings == [] and rebuilt.subject is None
+    if isinstance(rebuilt, InvalidManifest):
+        assert rebuilt.validation.errors == [str(exc)]
 
 
 @pytest.mark.parametrize(

--- a/tests/workspace/manifest_utils.py
+++ b/tests/workspace/manifest_utils.py
@@ -38,6 +38,7 @@ def make_job(
         "launcher": launcher,
     }
     job: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef(job_ref),
         "entry_point": entry_point,
         "triggers": [TTrigger(t) for t in triggers or []],

--- a/tests/workspace/mcp/test_access.py
+++ b/tests/workspace/mcp/test_access.py
@@ -1,0 +1,179 @@
+"""Tools declare the access they require, and the server serves what the grant covers."""
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from dlt._workspace.access import (
+    FULL_ACCESS,
+    RequiresAccess,
+    format_access,
+    missing_access,
+    parse_access,
+    required_access,
+)
+from dlt._workspace.mcp.tools import context_tools, data_tools, secrets_tools, toolkit_tools
+from dlt._workspace.typing import TWorkspaceAccess
+
+from tests.workspace.utils import isolated_workspace
+
+# every tool dlt serves, and what it needs. A new tool belongs here deliberately.
+TOOL_ACCESS = {
+    "list_pipelines": {"data": ["read"]},
+    "list_profiles": {"local": ["read"]},
+    "get_workspace_info": {"local": ["read"]},
+    "list_tables": {"data": ["read"]},
+    "get_table_schema": {"data": ["read"]},
+    "get_table_create_sql": {"data": ["read"]},
+    "preview_table": {"data": ["read"]},
+    "execute_sql_query": {"data": ["read"]},
+    "get_row_counts": {"data": ["read"]},
+    "get_local_pipeline_state": {"data": ["read"]},
+    # `save_to_file` writes wherever it is told
+    "export_schema": {"data": ["read"], "local": ["write"]},
+    # dlt's own catalogue, fetched into dlt's own cache: declared as needing nothing
+    "list_toolkits": {},
+    "toolkit_info": {},
+    "secrets_list": {"local": ["read"]},
+    "secrets_view_redacted": {"local": ["read"]},
+    "secrets_update_fragment": {"local": ["write"]},
+    "search_dlthub_sources": {"context": ["read"]},
+}
+
+
+def _all_tools() -> Dict[str, Any]:
+    tools = (
+        list(data_tools.__tools__)
+        + [data_tools.get_workspace_info]
+        + list(toolkit_tools.__tools__)
+        + list(secrets_tools.__tools__)
+        + list(context_tools.__tools__)
+    )
+    return {tool.__name__: tool for tool in tools}
+
+
+def test_every_tool_declares_what_it_needs() -> None:
+    served = _all_tools()
+    assert set(served) == set(TOOL_ACCESS), "a tool was added or removed without an access decision"
+    assert {name: required_access(tool) for name, tool in served.items()} == TOOL_ACCESS
+
+
+@pytest.mark.parametrize(
+    "granted,served,pruned",
+    [
+        (
+            {"data": ["read"]},
+            ["preview_table", "execute_sql_query", "list_toolkits"],
+            ["secrets_update_fragment", "export_schema", "secrets_list", "search_dlthub_sources"],
+        ),
+        (
+            {"local": ["read", "write"]},
+            ["secrets_list", "secrets_update_fragment", "get_workspace_info"],
+            ["preview_table", "export_schema", "search_dlthub_sources"],
+        ),
+        ({"local": ["all"], "data": ["all"], "context": ["read"]}, list(TOOL_ACCESS), []),
+        ({}, ["list_toolkits", "toolkit_info"], ["list_pipelines", "secrets_list"]),
+    ],
+    ids=["data-read", "local-read-write", "everything", "nothing"],
+)
+def test_access_decides_which_tools_are_served(
+    granted: TWorkspaceAccess, served: List[str], pruned: List[str]
+) -> None:
+    for name in served:
+        assert not missing_access(required_access(_all_tools()[name]), granted), name
+    for name in pruned:
+        assert missing_access(required_access(_all_tools()[name]), granted), name
+
+
+@pytest.mark.parametrize("text", [None, "", " , "], ids=["none", "empty", "blank-tokens"])
+def test_an_empty_grant_is_refused(text: Any) -> None:
+    """Empty text stands for nothing: a caller granting everything passes `FULL_ACCESS`."""
+    with pytest.raises(ValueError, match="declares no access"):
+        parse_access(text)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("data:read", {"data": ["read"]}),
+        ("data:read,local:write", {"data": ["read"], "local": ["write"]}),
+        ("local:read,local:write", {"local": ["read", "write"]}),
+        ("data:", {}),
+        ("local:,data:read,context:", {"data": ["read"]}),
+    ],
+    ids=["one", "two-axes", "two-verbs", "nothing", "empty-axes"],
+)
+def test_access_round_trips_through_the_cli_argument(text: str, expected: Any) -> None:
+    parsed = parse_access(text)
+    assert parsed == expected
+    assert parse_access(format_access(parsed)) == expected
+
+
+@pytest.mark.parametrize(
+    "text", ["data", "nonsense:read", "nonsense:"], ids=["no-colon", "axis", "bare-axis"]
+)
+def test_malformed_access_is_refused(text: str) -> None:
+    with pytest.raises(ValueError, match="access value"):
+        parse_access(text)
+
+
+def test_requires_access_reads_through_annotations() -> None:
+    from dlt.common.typing import Annotated
+
+    def tool() -> Annotated[str, RequiresAccess(data=["read"], local=["write"])]:
+        return ""
+
+    def needs_nothing() -> Annotated[str, RequiresAccess()]:
+        return ""
+
+    assert required_access(tool) == {"data": ["read"], "local": ["write"]}
+    assert required_access(needs_nothing) == {}
+
+
+def test_an_undeclared_tool_is_assumed_to_need_everything() -> None:
+    """A tool that declares nothing needs everything, so no limited caller is served it."""
+
+    def undeclared() -> str:
+        return ""
+
+    assert required_access(undeclared) == FULL_ACCESS
+    assert missing_access(required_access(undeclared), parse_access("data:read"))
+    # and it is served when the caller was granted everything
+    assert not missing_access(required_access(undeclared), FULL_ACCESS)
+
+
+def test_stdio_args_carry_the_access() -> None:
+    from dlt._workspace.cli.utils import mcp_stdio_args
+
+    access: TWorkspaceAccess = {"data": ["read"]}
+    args = mcp_stdio_args(["pipeline"], with_defaults=False, access=access)
+
+    assert args[:4] == ["ai", "mcp", "run", "--stdio"]
+    assert "--access" in args and args[args.index("--access") + 1] == "data:read"
+    # the server parses back exactly what the loop granted
+    assert parse_access(args[args.index("--access") + 1]) == access
+    # a grant of nothing is spelled out, so the server never sees an empty argument
+    args = mcp_stdio_args(["toolkit"], with_defaults=False, access={})
+    assert args[args.index("--access") + 1] == "local:,data:,context:"
+    assert parse_access(args[args.index("--access") + 1]) == {}
+
+
+@pytest.mark.parametrize(
+    "granted,expected",
+    [(None, 17), (FULL_ACCESS, 17), ({"data": ["read"]}, 10), ({"local": ["write"]}, 3), ({}, 2)],
+    ids=["default", "everything", "data-read", "local-write", "nothing"],
+)
+def test_the_server_registers_only_what_it_serves(
+    granted: Optional[TWorkspaceAccess], expected: int
+) -> None:
+    """Pruning happens before `add_tool`, so a tool the grant misses does not exist."""
+    from dlt._workspace.mcp.server import WorkspaceMCP
+
+    with isolated_workspace("empty", profile="dev"):
+        # the server defaults to everything; a caller narrowing it says so
+        server = WorkspaceMCP("dlt") if granted is None else WorkspaceMCP("dlt", access=granted)
+    served = {tool.name for tool in server._local_provider._components.values()}
+
+    assert len(served) == expected
+    if granted == {"data": ["read"]}:
+        assert "preview_table" in served and "secrets_update_fragment" not in served

--- a/tests/workspace/mcp/test_mcp_server.py
+++ b/tests/workspace/mcp/test_mcp_server.py
@@ -17,7 +17,7 @@ from dlt.common.runtime.anon_tracker import disable_anon_tracker
 from dlt.common.typing import DictStrAny
 
 from dlt._workspace.mcp import PipelineMCP, WorkspaceMCP
-from dlt._workspace.mcp.server import resolve_features
+from dlt._workspace.cli.utils import resolve_features
 from dlt._workspace._plugins import (
     McpFeatures,
     plug_mcp_context,
@@ -381,3 +381,26 @@ def test_mcp_tool_telemetry_emits_event(
     # agent_info is None when called outside a real MCP session
     assert "agent_info" in props
     assert props["agent_info"] is None
+
+
+def test_no_default_features_serves_only_what_was_asked() -> None:
+    """A background agent gets its declared feature groups, not the interactive defaults."""
+    from dlt._workspace.cli.utils import make_mcp_run_flags, mcp_stdio_args
+
+    assert resolve_features(["telemetry"], set()) == {"telemetry"}
+    assert resolve_features(None, set()) == set()
+
+    args = mcp_stdio_args(["telemetry"], with_defaults=False)
+    assert args == [
+        "ai",
+        "mcp",
+        "run",
+        "--stdio",
+        "--no-default-features",
+        "--features",
+        "telemetry",
+    ]
+    # the server the loop spawns parses them back into the same set
+    parsed = make_mcp_run_flags().parse_args(args[3:])
+    assert parsed.no_default_features is True
+    assert resolve_features(parsed.features, set()) == {"telemetry"}

--- a/tests/workspace/mcp/test_mcp_tools.py
+++ b/tests/workspace/mcp/test_mcp_tools.py
@@ -142,9 +142,57 @@ def test_execute_sql_query(
         assert "name" in json.loads(lines[0])
 
 
-def test_execute_sql_query_rejects_dml(pokemon_pipeline_context: RunContextBase) -> None:
-    with pytest.raises(ToolError, match="modification"):
-        execute_sql_query("rest_api_pokemon", "DELETE FROM pokemon")
+@pytest.mark.parametrize(
+    "query",
+    [
+        "DELETE FROM pokemon",
+        "UPDATE pokemon SET name = 'x'",
+        "INSERT INTO pokemon VALUES (1)",
+        # a mutating statement nested in a CTE has a SELECT at the root
+        "WITH x AS (DELETE FROM pokemon RETURNING *) SELECT * FROM x",
+        "DROP TABLE pokemon",
+        "CREATE TABLE evil AS SELECT * FROM pokemon",
+        "TRUNCATE TABLE pokemon",
+        "ALTER TABLE pokemon ADD COLUMN x INT",
+        # the statement guard is not the whole story: these read the host, not the dataset
+        "SELECT * FROM read_text('/etc/passwd')",
+        "SELECT read_blob('/etc/shadow')",
+        "SELECT * FROM read_csv_auto('http://127.0.0.1:1/x.csv')",
+        "SELECT * FROM parquet_scan('s3://bucket/x.parquet')",
+        "ATTACH 'other.db'",
+        "SELECT 1; DROP TABLE pokemon",
+    ],
+    ids=[
+        "delete",
+        "update",
+        "insert",
+        "cte-delete",
+        "drop",
+        "create-as-select",
+        "truncate",
+        "alter",
+        "read-text",
+        "read-blob",
+        "read-csv-url",
+        "parquet-scan",
+        "attach",
+        "multi-statement",
+    ],
+)
+def test_execute_sql_query_is_read_only(
+    pokemon_pipeline_context: RunContextBase, query: str
+) -> None:
+    """`data: [read]` must not reach the host or write the dataset — GHSA-xxqf-4m3r-qx6c."""
+    with pytest.raises(ToolError, match="allowed"):
+        execute_sql_query("rest_api_pokemon", query)
+
+
+def test_execute_sql_query_still_runs_a_select(pokemon_pipeline_context: RunContextBase) -> None:
+    assert "pokemon" in execute_sql_query("rest_api_pokemon", "SELECT * FROM pokemon LIMIT 1")
+    # a CTE that only reads is not collateral damage
+    assert execute_sql_query(
+        "rest_api_pokemon", "WITH x AS (SELECT 1 AS a) SELECT * FROM x", output_format="jsonl"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/workspace/mcp/test_mcp_tools.py
+++ b/tests/workspace/mcp/test_mcp_tools.py
@@ -16,6 +16,7 @@ from dlt._workspace.mcp.tools.data_tools import TMcpSchemaFormat, TResultFormat
 from dlt._workspace.mcp.tools.context_tools import search_dlthub_sources
 from dlt._workspace.mcp.tools.toolkit_tools import list_toolkits, toolkit_info
 from dlt._workspace.mcp.tools.data_tools import (
+    _ensure_read_only,
     list_pipelines,
     list_profiles,
     list_tables,
@@ -154,12 +155,11 @@ def test_execute_sql_query(
         "CREATE TABLE evil AS SELECT * FROM pokemon",
         "TRUNCATE TABLE pokemon",
         "ALTER TABLE pokemon ADD COLUMN x INT",
-        # the statement guard is not the whole story: these read the host, not the dataset
-        "SELECT * FROM read_text('/etc/passwd')",
-        "SELECT read_blob('/etc/shadow')",
-        "SELECT * FROM read_csv_auto('http://127.0.0.1:1/x.csv')",
-        "SELECT * FROM parquet_scan('s3://bucket/x.parquet')",
+        "COPY (SELECT 1) TO '/tmp/out.csv'",
         "ATTACH 'other.db'",
+        # table functions that attach a database or run a statement on an attached one
+        "SELECT * FROM postgres_execute('pg', 'DROP TABLE pokemon')",
+        "SELECT * FROM sqlite_attach('/tmp/other.db')",
         "SELECT 1; DROP TABLE pokemon",
     ],
     ids=[
@@ -171,11 +171,10 @@ def test_execute_sql_query(
         "create-as-select",
         "truncate",
         "alter",
-        "read-text",
-        "read-blob",
-        "read-csv-url",
-        "parquet-scan",
+        "copy-to",
         "attach",
+        "postgres-execute",
+        "sqlite-attach",
         "multi-statement",
     ],
 )
@@ -193,6 +192,21 @@ def test_execute_sql_query_still_runs_a_select(pokemon_pipeline_context: RunCont
     assert execute_sql_query(
         "rest_api_pokemon", "WITH x AS (SELECT 1 AS a) SELECT * FROM x", output_format="jsonl"
     )
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM read_csv('/tmp/rows.csv')",
+        "SELECT * FROM read_parquet('s3://bucket/x.parquet')",
+        "SELECT * FROM '/tmp/rows.parquet'",
+        "SELECT * FROM postgres_query('pg', 'SELECT 1')",
+    ],
+    ids=["read-csv", "read-parquet", "bare-path", "postgres-query"],
+)
+def test_read_only_guard_lets_reads_through(query: str) -> None:
+    """Reading a file or a foreign database is not a write; the local access axis is not enforced here."""
+    _ensure_read_only(query, "duckdb")
 
 
 @pytest.mark.parametrize(

--- a/tests/workspace/runner/test_runner.py
+++ b/tests/workspace/runner/test_runner.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.workspace.runner._runner.runner import run, _log, _log_job
 from dlt._workspace.deployment.typing import (
+    MANIFEST_ENGINE_VERSION,
     TFreshnessConstraint,
     TJobDefinition,
     TJobRef,
@@ -25,6 +26,7 @@ def _batch_job(
     if triggers is None:
         triggers = [f"manual:{ref}"]
     return {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef(ref),
         "entry_point": TEntryPoint(
             module=f"{WORKSPACE}.batch_jobs",
@@ -100,6 +102,7 @@ def test_run_failing_job() -> None:
     """Failing job returns exit code 1."""
     jobs: List[TJobDefinition] = [
         {
+            "engine_version": MANIFEST_ENGINE_VERSION,
             "job_ref": TJobRef("jobs.test.failing"),
             "entry_point": TEntryPoint(
                 module="tests.workspace.runner.cases.failing_job",
@@ -118,6 +121,7 @@ def test_run_failing_job() -> None:
 def test_orphaned_event_trigger_exits() -> None:
     """Job waiting on failed upstream's success exits with warning."""
     failing: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef("jobs.test.upstream"),
         "entry_point": TEntryPoint(
             module="tests.workspace.runner.cases.failing_job",
@@ -242,6 +246,7 @@ def test_freshness_blocks_interval_job_when_upstream_not_fresh(
 ) -> None:
     """Interval job with freshness constraint is skipped when upstream hasn't completed."""
     upstream: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef("jobs.batch_jobs.backfill"),
         "entry_point": TEntryPoint(
             module=f"{WORKSPACE}.batch_jobs",
@@ -256,6 +261,7 @@ def test_freshness_blocks_interval_job_when_upstream_not_fresh(
         "default_trigger": TTrigger("schedule:* * * * *"),
     }
     downstream: TJobDefinition = {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef("jobs.batch_jobs.transform"),
         "entry_point": TEntryPoint(
             module=f"{WORKSPACE}.batch_jobs",

--- a/tests/workspace/runner/test_runner_refresh.py
+++ b/tests/workspace/runner/test_runner_refresh.py
@@ -267,19 +267,18 @@ def test_cascade_skips_interval_store_seed(
 
 
 @pytest.mark.parametrize(
-    "jd_patch,expected_allow,expected_mode",
+    "jd_patch,expected_mode",
     [
-        ({}, None, None),  # not set in manifest → entry_point gets neither key
-        ({"incremental_mode": "interval"}, True, "interval"),
-        ({"incremental_mode": "pipeline"}, False, "pipeline"),
-        ({"auto_refresh_pipeline_mode": "drop_sources"}, None, None),
+        ({}, None),  # not set in manifest → entry_point gets no mode key
+        ({"incremental_mode": "interval"}, "interval"),
+        ({"incremental_mode": "pipeline"}, "pipeline"),
+        ({"auto_refresh_pipeline_mode": "drop_sources"}, None),
     ],
     ids=["unset", "mode-interval", "mode-pipeline", "auto-refresh-mode"],
 )
 def test_incremental_mode_propagates_to_entry_point(
     runner_state: Dict[str, TJobDefinition],
     jd_patch: Dict[str, Any],
-    expected_allow: bool,
     expected_mode: Any,
 ) -> None:
     """`_start_job` propagates incremental mode into the entry_point."""
@@ -322,8 +321,9 @@ def test_incremental_mode_propagates_to_entry_point(
     import json as _json
 
     ep = _json.loads(cmd[ep_idx])
-    assert ep.get("allow_external_schedulers") is expected_allow
     assert ep.get("incremental_mode") == expected_mode
+    # the runner launches on the installed dlt, which reads the mode and not the old flag
+    assert "allow_external_schedulers" not in ep
     # auto_refresh_pipeline_mode passes through verbatim when present
     assert ep.get("auto_refresh_pipeline_mode") == jd_patch.get("auto_refresh_pipeline_mode")
     # interval should be set since this is a non-interval job dispatched manually

--- a/tests/workspace/runner/test_scheduler.py
+++ b/tests/workspace/runner/test_scheduler.py
@@ -6,6 +6,7 @@ from typing import List, Tuple
 from tests.workspace.runner._runner.scheduler import TriggerScheduler
 from dlt._workspace.deployment._trigger_helpers import match_triggers_with_selectors
 from dlt._workspace.deployment.typing import (
+    MANIFEST_ENGINE_VERSION,
     TEntryPoint,
     TExecuteSpec,
     TJobDefinition,
@@ -16,6 +17,7 @@ from dlt._workspace.deployment.typing import (
 
 def _job(ref: str, triggers: List[str]) -> TJobDefinition:
     return {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef(ref),
         "entry_point": TEntryPoint(
             module="m",

--- a/tests/workspace/runner/test_selection.py
+++ b/tests/workspace/runner/test_selection.py
@@ -6,6 +6,7 @@ import pytest
 
 from tests.workspace.runner._runner.runner import run, select_jobs, _resolve_selectors
 from dlt._workspace.deployment.typing import (
+    MANIFEST_ENGINE_VERSION,
     TEntryPoint,
     TExecuteSpec,
     TJobDefinition,
@@ -24,6 +25,7 @@ def _batch_job(
     if triggers is None:
         triggers = [f"manual:{ref}"]
     return {
+        "engine_version": MANIFEST_ENGINE_VERSION,
         "job_ref": TJobRef(ref),
         "entry_point": TEntryPoint(
             module=f"{WORKSPACE}.batch_jobs",

--- a/tests/workspace/utils.py
+++ b/tests/workspace/utils.py
@@ -1,7 +1,9 @@
 from contextlib import contextmanager, nullcontext
 import os
 import shutil
-from typing import Generator, Iterator
+import sys
+from typing import Any, Generator, Iterator, List, Tuple
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -11,12 +13,15 @@ from dlt.common.configuration.specs.pluggable_run_context import RunContextBase,
 from dlt.common.runtime.run_context import switch_context
 from dlt.common.storages.file_storage import FileStorage
 from dlt.common.utils import set_working_dir
+from dlt.pipeline import platform
 
 from dlt._workspace._workspace_context import WorkspaceRunContext
 
 from tests.utils import get_test_storage_root
 
 WORKSPACE_CASES_DIR = os.path.abspath(os.path.join("tests", "workspace", "cases", "workspaces"))
+TEST_SETTINGS_DIR = os.path.abspath(os.path.join("tests", ".dlt"))
+"""The `.dlt` the test session reads secrets and config from, as `tests/conftest.py` wires it."""
 
 
 def test_storage_root_abs() -> str:
@@ -33,11 +38,14 @@ def empty_workspace_dir() -> str:
 
 @contextmanager
 def isolated_workspace(
-    name: str, profile: str = None, required: str = "WorkspaceRunContext"
+    name: str,
+    profile: str = None,
+    required: str = "WorkspaceRunContext",
+    global_dir: str = None,
 ) -> Iterator[WorkspaceRunContext]:
     """Copies `name` workspace from WORKSPACE_CASES_DIR to `_storage` top level folder
     changes cwd to a workspace copy and activates it to create a fully isolated workspace.
-    Note that global_dir is patched (TODO: replace with workspace config)
+    `global_dir` stands in for the user's `~/.dlt`: an empty folder in the copy unless given.
     """
     new_run_dir = restore_clean_workspace(name)
     with set_working_dir(new_run_dir):
@@ -45,11 +53,33 @@ def isolated_workspace(
         assert ctx.run_dir == new_run_dir
         # also mock global dir so it does not point to default user ~
         if hasattr(ctx, "_global_dir"):
-            ctx._global_dir = os.path.abspath(".global_dir")
+            ctx._global_dir = global_dir or os.path.abspath(".global_dir")
             os.makedirs(ctx._global_dir, exist_ok=True)
             # reload toml providers after patching
             Container()[PluggableRunContext].reload_providers()
         yield ctx  # type: ignore
+
+
+@contextmanager
+def importable_workspace(
+    name: str, *modules: str, global_dir: str = None
+) -> Iterator[WorkspaceRunContext]:
+    """`isolated_workspace` with its root on `sys.path`, as `python -m` gives a launcher.
+
+    Args:
+        name (str): Workspace under `WORKSPACE_CASES_DIR`.
+        modules (str): Workspace modules to drop from `sys.modules` on exit, so the next
+            copy of the workspace is imported afresh.
+        global_dir (str): Passed to `isolated_workspace`.
+    """
+    with isolated_workspace(name, global_dir=global_dir) as ctx:
+        sys.path.insert(0, ctx.run_dir)
+        try:
+            yield ctx
+        finally:
+            sys.path.remove(ctx.run_dir)
+            for module in modules:
+                sys.modules.pop(module, None)
 
 
 def restore_clean_workspace(name: str) -> str:
@@ -88,6 +118,34 @@ def restore_clean_workspace(name: str) -> str:
         shutil.copytree(source_workspace_dir, new_run_dir, dirs_exist_ok=True)
 
     return new_run_dir
+
+
+def drain_beacon() -> None:
+    """Waits for the fire-and-forget beacon pool, so a test sees everything a run sent."""
+    assert platform._THREAD_POOL is not None
+    platform._THREAD_POOL.thread_pool.shutdown(wait=True)
+
+
+@pytest.fixture
+def beacon() -> Iterator[List[Tuple[str, str]]]:
+    """Beacon PUTs the test's runs send, as `(url, body)`, on a tracker reset around the test."""
+    sent: List[Tuple[str, str]] = []
+
+    def _put(url: str, data: str) -> Any:
+        sent.append((url, data))
+        return MagicMock(status_code=200)
+
+    platform._THREAD_POOL = None
+    platform.init_platform_tracker()
+    patcher = patch.object(platform, "requests")
+    patcher.start().put.side_effect = _put
+    try:
+        yield sent
+    finally:
+        # drained while still patched, so a late PUT lands here and not on the network
+        drain_beacon()
+        patcher.stop()
+        platform._THREAD_POOL = None
 
 
 @pytest.fixture

--- a/tools/check_hub_extras.py
+++ b/tools/check_hub_extras.py
@@ -21,7 +21,7 @@ from dlt.common.runtime.run_context import ensure_plugin_version_match
 from dlt.version import __version__ as dlt_version, DLT_PKG_NAME
 
 # hub extras not version-coupled to dlt: shown for info, version match never enforced
-INFO_ONLY_PKGS = {"dlthub-client"}
+INFO_ONLY_PKGS = {"dlthub-client", "pydantic"}
 
 
 class HubExtraInfo(NamedTuple):

--- a/uv.lock
+++ b/uv.lock
@@ -145,7 +145,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.14.1"
+version = "3.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -158,126 +158,126 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/67/58ded4b3f2e10f94972d8928050c85330e249a31dd45a0e5f3c0e9c3fa05/aiohttp-3.14.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8f6bb621e5863cfe8fe5ff5468002d200ec31f30f1280b259dc505b02595099e", size = 766140, upload-time = "2026-06-07T21:05:37.471Z" },
-    { url = "https://files.pythonhosted.org/packages/18/68/4ae5b4e08943f316594bb68da89957d3baf5760588fa09509594bd777e4b/aiohttp-3.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4f7215cb3933784f79ed20e5f050e15984f390424339b22375d5a53c933a0491", size = 519430, upload-time = "2026-06-07T21:05:40.751Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/c1/316c8f3549dbe5245f92bfd523ec6f32dd4d98cafe21df3f6a19b1184c75/aiohttp-3.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d9d4e294455b23a68c9b8f042d0e8e377a265bcb15332753695f6e5b6819e0ce", size = 514406, upload-time = "2026-06-07T21:05:42.111Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/ee/fb0ac28684e8d753b83c8a4eebc19a5846912aa0a4daaabb6a9936363840/aiohttp-3.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b238af795833d5731d049d82bc84b768ae6f8f97f0495963b3ed9935c5901cc3", size = 1703649, upload-time = "2026-06-07T21:05:43.427Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/57/aa2beab673331f111885db8a7b69dfe3ab0e53e446a0ace18ca694b4dc58/aiohttp-3.14.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4e5e0ae56914ecdbf446493addefc0159053dd53962cef37d7839f37f73d505", size = 1675126, upload-time = "2026-06-07T21:05:44.897Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ea/dad128abe365e79be03b16ed464198ac73e0d257e8260c6f7d6f31cbef26/aiohttp-3.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:092e4ce3619a7c6dee52a6bdabda973d9b34b66781f840ce93c7e0cec30cf521", size = 1771558, upload-time = "2026-06-07T21:05:46.405Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f3/b5b4e10327cb85d34d24232c6b71b64602f190b3ccb238a043ac6b187dac/aiohttp-3.14.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb33777ea21e8b7ecde0e6fc84f598be0a1192eab1a63bc746d75aa75d38e7bd", size = 1856631, upload-time = "2026-06-07T21:05:47.844Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9d/93294c3045775c708ac8310eb3d3622a11d2951345ad590d532d62a1faa4/aiohttp-3.14.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23119f8fd4f5d16902ed459b63b100bcd269628075162bddac56cc7b5273b3fb", size = 1714139, upload-time = "2026-06-07T21:05:49.982Z" },
-    { url = "https://files.pythonhosted.org/packages/29/c4/93067c85a0373492ce8e577435203c5947c454af074ac48ed4f3a1b9dd4a/aiohttp-3.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:57fc6745a4b7d0f5a9eb4f40a69718be6c0bc1b8368cc9fe89e90118719f4f42", size = 1588321, upload-time = "2026-06-07T21:05:51.431Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/39/9ff91aaf02af8b7b8222a987466da539f154c3e01732c22b5f5a20a8ee66/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6fd35beba67c4183b09375c5fff9accb47524191a244a99f95fd4472f5402c2b", size = 1670375, upload-time = "2026-06-07T21:05:53.109Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e4/77452a3676b8d99ac1375f77691d6bf65ea6e9f4b201b82ef77c916dc767/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:672b9d65f42eb877f5c3f234a4547e4e1a226ca8c2eed879bb34670a0ce51192", size = 1690933, upload-time = "2026-06-07T21:05:54.902Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/84/b0059a7c7fc05ea23f3bc1596ba91c12f79588b9450564a24cac37536d0a/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:24ba13339fed9251d9b1a1bec8c7ab84c0d1675d79d33501e11f94f8b9a84e05", size = 1740798, upload-time = "2026-06-07T21:05:56.458Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3a/e2a513ecbfc362591caa51a7f7e011b3bfc8938b388ae44cd95560d36999/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:94da27378da0610e341c4d30de29a191672683cc82b8f9556e8f7c7212a020fe", size = 1576412, upload-time = "2026-06-07T21:05:57.953Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/10/08f1654f538f93d36dcac66310a06eefce4641cdafca83f9f0a5317be254/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:52cdac9432d8b4a719f35094a818d95adcae0f0b4fe9b9b921909e0c87de9e7d", size = 1750199, upload-time = "2026-06-07T21:05:59.488Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e4/d91b70c57d8b8e9611e4a2e52238ca3698d3dc1c2efe25b7a9bf594ac584/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:672ac254412a24d0d0cf00a9e6c238877e4be5e5fa2d188832c1244f45f31966", size = 1699356, upload-time = "2026-06-07T21:06:01.131Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f1/15340176f35ff61b95dbe34020bcf43f9e624a2d7bbac934715ff97d2033/aiohttp-3.14.1-cp310-cp310-win32.whl", hash = "sha256:2fe3607e71acc6ebb0ec8e492a247bf7a291226192dc0084236dfc12478916f6", size = 458939, upload-time = "2026-06-07T21:06:02.86Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c2/a2f1ec5b37f903109e43ae2862268cfe4a67a60c1b2cf43169fcdff5995f/aiohttp-3.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:30099eda75a53c32efb0920e9c33c195314d2cc1c680fbfd30894932ac5f27df", size = 482583, upload-time = "2026-06-07T21:06:04.666Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/7a/7b56f6732ef79530afaa72aa335d41b67c8d79b946995f0b11ad72985435/aiohttp-3.14.1-cp310-cp310-win_arm64.whl", hash = "sha256:5a837f49d901f9e368651b676912bff1104ed8c1a83b280bcd7b29adccef5c9c", size = 453470, upload-time = "2026-06-07T21:06:06.322Z" },
-    { url = "https://files.pythonhosted.org/packages/26/dd/bf526e6f0a1120dd6f2df2e97bacfe4d358f13d17a0ff5847301a1375a51/aiohttp-3.14.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:aa00140699487bd435fde4342d85c94cb256b7cd3a5b9c3396c67f19922afda2", size = 765225, upload-time = "2026-06-07T21:06:07.957Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e1/a2872aa55495a70f61310d411541c6ee23812d9a884e000c716e1bc3edbf/aiohttp-3.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c1af67559445498b502030c35c59db59966f47041ca9de5b4e707f86bd10b5f", size = 518743, upload-time = "2026-06-07T21:06:09.749Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e7/c60c7b209e509cc787de3cea0550a518538cfc08003e1c1e14c1c63fff71/aiohttp-3.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d44ec478e713ee7f29b439f7eb8dc2b9d4079e11ae114d2c2ac3d5daf30516c8", size = 514139, upload-time = "2026-06-07T21:06:11.26Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/8d/614ace2f579702c9840ab1e1447fd8509e35b0b904f7196418fa2f57b25d/aiohttp-3.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3b1a184a9a8f548a6b73f1e26b96b052193e4b3175ed7342aaf1151a1f00a04", size = 1784088, upload-time = "2026-06-07T21:06:12.887Z" },
-    { url = "https://files.pythonhosted.org/packages/49/e0/726e90f99542bf292f81a96a12cc4847deb86f3ccf62c6f4014a201f4d33/aiohttp-3.14.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5f2504bc0322437c9a1ff6d3333ca56c7477b727c995f036b976ae17b98372c8", size = 1737835, upload-time = "2026-06-07T21:06:14.564Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/4b/d176d5c4db9d33dacf0543102ea59503bc1d528af4cfd0b719949ca49389/aiohttp-3.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73f05ea02013e02512c3bf42714f1208c57168c779cc6fe23516e4543089d0a6", size = 1842801, upload-time = "2026-06-07T21:06:16.228Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/d6/5a99b563690ea0cbed912ae94a2ce33993a5709a651a3a4fe761e7dd973a/aiohttp-3.14.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:797457503c2d426bee06eef808d07b31ede30b65e054444e7de64cad0061b7af", size = 1929992, upload-time = "2026-06-07T21:06:17.947Z" },
-    { url = "https://files.pythonhosted.org/packages/76/7f/a987b14a3859094b3cea3f4825219c3e5536242564af6e3f9c2f6c994eb2/aiohttp-3.14.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b821a1f7dedf7e37450654e620038ac3b2e81e8fa6ea269337e97101978ec730", size = 1786989, upload-time = "2026-06-07T21:06:19.677Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/1a/420e5c85a3e73349372ed22ce0b6af86bfa6ce16a4b20a64a2e94608c781/aiohttp-3.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4cd96b5ba05d67ed0cf00b5b405c8cd99586d8e3481e8ee0a831057591af7621", size = 1640129, upload-time = "2026-06-07T21:06:22.558Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/80/18a592ed3be0a402cc03670bd72ee1f8563ddbe1d8d5542dbf868f274136/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d459b98a932296c6f0e94f87511a0b1b90a8a02c30a50e60a297619cd5a58ee", size = 1756576, upload-time = "2026-06-07T21:06:24.8Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/0b/8b3d5713373858ff71a617daf6e3b0e81ad63e79d09a3cf2f6b6b983939c/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:764457a7be60825fb770a644852ff717bcbb5042f189f2bd16df61a81b3f6573", size = 1754668, upload-time = "2026-06-07T21:06:26.528Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/49/fd564575cf225821d7ba5a117cb8bc27213d8a7e1811162afb43ae077039/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f7a16ef45b081454ef844502d87a848876c490c4cb5c650c230f6ec79ed2c1e7", size = 1817019, upload-time = "2026-06-07T21:06:28.297Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1b/e850c9ae6fc91356552ae668bb6c51e93fa29c8aef13398a10b56678557f/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2fbc3ed048b3475b9f0cbcb9978e9d2d3511acd91ead203af26ed9f0056004cf", size = 1631638, upload-time = "2026-06-07T21:06:30.242Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/94/3c337ba72451a89806ace6f75bddc92bafc5b8d53d90115a512858024b63/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:bedb0cd073cc2dc035e30aeb99444389d3cd2113afe4ef9fcd23d439f5bade85", size = 1835660, upload-time = "2026-06-07T21:06:31.943Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9c/9c18cf367a0498212d9ba7daf990b504a5e8ae064cda4b504e2647c89c03/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b6feea921016eb3d4e04d65fc4e9ca402d1a3801f562aef94989f54694917af3", size = 1775698, upload-time = "2026-06-07T21:06:33.72Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/63/a251a9d2a6cb45065b2ddc0bde2b3dd10108740a9a42f632c66405a761a2/aiohttp-3.14.1-cp311-cp311-win32.whl", hash = "sha256:313701e488100074ce99850404ee36e741abf6330179fec908a1944ecf570126", size = 458386, upload-time = "2026-06-07T21:06:35.279Z" },
-    { url = "https://files.pythonhosted.org/packages/17/ca/69274c51dcd6e8947d77b2806cf47a4a15f2c846e2cbeb1882547d3da283/aiohttp-3.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:03ab4530fdcb3a543a122ba4b65ac9919da9fe9f78a03d328a6e38ff962f7aa5", size = 483406, upload-time = "2026-06-07T21:06:36.824Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/8a/c25904f77690c3688ec140f87591ef11a0cfe36bf3d5c0f1f38056fb62b3/aiohttp-3.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:486f7d16ed54c39c2cbd7ca71fd8ba2b8bb7860df65bd7b6ed640bab96a38a8b", size = 452987, upload-time = "2026-06-07T21:06:38.371Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/21/151624b51cd92553d95424daf4bf19f19ce9be9002d19253e7e7ce67197b/aiohttp-3.14.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480", size = 757402, upload-time = "2026-06-07T21:06:40.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/82/280619e0bd7bf2454987e19282616e84762255dd9c8468f62382e8c191f1/aiohttp-3.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bcfb80a2cc36fba2534e5e5b5264dc7ae6fcd9bf15256da3e53d2f499e6fa29d", size = 512310, upload-time = "2026-06-07T21:06:42.207Z" },
-    { url = "https://files.pythonhosted.org/packages/55/b2/2aac325583aaa1353045f96dffa586d8a34e8322e14a7ba49cffeb103ab4/aiohttp-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2", size = 512448, upload-time = "2026-06-07T21:06:43.813Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
-    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
-    { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
-    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
-    { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/61/a0c0a8f327a9c52095cdd8e312391b00d3ed64ab6c72bb5c33d8ec251cf7/aiohttp-3.14.1-cp312-cp312-win32.whl", hash = "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4", size = 452771, upload-time = "2026-06-07T21:07:09.669Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d9/ea367c75f16ac9c6cdc8febb25e8318fa21a2b1bc8d6514d4b2d890bface/aiohttp-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271", size = 479873, upload-time = "2026-06-07T21:07:11.538Z" },
-    { url = "https://files.pythonhosted.org/packages/03/64/8d96784a7851156db8a4c6c3f6f91042fdf39fb15a4cc38c8b3c14833c45/aiohttp-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847", size = 448073, upload-time = "2026-06-07T21:07:13.637Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/97/bd137012dd97e1649162b099135a80e1fd59aaa807b2430fc448d1029aff/aiohttp-3.14.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:b3a03285a7f9c7b016324574a6d92a1c895da6b978cb8f1deee3ac72bc6da178", size = 506882, upload-time = "2026-06-07T21:07:15.501Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
-    { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
-    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
-    { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/a1/5fafa04e1ca91ddb47608699d60649c1c6db3cf41c99e78fc4056f9513db/aiohttp-3.14.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:7c106c26852ca1c2047c6b80384f17100b4e439af276f21ef3d4e2f450ae7e15", size = 508531, upload-time = "2026-06-07T21:08:02.093Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/2e/bfa02f699d87ffc86d5959270b28f1cb410add3ccaced8ed2e0b8a5238fc/aiohttp-3.14.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:20205f7f5ade7aaec9f4b500549bbc071b046453aed72f9c06dcab87896a83e8", size = 514718, upload-time = "2026-06-07T21:08:04.476Z" },
-    { url = "https://files.pythonhosted.org/packages/85/a5/9594ad6289eebbc97d167c44213d557807f90e59115caad24de21ad2c3b1/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:62a759436b29e677181a9e76bab8b8f689a29cb9c535f45f7c48c9c830d3f8c3", size = 487918, upload-time = "2026-06-07T21:08:06.377Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/61/16a32c36c3c49edec122a3dc811f2057df2f94d3b14aa107c8017d981618/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:2964cbf553df4d7a57348da44d961d871895fc1ee4e8c322b2a95612c7b17fba", size = 494014, upload-time = "2026-06-07T21:08:08.263Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/89/3ebcf96ed99c05bec9c434aaac6963fd3cbab4a786ae739908a144d9ce44/aiohttp-3.14.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:237651caadc3a59badd39319c54642b5299e9cc98a3a194310e55d5bb9f5e397", size = 502398, upload-time = "2026-06-07T21:08:10.244Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/3d/b74870a0c2d40c355928cd5b96c7a11fa821b8a40fc41365e64479b151fb/aiohttp-3.14.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:896e12dfdbbab9d8f7e16d2b28c6769a60126fa92095d1ebf9473d02593a2448", size = 758018, upload-time = "2026-06-07T21:08:12.447Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/66/f42f5c984d99e49c6cff5f26f590750f2e2f7ef1fcfb99966ab5be1b632e/aiohttp-3.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d03f281ed22579314ba00821ce20115a7c0ac430660b4cc05704a3f818b3e004", size = 512462, upload-time = "2026-06-07T21:08:14.624Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a7/248e1aebe0c7810b0271e021a0f2a5eb6e78a051885b3c9df49f42a5802d/aiohttp-3.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:07eabb979d236335fed927e137a928c9adfb7df3b9ec7aa31726f133a62be983", size = 512824, upload-time = "2026-06-07T21:08:16.572Z" },
-    { url = "https://files.pythonhosted.org/packages/26/97/2aa0e5ba0727dc3bd5aaebb7ccbc510f7dfb7fb961ec87497cd496635ab1/aiohttp-3.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4fe1f1087cbadb280b5e1bb054a4f00d1423c74d6626c5e48400d871d34ecefe", size = 1749898, upload-time = "2026-06-07T21:08:18.635Z" },
-    { url = "https://files.pythonhosted.org/packages/00/8d/e97f6c96c891d457c8479d92a514ba194d0412f981d72c70341ee18488ed/aiohttp-3.14.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:367a9314fdc79dab0fac96e216cb41dd73c85bdca85306ce8999118ba7e0f333", size = 1710114, upload-time = "2026-06-07T21:08:20.892Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/e6/aa8d7e863048c8fceb5cd6ce74017311cec3ead07847387e12265fb4444e/aiohttp-3.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a24f677ebe83749039e7bdf862ff0bbb16818ae4193d4ef96505e269375bcce0", size = 1802541, upload-time = "2026-06-07T21:08:23.044Z" },
-    { url = "https://files.pythonhosted.org/packages/83/a8/72193137de57fda4ebfae4563182d082c8856e3b6e9871d0b46f028fb369/aiohttp-3.14.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c83afe0ba876be7e943d2e0ba645809ad441575d2840c895c21ee5de93b9377a", size = 1875776, upload-time = "2026-06-07T21:08:25.288Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/18/938441025db6769a3464596b2410af3afde0b21eb2f204c6f766f68af4bd/aiohttp-3.14.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:634e385930fb6d2d479cf3aa66515955863b77a5e3c2b5894ca259a25b308602", size = 1760329, upload-time = "2026-06-07T21:08:27.363Z" },
-    { url = "https://files.pythonhosted.org/packages/60/29/bf2496b4065e76e09fe48015aaffe5ce161d8f089b06ac6982070f653076/aiohttp-3.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eeea07c4397bbc57719c4eed8f9c284874d4f175f9b6d57f7a1546b976d455ca", size = 1587293, upload-time = "2026-06-07T21:08:29.805Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a2/2136674d52123b1354bd05dd5753c318db47dc0c927cc70b27bab3755456/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:335c0cc3e3545ce98dcb9cfcb836f40c3411f43fa03dab757597d80c89af8a35", size = 1714756, upload-time = "2026-06-07T21:08:32.094Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/b9/e5fd2e6f915503081c0f9b1e8540947037929c70c191da2e4d54b31a21a1/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ae6be797afdef264e8a84864a85b196ca06045586481b3df8a967322fd2fa844", size = 1721052, upload-time = "2026-06-07T21:08:34.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/5a/2833e324a2263e104e31e2e91bc5bbee81bc499afd32203faee048a883f0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:8560b4d712474335d08907db7973f71912d3a9a8f1dee992ec06b5d2fe359496", size = 1766888, upload-time = "2026-06-07T21:08:36.95Z" },
-    { url = "https://files.pythonhosted.org/packages/57/fa/dea6511870913162f3b2e8c42a7614eb203a4540b8c2da43e0bfb0548f3c/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7edd08e0a5deb1e8564a2fcd8f4561014a3f05252334671bbf55ddd47db0e5", size = 1581679, upload-time = "2026-06-07T21:08:39.292Z" },
-    { url = "https://files.pythonhosted.org/packages/14/bd/3cf0d55e71784b33534e9710a67d382d900598b4787fbce6cc7317f8c42a/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b6ff7fcee63287ae57b5df3e4f5957ce032122802509246dec1a5bcc55904c95", size = 1782021, upload-time = "2026-06-07T21:08:41.407Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/af/14bb5843eccbe234f4dfb78ab73e549d99727247e62ae5d62cbd22eaf5b0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6ffbb2f4ec1ceaff7e07d43922954da26b223d188bf30658e561b98e23089444", size = 1742574, upload-time = "2026-06-07T21:08:43.795Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/1e/fbeb7af9210a67ac0f9c9bec0f8f4568497924e33137a3d5b48e1cf85f3f/aiohttp-3.14.1-cp314-cp314-win32.whl", hash = "sha256:a9875b46d910cff3ea2f5962f9d266b465459fe634e22556ab9bd6fc1192eea0", size = 457773, upload-time = "2026-06-07T21:08:46.168Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/2b/13e8d741a9ec5db7d900c060554cf8352ab85e44e2a4469ebb9d377bda17/aiohttp-3.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:af8b4b81a960eeaf1234971ac3cd0ba5901f3cd42eae42a46b4d089a8b492719", size = 485001, upload-time = "2026-06-07T21:08:48.401Z" },
-    { url = "https://files.pythonhosted.org/packages/df/30/491acfa2c4d6c3ff59c49a14fc1b50be3241e25bbb0c84c09e2da4d11395/aiohttp-3.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:cf4491381b1b57425c315a56a439251b1bdac07b2275f19a8c44bc57744532ec", size = 453809, upload-time = "2026-06-07T21:08:50.7Z" },
-    { url = "https://files.pythonhosted.org/packages/34/e3/19dbe1a1f4cc6230eb9e314de7fe68053b0992f9302b27d12141a0b5db53/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:819c054312f1af92947e6a55883d1b66feefab11531a7fc45e0fb9b63880b5c2", size = 793320, upload-time = "2026-06-07T21:08:52.775Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/20/1b7182219ba1b108430d6e4dc53d25ae02dcfcf5a045b33af4e8c5167527/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10ee9c1753a8f706345b22496c79fbddb5be0599e0823f3738b1534058e25340", size = 529077, upload-time = "2026-06-07T21:08:55Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c8/14ce60ec31a2e5f5274bb17d383a6f7a3aabca31ac04eee05585bbadab16/aiohttp-3.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1601cc37baf5750ccacae618ec2daf020769581695550e3b654a911f859c563d", size = 532476, upload-time = "2026-06-07T21:08:57.176Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/02/9ac85e081e53da2e061b02fa7758fe0a12d17b8ce2d1f5e6c7cb76730328/aiohttp-3.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d6e0ac9da31c9c04c84e1c0182ad8d6df35965a85cae29cd71d089621b3ae94", size = 1922347, upload-time = "2026-06-07T21:08:59.563Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/3e/d3ba07a0ab38b5389e10bec4362d21e10a4f667cba2d79ba30837b3a5059/aiohttp-3.14.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e8f2d660c350b3d0e259c7a7e3d9b7fc8b41210cbcc3d4a7076ff0a5e5c2fdc", size = 1786465, upload-time = "2026-06-07T21:09:01.909Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/cb/e2ee978a00cfb2df829704a69528b18154eba5939f45bc1efa8f33aee4c5/aiohttp-3.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4691802dda97be727f79d86818acaad7eb8e9252626a1d6b519fedbb92d5e251", size = 1909423, upload-time = "2026-06-07T21:09:04.357Z" },
-    { url = "https://files.pythonhosted.org/packages/73/5d/1430334858b1022b58ae50399a918f0bd6fe8fa7fa183598d657ff61e040/aiohttp-3.14.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c389c482a7e9b9dc3ee2701ac46c4125297a3818875b9c305ddb603c04828fd1", size = 2001906, upload-time = "2026-06-07T21:09:06.722Z" },
-    { url = "https://files.pythonhosted.org/packages/66/4e/560c7472d3d198a23aa5c8b19a5115bf6a9b77b7d3e4bb363da320430ad2/aiohttp-3.14.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc0cacab7ba4e56f0f81c82a98c09bed2f39c940107b03a34b168bdf7597edd3", size = 1877095, upload-time = "2026-06-07T21:09:09.011Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/f1/4745806578d447db4a784a8591e2dae3afdfc2bcb96f8f81271b13df6543/aiohttp-3.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:979ed4717f59b8bb12e3963378fa285d93d367e15bcd66c721311826d3c44a6c", size = 1676222, upload-time = "2026-06-07T21:09:11.461Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c9/48255813cca749a229ef0ab476004ec623728ad79a9c0840616f6c076325/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38e1e7daaea81df51c952e18483f323d878499a1e2bfe564790e0f9701d6f203", size = 1842922, upload-time = "2026-06-07T21:09:14.118Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/c0/bbd054e2bee909f529523a5af3891052606af5143c09f5f183ec3b234676/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4132e72c608fe9fecb8f409113567605915b83e9bdd3ea56538d2f9cd35002f1", size = 1825035, upload-time = "2026-06-07T21:09:16.447Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ae/90395d4376deceb74e09ec26b6adf7d2015a6f8802d6d84446af860fef04/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:eefd9cc9b6d4a2db5f00a26bc3e4f9acf71926a6ec557cd56c9c6f27c290b665", size = 1849512, upload-time = "2026-06-07T21:09:18.742Z" },
-    { url = "https://files.pythonhosted.org/packages/93/bd/fb25f3049957553d4ce0ba6ae480aa2f592a6985497fca590837d16c1be0/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b165790117eea512d7f3fb22f1f6dad3d55a7189571993eb015591c1401276d1", size = 1668571, upload-time = "2026-06-07T21:09:21.458Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/22/7f73303d64dd567ff3addca90b556690ed1233a47b8f55d242fb90af3681/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ed09c7eb1c391271c2ed0314a51903e72a3acb653d5ccfc264cdf3ef11f8269d", size = 1881159, upload-time = "2026-06-07T21:09:23.813Z" },
-    { url = "https://files.pythonhosted.org/packages/44/be/0474c5a8b5640e1e4aa1923430a91f4151be82e511373fe764189b89aef5/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:99abd37084b82f5830c635fddd0b4993b9742a66eb746dacf433c8590e8f9e3c", size = 1841409, upload-time = "2026-06-07T21:09:26.207Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4d/4a99fb425c5e0cad715eea7bd190aff46f38b959a0a2dadb993705d34b26/aiohttp-3.14.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:eb0495d778817619273c108784292be161a924b9f5ae5cbbc70a2caa6838250b", size = 765848, upload-time = "2026-07-23T01:52:08.217Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e8/43b85dc55b8e950dc644babe762add781319ea881b57b33d2cce12017d12/aiohttp-3.14.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c3c200cf9757edd785051dc699c7ecbec22110dbfcb3fefc7a9f9695eda8ea7a", size = 517476, upload-time = "2026-07-23T01:52:10.846Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9e/73b582c4dbbc3c12ef4473822475effaabf1f934b56f14f5b03fe5d3a2af/aiohttp-3.14.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd51ebf9d3a00c074df4ede271023f4d2dba289bcc740b88191872716014e3c5", size = 515334, upload-time = "2026-07-23T01:52:12.636Z" },
+    { url = "https://files.pythonhosted.org/packages/79/03/e98c3c9e05a5bdf97defe5ff9169baba4f0ec9a901f2d60e0f060c2f051e/aiohttp-3.14.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:134ac5ddcf61c6fad984b9a5727d83492ada43d63471db20fb73042c13fca62f", size = 1708830, upload-time = "2026-07-23T01:52:14.538Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2c/26e60b694844dfd2176c57f913a22d0cd6a16f9ff202cbda7580d0328b98/aiohttp-3.14.3-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:70c987b27534f9ae1a723f47ae921571d616da21d3208282bf4c52af5164ac43", size = 1674012, upload-time = "2026-07-23T01:52:16.486Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/672df92e3172cd876aacfa97a952ac560877eb169384b2991ac5b273de4c/aiohttp-3.14.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1b59533861b70a2185c8f4f350f791f39d64358ef6944ce71c5240c9ec0982c9", size = 1767015, upload-time = "2026-07-23T01:52:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c5/228dec7bfec1c373cc2217cdeb47d6456dcd7a13a4c55144930a75ae3851/aiohttp-3.14.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1c5281acc88b92396f88c7e1e2748f8466689df22b80170e4f51efa712fb47a8", size = 1858700, upload-time = "2026-07-23T01:52:20.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ff/cb36724e8c8d17f90ada567a9ff3efe1d6e9b549fba697a242aece180f21/aiohttp-3.14.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48d67b87db6279c044760787eb01f6413032c2e6f3ba1cafaa492b1c8e578479", size = 1714075, upload-time = "2026-07-23T01:52:22.071Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3a/296a4135c6366376263aeef54b15caca1f07676c2ae0c525d7832f2f808a/aiohttp-3.14.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f53bcd52f585e1ac3e590d61434eb61f9a88c38df041b4ea126d97144344a77b", size = 1588234, upload-time = "2026-07-23T01:52:23.757Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/81/9d5d853ef892dc066d1eb6db0e87a47348b920c1c879aa554612fdbd9d79/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0fdea2281997af69da84c77ffa6f5938a0285f21fb3887c249d67419ca865b3d", size = 1677300, upload-time = "2026-07-23T01:52:25.861Z" },
+    { url = "https://files.pythonhosted.org/packages/68/96/021d386ae32d9b26d4b88df2e794546232ff56bb6be952bf6be227c0bbc7/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:cda5fd5c95ad7a125a2e8464acc78b98b94c475a3780d6aa0aa157c93f470f4d", size = 1691501, upload-time = "2026-07-23T01:52:28Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9f/af66adce26a14af135c003cbd0f44ccaa68cebd30ff8ac99ca47fb4958f7/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:6debfa7312ff9d4c124dc71d72e9a0a4b9e0879e48ba6fcb42bef5c3300289e2", size = 1735113, upload-time = "2026-07-23T01:52:29.995Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/28c390d4c9851effe52ac25b5a2e1d92246acd00728b4fc7975dafb67484/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:f4e05329faa0ea1a404b37de4f034fd2c2defcca06a68dc6745e4e56c88e8a48", size = 1577486, upload-time = "2026-07-23T01:52:31.937Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c2/00e23a1bf2abb70dd353f6987db7e7f2491d0261f7363997738c71c98f95/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:a3a8296e7ab5c295f53f1041487cb088e1480775aafbf7fe545d93b770a0f96f", size = 1751353, upload-time = "2026-07-23T01:52:33.688Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/7d/d51a706a8cbfa57f0611127daf61ab3ae02ab8420b0407412079227d1c65/aiohttp-3.14.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5373dc80ad1aa2fb9ad95c83f24eef418bbda3a61375f128e5b0192e4f3f9b32", size = 1698681, upload-time = "2026-07-23T01:52:38.167Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b0/90bd5cd9fdd9787cb4211d284d1fb8401339a933cb0227a15b71e789232f/aiohttp-3.14.3-cp310-cp310-win32.whl", hash = "sha256:a3e22975f905b89a55a488c2a08f2fdb2186175349e917d48985cc468a3d4c6e", size = 456733, upload-time = "2026-07-23T01:52:41.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/15/fe5b8f6a71ae112bc677163d0b0701bda5dc15005249582258ede0eb88c7/aiohttp-3.14.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdd0e2834dce1a26c1bbe26464861e16bbe217042cbff619247c11594472518c", size = 480460, upload-time = "2026-07-23T01:52:43.905Z" },
+    { url = "https://files.pythonhosted.org/packages/54/00/45e98b6645cd7f00a4b78b749ebd309094b0eaeb2d2e96157eadbc0d0050/aiohttp-3.14.3-cp310-cp310-win_arm64.whl", hash = "sha256:eac645b09bcfdf73df7536331f0678c1086ea250981118ddb5199e17ccef72bb", size = 453479, upload-time = "2026-07-23T01:52:46.075Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5c/b3e4ff8ad43a8afef9602c5e90285936da1beaea8b029016b793891f03c3/aiohttp-3.14.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e568e14940c09955aa51f4e645b6daa18a581c5dcfcd73744dcc86a856e3ced3", size = 764250, upload-time = "2026-07-23T01:52:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/da/f1b384465e51449d844056b75070461da03a9a23e6c1747003695bf4172a/aiohttp-3.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:54cfcdee2770dac994417cbb0ee1f3eb0e7cb6b30c79bf44f2c02ff79ec5124a", size = 516281, upload-time = "2026-07-23T01:52:51.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/3f/01264f820ee2e3712a827892b1cd6ff80f3300c1fcbffbb45714a915d47a/aiohttp-3.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:21c016079415ed3fd676963e9793700a566d85dbbd6bfc564b9b2d209147dcc8", size = 514742, upload-time = "2026-07-23T01:52:53.779Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8d/a71c6f2db52ac1ed142b133f7feddaa6b70539c3f4de24d7e226c95b794c/aiohttp-3.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6088ec9894113802bddb3c09e974929aed2c7b3a8c456219b8aab4481f1a239", size = 1780613, upload-time = "2026-07-23T01:52:56.948Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/11/3dd9b3fb3a170f6ec9011b5291d876a6fab4086714c9e158600edf01b4fd/aiohttp-3.14.3-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:16ea7e24c309fb7c0bbd505d149abe4fe4dccfb8db911db7dbec0921bc889a6f", size = 1737688, upload-time = "2026-07-23T01:52:59.294Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/3e/834c26918be7d88068822b40e0db30fca50b5f4fe79104aa16a93f1d74e6/aiohttp-3.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56f355e79f71aef2a85c80305cc915f894b170dba76de5fe84f6351939b83c06", size = 1845742, upload-time = "2026-07-23T01:53:01.641Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/49ab8572df7d66bc13d11e31f781292badb04180dd87ba98733066c6aed7/aiohttp-3.14.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:18c441d0a8fca6de8d1f546849b9f0ab20d435993e2c5b59562b2fae6be2f929", size = 1928412, upload-time = "2026-07-23T01:53:04.018Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/2b8f0c0ce09c87a1daf80fd483431b56b1435d3f62789bc86f572e1245de/aiohttp-3.14.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:53e7b4ce82b54a8bcc71b3b67a5cbd177ca1d7f592cbc92cd38b7349f73482db", size = 1786220, upload-time = "2026-07-23T01:53:06.481Z" },
+    { url = "https://files.pythonhosted.org/packages/85/00/9c45f81de11710460edfa1dc81317b6e882703b160926c879a9d20da9fcc/aiohttp-3.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f55119f7bf25f49ed210f6096090715da24f2943c62102448915fde3c62877ce", size = 1637231, upload-time = "2026-07-23T01:53:10.258Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ce/967d628e910756f3539c6107cb7844a1b69440dcb3029a5ee7871b09ab63/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9aa6e61fdf20105c4144e755bd586008ff450791d67b1c8146fdc15959c4d51c", size = 1753161, upload-time = "2026-07-23T01:53:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b2/0c3d4114f0aee4f580f5b3b4eb71b24d7a23b834ea506a4dfebe76513f35/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:ccd4893707b3e2a13e39c90d43cf80edf2e4d0457935bcc103bf2346214c3f15", size = 1756356, upload-time = "2026-07-23T01:53:16.211Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5d/99e7d91c82f1399d1ae2a854e080bd1493fbc31e5e959dbc4ec33dac3bec/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b2466434105a4e03113c36ec775cc2ebe6676b62eae326fa670bb607ef788c1c", size = 1819846, upload-time = "2026-07-23T01:53:18.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/05/d5e1cb6480eeffd3f901d40a2c5e2d1e7effdc797837da3b490272699f13/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:ba59d59aba08ac02fc03b0c8983ccd5ee39a199d0552ce9e6d2b4845b34d59ae", size = 1628531, upload-time = "2026-07-23T01:53:23.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/90/b934682bcaefae18a9e04f3dff5b68522ba810906358ae5029b68110ea3b/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ed099d105449c4f9e84f24af203cd131349d4761d8813fa7e02c32e7128cd910", size = 1832712, upload-time = "2026-07-23T01:53:27.551Z" },
+    { url = "https://files.pythonhosted.org/packages/21/df/6061679faaf81fac746e7307c7adb71e858071a5d34c27583afefc64f543/aiohttp-3.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:152516815ef926786a0b6ae2b8f1fd2e0c71582dee0b435636865316fd4891b7", size = 1775014, upload-time = "2026-07-23T01:53:30.223Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1d/f854878bbc69b88faefe924b619a34a6f59ec05fd387c77690667eaa75eb/aiohttp-3.14.3-cp311-cp311-win32.whl", hash = "sha256:a4af35c443e0b1a1bd6a8af3f3485d7fda15c142751a00f3ff8090f0b93346fa", size = 456006, upload-time = "2026-07-23T01:53:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/2af9d1674baccd1dbd47282a93d660a22e57ef6167c856deb24b4214fbab/aiohttp-3.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:e1e74298bab6ee0d6e749ed4fd1901c7e604bdda32c03d787a2cc71c46d0433d", size = 481069, upload-time = "2026-07-23T01:53:39.673Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/76/88401ff3fc95e85c5fc38d588f36f55e61ecb64343b2bc8d69326f453cc0/aiohttp-3.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:03cd2bde3d7f085b64e549c985f4bb928cad7e8ecf5323bfca320db548d81b39", size = 453021, upload-time = "2026-07-23T01:53:43.749Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/eb96299230e20acf2efae207cb8d69051f1f68e357e5ea5e479bf6fb097a/aiohttp-3.14.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39aded8c7f3b935b54aab1d8d73c70ec0ee2d3ec3b943e0e86611bc150ba47f5", size = 754690, upload-time = "2026-07-23T01:53:47.332Z" },
+    { url = "https://files.pythonhosted.org/packages/88/11/e7a70a209eb9a067c0d3212b518a0134e3484f5178c7533878b6b514d469/aiohttp-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5bcb6ff3fdab1258a192679ff1a05d44f59626430aa05cd1a9d2447423599228", size = 509484, upload-time = "2026-07-23T01:53:51.159Z" },
+    { url = "https://files.pythonhosted.org/packages/30/07/4bbc222cc8dbe31d4c3e8a5baad2286e4d42026ac0c570027b89afce6344/aiohttp-3.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:617105e2c3018ee38d0c8ce5ee3c84f621a6d8b9f723202aacaff28449ca91ee", size = 511949, upload-time = "2026-07-23T01:53:55.083Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b9/42e74c46b7b7c794b995bbc1f573fb48950c38b19d8600c62a6804ee2d67/aiohttp-3.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f631fe87a6f30df5fbe6d79640b25e4cffb38c31c7fb6f10871517b84b0f8c1a", size = 1765282, upload-time = "2026-07-23T01:53:59.662Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ed/62bc4d74363ad346d518e0720363a949f63e2e23439a79eb5813d4d29bb3/aiohttp-3.14.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a94dbaae5ae27bd849c93570669bff91e0510f33a80805738e3de72a7be0447b", size = 1741511, upload-time = "2026-07-23T01:54:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9f/181e8a8bc79e47d13c7fc4540bd7a3b729d9505609c61f392a8dd2fbfe55/aiohttp-3.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8f2f1c4c032c7cedd7d8da6f54c97b70266c6570c3108d3fdffee7188bb70529", size = 1810680, upload-time = "2026-07-23T01:54:09.882Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/dec94d6ad694552fe3424e3f1928d7a606a5d9d9433a04e7ecdd9d38ae7f/aiohttp-3.14.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea05e1f97ceea523942d9b2a7d7c0359d781d683d6b043f5943a602b14da4787", size = 1905646, upload-time = "2026-07-23T01:54:13.475Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:543906c127fb1d929b95076db19b83fa2d46751006ff1e23b093aa5ac4d8db42", size = 1792122, upload-time = "2026-07-23T01:54:15.752Z" },
+    { url = "https://files.pythonhosted.org/packages/66/73/10b1ef93afa61f4963c746257b70ced619cf31a4798671de5fdb2608501d/aiohttp-3.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0a5ff2dfbb9ce645fa5b8ef3e02c6c0b9cc3f6030ff863d0c51fffc50cb5541b", size = 1591127, upload-time = "2026-07-23T01:54:19.489Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ed/3b203fa6de1b338c14acdc06bf6ca9b043b7944f005966958c2ced932cde/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:041badb8f84396357c4d3ad26de6afd7a32b112f43d3c63045c0c8278cfd2043", size = 1725210, upload-time = "2026-07-23T01:54:24.129Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b7/1c2aab8c706436dcc28598452488ac9cd7c409da815237c28c27d58993e6/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:530125ee1163c4219af35dc3aa1206e541e7b31b6efc1a3f93b70a136f65d427", size = 1764848, upload-time = "2026-07-23T01:54:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/54/50/94c28f08b131c4bf10984ea2c7a536c9920608bb2d6e7f95642c30cc87b7/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c8653fd547c93a61aadc612007790f5555cdd18946fa48cf45e26d8ea4ea473d", size = 1777102, upload-time = "2026-07-23T01:54:31.775Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d4/e7d09ba7d345fb2d74440fd2fa033c5e079fac05552927705986f41a364f/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:89176250f686cb9853c0fb7ead90e639e915b84a6f43eedc2a4e7ec21f1037f0", size = 1580205, upload-time = "2026-07-23T01:54:34.518Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/072a91d68e1e1eb587985b54baab94221277f877e8ef274fc213a0ceae28/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3a26434dafe408229ff3403458ca58de24fb51936504decac49ce6755f77e59d", size = 1797219, upload-time = "2026-07-23T01:54:36.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/eb/aad34e897e668424d6e995da5dff8a4a09af93363d3392488772957a63aa/aiohttp-3.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d1558173930a5a8d3069cee5c92fc91c87c4dbcb099debbb3622053717145a19", size = 1768629, upload-time = "2026-07-23T01:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/6bb88ddba0fecd9122aa3ebcad25996cf6c083a4a7040dbb3a4f97972af6/aiohttp-3.14.3-cp312-cp312-win32.whl", hash = "sha256:16100ad3ab8d649fdfbee87602d9d2dcdca9df0b9eda8a1b5fdc0d41f96da559", size = 451481, upload-time = "2026-07-23T01:54:42.547Z" },
+    { url = "https://files.pythonhosted.org/packages/76/9b/f2f8f108da17ecef2cc3efc424e8b7ad3782b1a8360f7b8eae8ced84f6ea/aiohttp-3.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:33a2d7c28d33797a2e99923dffa63f83d908a19b6bf26cfe80fa790aa5e1a75a", size = 476845, upload-time = "2026-07-23T01:54:44.853Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/44/28dac80a8941b604f4da10ce21097614ca1bf905ce93dca28d8d7de9c1e7/aiohttp-3.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:362a3fd481769cac1a824514bcd86fda51c65e8fe6e051099e008fddde6db17c", size = 448050, upload-time = "2026-07-23T01:54:47.087Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/5afd201cc0ab139029aadb75392efe85a293403d9dd3a3226161c21ce00c/aiohttp-3.14.3-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:2e9878ae68e4a5f1c0abe4dd497dbc3d51946f5837b56759e2a02e78fa90ef86", size = 506269, upload-time = "2026-07-23T01:54:49.075Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/dec8189d62b45ade009f6792a2264b942a90cb88aeaf181239933cd72c3c/aiohttp-3.14.3-cp313-cp313-android_21_x86_64.whl", hash = "sha256:f3d2669fe7dec7fc359ecdb5984b29b50d85d5d00f8c1cb61de4f4a24ee42627", size = 515166, upload-time = "2026-07-23T01:54:51.894Z" },
+    { url = "https://files.pythonhosted.org/packages/28/24/2854869d29ed8a8b19d74f9ec6629515f7e04d02dd329d9d179201e58e47/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:cc7cb243a68167172f48c1fd43cee91ec4b1d40cefd190edd43369d1a6bc9c82", size = 486263, upload-time = "2026-07-23T01:54:54.223Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/dd/57187c8be2a35aea65eaee3bd2c3dcbbcf0204f5106c89637e3610380cd1/aiohttp-3.14.3-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:78253b573e6ffab5028924fc98bc281aae05445969982a10864bc360dea2016c", size = 492299, upload-time = "2026-07-23T01:54:56.236Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/11/06ae6ed8f0d414edf4068861e233d8fe23ee699bfd4b3ceb8663db948a62/aiohttp-3.14.3-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7041d52c3a7fa20c9e8c182b534704abb19502c8bdcbde7ab23bfda6f642394f", size = 502235, upload-time = "2026-07-23T01:54:58.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a3/559639c34a345d2cf7c52dff6838119f2eaf29eb508227b5b83f573af813/aiohttp-3.14.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac74facc01463f138b0da5580329cfcc82818dea5656e83ddcd11268fc12ff80", size = 750883, upload-time = "2026-07-23T01:55:00.65Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cd/41e131f13afd1e7b0172a9d9eda085ef90eb8439f41f0d279db81ed3ae60/aiohttp-3.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d6218d92e450824e9b4881f44e8c09f1853b490f9a64130801024a4793b1b3b0", size = 508473, upload-time = "2026-07-23T01:55:02.945Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6b/e7f13410d391c6e55b4c007a8de024355389d7d459e3d64c42b2d33617e5/aiohttp-3.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:11fb37ef075669eee52ab1928fbf6e1741fada40409fa309ebde9607a962aebf", size = 509190, upload-time = "2026-07-23T01:55:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/97/21/6464573e53d69672cc1eada3e5c5cb2d2efa82701e8305a0f2047a576967/aiohttp-3.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55bdcc472aafe2de4a253045cc128007a64f1e0264fb675791e132ea5edaa3bd", size = 1761478, upload-time = "2026-07-23T01:55:07.383Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/81/d217043a4c17fbce360905e3b2bdd20139ebc9a2de836d035d179c4da006/aiohttp-3.14.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c39846c3aad97a8530c89d7a3869a8f8e9e3762c6ac0504481e5c80948f7e807", size = 1735092, upload-time = "2026-07-23T01:55:09.803Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/66/e13a02d0eeb1a9a502402a977abb4e4abff9fe4051c26f80558c57a7c975/aiohttp-3.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5895ef58c4620afe02fa16044f023dc4dafec08158f9d08874a46a7dbc0341b8", size = 1800546, upload-time = "2026-07-23T01:55:12.012Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5e/57d42fca1d18cb5acc1cad945d017fabc5d6ae71d8a08ad66be8dc3ee544/aiohttp-3.14.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa9467a8113aa69d3d7c55a70ef0b7c636010a40993f3df9d9d0d73b3eb7ef24", size = 1895250, upload-time = "2026-07-23T01:55:14.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/1c/7da8d08e74d56f00070822f9638ff3f1c563f8ad87d1efa996c87bfc8644/aiohttp-3.14.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d7d2deec16eeedf55f2c7cf75b521ea3856a5177e123844f8fd0f114ce252cb5", size = 1789289, upload-time = "2026-07-23T01:55:16.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0f/cf16bcf56896981c1a0319f5d5db9337994b5165730c48a8fa07e9b34be6/aiohttp-3.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dd54d0e8717de95939766febac482ac0474d8ac3b048115f9f2b1d23a16e7db4", size = 1586706, upload-time = "2026-07-23T01:55:18.913Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/6f/76eac12a7f2480e1e304f842efdb07db33256b0d9165b866b6ef0806c202/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:df82f3787c940c94986b34222d59c9e38843fba85139f36e85255a82ad5355a9", size = 1724652, upload-time = "2026-07-23T01:55:21.296Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/19c8c592baeeb94b75f966547d40c02ac7590902306ec5863d5c027cf506/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:42a67efc36300d052fb4508a53e8b6901b9284b599ae63945c377569c5fcc1e1", size = 1756239, upload-time = "2026-07-23T01:55:23.705Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c9/4e9383150296f97f873b680c4de8fb2cd88608fb9f48c79edcb111611abc/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7a75aa63cbf9b21cfaf60dc2657e19df2c2867d91707d653fee171ffeedd1371", size = 1769161, upload-time = "2026-07-23T01:55:26.082Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1e/147bdc6cc5de5f3ab011be8bf5d6e786633249f22c20bae06f85e45f5387/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e92eb8acc45eb6a9f4935071a77edf5b85cc6f8dfad5cd99e97653c26593cdde", size = 1578759, upload-time = "2026-07-23T01:55:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/31/78388a9d6040ece2e11df62ea229a822cf5e52d238374b220ae9975b2623/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b014a6ed7cf912e787149fdc529166d3ceabac23f26efeea3158c9aba2354e7e", size = 1792025, upload-time = "2026-07-23T01:55:31.457Z" },
+    { url = "https://files.pythonhosted.org/packages/03/51/a3d29fdf2c25d796746af8ad6fe56a45d6256c38b0a8a2ed752e1160b3a2/aiohttp-3.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d4f72af88ac2474bb5bca640030320e3d38a0163a1d7533500e87be458eef71", size = 1768477, upload-time = "2026-07-23T01:55:33.87Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a6/442e18b5afeade534d877a2dc3c3e392aff8d49787890b0cf84790410267/aiohttp-3.14.3-cp313-cp313-win32.whl", hash = "sha256:5f08ec777f35ee70720233b8b9811d3bb5d728137f30ac91b7457709c3261ac0", size = 451069, upload-time = "2026-07-23T01:55:36.121Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/3d876ac02659f271cf7f6769f14a8e3de5b6e888ed8b5a7e998086a4cec8/aiohttp-3.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:dff9461ec275f22135650d5ba4b4931a11f3958df7dfbb8db630000d4dee0883", size = 476518, upload-time = "2026-07-23T01:55:38.303Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/0e/50d6e6471cd31edce8b282bdec59375a3a69124d8a989a0b1313355cae52/aiohttp-3.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:ddcac3c6b382e81f1dd0499199d4136b877beb4cb5ef770bbbfba56c4b8f55d2", size = 447676, upload-time = "2026-07-23T01:55:40.451Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/20/887fdcf832326571b370ffc347b3e70abe101096f3720126aac161b1d872/aiohttp-3.14.3-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:49f7325beb0f85ef4aef5f48f490269575f83e6e2acad00a1d80b807eb027062", size = 509067, upload-time = "2026-07-23T01:55:42.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a3/92cec936f78cc4bf0fa5554ebe593b73459d94e3c62303e1902a4cccb6f7/aiohttp-3.14.3-cp314-cp314-android_24_x86_64.whl", hash = "sha256:e3be98a7c30b8c25d573dafba7171d66dfb05ee6a9070fc46535464ff97700a6", size = 514774, upload-time = "2026-07-23T01:55:44.937Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/2a0c38df3fc557620b6a5acd98364af050053b6285b4dc7ee74100c63c18/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:614c61d478b83953e261d02bb2df750f17227cd33ef8002945bf5aebbde21919", size = 488134, upload-time = "2026-07-23T01:55:47.135Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d6/d51b7d4bf309af3693940d8ffd2b9ed0b682434ef85959b7c9c137f60cf8/aiohttp-3.14.3-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:1caa7b0d05f3e3a36f87788c59e970a7ee1cefcfcbb924a9f138c4a6551c9cb7", size = 494201, upload-time = "2026-07-23T01:55:49.451Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5a/8f624384e5f1efabb5229b94157eb966b021e97bdb188c62860c2ae243c2/aiohttp-3.14.3-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:dfa68deb2a443bdaa3ea5297b0699c1464f08aef3812b486d1348eee61b07dc0", size = 502766, upload-time = "2026-07-23T01:55:51.656Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/26/4ff0164370deec18fb19254ee4ab10b7a73304ac0c860b13f5f84663759b/aiohttp-3.14.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:e72ee89e28d907a18f46959b4eb0bb06701cc7f8cf4366e00029e2ccfaaf5924", size = 756557, upload-time = "2026-07-23T01:55:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ad4c8b7488d745d2ca4838ebd8ae5ba9b56341d30b1da43640e4ce87f9f49646", size = 510168, upload-time = "2026-07-23T01:55:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:db332af25642007330fca8be5c4d194caf2bea7a7fc84415aff3497af5dfee6b", size = 512957, upload-time = "2026-07-23T01:55:58.437Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d1/8aba53f15ccb2238405f5e9d30e2a8ca44f93878c26e7165ade00d374b1c/aiohttp-3.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25bd2708db6bdf6a6630dd37bdcdfcb47c4434d22ac69c64665b802910140b30", size = 1750149, upload-time = "2026-07-23T01:56:00.856Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/40c3fee327529284375c6701cbb0fa4600cc2e8432af1378f897e2ef7d3a/aiohttp-3.14.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cef89a58e628c4efcac3275c2d68083f82426dcdc89c1492a6f654f9f7ea6ab9", size = 1707685, upload-time = "2026-07-23T01:56:03.371Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a3/ca0cc6724cca8114b05694abd916060758c79894c3aa5b012cdadc1bc28e/aiohttp-3.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c23ec8ee9d5ab2f5421f9c7fffce208435607af27fd46d4a44e031954352838f", size = 1803911, upload-time = "2026-07-23T01:56:05.817Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/85b099c299c3ffd38ad9b3e43694c8a346934e4a30c88c4fd5a841234f77/aiohttp-3.14.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e2667f0bbe7eb6c74eae5e9691441ad186e5845ca3cff63230fc09c4e7514f5d", size = 1876929, upload-time = "2026-07-23T01:56:08.413Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18cb43369747b2ae007bd2655fb8e63a099c2ff1d207962943636dac989b3147", size = 1761112, upload-time = "2026-07-23T01:56:10.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/16/bc4b55e3e5cb175fd69c53c90d60d2f47797cb343da5106e23863dc4dba4/aiohttp-3.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d77640cc618c1d99fc4f8589c0f24a730adfa54eb1e57ef7bf0c8dfb78da898c", size = 1583500, upload-time = "2026-07-23T01:56:13.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e8/13a9d957a1ee40837f46aa30f0f4c657e673ad86a2e6362a9f9be20d26d9/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:53e5179d8abb5710f8e83ba207c41c8d1261fcffd4616500e15ca2b7a33be10a", size = 1713940, upload-time = "2026-07-23T01:56:15.969Z" },
+    { url = "https://files.pythonhosted.org/packages/38/05/d33c680c1bcf1c7e130f9cbfc1fc02fe8bb0c4af2a94a53dd5fb56131e5c/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:cd817772b2fcf2b8c0905795318485f9ec16eae60b29feb7f4c77085311637f0", size = 1724413, upload-time = "2026-07-23T01:56:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1d/af798d306f7a74b6a632dbcabcf62a4c91391b7582d2a8c6d7712e2cc54e/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4e3ac92d90e92773b2362d506068e9a948192bd553e743c5b2429e28527c8661", size = 1770748, upload-time = "2026-07-23T01:56:21.074Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/92/ad720d472556a995049206867765e9410969684f86ee09423ff9969044c1/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3f42e9b78301f11c8f861746175d8b9c1ccef713fcad9eab396e2f6db8ed4a22", size = 1577564, upload-time = "2026-07-23T01:56:23.475Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ad/0ed7586cbef7a884e23a752fa2bb987a122e6a5dd50dab109258d0a95193/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9d9edccfe496b476db5f398d97b865e9a6752bcf8aec4eef8390ce20fb64bb41", size = 1782080, upload-time = "2026-07-23T01:56:25.994Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ea/dbaed0d73e8a69aad653b045dab451c67c2454bb731a37b45a86593e9422/aiohttp-3.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c5ec8fb1bcc31a8466f74aaf26c345d5c386fa4bd08a3f0eb9c7a4a3fe8b5bf", size = 1745813, upload-time = "2026-07-23T01:56:28.604Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1b/6893d4bc57e434fc93a6c9217c637d967a0b651d989f6e3265179375754a/aiohttp-3.14.3-cp314-cp314-win32.whl", hash = "sha256:38901a84da3ce22249f6e860bf8f90d141bcab7da090cc398f8bb58c0e44b7da", size = 455872, upload-time = "2026-07-23T01:56:31.031Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/8b/c7baa1ba1eda4db6989baefe5de6d99834921b84ebd7918624febcb9f290/aiohttp-3.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:8b3b60de05f3dcb6f6a00f818bb2ec781cee4de0645f59ccaf99b1d1823b6100", size = 481030, upload-time = "2026-07-23T01:56:33.365Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8c/c29d067df825a2df88ca432db848aa2fe8199598359cc06c12b09320cac9/aiohttp-3.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:1576145bdceeb92382d899751e12743a3a5b8e460a841e3e50543859e54864dc", size = 453669, upload-time = "2026-07-23T01:56:35.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a4/9c033beb355d39b6147980597ec9645e4729243f686ee4dc73945de72030/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8800c996b01c2772a783e3e46f3e1abd5823029adca0df54231960de9bfefa5b", size = 791403, upload-time = "2026-07-23T01:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/87c32a0a7704583cfc49660bd817889bae5b830bf53b5dcb4e92145ac2da/aiohttp-3.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ebe8e504f058fe91223351cecd2d9d6946c9d241bb0250d898ffbdf584cc72b0", size = 526413, upload-time = "2026-07-23T01:56:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/8ec0e471248c500acdce2be3f46db8fb62b5eb60efef072529cc85ee1d26/aiohttp-3.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30402d03a7c0ff52bce290b57e564e9079fd9d0cb545c8aba73f86a103162d2e", size = 532135, upload-time = "2026-07-23T01:56:42.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/45/f8919fd936e8b79fcd9bda7b6d8e62613462a713f4f17987fd7c34399142/aiohttp-3.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9fc7b5bfec6573f3ae844f457fdde5adeb713f8b8e4a81ad64fc207b49383716", size = 1922742, upload-time = "2026-07-23T01:56:45.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ec/9ca76b28a27525b0cc53e20842e0228b022f301ce1f436b7d814b4aaf2df/aiohttp-3.14.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8a5fd34f7f7410d1730d5c2ba873cacb2eed3fede366feb268a70ba22581ed8f", size = 1787371, upload-time = "2026-07-23T01:56:48.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/6acdbf17315f7b55f1937e3387acb89a3cddeb4995689553d064af8e92ab/aiohttp-3.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:270d3dace9ca2f10f0da5d8ebe519b7a310fc6112ed916e32df5866df0888553", size = 1912623, upload-time = "2026-07-23T01:56:50.605Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e6/438b0c79ca6f45eb9fd9817dd4c01a91919a38c0de5ee9e05e2b4dc0ece7/aiohttp-3.14.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3ae5b3a59436d089b5395d910121a390feed4d00578eb95a0fd1a329fe963100", size = 2005515, upload-time = "2026-07-23T01:56:53.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/62cbd6577758699525f5c712d1ddef57d9875fbab0ae8d5f5a202fd598f8/aiohttp-3.14.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2498f0fe69ead802f9675beca44a7c21c62fdaa4ec5145ea1c3ad6edbee29f85", size = 1879906, upload-time = "2026-07-23T01:56:55.818Z" },
+    { url = "https://files.pythonhosted.org/packages/00/95/18bcbf830a21dc3aae24d8f6b6feaf3db1d2090242d00a7868db2ffb0b67/aiohttp-3.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a0dc483c00da8b673abbb367eb6f8d8f4bcec30eb58529ea13cb42e7fd2dfa33", size = 1675849, upload-time = "2026-07-23T01:56:58.861Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/19/47f4968659c5e23606c3790c80fc624e691c153d036148449ee84d31b287/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c7d3a97c678d34fc5b59da671ee9cd630096ddc643e7b5a30d54a2a6f3574d3f", size = 1843496, upload-time = "2026-07-23T01:57:01.591Z" },
+    { url = "https://files.pythonhosted.org/packages/64/af/38c33c4dd82fddcb4e56c4653b6f1072a8edbc6b7fa15809f14932c41e2d/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f8fb78a83c9e5f741ca3a68cfb455c1f5bb83b4e7249a3848b3cd78d0a8563b0", size = 1827746, upload-time = "2026-07-23T01:57:05.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/0537cda4885ac8f5b7053d164dd06312f4c483a4edcb8ee5b8aaf2a989bf/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:74ab5b6a9fb13e873e5a90946588baecaf488745e1db1a4a5c433f971f035098", size = 1853810, upload-time = "2026-07-23T01:57:08.043Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fe/26f9c5e6458385aa86497836b0dea6fb2f027827d63f37c7856cce9286ee/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd52f811e65f6fb634b1047159657c98f52b407f8efec907bcfc09da9a4c0a25", size = 1668895, upload-time = "2026-07-23T01:57:10.837Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4c/618b1db9b9ba079b8875d2cdf78e7c4a3bf72903bd5850fee7dd9544600a/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:f0f177d1b195b9e06376cfd7d308d8a1b920909a609d03ac82a8c73bbb16d3b9", size = 1883833, upload-time = "2026-07-23T01:57:13.672Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c6/bd959bd1e4771f9fd944e9e436224c48c77b018b73b519b5aad346335bcc/aiohttp-3.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:498c6c623134f8e09a3c4e60bcd607a0b4590dd7dbf08dd40851b27cbb520ccb", size = 1844251, upload-time = "2026-07-23T01:57:16.593Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/08d41839658bdd44a0ed2480f3891705ecb487ce28c0dde62c9040c997e0/aiohttp-3.14.3-cp314-cp314t-win32.whl", hash = "sha256:b304db572b4368edd8dda8a2274f73156fe15558fca4a917cb8a09fc47af5963", size = 474180, upload-time = "2026-07-23T01:57:19.306Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/3cd6ef0a2b2851f7ab913b5b079334781bd50ff56a323e4454063377a080/aiohttp-3.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:b20032766aedf6261c7a566585a40867d092ac03a0d81592d5370ef9b054f99b", size = 500528, upload-time = "2026-07-23T01:57:21.762Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/37/cfd1ed540a4d318da025590d96b728e63713c09e9377950fc655dadeb856/aiohttp-3.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:2e1161602f45a54de2ce0905243a95f58cb42dcd378402f3697f5e0b21e9d2e7", size = 469280, upload-time = "2026-07-23T01:57:24.241Z" },
 ]
 
 [[package]]
@@ -375,18 +375,35 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "docstring-parser", marker = "sys_platform == 'never'" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/1a/b5af41cc1fa14da277ec20ca5554dd2fcbc09b8523ac59b7a97fbb88e452/anthropic-1.2.0.tar.gz", hash = "sha256:12f8eedee7b7fb5685837b1371b7bfae1b281703f62355f4632598ec2fc53b34", size = 1137443, upload-time = "2026-08-27T20:29:12.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/78/3f8b52708b03309e511990700bb8d0ec7a0c9db3d2a1e0d1c3ca417a4604/anthropic-1.2.0-py3-none-any.whl", hash = "sha256:b60642b3e3cd6b8e3e328a2d3f2863ad2b6e743f1037e42cc0143f7df99f63c6", size = 1289535, upload-time = "2026-08-27T20:29:11.01Z" },
+]
+
+[[package]]
 name = "anyio"
-version = "4.9.0"
+version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
-    { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -449,7 +466,8 @@ dependencies = [
     { name = "python-dateutil", marker = "python_full_version < '3.13'" },
     { name = "python-nvd3", marker = "python_full_version < '3.13'" },
     { name = "python-slugify", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "requests-toolbelt", marker = "python_full_version < '3.13'" },
     { name = "rfc3339-validator", marker = "python_full_version < '3.13'" },
     { name = "rich", marker = "python_full_version < '3.13'" },
@@ -494,17 +512,16 @@ wheels = [
 
 [[package]]
 name = "apache-airflow-providers-common-sql"
-version = "1.27.1"
+version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
-    { name = "methodtools", marker = "python_full_version < '3.13'" },
     { name = "more-itertools", marker = "python_full_version < '3.13'" },
-    { name = "sqlparse", version = "0.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "sqlparse", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/a0/974f67323ba80aa55db842b4904457d3dbf97d7541b236eab445305a5f96/apache_airflow_providers_common_sql-1.27.1.tar.gz", hash = "sha256:72b25267c8b2969ba676b12bf74c49372150bc1b4ffef5e4093dd7ecc10311b7", size = 100001, upload-time = "2025-05-18T10:42:06.121Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/40/cad43f2b3363a6390c8d3c750fce110015016675fcd8f39fdfefb503a388/apache_airflow_providers_common_sql-1.19.0.tar.gz", hash = "sha256:132ca3fe30255f837d49d2346a9df56597ad0e27515024901a535d1857cc110e", size = 35361, upload-time = "2024-10-31T07:09:49.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/90/dd0b0db21bd507f75eebc85e61278b801a682ff144d7eb52836ae0d34f79/apache_airflow_providers_common_sql-1.27.1-py3-none-any.whl", hash = "sha256:1c42dfc9e37e52880963ec5bf65a3c62469889bcc59df2acadab358bb1584a43", size = 63977, upload-time = "2025-05-18T10:39:29.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/08/5e323efa09ac5a1271ccb98c158687981c3441fd19d790031492c8eded8a/apache_airflow_providers_common_sql-1.19.0-py3-none-any.whl", hash = "sha256:deade7d7a325e81ee63863823f2d8681d0fa39d3064685fd77a16127e5370045", size = 47210, upload-time = "2024-10-31T07:09:20.691Z" },
 ]
 
 [[package]]
@@ -545,7 +562,8 @@ dependencies = [
     { name = "aiohttp", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "asgiref", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "requests-toolbelt", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b6/fe/a673bab5936d96719660b80cdd84c2f2d69f9d1e40157a183a3f19734391/apache_airflow_providers_http-5.3.0.tar.gz", hash = "sha256:729a2ddcbf6ab9927b5a524be8e7979a9a96359dd6aece6af76fa9808e5256ca", size = 61486, upload-time = "2025-05-18T10:42:29.879Z" }
@@ -580,15 +598,15 @@ wheels = [
 
 [[package]]
 name = "apache-airflow-providers-sqlite"
-version = "4.1.0"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
     { name = "apache-airflow-providers-common-sql", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/0c/46342326da843b5346524ec0ac937ad583f9b833fb5f6f96097dc6f18b0e/apache_airflow_providers_sqlite-4.1.0.tar.gz", hash = "sha256:433e294df80cfd4afa4346dfe83b6f0638107592fcb0d933202958d31dd72a4e", size = 31135, upload-time = "2025-05-18T10:43:10.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/40/8d2f2317d4410afeeeb1e55db6836bef9a285e20d3e927bc44440ccfd4cd/apache_airflow_providers_sqlite-3.9.0.tar.gz", hash = "sha256:34f5ad67bdeded2fc00c67dc052e230ca53101deb2b0af4d60e7237bcd00cfe0", size = 9452, upload-time = "2024-08-22T10:36:04.751Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/5d/e3695ac06671731d18785b7f6230806c78d5ca8a6109aa21d692aa803d15/apache_airflow_providers_sqlite-4.1.0-py3-none-any.whl", hash = "sha256:40a06d77858462c73730a3d456b49d4e3d1e47a62a0ca51dfe671e7a1d807839", size = 11074, upload-time = "2025-05-18T10:41:14.982Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/7b/3f2fdbe255739c88162ca33222cf66aba79c1d7a5e5793a9db439d3ad5cf/apache_airflow_providers_sqlite-3.9.0-py3-none-any.whl", hash = "sha256:0a1ff2832a1cf70f7e50cdecfa54e0adf365b72d9e79458bbefcdc3a4527268a", size = 13970, upload-time = "2024-08-22T10:34:36.151Z" },
 ]
 
 [[package]]
@@ -815,7 +833,8 @@ name = "azure-core"
 version = "1.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "six" },
     { name = "typing-extensions" },
 ]
@@ -833,7 +852,8 @@ dependencies = [
     { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "msal", version = "1.32.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
     { name = "msal", version = "1.37.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/ff/61369d06422b5ac48067215ff404841342651b14a89b46c8d8e1507c8f17/azure-datalake-store-0.0.53.tar.gz", hash = "sha256:05b6de62ee3f2a0a6e6941e6933b792b800c3e7f6ffce2fc324bc19875757393", size = 71430, upload-time = "2023-05-10T21:17:05.665Z" }
 wheels = [
@@ -992,8 +1012,7 @@ name = "black"
 version = "23.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click" },
     { name = "mypy-extensions" },
     { name = "packaging" },
     { name = "pathspec" },
@@ -1074,12 +1093,6 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-athena = [
-    { name = "mypy-boto3-athena", marker = "python_full_version < '3.14'" },
-]
-glue = [
-    { name = "mypy-boto3-glue", marker = "python_full_version < '3.14'" },
-]
 lakeformation = [
     { name = "mypy-boto3-lakeformation" },
 ]
@@ -1088,9 +1101,6 @@ s3 = [
 ]
 s3tables = [
     { name = "mypy-boto3-s3tables" },
-]
-sts = [
-    { name = "mypy-boto3-sts", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -1399,37 +1409,31 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.1.8"
+name = "claude-agent-sdk"
+version = "0.2.148"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "anyio" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f4/fb7f81b31e44f69af9f53b93c32e2047f3ca15cd6311cfe72bfdf420f1f5/claude_agent_sdk-0.2.148.tar.gz", hash = "sha256:45c9972fa72dc6006745239c6838cc3cea7a9b42d6927c89f7bdb6996a1983b0", size = 344717, upload-time = "2026-08-28T18:33:51.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/f5/f4affb9f882bcf61422ea48491effb6ee2de28bfbdafd0ec90d1b959dad2/claude_agent_sdk-0.2.148-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026e2b54bb3f3909712ff462b8469e2b1fc5471cfde796abc23f32d30b2c8ba1", size = 83882833, upload-time = "2026-08-28T18:33:56.238Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cf/e1b11dd9fac877c8b44f022cf895f54f23854b916e09b32360e71209904c/claude_agent_sdk-0.2.148-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:c8cca1f4e4eb4e0c9f44ccfca6f651cf35e8f3914e483632ae8867c5619818a0", size = 88314490, upload-time = "2026-08-28T18:34:01.284Z" },
+    { url = "https://files.pythonhosted.org/packages/34/d4/53de4727576fa6b5a261414d420895f4eb5f0369e232d403f1096205709e/claude_agent_sdk-0.2.148-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:3fbbea7cc30099d14f894e12fef68b0ee42fa9982567df94e59499b6aff55959", size = 94014630, upload-time = "2026-08-28T18:34:06.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e9/2ea469751ed4df75a911c4bf4dcad1ff5b71ccc9aa1a4aa108583a2a66b5/claude_agent_sdk-0.2.148-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:221efbc0f583c80258189ab93e4f0d6b6a61ad61335de1fdf3e2331ad423dbeb", size = 94210928, upload-time = "2026-08-28T18:34:11.592Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ea/86ccd7a34446c37174e53f03c389b25f168c7f4fd4f00f3e130baae9c902/claude_agent_sdk-0.2.148-py3-none-win_amd64.whl", hash = "sha256:f155252940fd77f1bcc707836924ca3a9691d19bbc464914ae2b7ccf17f0410f", size = 96875177, upload-time = "2026-08-28T18:34:16.378Z" },
 ]
 
 [[package]]
 name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.14' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
@@ -1441,7 +1445,7 @@ name = "clickclick"
 version = "20.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "click", marker = "python_full_version < '3.13'" },
     { name = "pyyaml", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c6/19/f91d85941b79964d569a3729bf9f8b7f85ab47240248e77b7c0c8ed6ecc3/clickclick-20.10.2.tar.gz", hash = "sha256:4efb13e62353e34c5eef7ed6582c4920b418d7dedc86d819e22ee089ba01802c", size = 9914, upload-time = "2020-10-03T13:36:47.966Z" }
@@ -1698,7 +1702,8 @@ dependencies = [
     { name = "jsonschema", marker = "python_full_version < '3.13'" },
     { name = "packaging", marker = "python_full_version < '3.13'" },
     { name = "pyyaml", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "werkzeug", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8f/8b/c1d8a2e9327787354e936184f424b1ae96e526a0dad031bbc218c9dcaf35/connexion-2.14.2.tar.gz", hash = "sha256:dbc06f52ebeebcf045c9904d570f24377e8bbd5a6521caef15a06f634cf85646", size = 82819, upload-time = "2023-01-25T10:05:14.261Z" }
@@ -1860,11 +1865,10 @@ name = "databricks-sdk"
 version = "0.73.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "requests" },
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/7f/cfb2a00d10f6295332616e5b22f2ae3aaf2841a3afa6c49262acb6b94f5b/databricks_sdk-0.73.0.tar.gz", hash = "sha256:db09eaaacd98e07dded78d3e7ab47d2f6c886e0380cb577977bd442bace8bd8d", size = 801017, upload-time = "2025-11-05T06:52:58.509Z" }
 wheels = [
@@ -1884,7 +1888,8 @@ dependencies = [
     { name = "pybreaker" },
     { name = "pyjwt" },
     { name = "python-dateutil" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "thrift" },
     { name = "urllib3" },
 ]
@@ -1898,9 +1903,9 @@ name = "databricks-zerobus-ingest-sdk"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "requests" },
+    { name = "protobuf" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/60/e6ae4785e933eec4e9cec823798f65a8946c4c2bba0c43b97eb1e1489dff/databricks_zerobus_ingest_sdk-1.2.0.tar.gz", hash = "sha256:5330f1bf7544fcc016de34e18b7bbfc66ec589dbaf59bbd530185d19b444d750", size = 65236, upload-time = "2026-04-27T13:15:55.728Z" }
 wheels = [
@@ -1927,7 +1932,8 @@ dependencies = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pyyaml" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "tqdm" },
     { name = "xxhash" },
 ]
@@ -1967,84 +1973,37 @@ wheels = [
 
 [[package]]
 name = "dbt-adapters"
-version = "1.24.2"
+version = "1.24.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "agate", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-common", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-protos", marker = "python_full_version >= '3.14'" },
-    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pytz", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "agate" },
+    { name = "dbt-common" },
+    { name = "dbt-protos" },
+    { name = "mashumaro", extra = ["msgpack"] },
+    { name = "protobuf" },
+    { name = "pytz" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/6c/65190ca22dea211471275355c69fd84925d2e1712993c5868352234cb084/dbt_adapters-1.24.2.tar.gz", hash = "sha256:fb27141acdfad1188bcb584e9b9b1976cb9ae718618fcac132660fdaeb9b11a4", size = 143779, upload-time = "2026-05-21T10:36:02.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/d4/bea32dd730def5b875a76c05d281d397ed720b9184d936cc4cedac605948/dbt_adapters-1.24.5.tar.gz", hash = "sha256:87de096a0d5b219905f1079b002f13e3447ffb63558f4f3c5b7278670d198acb", size = 146532, upload-time = "2026-07-15T07:18:49.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/d5/e1f3d6a1bfa472ea00c3caa76301b73ec0e4f87b32468111ae7d31c16efa/dbt_adapters-1.24.2-py3-none-any.whl", hash = "sha256:f6afcef287165984d6e785bf1661473fdfbb6d2e723eaebd00355df2985124da", size = 176555, upload-time = "2026-05-21T10:36:00.965Z" },
-]
-
-[[package]]
-name = "dbt-athena-community"
-version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "boto3", marker = "python_full_version < '3.14'" },
-    { name = "boto3-stubs", extra = ["athena", "glue", "lakeformation", "sts"], marker = "python_full_version < '3.14'" },
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pyathena", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "tenacity", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b9/85e6b52c425723fb536480486580078d4a0320a142dafef59cc815500838/dbt-athena-community-1.7.0.tar.gz", hash = "sha256:7ad95daa28c55080e5945380cebd960d28a66d614f6b5b3ec77cfcb580e6c6ee", size = 73043, upload-time = "2023-11-10T09:46:16.826Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/06/f62e9d82a615dc799466640acf597b5b044c5eef512ee0f5372cc02c1bf5/dbt_athena_community-1.7.0-py3-none-any.whl", hash = "sha256:2f1003beccaa805a3e506572c7f1923528e4b35fb68fad17167733d7d2152019", size = 69089, upload-time = "2023-11-10T09:46:14.949Z" },
-]
-
-[[package]]
-name = "dbt-bigquery"
-version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
-dependencies = [
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-api-core", version = "2.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-cloud-bigquery", marker = "python_full_version < '3.14'" },
-    { name = "google-cloud-dataproc", marker = "python_full_version < '3.14'" },
-    { name = "google-cloud-storage", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/5b/d09f6f931e2a76fc51c26ea1ba20f70eea5a940b36dce73ae35dfe88612a/dbt-bigquery-1.7.2.tar.gz", hash = "sha256:27c7f492f65ab5d1d43432a4467a436fc3637e3cb72c5b4ab07ddf7573c43596", size = 54448, upload-time = "2023-11-10T01:21:34.831Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/de/c821edbf6d1c005fb2ab926e7f5bed9df1ca7c45935aced6bbb4e67504eb/dbt_bigquery-1.7.2-py3-none-any.whl", hash = "sha256:75015755363d9e8b8cebe190d59a5e08375032b37bcfec41ec8753e7dea29f6e", size = 75172, upload-time = "2023-11-10T01:21:23.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/07f0e315458128c6ef246ba9698dc0f5e9333394ab8844508adac468c617/dbt_adapters-1.24.5-py3-none-any.whl", hash = "sha256:32345118b921160722a13f12c3e369b9d59a0fb8fb9b3297e29d8cd53f973411", size = 177259, upload-time = "2026-07-15T07:18:47.314Z" },
 ]
 
 [[package]]
 name = "dbt-bigquery"
 version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
 dependencies = [
-    { name = "dbt-adapters", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-common", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-core", version = "1.11.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-cloud-aiplatform", marker = "python_full_version >= '3.14'" },
-    { name = "google-cloud-bigquery", extra = ["pandas"], marker = "python_full_version >= '3.14'" },
-    { name = "google-cloud-dataproc", marker = "python_full_version >= '3.14'" },
-    { name = "google-cloud-storage", marker = "python_full_version >= '3.14'" },
-    { name = "nbformat", marker = "python_full_version >= '3.14'" },
+    { name = "dbt-adapters" },
+    { name = "dbt-common" },
+    { name = "dbt-core" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-aiplatform" },
+    { name = "google-cloud-bigquery", extra = ["pandas"] },
+    { name = "google-cloud-dataproc" },
+    { name = "google-cloud-storage" },
+    { name = "nbformat" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4c/15/8becb292fe176a730c4b92dee22a17048379cc3cbbd06b8d02fde96c5469/dbt_bigquery-1.11.1.tar.gz", hash = "sha256:e0a4b67b6670cf1a23d53cc6701d3d1192ab49ba72b0f4784b16330fdd9b3898", size = 164123, upload-time = "2026-03-03T20:43:34.834Z" }
 wheels = [
@@ -2053,146 +2012,83 @@ wheels = [
 
 [[package]]
 name = "dbt-common"
-version = "1.38.0"
+version = "1.39.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "agate", marker = "python_full_version >= '3.14'" },
-    { name = "colorama", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-protos", marker = "python_full_version >= '3.14'" },
-    { name = "deepdiff", marker = "python_full_version >= '3.14'" },
-    { name = "isodate", marker = "python_full_version >= '3.14'" },
-    { name = "jinja2", marker = "python_full_version >= '3.14'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.14'" },
-    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version >= '3.14'" },
-    { name = "pathspec", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "agate" },
+    { name = "colorama" },
+    { name = "dbt-protos" },
+    { name = "deepdiff" },
+    { name = "isodate" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "mashumaro", extra = ["msgpack"] },
+    { name = "opentelemetry-api" },
+    { name = "pathspec" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/27/1cb45b595e280d4e66b122c539655be280236af27a964114b8f163702674/dbt_common-1.38.0.tar.gz", hash = "sha256:05f9c682c1c09b6a0ce79fe18dd7244a4549c3740329692bc19be9e7498f516f", size = 87065, upload-time = "2026-05-04T20:28:19.274Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/60/83f4a90ffa271b74b209d584e3be3b54b32f45aca36b0e0861e84e3f2d8c/dbt_common-1.39.0.tar.gz", hash = "sha256:868256ab2b59328efdd455644172ad17303f3f6a78a015f06667e865e068d620", size = 88069, upload-time = "2026-08-11T09:15:16.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/d9/11763d94eb3257c11463781c18aef3e9613829b9f0e55609a494e596f574/dbt_common-1.38.0-py3-none-any.whl", hash = "sha256:1646e5384a8e317fa63890e60e41ca50dd4c5a89e02ad9a141c184d4b672b696", size = 88460, upload-time = "2026-05-04T20:28:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/bc/56a9e62e67634631c7a99b246d92d1be22df746d265b36185fd7517b9163/dbt_common-1.39.0-py3-none-any.whl", hash = "sha256:30d63490b9ef2aad6f469ec841fb758430fcb1d997b79ff3df36fcb7b79a241f", size = 89092, upload-time = "2026-08-11T09:15:14.595Z" },
 ]
 
 [[package]]
 name = "dbt-core"
-version = "1.7.19"
+version = "1.12.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
 dependencies = [
-    { name = "agate", marker = "python_full_version < '3.14'" },
-    { name = "cffi", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "colorama", marker = "python_full_version < '3.14'" },
-    { name = "dbt-extractor", marker = "python_full_version < '3.14'" },
-    { name = "dbt-semantic-interfaces", version = "0.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "idna", marker = "python_full_version < '3.14'" },
-    { name = "isodate", marker = "python_full_version < '3.14'" },
-    { name = "jinja2", marker = "python_full_version < '3.14'" },
-    { name = "jsonschema", marker = "python_full_version < '3.14'" },
-    { name = "logbook", marker = "python_full_version < '3.14'" },
-    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version < '3.14'" },
-    { name = "minimal-snowplow-tracker", marker = "python_full_version < '3.14'" },
+    { name = "agate" },
+    { name = "click" },
+    { name = "daff" },
+    { name = "dbt-adapters" },
+    { name = "dbt-common" },
+    { name = "dbt-core-experimental-parser" },
+    { name = "dbt-extractor" },
+    { name = "dbt-protos" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "mashumaro", extra = ["msgpack"] },
+    { name = "metricflow" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "pathspec", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "pytz", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
-    { name = "sqlparse", version = "0.5.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "urllib3", marker = "python_full_version < '3.14'" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pytz" },
+    { name = "pyyaml" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "snowplow-tracker" },
+    { name = "sqlparse" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/66/32e97ff2dd9560a1b7e2b88a4fbaacc5bc1d0f668fede072c0a4c7f6c9a0/dbt_core-1.7.19.tar.gz", hash = "sha256:39f868f050be4f66f7791a6aad550b59b4f096cf79859e8efa2794fae5a7e318", size = 916539, upload-time = "2024-12-02T18:23:00.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/75/a9e29001e7a759ab9c656102c16576729fc27a4980be450fb0a532e24086/dbt_core-1.12.4.tar.gz", hash = "sha256:cf869cac339eb9d108181fc5b9bce0a467917e0515b48498e9d49311c82375b8", size = 1036040, upload-time = "2026-09-08T10:01:41.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/63/d8f91045e96d653c5301636aed29a5d7ab096c865863617ac36fd71d8f9b/dbt_core-1.7.19-py3-none-any.whl", hash = "sha256:682ef2ef36571b1d180462b54af0cbf4be4a2f042494f104063365bd26e0f32b", size = 1025955, upload-time = "2024-12-02T18:22:55.382Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c4/bf8dbcce1811964b2daad4abfa35577d35431ae634975599f317ccf227c6/dbt_core-1.12.4-py3-none-any.whl", hash = "sha256:a5d567a54f7ed44c5f08da86f7c01d5ca42f6756e69a9183b514fd37a2e89e1d", size = 1132392, upload-time = "2026-09-08T10:01:39.779Z" },
 ]
 
 [[package]]
-name = "dbt-core"
-version = "1.11.11"
+name = "dbt-core-experimental-parser"
+version = "2.0.0rc2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
-dependencies = [
-    { name = "agate", marker = "python_full_version >= '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "daff", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-adapters", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-common", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-extractor", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-protos", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-semantic-interfaces", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "jinja2", marker = "python_full_version >= '3.14'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.14'" },
-    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version >= '3.14'" },
-    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.14'" },
-    { name = "pathspec", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pydantic", marker = "python_full_version >= '3.14'" },
-    { name = "pytz", marker = "python_full_version >= '3.14'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
-    { name = "snowplow-tracker", marker = "python_full_version >= '3.14'" },
-    { name = "sqlparse", version = "0.5.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/62/af8f4ab1e3e979b5677e876444f3a9c1b1021c2d4e77143e80f421bdc1f7/dbt_core-1.11.11.tar.gz", hash = "sha256:e53cfccc8c9c13a082e518bf80cf3bb33c2f1fdc3cab48ec822ef93737eccb81", size = 973079, upload-time = "2026-05-20T11:10:01.8Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/d2/9e1eb5d3c8f375d4e5523b9123b2ae25ea21d85abb044db2eff2e3ee9c1d/dbt_core-1.11.11-py3-none-any.whl", hash = "sha256:7f9e11f3f5400e20f40f544440800ace23fa0755086f87b08e9446181f8720e1", size = 1061938, upload-time = "2026-05-20T11:09:59.856Z" },
-]
-
-[[package]]
-name = "dbt-duckdb"
-version = "1.7.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
-dependencies = [
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "duckdb", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/b3/0d37f2a4772a67f553f9da9277093414e332f3cd63aaeec60d2876d9cdeb/dbt_duckdb-1.7.5.tar.gz", hash = "sha256:7ff2fc21a656f61c30b30ff44865f02de6818d950fe99a475245546d63d22b98", size = 52824, upload-time = "2024-05-08T05:43:41.617Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/dd/021377cc49d5ec274ae47d2aeafbcbaef077542fd496e55679a12c4eb55e/dbt_duckdb-1.7.5-py3-none-any.whl", hash = "sha256:a2eeb10e83058ff55738228da953538c5f2eddff3be3c8defcee1f300611f9d3", size = 58873, upload-time = "2024-05-08T05:43:40.077Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/25/89/fabe9547f247b9422f32ef0935e9a4c10c60b28764b386d023d7275b5c7d/dbt_core_experimental_parser-2.0.0rc2.tar.gz", hash = "sha256:44d6d888b283c9b3805439800f1594f43cdefa0deb9887c4b4e5e81a061f15d0", size = 4993, upload-time = "2026-09-08T14:58:53.424Z" }
 
 [[package]]
 name = "dbt-duckdb"
 version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
 dependencies = [
-    { name = "dbt-adapters", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-common", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-core", version = "1.11.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "duckdb", marker = "python_full_version >= '3.14'" },
+    { name = "dbt-adapters" },
+    { name = "dbt-common" },
+    { name = "dbt-core" },
+    { name = "duckdb" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/d3/0f9f6a4de94e0f95dcfabbba5e8ef7670de695483345edd9e5b36e93d024/dbt_duckdb-1.10.1.tar.gz", hash = "sha256:5d6df1589d4ba21fe20ac08454a32763d3263798c9f5914280eabd1dc285cbc0", size = 145907, upload-time = "2026-02-17T17:29:04.283Z" }
 wheels = [
@@ -2224,30 +2120,63 @@ wheels = [
 
 [[package]]
 name = "dbt-fabric"
-version = "1.7.4"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "azure-identity", marker = "python_full_version < '3.13'" },
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+resolution-markers = [
+    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/f7/b94cc6672d50d0cef9f3910c49fd4a1ceebe26874fbd2b0ec95f39cd17cc/dbt-fabric-1.7.4.tar.gz", hash = "sha256:6f17f0ba683c2944c8f846589dca4b54106579af32ac5acafe701d1becc2496f", size = 25820, upload-time = "2024-02-02T21:00:42.189Z" }
+dependencies = [
+    { name = "azure-core", marker = "python_full_version < '3.11'" },
+    { name = "azure-identity", marker = "python_full_version < '3.11'" },
+    { name = "dbt-adapters", marker = "python_full_version < '3.11'" },
+    { name = "dbt-common", marker = "python_full_version < '3.11'" },
+    { name = "dbt-core", marker = "python_full_version < '3.11'" },
+    { name = "pyodbc", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/7e/836570a706fbc6dfe7f442050ed7afec1c8d1510a2b62b9daf47d5eade98/dbt_fabric-1.10.0.tar.gz", hash = "sha256:23b4ba6006c544d6f56c308b651bcbea33c67e4c297be998d42ebdf01d355c2f", size = 45981, upload-time = "2026-05-18T06:09:39.893Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/a8/75e87a4f1633d74eade9a9205ddd72242ad3dab4f01ad4ac54d565b3f845/dbt_fabric-1.7.4-py3-none-any.whl", hash = "sha256:e59dfe36ca8d3e47e7c22280d56e04da3529f6fc3c7855dab6fcef2d8f820f7e", size = 36440, upload-time = "2024-02-02T21:00:40.302Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/94/d5d982d52ed5a0ecac751eb05bc5d9c4f1f843fd0cd356c1f34772eb01f3/dbt_fabric-1.10.0-py3-none-any.whl", hash = "sha256:94645844402f09c90583fedcbad38e2c777d2966426e2c74cfb24b2b60332da4", size = 61523, upload-time = "2026-05-18T06:09:38.606Z" },
+]
+
+[[package]]
+name = "dbt-fabric"
+version = "1.11.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
+    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
+]
+dependencies = [
+    { name = "azure-core", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "azure-identity", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "dbt-adapters", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "dbt-common", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "dbt-core", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "mssql-python", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/9e/940744ae2555e835d29ea14c8edcc052ec11d90827b1bec8830384039c1d/dbt_fabric-1.11.1.tar.gz", hash = "sha256:6927abb6c71950fc7decb6f5b02afd06bc2b395eb13c87b0891c1a5ac90a2846", size = 145552, upload-time = "2026-08-20T04:31:25.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/97/5b1e6edd560cec4d7d128b69f79647a2835bb75c398ae08a616a6855e417/dbt_fabric-1.11.1-py3-none-any.whl", hash = "sha256:f82e349d582ac52e12a0b7a197b6fb379627f4bc2f775388355e737901df2f89", size = 126399, upload-time = "2026-08-20T04:31:24.485Z" },
 ]
 
 [[package]]
 name = "dbt-postgres"
-version = "1.7.19"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agate", marker = "python_full_version < '3.14'" },
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "dbt-adapters", marker = "python_full_version < '3.14'" },
+    { name = "dbt-common", marker = "python_full_version < '3.14'" },
+    { name = "dbt-core", marker = "python_full_version < '3.14'" },
     { name = "psycopg2-binary", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/f8/1023851b2771af855593e8186228ef3550b7220c4b4b4a42299e0d21cd3d/dbt_postgres-1.7.19.tar.gz", hash = "sha256:daff1e5bc08f08634be55a1279a8fe1f8e4d1d1e93ef96ca8cff9e255553a354", size = 20332, upload-time = "2024-12-02T18:23:01.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/54/0af71f917d47a03f244aad15510e5df7853676e88c82be5c6afcef5464be/dbt_postgres-1.11.0.tar.gz", hash = "sha256:0a8558e03776231969a9614075eb31eb7daca03bcee1db7bc36f85f027826965", size = 162279, upload-time = "2026-07-16T15:52:36.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/3a/70927db3f17256c45cb34010228b00a8fe210adc8d326041b9bc493e0cd6/dbt_postgres-1.7.19-py3-none-any.whl", hash = "sha256:e63db87b266fd4050f90158806d33ad6f02bec70476e28b78eb798c2146e8e3e", size = 29116, upload-time = "2024-12-02T18:22:56.899Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/61/e92738b7bdc6e36de7f2450ded77b221fd2768f85a345e93ff412ac95c7c/dbt_postgres-1.11.0-py3-none-any.whl", hash = "sha256:b88f994dc2f00150579d62f8ff91af715428a3cfe064e067945359ca4509872c", size = 36790, upload-time = "2026-07-16T15:52:35.34Z" },
 ]
 
 [[package]]
@@ -2255,7 +2184,7 @@ name = "dbt-protos"
 version = "1.0.514"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/42/95900473fad036d813da7785c33a27d5ccca9f0eae1065364cabbc1e40d1/dbt_protos-1.0.514.tar.gz", hash = "sha256:4429a8b0675140467206aaaf9d9468e619a9697f443e4b3921f297d01e4a77a0", size = 166219, upload-time = "2026-05-28T23:43:10.215Z" }
 wheels = [
@@ -2264,76 +2193,27 @@ wheels = [
 
 [[package]]
 name = "dbt-redshift"
-version = "1.7.7"
+version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "agate", marker = "python_full_version < '3.14'" },
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "dbt-adapters", marker = "python_full_version < '3.14'" },
+    { name = "dbt-common", marker = "python_full_version < '3.14'" },
+    { name = "dbt-core", marker = "python_full_version < '3.14'" },
     { name = "dbt-postgres", marker = "python_full_version < '3.14'" },
     { name = "redshift-connector", marker = "python_full_version < '3.14'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version == '3.13.*'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "sqlparse", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/76/1e/a7011314667e27b80f57bc7e7dcff579d877140baf3261c8a72300f58513/dbt_redshift-1.7.7.tar.gz", hash = "sha256:6189312ec50ec60f7e8c3bea314e1768a1d69028c726c52b43e028b0c38a0a8d", size = 32427, upload-time = "2024-04-18T21:21:27.689Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/da/a96de8541a4684e5ca2584fb5cff389b7bae3fb2f47e77de44e1e8902045/dbt_redshift-1.11.1.tar.gz", hash = "sha256:9921457b139efa694e74c6c6c316daa56bb2034e65c1699faada8ae8297ab800", size = 109170, upload-time = "2026-08-21T07:25:23.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/34/72aeb1687f5fc902f381d981533a1749a0ee9bca53de3346ca5ee87904cb/dbt_redshift-1.7.7-py3-none-any.whl", hash = "sha256:197e4a1c237af056869caf671ad8ce835c4c2c81dfaf8d0c5081981dcd1c2590", size = 46501, upload-time = "2024-04-18T21:21:23.01Z" },
-]
-
-[[package]]
-name = "dbt-semantic-interfaces"
-version = "0.4.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
-dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.14'" },
-    { name = "jinja2", marker = "python_full_version < '3.14'" },
-    { name = "jsonschema", marker = "python_full_version < '3.14'" },
-    { name = "more-itertools", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/38/e889ad15d281093e53a7ec1e692a387a92dc056fff56b8c2961634b1968b/dbt_semantic_interfaces-0.4.4.tar.gz", hash = "sha256:3b8126deb964c03d14e8af1cb4bdfb9f20c53dfcef28fa3a0bc158a8312e4070", size = 75128, upload-time = "2024-02-26T19:34:34.962Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/a8/718950dfc5975f49f5b05cd3604d266a5d68c37e2e2e95d353363d33a01c/dbt_semantic_interfaces-0.4.4-py3-none-any.whl", hash = "sha256:0149a4fd7fd4f25309edf5f856410536eaf2019f29dad58967dcf6d0625e6914", size = 118618, upload-time = "2024-02-26T19:34:36.853Z" },
-]
-
-[[package]]
-name = "dbt-semantic-interfaces"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
-dependencies = [
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "importlib-metadata", marker = "python_full_version >= '3.14'" },
-    { name = "jinja2", marker = "python_full_version >= '3.14'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.14'" },
-    { name = "more-itertools", marker = "python_full_version >= '3.14'" },
-    { name = "pydantic", marker = "python_full_version >= '3.14'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.14'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/91/c702d8fb143541fda10f5eb7a7a89f34bda38ee043ecb3e3653363d0c5a0/dbt_semantic_interfaces-0.9.0.tar.gz", hash = "sha256:5c921257dce8bb51c9ffb5479f2bdd959e16ebfb98ee833de6daa70788c47271", size = 93865, upload-time = "2025-07-09T20:06:30.454Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/82/41708b2b69d5fead88dea5ca0d863d6291da83ca6f1bd19246842d397e2b/dbt_semantic_interfaces-0.9.0-py3-none-any.whl", hash = "sha256:1b54c06ba89190a47a7f0563360930a0cce869e55b484ca09d261ade0e319155", size = 147008, upload-time = "2025-07-09T20:06:32.466Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d7/f5e667584ae72ee88622efc05f6dfa619a1daf3faf8359a99d2b90e588fc/dbt_redshift-1.11.1-py3-none-any.whl", hash = "sha256:a1066a5818e6004500995790037c23aa740296fc852fb3b6278df1f358581d3b", size = 63277, upload-time = "2026-08-21T07:25:22.273Z" },
 ]
 
 [[package]]
 name = "dbt-snowflake"
-version = "1.7.5"
+version = "1.10.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
@@ -2347,12 +2227,15 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "agate", marker = "python_full_version < '3.14'" },
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "certifi", marker = "python_full_version < '3.14'" },
+    { name = "dbt-adapters", marker = "python_full_version < '3.14'" },
+    { name = "dbt-common", marker = "python_full_version < '3.14'" },
+    { name = "dbt-core", marker = "python_full_version < '3.14'" },
     { name = "snowflake-connector-python", version = "3.18.0", source = { registry = "https://pypi.org/simple" }, extra = ["secure-local-storage"], marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/7f/37dfdeeb2ccca07a4d3863df7a77c82fa3c543cc0ba9d45c5fe5df144c96/dbt_snowflake-1.7.5.tar.gz", hash = "sha256:ea68ccb7569d8d821dbb49323fbb23dbcbeb20291875950d49ba23cc2d5f4937", size = 33888, upload-time = "2024-05-22T22:23:25.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/eb/45563c1ad316c2ef4c7fff573c50d7a92404b3b4f4240fe549c223c5933c/dbt_snowflake-1.10.5.tar.gz", hash = "sha256:a96922330cd5a6ee618c901e4299d09749d9cfa89d5c21c33985038a1ca1b896", size = 117729, upload-time = "2025-12-18T02:57:50.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/06/1f315b8b8794c1d4b042a0dea3afe134ea759a545aa18ef642dea067a40f/dbt_snowflake-1.7.5-py3-none-any.whl", hash = "sha256:747cab232cee33ce4fc388ac5daf02eff5c9b90ab36f8e7432b44a226f6c3bb7", size = 46475, upload-time = "2024-05-22T22:23:22.699Z" },
+    { url = "https://files.pythonhosted.org/packages/13/cd/250adac87631fda28a64d4772184efd7a96c2daadbddd49825588158cae5/dbt_snowflake-1.10.5-py3-none-any.whl", hash = "sha256:8d29112899ce7147811ef7408a0c313d5a985cb5087ea984f280259b9ea826bc", size = 69785, upload-time = "2025-12-18T02:57:49.066Z" },
 ]
 
 [[package]]
@@ -2368,7 +2251,7 @@ dependencies = [
     { name = "certifi", marker = "python_full_version >= '3.14'" },
     { name = "dbt-adapters", marker = "python_full_version >= '3.14'" },
     { name = "dbt-common", marker = "python_full_version >= '3.14'" },
-    { name = "dbt-core", version = "1.11.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "dbt-core", marker = "python_full_version >= '3.14'" },
     { name = "snowflake-connector-python", version = "4.6.0", source = { registry = "https://pypi.org/simple" }, extra = ["secure-local-storage"], marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/94/bc8a405b364036c6e0918dc190c88cdbfbe7982472086b8d4a1bb4facd71/dbt_snowflake-1.11.1.tar.gz", hash = "sha256:0b6b92d77bf037d02e6745e0add44732cba7bb34b0a0cd3a1c6166278e41b340", size = 130456, upload-time = "2026-01-08T18:23:50.58Z" }
@@ -2378,17 +2261,17 @@ wheels = [
 
 [[package]]
 name = "dbt-sqlserver"
-version = "1.7.4"
+version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-identity", marker = "python_full_version < '3.13'" },
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "dbt-fabric", marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "dbt-adapters", marker = "python_full_version < '3.13'" },
+    { name = "dbt-common", marker = "python_full_version < '3.13'" },
+    { name = "dbt-core", marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/97/d7244c6ab1ce380ec8ce453ecebe4692325028c7c2fe9863c5fbb163ca04/dbt-sqlserver-1.7.4.tar.gz", hash = "sha256:b9e85771a1c00e8f4aadefb37b00d02b3d49bc93ad7c52782fd9cae9db31dd98", size = 13386, upload-time = "2024-03-04T14:46:41.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/60/27a4f9d94df3fe64ea720f746c667d7ebd1fba7fa3654d85ac21fc5489ed/dbt_sqlserver-1.11.1.tar.gz", hash = "sha256:6423cf4273e0167eeda6b23c56bd9a64b53d0f308854d89214a8a524d3b1807b", size = 98533, upload-time = "2026-08-11T15:06:35.767Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/08/b19cf69a57b9de1a1f9dd4658fc20b1c28c56ef10753748f323c48a66d8b/dbt_sqlserver-1.7.4-py3-none-any.whl", hash = "sha256:7b67babca5ad5d7b9be923250e8a32ffe94dfef78ee2d3ce6bd145cc3e157a8d", size = 15484, upload-time = "2024-03-04T14:46:39.53Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d6/5a506e67e9c69157fcc6c297501528dbb289ca51701a23011403fbd2c7bd/dbt_sqlserver-1.11.1-py3-none-any.whl", hash = "sha256:a59d8deece584b07b6c9816dcb1e2244e9ee556d694125ad89b6766d3039e3a3", size = 117464, upload-time = "2026-08-11T15:06:34.498Z" },
 ]
 
 [[package]]
@@ -2417,7 +2300,7 @@ name = "deepdiff"
 version = "8.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "orderly-set", marker = "python_full_version >= '3.14'" },
+    { name = "orderly-set" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/50/767448e792d41bfb6094ee317a355c1cb221dca24b2e178e2203bbea2a77/deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e", size = 634860, upload-time = "2026-03-18T17:16:33.785Z" }
 wheels = [
@@ -2501,11 +2384,10 @@ wheels = [
 
 [[package]]
 name = "dlt"
-version = "1.30.0"
+version = "1.30.1a0"
 source = { editable = "." }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click" },
     { name = "croniter" },
     { name = "fsspec" },
     { name = "gitpython" },
@@ -2520,7 +2402,8 @@ dependencies = [
     { name = "pytz" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "requirements-parser" },
     { name = "rich-argparse" },
     { name = "semver" },
@@ -2589,8 +2472,7 @@ ducklake = [
 fabric = [
     { name = "adlfs" },
     { name = "pyarrow" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyodbc" },
 ]
 filesystem = [
     { name = "botocore" },
@@ -2615,6 +2497,7 @@ http = [
 hub = [
     { name = "dlthub" },
     { name = "dlthub-client" },
+    { name = "pydantic" },
 ]
 lance = [
     { name = "duckdb" },
@@ -2634,8 +2517,7 @@ motherduck = [
     { name = "pyarrow" },
 ]
 mssql = [
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyodbc" },
 ]
 oracle = [
     { name = "oracledb" },
@@ -2686,8 +2568,7 @@ sqlalchemy = [
 synapse = [
     { name = "adlfs" },
     { name = "pyarrow" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "pyodbc" },
 ]
 weaviate = [
     { name = "weaviate-client" },
@@ -2698,6 +2579,13 @@ adbc = [
     { name = "adbc-driver-manager" },
     { name = "dbc" },
 ]
+agent = [
+    { name = "aiohttp" },
+    { name = "pydantic-ai-slim", extra = ["anthropic", "google", "mcp", "openai", "spec"] },
+]
+agent-claude = [
+    { name = "claude-agent-sdk" },
+]
 airflow = [
     { name = "apache-airflow", marker = "python_full_version < '3.13'" },
 ]
@@ -2706,16 +2594,13 @@ dashboard-tests = [
     { name = "pytest-playwright" },
 ]
 dbt = [
-    { name = "dbt-athena-community", marker = "python_full_version < '3.14'" },
-    { name = "dbt-bigquery", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "dbt-bigquery", version = "1.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "dbt-core", version = "1.7.19", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "dbt-core", version = "1.11.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "dbt-duckdb", version = "1.7.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "dbt-duckdb", version = "1.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "dbt-fabric", marker = "python_full_version < '3.13'" },
+    { name = "dbt-bigquery" },
+    { name = "dbt-core" },
+    { name = "dbt-duckdb" },
+    { name = "dbt-fabric", version = "1.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "dbt-fabric", version = "1.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "dbt-redshift", marker = "python_full_version < '3.14'" },
-    { name = "dbt-snowflake", version = "1.7.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "dbt-snowflake", version = "1.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "dbt-snowflake", version = "1.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "dbt-sqlserver", marker = "python_full_version < '3.13'" },
 ]
@@ -2843,8 +2728,8 @@ requires-dist = [
     { name = "db-dtypes", marker = "extra == 'bigquery'", specifier = ">=1.2.0" },
     { name = "db-dtypes", marker = "extra == 'gcp'", specifier = ">=1.2.0" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=0.25.1" },
-    { name = "dlthub", marker = "extra == 'hub'", specifier = ">=0.30.0a1,<0.31" },
-    { name = "dlthub-client", marker = "extra == 'hub'", specifier = ">=0.28.1" },
+    { name = "dlthub", marker = "extra == 'hub'", specifier = ">=0.30.0a1,<0.32" },
+    { name = "dlthub-client", marker = "extra == 'hub'", specifier = ">=0.28.3" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
     { name = "duckdb", marker = "extra == 'ducklake'", specifier = ">=1.2.0" },
     { name = "duckdb", marker = "extra == 'lance'", specifier = ">=1.4.3" },
@@ -2898,6 +2783,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'pyiceberg'", specifier = ">=16.0.0" },
     { name = "pyarrow", marker = "extra == 'synapse'", specifier = ">=16.0.0" },
     { name = "pyathena", marker = "extra == 'athena'", specifier = ">=2.9.6" },
+    { name = "pydantic", marker = "extra == 'hub'", specifier = ">=2.10" },
     { name = "pydbml", marker = "extra == 'dbml'" },
     { name = "pyiceberg", marker = "extra == 'pyiceberg'", specifier = ">=0.9.1" },
     { name = "pyiceberg-core", marker = "extra == 'pyiceberg'", specifier = ">=0.6.0" },
@@ -2940,15 +2826,19 @@ adbc = [
     { name = "adbc-driver-manager", specifier = ">=1.8.0" },
     { name = "dbc", specifier = ">=0.1.0" },
 ]
+agent = [
+    { name = "aiohttp", specifier = ">=3.14.3" },
+    { name = "pydantic-ai-slim", extras = ["anthropic", "openai", "google", "mcp", "spec"], specifier = ">=2.35.0" },
+]
+agent-claude = [{ name = "claude-agent-sdk", specifier = ">=0.2.144" }]
 airflow = [{ name = "apache-airflow", marker = "python_full_version < '3.13'", specifier = ">=2.8.0,<3" }]
 dashboard-tests = [
     { name = "playwright", specifier = ">=1.58.0,<2" },
     { name = "pytest-playwright", specifier = ">=0.7.1,<1" },
 ]
 dbt = [
-    { name = "dbt-athena-community", marker = "python_full_version < '3.14'", specifier = ">=1.7.0" },
     { name = "dbt-bigquery", specifier = ">=1.7.0" },
-    { name = "dbt-core", specifier = ">=1.7.0" },
+    { name = "dbt-core", specifier = ">=1.12.0" },
     { name = "dbt-duckdb", specifier = ">=1.7.0" },
     { name = "dbt-fabric", marker = "python_full_version < '3.13'", specifier = ">=1.7.0" },
     { name = "dbt-redshift", marker = "python_full_version < '3.14'", specifier = ">=1.7.0" },
@@ -3036,7 +2926,7 @@ sources = [
 streamlit = [{ name = "streamlit", specifier = ">1.50" }]
 workspace-deps = [
     { name = "duckdb", specifier = ">=0.9" },
-    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "fastmcp", specifier = ">=3.1.0" },
     { name = "ibis-framework", specifier = ">=12.0.0" },
     { name = "marimo", specifier = ">=0.14.5" },
     { name = "mowidgets", marker = "python_full_version >= '3.11'", specifier = ">=0.2.1" },
@@ -3057,7 +2947,7 @@ wheels = [
 
 [[package]]
 name = "dlthub-client"
-version = "0.28.1"
+version = "0.28.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -3068,9 +2958,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "tabulate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/87/53412615805aadf53d3c95e9d94e7f703b33a8fe8f441ff3bf9d73e0f7ea/dlthub_client-0.28.1.tar.gz", hash = "sha256:2a47d950aa5e1ba77409655b2cecb5f3e626a2964a3952fb32a9d3292e6ba1db", size = 146048, upload-time = "2026-07-07T11:09:04.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/74/6587c21a87f07029cb2d3227f8eaaf1f31b2afb379e7c8e8b01ec0fe8e8b/dlthub_client-0.28.3.tar.gz", hash = "sha256:fbc539598f6ed4b1783dbc285a0c3af7db4a810ea3104e21b91142e9cd4e6ff5", size = 190379, upload-time = "2026-08-31T11:46:08.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/93/453841023154ef23d8def64cc4d48ee4e61a76451303a3046fe405230bb6/dlthub_client-0.28.1-py3-none-any.whl", hash = "sha256:04f7b86181e09db69714ac297ad7fa829c7c939096bbc2a65cb781df511082bf", size = 336690, upload-time = "2026-07-07T11:09:02.927Z" },
+    { url = "https://files.pythonhosted.org/packages/62/01/823a360d81d550fad78cbc6b7be33ae6909d7b97fded2fcea1ff014829d7/dlthub_client-0.28.3-py3-none-any.whl", hash = "sha256:88cfd1b05aec489cd3c4b0c10e9c0a81c20cd5cb764bacc82fedd888215a3c53", size = 472997, upload-time = "2026-08-31T11:46:09.697Z" },
 ]
 
 [[package]]
@@ -3242,7 +3132,8 @@ dependencies = [
     { name = "onnxruntime", marker = "python_full_version < '3.14'" },
     { name = "pillow", version = "11.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "py-rust-stemmers", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version == '3.13.*'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "tokenizers", marker = "python_full_version < '3.14'" },
     { name = "tqdm", marker = "python_full_version < '3.14'" },
 ]
@@ -3427,7 +3318,7 @@ name = "flask"
 version = "2.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "click", marker = "python_full_version < '3.13'" },
     { name = "itsdangerous", marker = "python_full_version < '3.13'" },
     { name = "jinja2", marker = "python_full_version < '3.13'" },
     { name = "werkzeug", marker = "python_full_version < '3.13'" },
@@ -3443,7 +3334,7 @@ version = "4.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apispec", extra = ["yaml"], marker = "python_full_version < '3.13'" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "click", marker = "python_full_version < '3.13'" },
     { name = "colorama", marker = "python_full_version < '3.13'" },
     { name = "email-validator", marker = "python_full_version < '3.13'" },
     { name = "flask", marker = "python_full_version < '3.13'" },
@@ -3704,15 +3595,28 @@ dependencies = [
     { name = "aiohttp" },
     { name = "decorator" },
     { name = "fsspec" },
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "google-cloud-storage" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/55/cd737f96929f9cf52666bd49e9b4d1aac697655b3ab17c49ab4fb587bb12/gcsfs-2025.9.0.tar.gz", hash = "sha256:36b8c379d9789d5332a45a3aa2840ec518ff73c6d21c1e962f53318d1cd65db9", size = 82843, upload-time = "2025-09-02T19:23:19.22Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/41/f793f3bae39f9fbaabf935d0afcf3aa99e417c92096f3e232ac085aaddbf/gcsfs-2025.9.0-py2.py3-none-any.whl", hash = "sha256:38208bc79af60c693e44ff2f0bd6fd3ca664fea1940fe6770ac1c6003aa0f559", size = 36893, upload-time = "2025-09-02T19:23:18.002Z" },
+]
+
+[[package]]
+name = "genai-prices"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e3/23f4be7d5626878a6297c728f5f8db83bd9b135da481935d4c1bb82efc21/genai_prices-0.1.4.tar.gz", hash = "sha256:f3b8a0bf0c21b01f5af3ca42babcab2f17728bf3c602f87f42b72d1d2bf61d98", size = 94678, upload-time = "2026-08-19T23:53:25.527Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/54/911961e926a4c4ea30bf1fa0bf9d8ffc5c9ac5ed6a3f77b3d9e0ab5bb9a5/genai_prices-0.1.4-py3-none-any.whl", hash = "sha256:1d1b01cc7ab1adfa17c3a1121f4c13990bd0a4377640ecd37ebfde5836768240", size = 99160, upload-time = "2026-08-19T23:53:24.52Z" },
 ]
 
 [[package]]
@@ -3750,49 +3654,15 @@ wheels = [
 
 [[package]]
 name = "google-api-core"
-version = "2.11.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
-dependencies = [
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "googleapis-common-protos", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/b8/f727ada5b63aba53848e3791dd57be7481d5c9bf86978600ca9cca4ab03e/google-api-core-2.11.1.tar.gz", hash = "sha256:25d29e05a0058ed5f19c61c0a78b1b53adea4d9364b464d014fbda941f6d1c9a", size = 129114, upload-time = "2023-06-14T18:47:12.762Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/c4/c3cd048b6cbeba8d9ae50dd7643ac065b85237338aa7501b0efae91eb4d9/google_api_core-2.11.1-py3-none-any.whl", hash = "sha256:d92a5a92dc36dd4f4b9ee4e55528a90e432b059f93aee6ad857f9de8cc7ae94a", size = 120538, upload-time = "2023-06-14T18:47:05.785Z" },
-]
-
-[package.optional-dependencies]
-grpc = [
-    { name = "grpcio", marker = "python_full_version < '3.14'" },
-    { name = "grpcio-status", marker = "python_full_version < '3.14'" },
-]
-
-[[package]]
-name = "google-api-core"
 version = "2.25.2"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
 dependencies = [
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "googleapis-common-protos", marker = "python_full_version >= '3.14'" },
-    { name = "proto-plus", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/cd/63f1557235c2440fe0577acdbc32577c5c002684c58c7f4d770a92366a24/google_api_core-2.25.2.tar.gz", hash = "sha256:1c63aa6af0d0d5e37966f157a77f9396d820fba59f9e43e9415bc3dc5baff300", size = 166266, upload-time = "2025-10-03T00:07:34.778Z" }
 wheels = [
@@ -3801,8 +3671,8 @@ wheels = [
 
 [package.optional-dependencies]
 grpc = [
-    { name = "grpcio", marker = "python_full_version >= '3.14'" },
-    { name = "grpcio-status", marker = "python_full_version >= '3.14'" },
+    { name = "grpcio" },
+    { name = "grpcio-status" },
 ]
 
 [[package]]
@@ -3810,10 +3680,8 @@ name = "google-api-python-client"
 version = "2.170.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "httplib2" },
     { name = "uritemplate" },
@@ -3825,48 +3693,22 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.40.2"
+version = "2.57.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
 dependencies = [
-    { name = "cachetools", marker = "python_full_version < '3.14'" },
-    { name = "pyasn1-modules", marker = "python_full_version < '3.14'" },
-    { name = "rsa", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/84/f67f53c505a6b2c5da05c988e2a5483f5ba9eee4b1841d2e3ff22f547cd5/google_auth-2.40.2.tar.gz", hash = "sha256:a33cde547a2134273226fa4b853883559947ebe9207521f7afc707efbf690f58", size = 280990, upload-time = "2025-05-21T18:04:59.816Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/c7/e2d82e6702e2a9e2311c138f8e1100f21d08aed0231290872b229ae57a86/google_auth-2.40.2-py2.py3-none-any.whl", hash = "sha256:f7e568d42eedfded58734f6a60c58321896a621f7c116c411550a4b4a13da90b", size = 216102, upload-time = "2025-05-21T18:04:57.547Z" },
-]
-
-[[package]]
-name = "google-auth"
-version = "2.55.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
-dependencies = [
+    { name = "cryptography", version = "41.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pyasn1-modules", marker = "python_full_version >= '3.14'" },
+    { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb", size = 349379, upload-time = "2026-06-15T22:33:16.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", hash = "sha256:9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789", size = 370794, upload-time = "2026-08-25T19:18:26.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a", size = 252400, upload-time = "2026-06-15T22:33:14.992Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
 ]
 
 [package.optional-dependencies]
 requests = [
-    { name = "requests", marker = "python_full_version >= '3.14'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 
 [[package]]
@@ -3874,8 +3716,7 @@ name = "google-auth-httplib2"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-auth" },
     { name = "httplib2" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/be/217a598a818567b28e859ff087f347475c807a5649296fb5a817c58dacef/google-auth-httplib2-0.2.0.tar.gz", hash = "sha256:38aa7badf48f974f1eb9861794e9c0cb2a0511a4ec0679b1f886d108f5640e05", size = 10842, upload-time = "2023-12-12T17:40:30.722Z" }
@@ -3888,8 +3729,7 @@ name = "google-auth-oauthlib"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-auth" },
     { name = "requests-oauthlib" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fb/87/e10bf24f7bcffc1421b84d6f9c3377c30ec305d082cd737ddaa6d8f77f7c/google_auth_oauthlib-1.2.2.tar.gz", hash = "sha256:11046fb8d3348b296302dd939ace8af0a724042e8029c1b872d87fabc9f41684", size = 20955, upload-time = "2025-04-22T16:40:29.172Z" }
@@ -3899,25 +3739,25 @@ wheels = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.148.1"
+version = "1.91.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docstring-parser", marker = "python_full_version >= '3.14' and sys_platform == 'never'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-cloud-bigquery", marker = "python_full_version >= '3.14'" },
-    { name = "google-cloud-resource-manager", marker = "python_full_version >= '3.14'" },
-    { name = "google-cloud-storage", marker = "python_full_version >= '3.14'" },
-    { name = "google-genai", marker = "python_full_version >= '3.14'" },
-    { name = "packaging", marker = "python_full_version >= '3.14'" },
-    { name = "proto-plus", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pydantic", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "docstring-parser", marker = "sys_platform == 'never'" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-bigquery" },
+    { name = "google-cloud-resource-manager" },
+    { name = "google-cloud-storage" },
+    { name = "packaging" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "shapely" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/f3/b2a9417014c93858a2e3266134f931eefd972c2d410b25d7b8782fc6f143/google_cloud_aiplatform-1.148.1.tar.gz", hash = "sha256:75d605fba34e68714bd08e1e482755d0a6e3ae972805f809d088e686c30879e7", size = 10278758, upload-time = "2026-04-17T23:45:26.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/08/5854569782efbbc8efd0aeda3a4486153605104cbab6ac836b2328bae48e/google_cloud_aiplatform-1.91.0.tar.gz", hash = "sha256:b14e5e52b52b6012c7dc253beab34c511fdc53c69b13f436ddb06882c1a92cd7", size = 9102586, upload-time = "2025-04-30T17:15:23.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/5b/e3515d7bbba602c2b0f6a0da5431785e897252443682e4735d0e6873dc8f/google_cloud_aiplatform-1.148.1-py2.py3-none-any.whl", hash = "sha256:035101e2d8e65c6a706cc3930b2452de7ddcbde50dd130320fcea0d8b03b0c5a", size = 8434481, upload-time = "2026-04-17T23:45:22.919Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/88/cea8583fadd142e8ef26f8ec14a6ee4d7c69c4e5ab82bea01a077fddddbe/google_cloud_aiplatform-1.91.0-py2.py3-none-any.whl", hash = "sha256:ff8df100c2af692d114a2219d3abbb96110b3e5655f342fdbb6aefad43901b52", size = 7591910, upload-time = "2025-04-30T17:15:19.6Z" },
 ]
 
 [[package]]
@@ -3925,15 +3765,14 @@ name = "google-cloud-bigquery"
 version = "3.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.11.1", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
     { name = "google-cloud-core" },
     { name = "google-resumable-media" },
     { name = "packaging" },
     { name = "python-dateutil" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/1c/2a6f52c0bb7eb0a9d0eb77bc3606fa40d0d5e5ee20b62f12422f160c5930/google-cloud-bigquery-3.19.0.tar.gz", hash = "sha256:8e311dae49768e1501fcdc5e916bff4b7e169471e5707919f4a6f78a02b3b5a6", size = 441356, upload-time = "2024-03-11T16:34:43.637Z" }
 wheels = [
@@ -3942,9 +3781,9 @@ wheels = [
 
 [package.optional-dependencies]
 pandas = [
-    { name = "db-dtypes", marker = "python_full_version >= '3.14'" },
-    { name = "pandas", marker = "python_full_version >= '3.14'" },
-    { name = "pyarrow", marker = "python_full_version >= '3.14'" },
+    { name = "db-dtypes" },
+    { name = "pandas" },
+    { name = "pyarrow" },
 ]
 
 [[package]]
@@ -3952,13 +3791,10 @@ name = "google-cloud-bigquery-storage"
 version = "2.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.11.1", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
     { name = "proto-plus" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/8f/b1050c6d62fcbb74217e8538961a912bedd5703311776ed4e146f49d7ac6/google_cloud_bigquery_storage-2.32.0.tar.gz", hash = "sha256:e944f5f4385f0be27e049e73e4dccf548b77348301663a773b5d03abdbd49e20", size = 294676, upload-time = "2025-05-28T22:11:16.598Z" }
 wheels = [
@@ -3970,10 +3806,8 @@ name = "google-cloud-core"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/b8/2b53838d2acd6ec6168fd284a990c76695e84c65deee79c9f3a4276f6b4f/google_cloud_core-2.4.3.tar.gz", hash = "sha256:1fab62d7102844b278fe6dead3af32408b1df3eb06f5c7e8634cbd40edc4da53", size = 35861, upload-time = "2025-03-10T21:05:38.948Z" }
 wheels = [
@@ -3985,14 +3819,11 @@ name = "google-cloud-dataproc"
 version = "5.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.11.1", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version < '3.14'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
     { name = "grpc-google-iam-v1" },
     { name = "proto-plus" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/af/ba83512f21d13e6f16a1515cbd8d68cf8e36f6b7047abeaf9b286c28ce0d/google_cloud_dataproc-5.18.1.tar.gz", hash = "sha256:bc81afdf6ef96e79e5f9991a652d2dd7e210440c4d804becdcd5b8963c703a5b", size = 562692, upload-time = "2025-03-17T11:31:03.92Z" }
 wheels = [
@@ -4004,11 +3835,11 @@ name = "google-cloud-resource-manager"
 version = "1.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, extra = ["grpc"], marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "grpc-google-iam-v1", marker = "python_full_version >= '3.14'" },
-    { name = "proto-plus", marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/ca/a4648f5038cb94af4b3942815942a03aa9398f9fb0bef55b3f1585b9940d/google_cloud_resource_manager-1.14.2.tar.gz", hash = "sha256:962e2d904c550d7bac48372607904ff7bb3277e3bb4a36d80cc9a37e28e6eb74", size = 446370, upload-time = "2025-03-17T11:35:56.343Z" }
 wheels = [
@@ -4020,14 +3851,13 @@ name = "google-cloud-storage"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core", version = "2.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
     { name = "google-cloud-core" },
     { name = "google-crc32c" },
     { name = "google-resumable-media" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/88/fc34f8c177ad56408d42f4b54c10402366d309737fae206d59fa16a4a27a/google-cloud-storage-2.14.0.tar.gz", hash = "sha256:2d23fcf59b55e7b45336729c148bb1c464468c69d5efbaee30f7201dd90eb97e", size = 5518229, upload-time = "2023-12-12T19:05:31.871Z" }
 wheels = [
@@ -4071,23 +3901,24 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.75.0"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.14'" },
-    { name = "distro", marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, extra = ["requests"], marker = "python_full_version >= '3.14'" },
-    { name = "httpx", marker = "python_full_version >= '3.14'" },
-    { name = "pydantic", marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
-    { name = "sniffio", marker = "python_full_version >= '3.14'" },
-    { name = "tenacity", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
-    { name = "websockets", marker = "python_full_version >= '3.14'" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/59/3ed61240ef20b3ae6ed54e82c6f8b6d1f194947bc6679679dd6cdb037594/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf", size = 539039, upload-time = "2026-05-04T22:48:54.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/dd/eacd43097318ea6b3e648862713a964d5de261a2eabcc7826db9b9de9758/google_genai-2.20.0.tar.gz", hash = "sha256:d382186f024e9050a7a4b25af6eacba9aa16c6e09594f5d1b530f22ff7f9d76f", size = 664965, upload-time = "2026-08-25T21:28:27.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/b6/552d40e96da22921eb1fead7c14b00b5b5473a20e45959488660fab35ee2/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c", size = 793726, upload-time = "2026-05-04T22:48:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/a7/a979230234c9df019e008085c923726dc4d92c14a5701ad698e369c9ab2a/google_genai-2.20.0-py3-none-any.whl", hash = "sha256:49bddeccd29a4e6bf1706c5de67735f7115f537f08b6c36a70b8023c99399095", size = 1064276, upload-time = "2026-08-25T21:28:25.287Z" },
 ]
 
 [[package]]
@@ -4145,8 +3976,7 @@ name = "googleapis-common-protos"
 version = "1.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903, upload-time = "2025-04-14T10:17:02.924Z" }
 wheels = [
@@ -4267,8 +4097,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos", extra = ["grpc"] },
     { name = "grpcio" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/4e/8d0ca3b035e41fe0b3f31ebbb638356af720335e5a11154c330169b40777/grpc_google_iam_v1-0.14.2.tar.gz", hash = "sha256:b3e1fc387a1a329e41672197d0ace9de22c78dd7d215048c4c78712073f7bd20", size = 16259, upload-time = "2025-03-17T11:40:23.586Z" }
 wheels = [
@@ -4343,8 +4172,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7c/d7/013ef01c5a1c2fd0932c27c904934162f69f41ca0f28396d3ffe4d386123/grpcio-status-1.62.3.tar.gz", hash = "sha256:289bdd7b2459794a12cf95dc0cb727bd4a1742c37bd823f760236c937e53a485", size = 13063, upload-time = "2024-08-06T00:37:08.003Z" }
 wheels = [
@@ -4440,6 +4268,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httplib2"
 version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4478,6 +4319,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6e/fa/66bd985dd0b7c109a3bcb89272ee0bfb7e2b4d06309ad7b38ff866734b2a/httpx_sse-0.4.1.tar.gz", hash = "sha256:8f44d34414bc7b21bf3602713005c5df4917884f76072479b21f68befa4ea26e", size = 12998, upload-time = "2025-06-24T13:21:05.71Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/0a/6269e3473b09aed2dab8aa1a600c70f31f00ae1349bee30658f7e358a159/httpx_sse-0.4.1-py3-none-any.whl", hash = "sha256:cba42174344c3a5b06f255ce65b350880f962d99ead85e776f23c6618a377a37", size = 8054, upload-time = "2025-06-24T13:21:04.772Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -4600,7 +4467,7 @@ mssql = [
     { name = "pandas", marker = "python_full_version < '3.13'" },
     { name = "pyarrow", marker = "python_full_version < '3.13'" },
     { name = "pyarrow-hotfix", marker = "python_full_version < '3.13'" },
-    { name = "pyodbc", version = "5.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "pyodbc", marker = "python_full_version < '3.13'" },
     { name = "rich", marker = "python_full_version < '3.13'" },
 ]
 postgres = [
@@ -4627,11 +4494,11 @@ snowflake = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -4855,6 +4722,105 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/d8/b959609e44012a42b1f3e5ba98ea3b33c7e41e6d4b77cd8f00fd19b1d3ad/jiter-0.16.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fc4f8def331036a7b8e981b4347ebe409981edbc8308a5ea842b8c3614fa6c", size = 310082, upload-time = "2026-06-29T13:02:31.356Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3d/4d7f5667ea0e0548534ba880b84bb3d12924fd133aa83ad6c6c80fca3d76/jiter-0.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5a71d0d2014c3275043e1170bf3d4e771493cb0dcf07be54c567155f4d8ee64b", size = 315643, upload-time = "2026-06-29T13:02:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/83/bed2dcb5c9f3e1ccfcbc67dda48265fe7d5ad0c9cadda5fe95f6e3b87f94/jiter-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:741eed508c233a76313a1c7b001f8f21b82f14327e9196ae8bd29a2cc164ae84", size = 341363, upload-time = "2026-06-29T13:02:34.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2f/6bb3c3dda668ebc0445689c81a2b0f26a82b10843d67ed9c9b2c3edc177f/jiter-0.16.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb7bc819187b56dc48aa5c833aaf92257da8e07efdb9306156667bd2eeb491c", size = 365483, upload-time = "2026-06-29T13:02:36.295Z" },
+    { url = "https://files.pythonhosted.org/packages/92/35/8a045ccb39164e70dcdae696413b661771f148b68b12b175c3a04d901937/jiter-0.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c9610fd25ebccb43fca584136f5c2fbb26802447eccd430dfdbab95a0fd5126", size = 461219, upload-time = "2026-06-29T13:02:38.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/99/22292dbbf0ed0c610cfe5ddc7f3bd67237a412f121318f865196e62a07bd/jiter-0.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a1d68ff7ca1d3b5dee20a97a3decda7d5f15003823bf6d140c81f8561d3bc5c", size = 374905, upload-time = "2026-06-29T13:02:40.357Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ac/2f55ccb1f0eeafa6d89d24caf52f6f0944a59290ee199e9ade62177dca42/jiter-0.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb08c276dd02dac3a284acdd02cacc630d2e3cd6572a4b85519f35cbd133c3de", size = 348320, upload-time = "2026-06-29T13:02:41.923Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/7d88b9174c40064fabc07c84a9b62e6b10f5644562ec0e0a29392edbe978/jiter-0.16.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:8fc4d94713c4697347e38faf7d6ef91547c142219bdcfc7220c4870879974244", size = 356519, upload-time = "2026-06-29T13:02:43.436Z" },
+    { url = "https://files.pythonhosted.org/packages/27/57/c4a33aeef513a9d5e26e31534e0bcc752d6ea0e54c94ddb7b68bade669c2/jiter-0.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a0f05e229edb29e68cdd0ccb83cea13b64263416120cf943767a6fd72e6787f", size = 394204, upload-time = "2026-06-29T13:02:44.987Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/70/c6c23e76ebb3766b111bc399437bbc9f870a76e2a92e10b2a5f561d57372/jiter-0.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c842cbf374a8daf50b2c04212995bee34ca2ac2cdc29a901b4cdb072c9c4131", size = 521477, upload-time = "2026-06-29T13:02:46.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/d3/0001c8c0c5976af2625bb1cfb1895e8ec693b6589fe4574b8e6fc2c85501/jiter-0.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5ed466aee31294d7cdcd4d37dfe5c42c97bc29d9a5f00eacf24504358309cb9b", size = 552187, upload-time = "2026-06-29T13:02:48.144Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/76/311b718e07e85740e48619c0632b36f7e0b8d113984499e436452ed13a9a/jiter-0.16.0-cp310-cp310-win32.whl", hash = "sha256:b42e9ff5376819c053da25809a8d4b6fa6e473b4856ebe42e298ac958be3d7f9", size = 206513, upload-time = "2026-06-29T13:02:49.515Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7f/ac680eeb0777dc0eb7dc824800ba27880d7f6bc712e362d34ad8ee559f36/jiter-0.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:10438939205546132189c8e74a2d536a707841f3a25cd7c74ee91fe503407a26", size = 199505, upload-time = "2026-06-29T13:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4966,8 +4932,8 @@ name = "jupyter-core"
 version = "5.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "platformdirs", marker = "python_full_version >= '3.14'" },
-    { name = "traitlets", marker = "python_full_version >= '3.14'" },
+    { name = "platformdirs" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
@@ -5193,10 +5159,13 @@ wheels = [
 ]
 
 [[package]]
-name = "logbook"
-version = "1.5.3"
+name = "logfire-api"
+version = "4.41.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/d9/16ac346f7c0102835814cc9e5b684aaadea101560bb932a2403bd26b2320/Logbook-1.5.3.tar.gz", hash = "sha256:66f454ada0f56eae43066f604a222b09893f98c1adc18df169710761b8f32fe8", size = 85783, upload-time = "2019-10-16T18:00:26.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/83/a2e7de43bb092ffaad904b5756cfc1e0ea4a8d79fdacd24cd55e60790585/logfire_api-4.41.0.tar.gz", hash = "sha256:ec39252acac38b5b50d60cfb9cc62f0ea10c841345fc59692af32dbe3de4a140", size = 92818, upload-time = "2026-08-20T17:42:24.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/96/97552d0d742866719b3a6e8fd7e68dd2877804f4c3b10c44a19a1f99b0d6/logfire_api-4.41.0-py3-none-any.whl", hash = "sha256:c71010d086c0211b04b4640181e836e8a75cc635fcfa7f712557f7b0676c1413", size = 143003, upload-time = "2026-08-20T17:42:21.764Z" },
+]
 
 [[package]]
 name = "loguru"
@@ -5545,7 +5514,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
 ]
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "click", marker = "python_full_version < '3.11'" },
     { name = "docutils", marker = "python_full_version < '3.11'" },
     { name = "itsdangerous", marker = "python_full_version < '3.11'" },
     { name = "jedi", marker = "python_full_version < '3.11'" },
@@ -5582,8 +5551,7 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
 ]
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click", marker = "python_full_version >= '3.11'" },
     { name = "docutils", marker = "python_full_version >= '3.11'" },
     { name = "itsdangerous", marker = "python_full_version >= '3.11'" },
     { name = "jedi", marker = "python_full_version >= '3.11'" },
@@ -5725,14 +5693,14 @@ wheels = [
 
 [[package]]
 name = "mashumaro"
-version = "3.14"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/47/0a450b281bef2d7e97ec02c8e1168d821e283f58e02e6c403b2bb4d73c1c/mashumaro-3.14.tar.gz", hash = "sha256:5ef6f2b963892cbe9a4ceb3441dfbea37f8c3412523f25d42e9b3a7186555f1d", size = 166160, upload-time = "2024-10-23T21:48:40.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/67/c4e235256baf6837106d2620c7123eb1e5786c704c7f7d7fa488ad6afc61/mashumaro-3.17.tar.gz", hash = "sha256:de1d8b1faffee58969c7f97e35963a92480a38d4c9858e92e0721efec12258ed", size = 189877, upload-time = "2025-10-03T21:09:27.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/35/8d63733a2c12149d0c7663c29bf626bdbeea5f0ff963afe58a42b4810981/mashumaro-3.14-py3-none-any.whl", hash = "sha256:c12a649599a8f7b1a0b35d18f12e678423c3066189f7bc7bd8dd431c5c8132c3", size = 92183, upload-time = "2024-10-23T21:48:38.334Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2d/edc147aa1dce9e0e377687d453e62fdfcbccc08cd35d0b7413e3485c4b92/mashumaro-3.17-py3-none-any.whl", hash = "sha256:3964e2c804f62de9e4c58fb985de71dcd716f9507cc18374b1bd5c4f1a1b879b", size = 94198, upload-time = "2025-10-03T21:09:25.436Z" },
 ]
 
 [package.optional-dependencies]
@@ -5820,6 +5788,30 @@ wheels = [
 ]
 
 [[package]]
+name = "metricflow"
+version = "0.212.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "more-itertools" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "rapidfuzz", version = "3.14.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rapidfuzz", version = "3.14.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "referencing" },
+    { name = "sqlglot" },
+    { name = "tabulate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/0f/3b5fbe244d36f40481b6eef67f66aaa6d48624e0935db6df83d1c479933c/metricflow-0.212.0.tar.gz", hash = "sha256:d85a4d2a37791e2215a5aad373bf50721191b223102ffe9318d8326b926eeadc", size = 639958, upload-time = "2026-08-12T23:52:18.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/27/47c0c48f4467bf9e08d793f37df6e89d6776dca2347eba804bb8170139f6/metricflow-0.212.0-py3-none-any.whl", hash = "sha256:80bb3cfbd9d7c9190702f3b13b9de202cb723d3ff583f1116aeff07eeaed9e1d", size = 994084, upload-time = "2026-08-12T23:52:17.189Z" },
+]
+
+[[package]]
 name = "mimesis"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5827,16 +5819,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/35/08/182b081de5fc7a148
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/76/9cb8ef05ee9b07489fd3323f932acfb0e6fff753a3c368f25baa08635a53/mimesis-7.1.0-py3-none-any.whl", hash = "sha256:da65bea6d6d5d5d87d5c008e6b23ef5f96a49cce436d9f8708dabb5152da0290", size = 4371099, upload-time = "2023-04-06T21:11:39.831Z" },
 ]
-
-[[package]]
-name = "minimal-snowplow-tracker"
-version = "0.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests", marker = "python_full_version < '3.14'" },
-    { name = "six", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/9f/004f810169a48ed5c520279d98327e7793b6491f09d42cb2c5636c994f34/minimal-snowplow-tracker-0.0.2.tar.gz", hash = "sha256:acabf7572db0e7f5cbf6983d495eef54081f71be392330eb3aadb9ccb39daaa4", size = 12542, upload-time = "2018-10-13T12:58:37.368Z" }
 
 [[package]]
 name = "mmh3"
@@ -5995,7 +5977,8 @@ resolution-markers = [
 dependencies = [
     { name = "cryptography", version = "41.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
     { name = "pyjwt", extra = ["crypto"], marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
-    { name = "requests", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten')" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/90/81dcc50f0be11a8c4dcbae1a9f761a26e5f905231330a7cacc9f04ec4c61/msal-1.32.3.tar.gz", hash = "sha256:5eea038689c78a5a70ca8ecbe1245458b55a857bd096efb6989c69ba15985d35", size = 151449, upload-time = "2025-04-25T13:12:34.204Z" }
 wheels = [
@@ -6018,7 +6001,8 @@ dependencies = [
     { name = "cryptography", version = "41.0.7", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation == 'PyPy') or (python_full_version < '3.14' and sys_platform == 'emscripten')" },
     { name = "cryptography", version = "49.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pyjwt", extra = ["crypto"], marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
-    { name = "requests", marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy') or platform_python_implementation == 'PyPy' or sys_platform == 'emscripten'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.13' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.13' and sys_platform == 'emscripten')" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
 wheels = [
@@ -6165,6 +6149,65 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/fe/1dfd5f512b26b53043884e4f34710c73e294e7cc54278c3fe28380e42c37/msgspec-0.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:565f915d2e540e8a0c93a01ff67f50aebe1f7e22798c6a25873f9fda8d1325f8", size = 231758, upload-time = "2025-11-24T03:56:13.765Z" },
     { url = "https://files.pythonhosted.org/packages/97/f6/9ba7121b8e0c4e0beee49575d1dbc804e2e72467692f0428cf39ceba1ea5/msgspec-0.20.0-cp314-cp314t-win_amd64.whl", hash = "sha256:726f3e6c3c323f283f6021ebb6c8ccf58d7cd7baa67b93d73bfbe9a15c34ab8d", size = 206540, upload-time = "2025-11-24T03:56:15.029Z" },
     { url = "https://files.pythonhosted.org/packages/c8/3e/c5187de84bb2c2ca334ab163fcacf19a23ebb1d876c837f81a1b324a15bf/msgspec-0.20.0-cp314-cp314t-win_arm64.whl", hash = "sha256:93f23528edc51d9f686808a361728e903d6f2be55c901d6f5c92e44c6d546bfc", size = 183011, upload-time = "2025-11-24T03:56:16.442Z" },
+]
+
+[[package]]
+name = "mssql-python"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-identity", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "mssql-python-odbc", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/96/1b100cf1b5c5e20f2e70c0436c4397c80f54216fb87adfeaff996cd4a1d0/mssql_python-1.14.0-cp310-cp310-macosx_15_0_universal2.whl", hash = "sha256:4eb9bbc82c073136702bca7e8f1784c2a88033cff7beb5ab316accbf750b2632", size = 9926665, upload-time = "2026-08-28T11:06:53.209Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ed/0383086a056d6701478fb654cc2f0b915dc2501221c4df5ce74b2adc5704/mssql_python-1.14.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:dfec24f26e411556c94cecc4a4815db33609be90bf66ec61a48831092736a1ff", size = 5546063, upload-time = "2026-08-28T11:06:55.317Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a9/f3d21923ba388f5c2f4fc64232ab5218946465bf66fd4861c970f5c3a07a/mssql_python-1.14.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a461a4bfa468c524c83fc3058de9426cce18791a08bf7e92ec9712017d0fe6dc", size = 5829099, upload-time = "2026-08-28T11:06:56.906Z" },
+    { url = "https://files.pythonhosted.org/packages/72/45/1d730e4b46b6c91df7b41267bf02d3079d902efca0cb30a1bf7dbc9ad3ae/mssql_python-1.14.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b2b61b6501f046f3251916126e9c9d322c50061325cd9f533453293e78c2ea03", size = 5467167, upload-time = "2026-08-28T11:06:58.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ee/6b083cbe3946c9031ae093f44f1aa04319782aba72d854152df76a0897b9/mssql_python-1.14.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d914be8b5176d0f29c409ab0ce9bf728a9dc52935fbcef57affd7ffae56a547d", size = 5720702, upload-time = "2026-08-28T11:07:00.463Z" },
+    { url = "https://files.pythonhosted.org/packages/97/9c/c3f53316b68fdd8ae75cc6b4292cf1818bd3864d647cd4c088b2676e600a/mssql_python-1.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe14e95b54baba9db7b6cba938711ad737b2af8c0cbb5b588bffb0ebcdd75988", size = 5181655, upload-time = "2026-08-28T11:07:02.144Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/a82063a4792257aa1ee78a06163dbcc65025b3625206e153c04d6913c940/mssql_python-1.14.0-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:cde0c2323650e3f53bd067b07156e2406f24ccb7277970e5ab4c2cc6e4d01d63", size = 9934844, upload-time = "2026-08-28T11:07:03.783Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d7/bec60dbc594b35763b4a31ec94b5bd10e2b012ea4daaa67eedfde3cbef32/mssql_python-1.14.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:82303d24f1062ecffa55f054fa15c17f52e6a86d1234d20865c9264e772cb5f7", size = 6068234, upload-time = "2026-08-28T11:07:05.861Z" },
+    { url = "https://files.pythonhosted.org/packages/02/00/5086120d1a2a862e60783598b91d4fb72d436fc10c7a161a9f0eb9451e29/mssql_python-1.14.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:2f1cd90ec569ddce446c4ccf58ab3a6f6872e98fe950fcb223b2dab8992a9395", size = 6525120, upload-time = "2026-08-28T11:07:07.896Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0e/a5935a1ce6a76481761233e6e57602aba864e6d6ad72df8e10297ec5f739/mssql_python-1.14.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9682840a7f15ed79fafb647f49c03c7712f2d77881263ac90ad095b7bfbeaf7f", size = 5930733, upload-time = "2026-08-28T11:07:09.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f0/300b056ff35661a78da9f3cab4b1fb67bd424a81920ed0f0042c14d72426/mssql_python-1.14.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b2656b7949e79015a6504be6f76df49aca604f862259cc3acb8e0e877bed5260", size = 6340809, upload-time = "2026-08-28T11:07:11.182Z" },
+    { url = "https://files.pythonhosted.org/packages/95/fe/ba168a599cc1b69944137256c7d21870c6e76f6cd1ff244de6a34e74cf5d/mssql_python-1.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:3981fe3e1cc404ea0d7375cab9086dc7470fac06ab2b70135e87730ef4162879", size = 5182863, upload-time = "2026-08-28T11:07:13.064Z" },
+    { url = "https://files.pythonhosted.org/packages/12/41/b5f92b40c6cd60e207b4ca117db3a85520606eeb9b4e4b52c0b67ed125b5/mssql_python-1.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:057c7e2797fac1567f45975b5bd8e71da58da97a8000834061a3bd543a99248b", size = 5264547, upload-time = "2026-08-28T11:07:14.979Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/7e/506e086f751e95168a5ae0edeed02fa0758fc12523ee82a8bb18796437b8/mssql_python-1.14.0-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9549dd42d51cf3aa10324d82821bd80ee3d8ef95552bbf50fcf4d1abe9a6f485", size = 9963561, upload-time = "2026-08-28T11:07:16.783Z" },
+    { url = "https://files.pythonhosted.org/packages/31/4c/7eda7a54a0d97f804efdd51436a3e4f25acaf48eb18ccc0177d3bba418f5/mssql_python-1.14.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e403a766d65684455524042bb38e2507c06351526b57328fcaf571257db8fdf8", size = 6588732, upload-time = "2026-08-28T11:07:18.824Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3f/ad995fab32575c1ef611783fb6910ed3681a6faace523781a69b6f1bf282/mssql_python-1.14.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a2aa7cdc624b65dd4ad6beaa7fa2f16d881bc2e204defdf98f200887ff11e2b7", size = 7210759, upload-time = "2026-08-28T11:07:20.382Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/50/87469cd93f050932f66874394b14653277ad69697a21fa4865b85a499725/mssql_python-1.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:47617a5482d7b1734c4e7232ca112170e9501d06ce102c468aced9993b35f3b9", size = 6391212, upload-time = "2026-08-28T11:07:21.922Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/83/0f7a012e5a4a6d1085c2c154ab8065d929028d5b2f5517d6c8f9ce3bed72/mssql_python-1.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e05aa735b236dcf7e1f87d301d2c239e7c09693a6beab41d3167a7ee52d28226", size = 6959420, upload-time = "2026-08-28T11:07:24.429Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/7d/3e381a66542e5706b3de73eee7ff517d5c085d0aa539173a1093d3d874de/mssql_python-1.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:73be60e230f87be9036aa36ad39901501ce0d00c46340eddd761d4c9fb4d2c19", size = 5179672, upload-time = "2026-08-28T11:07:26.697Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2b/11686e87a4dde8c31601b80b80f2e5c186c58430abf9cfdc5392cb240227/mssql_python-1.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:38f20d643f30ea0345ce9588f31a7f4fac8019f83a01921d49592d26d20e4ece", size = 5261194, upload-time = "2026-08-28T11:07:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/14/97/6a97cb8aa8e828644b8c6f90d7b8272b195fb643ea415dcacdfb3ba37a02/mssql_python-1.14.0-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5eb3ec5505a2a9e780ad37e9c95ae991e6e331a859e7d21b88d689c7fc5f52e6", size = 9958721, upload-time = "2026-08-28T11:07:31.141Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/92/46c4ee9d3238ff160acc46a69e495f70702eedd2df615188f5e23c2933c9/mssql_python-1.14.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3ac43c2beadedf6490126dd88d598a79a159915f9835ed37ba144abb9c9a2de7", size = 7126064, upload-time = "2026-08-28T11:07:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2b/ac00ccb02aa3b1606dd1376df958daed58515f22c83d42980a967fa5c087/mssql_python-1.14.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:97b74fb31df77f18e95238d6907a98f8eb7470a200396231ac7706667215dd61", size = 7911224, upload-time = "2026-08-28T11:07:36.291Z" },
+    { url = "https://files.pythonhosted.org/packages/67/19/8f2000ab9f11bae31d71a8176b8f2803407237fb3e6e94788e21705957ee/mssql_python-1.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:485c0d512b24208ce62444a9ffec748f712a4575e395bb1d97964a80ae89448d", size = 6867882, upload-time = "2026-08-28T11:07:38.467Z" },
+    { url = "https://files.pythonhosted.org/packages/96/0c/7cf10185314dcaa33c4816e44c7a2b8b6b9b2c17798a0679c944744aaaec/mssql_python-1.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1bd0b6a7858a782bef3feac2539560cddcfea9b69185ff429c0c85a69d8c7fe6", size = 7585070, upload-time = "2026-08-28T11:07:40.728Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a7/707a73f19ee76d05862cc8415d6e47b565f903042d9b88316385ec32067d/mssql_python-1.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:16fff8831e13c526f5828621affb449710a74ea4c8a18d45da654d369feb3b07", size = 5177695, upload-time = "2026-08-28T11:07:42.751Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b8/14298b10f264eb07d90bd11c1350f2e6cee0bab5fe63887c484aa3e1f046/mssql_python-1.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c3b1afbef800b646c0247044d641b34c886c3262421d4775519374465258473", size = 5259310, upload-time = "2026-08-28T11:07:44.496Z" },
+    { url = "https://files.pythonhosted.org/packages/58/91/5cb8dac56175bab75566b031041a5c2cdf1f36030fb2992c9ce64b5e3f97/mssql_python-1.14.0-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:a3002fc8c576a4fce8931ecd44f9ef29d970afa992e33d74647c4a19883132cc", size = 9969642, upload-time = "2026-08-28T11:07:46.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/02/19a40e1cb2aece03becb516b7de305263f026e2bfbcbe8af584cac29942d/mssql_python-1.14.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:53d3b350fd6b32bec40461e989f8de349cd557f385fecd2a720749bcd2bc3754", size = 7676382, upload-time = "2026-08-28T11:07:49.001Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/fe/d8c2aea3b0297e67f4ae5086a3becde8222ff031f4575995535d5e2ec288/mssql_python-1.14.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:8af7649d8e0482bfa891fe9a7fd2abc2835ef29e31d2e7cdc83434d79db31b86", size = 8641367, upload-time = "2026-08-28T11:07:50.992Z" },
+    { url = "https://files.pythonhosted.org/packages/78/58/574cd082727f00bd4ab627b87c127a618a74152f6efba93647806b5cec62/mssql_python-1.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6ebe4f7a18a3832d630ad4cee09c07adf37c0417ceab44211679ed7f464c67fd", size = 7355453, upload-time = "2026-08-28T11:07:53.203Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b6/d17d6ad8608aecb9117b9f9c319ee46ae6a1cd1914ed5a63784d81072cf2/mssql_python-1.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:66d6623dac33026030c27d21a5eda7d994db2772a85af271011c9091d82832a7", size = 8241258, upload-time = "2026-08-28T11:07:55.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/6c/08c9c89bfd2ac6d3350fddd7ee4633886f98cf745c7a2034ac2afae980f2/mssql_python-1.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:e2de74e7f20f9bb89f7ef9600d0449d59d0437e349812180060a231187133c21", size = 5401974, upload-time = "2026-08-28T11:07:57.441Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/84/21af320fbf3ea69139d3c72ba9a349a3ad8e3d447c4650e2491a1ab0871a/mssql_python-1.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:1330028c1d365aa717277d21735a93897a4bf2a9d883dd73200114266d260d24", size = 5487990, upload-time = "2026-08-28T11:07:59.566Z" },
+]
+
+[[package]]
+name = "mssql-python-odbc"
+version = "18.6.2.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/21/5d8e34820d986426dc65f88702ccecd1a981184e6bffab2968011461eaef/mssql_python_odbc-18.6.2.1-py3-none-macosx_15_0_universal2.whl", hash = "sha256:c0c4d2446f37656be1ed32c8e3229233554c1fbfc9f23c73c2ab0d07a2bfdcf2", size = 2035381, upload-time = "2026-08-05T15:51:46.762Z" },
+    { url = "https://files.pythonhosted.org/packages/85/98/e07617483dd395156fba003cda6ff85ca9ad64de1347b823951f2afb3d60/mssql_python_odbc-18.6.2.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d665529c195829970dcb72b7b3200e3c0ee1b053bee88e9a6eabaa385874dd6e", size = 2730032, upload-time = "2026-08-05T15:51:48.6Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1f/6cdb575549fbbe6f49bcadb505768649c43226bd83ec57a53a934d48e459/mssql_python_odbc-18.6.2.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b8aad821f3b8637b0e6d4637f4b730ed9897c4665fa99d47e44e97fd1c79c77a", size = 3897879, upload-time = "2026-08-05T15:51:50.134Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ed/fa18a5f48eb4f0f003010af808b032806082c5441a076d698835ed5151b6/mssql_python_odbc-18.6.2.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:bcfca2a994b17499dc24a8b40228b851ccd0cd5807def855a6c41a8cedc4f8ac", size = 2730032, upload-time = "2026-08-05T15:51:51.672Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/66/7c96d719dfe7e9dcbbbf7acb345c72dfaef392fa6c5042e2718dfb1779b4/mssql_python_odbc-18.6.2.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3db256103b09156f0980bee2dedc47995f528f76d01388ab5c5f1758b7e8fc53", size = 3897877, upload-time = "2026-08-05T15:51:53.147Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f6/e7725d5dc791f5535fa7ec750c2ab9a1ff731f923d01b9c0d5cf1779b676/mssql_python_odbc-18.6.2.1-py3-none-win_amd64.whl", hash = "sha256:07a987221f99b368161db912065ef9e64c85f6b0901a2b05e9c1e6b41da08d55", size = 3712266, upload-time = "2026-08-05T15:51:54.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/d8/cda7ae46dd3c723196043109204fcc7749d688194de834b3f8aa4cd94415/mssql_python_odbc-18.6.2.1-py3-none-win_arm64.whl", hash = "sha256:00e1eae3c44a157ca60f992c6305be45856f18276ccff5258c1e9619847f3a5a", size = 7017266, upload-time = "2026-08-05T15:51:56.958Z" },
 ]
 
 [[package]]
@@ -6334,30 +6377,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-boto3-athena"
-version = "1.38.28"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/52/93a49eb0269da549337e6691c99d62d742928bacfaafcdd641ac6625a1f2/mypy_boto3_athena-1.38.28.tar.gz", hash = "sha256:5d7e74a59a4c778374848290d3c462665830954495912ec226ce270a4a4eae4d", size = 36553, upload-time = "2025-06-02T19:42:08.879Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/66/a9fd9ca7ea9dd117e96cb3f32d573a865f764aed5450f2ff9c68be0f7c60/mypy_boto3_athena-1.38.28-py3-none-any.whl", hash = "sha256:616ac18172c172be44dd68e208f582d4d7a050786b8e01ca5c6ad719181bab41", size = 40934, upload-time = "2025-06-02T19:42:03.101Z" },
-]
-
-[[package]]
-name = "mypy-boto3-glue"
-version = "1.38.22"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/73/97/a479bc9405da1d6ae4d2bc88965e76e4d3c8c1c83188eb03c7a49d902826/mypy_boto3_glue-1.38.22.tar.gz", hash = "sha256:a9c529fafaaa9845d39c3204b3fb6cbbb633fa747faf6a084a2b2a381ef12a2b", size = 122519, upload-time = "2025-05-22T19:27:07.452Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/64/33ff3fca5302bb54860d0ddd9ef89c0a2cfea80bd6d1336f10fd4857a1b7/mypy_boto3_glue-1.38.22-py3-none-any.whl", hash = "sha256:4fe34c858cbee41e8ad30382305c01b0dd9c1da4c84f894860b9249ddabb4a58", size = 130042, upload-time = "2025-05-22T19:26:59.181Z" },
-]
-
-[[package]]
 name = "mypy-boto3-lakeformation"
 version = "1.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6391,18 +6410,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/8c/c8d129f32737d09d2c23db5110a43164085b47c843460a5c89c748bf3f3f/mypy_boto3_s3tables-1.38.42.tar.gz", hash = "sha256:b3b24401f0e5e21f6c8ab35560a76a72e78983cf59f0b1adf6b7d07d9a6dabe5", size = 19731, upload-time = "2025-06-23T19:28:16.273Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/b2/b1f867226e95e2fad739b9bd781fe967d2cb276c4f60bf698d6d0a7eba39/mypy_boto3_s3tables-1.38.42-py3-none-any.whl", hash = "sha256:a24e5768e9773c963d8e1f6a7334488a107440fbeda040c71df1516aece88533", size = 26160, upload-time = "2025-06-23T19:28:14.971Z" },
-]
-
-[[package]]
-name = "mypy-boto3-sts"
-version = "1.38.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/51/24/638ceabff74e07855b59c3bb863b0c11e69ff7ec8fa8678ff6db9ee38318/mypy_boto3_sts-1.38.0.tar.gz", hash = "sha256:143a96f06bd17ec4bbb120e04b65e646cb4345e2d0d4c3c596f8aa0458d12707", size = 16561, upload-time = "2025-04-22T21:35:39.729Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/1b/532ec318c368a3e34c18b92f3cf9254e571dc32e150e400f323d73ba3159/mypy_boto3_sts-1.38.0-py3-none-any.whl", hash = "sha256:61d7ef65677be52cc0e369e359c41ced12b4cc3919f550905af5f480806b89b4", size = 20125, upload-time = "2025-04-22T21:35:38.625Z" },
 ]
 
 [[package]]
@@ -6460,10 +6467,10 @@ name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastjsonschema", marker = "python_full_version >= '3.14'" },
-    { name = "jsonschema", marker = "python_full_version >= '3.14'" },
-    { name = "jupyter-core", marker = "python_full_version >= '3.14'" },
-    { name = "traitlets", marker = "python_full_version >= '3.14'" },
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
 wheels = [
@@ -6710,7 +6717,7 @@ dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version == '3.13.*'" },
     { name = "packaging", marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "protobuf", marker = "python_full_version < '3.14'" },
     { name = "sympy", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
@@ -6732,6 +6739,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/89/2f64e250945fa87140fb917ba377d6d0e9122e029c8512f389a9b7f953f4/onnxruntime-1.22.0-cp313-cp313-win_amd64.whl", hash = "sha256:5a31d84ef82b4b05d794a4ce8ba37b0d9deb768fd580e36e17b39e0b4840253b", size = 12691777, upload-time = "2025-05-12T21:26:20.19Z" },
     { url = "https://files.pythonhosted.org/packages/9f/48/d61d5f1ed098161edd88c56cbac49207d7b7b149e613d2cd7e33176c63b3/onnxruntime-1.22.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a2ac5bd9205d831541db4e508e586e764a74f14efdd3f89af7fd20e1bf4a1ed", size = 14454003, upload-time = "2025-05-09T20:25:52.287Z" },
     { url = "https://files.pythonhosted.org/packages/c3/16/873b955beda7bada5b0d798d3a601b2ff210e44ad5169f6d405b93892103/onnxruntime-1.22.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64845709f9e8a2809e8e009bc4c8f73b788cee9c6619b7d9930344eae4c9cd36", size = 16427482, upload-time = "2025-05-09T20:26:20.376Z" },
+]
+
+[[package]]
+name = "openai"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/76/913b755a1a6b54e2d9140eb8d488aa0d47c7359b1d7eac5e864cb7913bbf/openai-3.6.0.tar.gz", hash = "sha256:18fe3f6e96390ef41ee27b152fc9effefca321c33673bd9b956a572493d3ab9b", size = 1455376, upload-time = "2026-08-28T22:29:18.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/94/805b87ecc951c49ec8f247f5e8eb324ab064bd2ad73b6a0e704dd49aa073/openai-3.6.0-py3-none-any.whl", hash = "sha256:508e2158bf971687f953b62e44b02f207792c815aac306816386d7ba34d37f5f", size = 1699841, upload-time = "2026-08-28T22:29:16.436Z" },
 ]
 
 [[package]]
@@ -6760,115 +6784,115 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.27.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated" },
-    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/83/93114b6de85a98963aec218a51509a52ed3f8de918fe91eb0f7299805c3f/opentelemetry_api-1.27.0.tar.gz", hash = "sha256:ed673583eaa5f81b5ce5e86ef7cdaf622f88ef65f0b9aab40b843dcae5bef342", size = 62693, upload-time = "2024-08-28T21:35:31.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/1f/737dcdbc9fea2fa96c1b392ae47275165a7c641663fbb08a8d252968eed2/opentelemetry_api-1.27.0-py3-none-any.whl", hash = "sha256:953d5871815e7c30c81b56d910c707588000fff7a3ca1c73e6531911d53065e7", size = 63970, upload-time = "2024-08-28T21:35:00.598Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp"
-version = "1.27.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/d3/8156cc14e8f4573a3572ee7f30badc7aabd02961a09acc72ab5f2c789ef1/opentelemetry_exporter_otlp-1.27.0.tar.gz", hash = "sha256:4a599459e623868cc95d933c301199c2367e530f089750e115599fccd67cb2a1", size = 6166, upload-time = "2024-08-28T21:35:33.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/45/7af37fe54e5d3e66e7dcd7ba8b8aeee73f202bfac909cc94b8c4e428f9ac/opentelemetry_exporter_otlp-1.44.0.tar.gz", hash = "sha256:af1cde7c33ea8ed624bf04ac49a885730fe44c1f1ad698656e592c38f70ce106", size = 6090, upload-time = "2026-07-16T15:25:34.585Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/6d/95e1fc2c8d945a734db32e87a5aa7a804f847c1657a21351df9338bd1c9c/opentelemetry_exporter_otlp-1.27.0-py3-none-any.whl", hash = "sha256:7688791cbdd951d71eb6445951d1cfbb7b6b2d7ee5948fac805d404802931145", size = 7001, upload-time = "2024-08-28T21:35:04.02Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c3/7b466a9463944e70b37b744072a0c1b88a425dade3fff0631adec66c9bcc/opentelemetry_exporter_otlp-1.44.0-py3-none-any.whl", hash = "sha256:4a498fa8d8fd8be9e8e2d175fe5524a3fe581ccffadd8509db86526a5fb97051", size = 6727, upload-time = "2026-07-16T15:25:14.445Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.27.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/2e/7eaf4ba595fb5213cf639c9158dfb64aacb2e4c7d74bfa664af89fa111f4/opentelemetry_exporter_otlp_proto_common-1.27.0.tar.gz", hash = "sha256:159d27cf49f359e3798c4c3eb8da6ef4020e292571bd8c5604a2a573231dd5c8", size = 17860, upload-time = "2024-08-28T21:35:34.896Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/27/4610ab3d9bb3cde4309b6505f98b3aabca04a26aa480aa18cede23149837/opentelemetry_exporter_otlp_proto_common-1.27.0-py3-none-any.whl", hash = "sha256:675db7fffcb60946f3a5c43e17d1168a3307a94a930ecf8d2ea1f286f3d4f79a", size = 17848, upload-time = "2024-08-28T21:35:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.27.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
     { name = "grpcio", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-api", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-exporter-otlp-proto-common", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-proto", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-sdk", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d0/c1e375b292df26e0ffebf194e82cd197e4c26cc298582bda626ce3ce74c5/opentelemetry_exporter_otlp_proto_grpc-1.27.0.tar.gz", hash = "sha256:af6f72f76bcf425dfb5ad11c1a6d6eca2863b91e63575f89bb7b4b55099d968f", size = 26244, upload-time = "2024-08-28T21:35:36.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/80/32217460c2c64c0568cea38410124ff680a9b65f6732867bbf857c4d8626/opentelemetry_exporter_otlp_proto_grpc-1.27.0-py3-none-any.whl", hash = "sha256:56b5bbd5d61aab05e300d9d62a6b3c134827bbd28d0b12f2649c2da368006c9e", size = 18541, upload-time = "2024-08-28T21:35:06.493Z" },
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.27.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "googleapis-common-protos", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-api", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-exporter-otlp-proto-common", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-proto", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-sdk", marker = "python_full_version < '3.13'" },
-    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/0a/f05c55e8913bf58a033583f2580a0ec31a5f4cf2beacc9e286dcb74d6979/opentelemetry_exporter_otlp_proto_http-1.27.0.tar.gz", hash = "sha256:2103479092d8eb18f61f3fbff084f67cc7f2d4a7d37e75304b8b56c1d09ebef5", size = 15059, upload-time = "2024-08-28T21:35:37.079Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/8d/4755884afc0b1db6000527cac0ca17273063b6142c773ce4ecd307a82e72/opentelemetry_exporter_otlp_proto_http-1.27.0-py3-none-any.whl", hash = "sha256:688027575c9da42e179a69fe17e2d1eba9b14d81de8d13553a21d3114f3b4d75", size = 17203, upload-time = "2024-08-28T21:35:08.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.27.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "protobuf", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/59/959f0beea798ae0ee9c979b90f220736fbec924eedbefc60ca581232e659/opentelemetry_proto-1.27.0.tar.gz", hash = "sha256:33c9345d91dafd8a74fc3d7576c5a38f18b7fdf8d02983ac67485386132aedd6", size = 34749, upload-time = "2024-08-28T21:35:45.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/3d2d826834209b19a5141eed717f7922150224d1a982385d19a9444cbf8d/opentelemetry_proto-1.27.0-py3-none-any.whl", hash = "sha256:b133873de5581a50063e1e4b29cdcf0c5e253a8c2d8dc1229add20a4c3830ace", size = 52464, upload-time = "2024-08-28T21:35:21.434Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.27.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-semantic-conventions", marker = "python_full_version < '3.13'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/9a/82a6ac0f06590f3d72241a587cb8b0b751bd98728e896cc4cbd4847248e6/opentelemetry_sdk-1.27.0.tar.gz", hash = "sha256:d525017dea0ccce9ba4e0245100ec46ecdc043f2d7b8315d56b19aff0904fa6f", size = 145019, upload-time = "2024-08-28T21:35:46.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/bd/a6602e71e315055d63b2ff07172bd2d012b4cba2d4e00735d74ba42fc4d6/opentelemetry_sdk-1.27.0-py3-none-any.whl", hash = "sha256:365f5e32f920faf0fd9e14fdfd92c086e317eaa5f860edba9cdc17a380d9197d", size = 110505, upload-time = "2024-08-28T21:35:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.48b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated", marker = "python_full_version < '3.13'" },
     { name = "opentelemetry-api", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/89/1724ad69f7411772446067cdfa73b598694c8c91f7f8c922e344d96d81f9/opentelemetry_semantic_conventions-0.48b0.tar.gz", hash = "sha256:12d74983783b6878162208be57c9effcb89dc88691c64992d70bb89dc00daa1a", size = 89445, upload-time = "2024-08-28T21:35:47.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/7a/4f0063dbb0b6c971568291a8bc19a4ca70d3c185db2d956230dd67429dfc/opentelemetry_semantic_conventions-0.48b0-py3-none-any.whl", hash = "sha256:a0de9f45c413a8669788a38569c7e0a11ce6ce97861a628cca785deecdc32a1f", size = 149685, upload-time = "2024-08-28T21:35:25.983Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -7095,10 +7119,8 @@ version = "0.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "db-dtypes" },
-    { name = "google-api-core", version = "2.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core" },
+    { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "google-cloud-bigquery" },
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
@@ -7679,8 +7701,7 @@ name = "proto-plus"
 version = "1.26.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
 wheels = [
@@ -7689,36 +7710,8 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "4.25.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/01/34c8d2b6354906d728703cb9d546a0e534de479e25f1b581e4094c4a85cc/protobuf-4.25.8.tar.gz", hash = "sha256:6135cf8affe1fc6f76cced2641e4ea8d3e59518d1f24ae41ba97bcad82d397cd", size = 380920, upload-time = "2025-05-28T14:22:25.153Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/ff/05f34305fe6b85bbfbecbc559d423a5985605cad5eda4f47eae9e9c9c5c5/protobuf-4.25.8-cp310-abi3-win32.whl", hash = "sha256:504435d831565f7cfac9f0714440028907f1975e4bed228e58e72ecfff58a1e0", size = 392745, upload-time = "2025-05-28T14:22:10.524Z" },
-    { url = "https://files.pythonhosted.org/packages/08/35/8b8a8405c564caf4ba835b1fdf554da869954712b26d8f2a98c0e434469b/protobuf-4.25.8-cp310-abi3-win_amd64.whl", hash = "sha256:bd551eb1fe1d7e92c1af1d75bdfa572eff1ab0e5bf1736716814cdccdb2360f9", size = 413736, upload-time = "2025-05-28T14:22:13.156Z" },
-    { url = "https://files.pythonhosted.org/packages/28/d7/ab27049a035b258dab43445eb6ec84a26277b16105b277cbe0a7698bdc6c/protobuf-4.25.8-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:ca809b42f4444f144f2115c4c1a747b9a404d590f18f37e9402422033e464e0f", size = 394537, upload-time = "2025-05-28T14:22:14.768Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/6d/a4a198b61808dd3d1ee187082ccc21499bc949d639feb948961b48be9a7e/protobuf-4.25.8-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:9ad7ef62d92baf5a8654fbb88dac7fa5594cfa70fd3440488a5ca3bfc6d795a7", size = 294005, upload-time = "2025-05-28T14:22:16.052Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c6/c9deaa6e789b6fc41b88ccbdfe7a42d2b82663248b715f55aa77fbc00724/protobuf-4.25.8-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:83e6e54e93d2b696a92cad6e6efc924f3850f82b52e1563778dfab8b355101b0", size = 294924, upload-time = "2025-05-28T14:22:17.105Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/c1/6aece0ab5209981a70cd186f164c133fdba2f51e124ff92b73de7fd24d78/protobuf-4.25.8-py3-none-any.whl", hash = "sha256:15a0af558aa3b13efef102ae6e4f3efac06f1eea11afb3a57db2901447d9fb59", size = 156757, upload-time = "2025-05-28T14:22:24.135Z" },
-]
-
-[[package]]
-name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
@@ -8076,6 +8069,45 @@ email = [
 ]
 
 [[package]]
+name = "pydantic-ai-slim"
+version = "2.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "genai-prices" },
+    { name = "griffelib" },
+    { name = "httpx2" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-graph" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/ad/a1db6a8ea93d4f8b7a9adaab64204ccd40d236933285c564fcd4b9037173/pydantic_ai_slim-2.36.0.tar.gz", hash = "sha256:43b53401099352bbb0d1a1ecbcf8855bb7c3d0c680311ba006c5549ed6d61039", size = 1313875, upload-time = "2026-08-29T01:39:37.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/0c/433c49819fa099700d69078586327b9dfad2c11492f96f51a13fa30208ad/pydantic_ai_slim-2.36.0-py3-none-any.whl", hash = "sha256:90957c37c99d3bfbfab4be632b733bf50d563686fbfbf8a2e42b6c91a4fca877", size = 1548738, upload-time = "2026-08-29T01:39:28.524Z" },
+]
+
+[package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+]
+google = [
+    { name = "google-genai" },
+]
+mcp = [
+    { name = "fastmcp-slim", extra = ["client"] },
+]
+openai = [
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+spec = [
+    { name = "pydantic-handlebars" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "pydantic-core"
 version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
@@ -8194,6 +8226,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-graph"
+version = "2.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "logfire-api" },
+    { name = "pydantic" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/79/af5579c790ee5f670c270e4183d4c8411a6392c9b267022ea467e9e1c831/pydantic_graph-2.36.0.tar.gz", hash = "sha256:1222b50a141f88bca299dc21e94694277e6ef60d6f1bbbf490f2f2796851594a", size = 45191, upload-time = "2026-08-29T01:39:39.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/f4/7b43affa018fa14ba0d8169fb2460ec496d4cb974c64bfc1f8e85fc4da44/pydantic_graph-2.36.0-py3-none-any.whl", hash = "sha256:c0c7cddb87038298b367036d799b4b605b2a23858869b2b661706df6e1b811f2", size = 52700, upload-time = "2026-08-29T01:39:32.131Z" },
+]
+
+[[package]]
+name = "pydantic-handlebars"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/73/e55a1fe1a8788a5fa82d9209e796f4111e28f2d2fecab7173aa6d80516ad/pydantic_handlebars-0.2.1.tar.gz", hash = "sha256:d4124cfbf7d6e3bded9331a08ccccf6f29f3e3a93665b35b5d6061650aeeb49f", size = 176949, upload-time = "2026-05-25T01:24:38.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/11/364bc401f1d8fdb3947079fc43ffdfbfc9132d065981a03a95d2e87440c4/pydantic_handlebars-0.2.1-py3-none-any.whl", hash = "sha256:c713427d6498cf4b66814447d54753a2748f8a8d3a9f00c194192ddb3df61e52", size = 50476, upload-time = "2026-05-25T01:24:37.104Z" },
+]
+
+[[package]]
 name = "pydantic-settings"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -8212,8 +8271,7 @@ name = "pydata-google-auth"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-auth", version = "2.40.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "google-auth", version = "2.55.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "setuptools" },
 ]
@@ -8254,8 +8312,7 @@ name = "pydoclint"
 version = "0.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click" },
     { name = "docstring-parser-fork" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -8300,13 +8357,13 @@ version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click" },
     { name = "fsspec" },
     { name = "mmh3" },
     { name = "pydantic" },
     { name = "pyparsing" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "rich" },
     { name = "sortedcontainers" },
     { name = "strictyaml" },
@@ -8431,48 +8488,8 @@ wheels = [
 
 [[package]]
 name = "pyodbc"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/22/6f/012f32aecf744e439980257be0ba4dd8c70a4e03c9f86f5fcd986fbfb012/pyodbc-5.0.1.tar.gz", hash = "sha256:03d7d0b04d5a9156099ce8d03e92f3956783746fa9234eb6f5b5cfc12b645011", size = 115228, upload-time = "2023-10-13T17:08:30.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/97/337e82c5325f6cc039c5ed65d8b687c942b17763b88c4fbe21420b84ae4d/pyodbc-5.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9824b175db875a2dd116c7cf16dc3bdf14855404417afd145c5b839da222cb46", size = 72207, upload-time = "2023-10-13T17:07:44Z" },
-    { url = "https://files.pythonhosted.org/packages/19/8c/d0f19b0fd2df3433c64a21d7ac27ca6c5edeaa39245b168c419a40f3bdbc/pyodbc-5.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b4d41d0a10523862aac9e2f578bae0ec66003c76e0644d1b53d6ac110b73e5ed", size = 71647, upload-time = "2023-10-13T17:07:46.07Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/8c/540e1649ff0c951f93e5ea5e3b6d56a96f83dbcf64ad01654135e07b8393/pyodbc-5.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd4a9ec6d0b31118f3c46020d9784923b99873585919d08e67d95bbf6ab99716", size = 330757, upload-time = "2023-10-13T17:07:47.284Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a3/8a052aab46ec2ba3bcdf8e1d3a903af3b3342209568451aad6753e339d61/pyodbc-5.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:654843036b714e4f3f4605fc359690738a3465d333f8297a74841e3990d3eabd", size = 334755, upload-time = "2023-10-13T17:07:49.207Z" },
-    { url = "https://files.pythonhosted.org/packages/15/f4/3b57fbd6f85daad1e88dff8a6ac76cf5775c1dfe253b277d94b83d0d6b0c/pyodbc-5.0.1-cp310-cp310-win32.whl", hash = "sha256:c68b3dd0b86d45fdebc566a9596f27b216d25068728bb43a4c961f0fcb9bb970", size = 62167, upload-time = "2023-10-13T17:07:51.072Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/70/e242d9eb3535532ff3d7c8857b9cc50cda29d8199e5e964cd1b44f9bb050/pyodbc-5.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:1d7dbef96ebb3eba8bc3f5431694d6e6969d50d0e21f6c4f3b0b2dc9fe8c4f25", size = 68728, upload-time = "2023-10-13T17:07:52.743Z" },
-    { url = "https://files.pythonhosted.org/packages/15/3f/3aabdd379ed3085008005d698cbd9731f248720eb7e82febbbf1cbcfff0c/pyodbc-5.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:459a245ae5409dd2fe6eb8531b907da8d61f72d3b18a6276c82cafe2e4896acf", size = 72248, upload-time = "2023-10-13T17:07:54.38Z" },
-    { url = "https://files.pythonhosted.org/packages/be/4c/5d938349f7db589ff4505917649101435c8c1b69a14a8280845517303caa/pyodbc-5.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b3ea6ed0fb8a1b46e643cfaba935656b9abe023d4ab66a8f653bf0c5bc1ce74d", size = 71680, upload-time = "2023-10-13T17:07:55.991Z" },
-    { url = "https://files.pythonhosted.org/packages/48/03/2bd9a56949aeb6e87eb2b14abe834b181a033ce9fcfc2ed1f740b3fb3eb1/pyodbc-5.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbfca542a528278a2c43a85d7a6bfde74854d0e7b3cd8c4ab31647bfe5a11069", size = 342093, upload-time = "2023-10-13T17:07:57.749Z" },
-    { url = "https://files.pythonhosted.org/packages/14/29/29d6ac703ca777343d0870d934bf8b23fb11d0aba648d149e47848292333/pyodbc-5.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8744c48f494bd365529935d3ac6ec15d3e3995e877587e293a3d3110ffcc0374", size = 344816, upload-time = "2023-10-13T17:07:59.139Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/61/9f172fd0cee42c234477f9ef69934e5b9d64991bd4c3544992f61bcc944d/pyodbc-5.0.1-cp311-cp311-win32.whl", hash = "sha256:b22474ede5b2841fe67658431f02a3ab9f16601c12a18c0286af435d742c2b71", size = 62171, upload-time = "2023-10-13T17:08:00.979Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/59/a7586cb8f7e2283c5ac50cf541d15c610805098238a98d0e789c516f0b50/pyodbc-5.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:ccc04742bb2fee1f5d2a5b84462f62cd68c346aa274b89b5257e328d41f9d69d", size = 68736, upload-time = "2023-10-13T17:08:02.36Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2b/af54b913f50c5e9df516e34e2304c6c0778743d90e4c8a3a1a3850c4429a/pyodbc-5.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9aef4f14f126ef607897245ff2742532ce0c299aee3c0e48d37bbdf1ff0b9532", size = 73034, upload-time = "2023-10-13T17:08:03.614Z" },
-    { url = "https://files.pythonhosted.org/packages/32/3d/518c4837a34226115139951ab9bb6af7a7729c41e265d6c0ccc72b443805/pyodbc-5.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dbf783d6cc923603de35a648db64c50f6699372188dc32b97a373c4b12694bd1", size = 72105, upload-time = "2023-10-13T17:08:05.223Z" },
-    { url = "https://files.pythonhosted.org/packages/76/52/eb724d2ff836adba883a4962c68b9c47836f57e06bf7be2b44a14d3bf4af/pyodbc-5.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2f32d98f9522de54958e3478d03c1a85c1efc103f378913bc4d9a7b610a3d02", size = 347156, upload-time = "2023-10-13T17:08:06.746Z" },
-    { url = "https://files.pythonhosted.org/packages/30/d6/5180b60cd752dba305dd7c9d866b331cff84c06ebdfe2ca459e12153e39c/pyodbc-5.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88d94c4fa53fc5440ce904c987e97316f271c21d3e968090f8fb76baf1a9be90", size = 352974, upload-time = "2023-10-13T17:08:08.417Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/b3/429067bed8efe9fad1d13cba34da9d4910b2573a1b808f45a65a69b90481/pyodbc-5.0.1-cp312-cp312-win32.whl", hash = "sha256:17d25a51823a5c8631fd117c1d352425404cd2116fd75b55aac4cb79da2e8c85", size = 62781, upload-time = "2023-10-13T17:08:10.203Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/ef/2d24457682b4b239748f1d25c8a88b88ba99214fd78bedde54ff6186422c/pyodbc-5.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a3204ba4d1374fe8c301a76e04c9e9207d71cc346ca8282a85c20260d135b5d", size = 69250, upload-time = "2023-10-13T17:08:11.428Z" },
-]
-
-[[package]]
-name = "pyodbc"
 version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/8f/85/44b10070a769a56bd910009bb185c0c0a82daff8d567cd1a116d7d730c7d/pyodbc-5.3.0.tar.gz", hash = "sha256:2fe0e063d8fb66efd0ac6dc39236c4de1a45f17c33eaded0d553d21c199f4d05", size = 121770, upload-time = "2025-10-17T18:04:09.43Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/cd/d0ac9e8963cf43f3c0e8ebd284cd9c5d0e17457be76c35abe4998b7b6df2/pyodbc-5.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6682cdec78f1302d0c559422c8e00991668e039ed63dece8bf99ef62173376a5", size = 71888, upload-time = "2025-10-17T18:02:58.285Z" },
@@ -8632,7 +8649,8 @@ version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
 wheels = [
@@ -8781,11 +8799,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
 ]
 
 [[package]]
@@ -8920,8 +8938,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version == '3.13.*'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "portalocker" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
     { name = "pydantic" },
     { name = "urllib3" },
 ]
@@ -8936,8 +8953,200 @@ fastembed = [
 ]
 
 [[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/b1/d6d6e7737fe3d0eb2ac2ac337686420d538f83f28495acc3cc32201c0dbf/rapidfuzz-3.14.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:071d96b957a33b9296b9284b6350a0fb6d030b154a04efd7c15e56b98b79a517", size = 1953508, upload-time = "2026-04-07T11:13:37.733Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/7b/94c1c953ac818bdd88b43213a9d38e4a41e953b786af3c3b2444d4a8f96d/rapidfuzz-3.14.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:667f40fe9c81ad129b198d236881b00dd9e8314d9cc72d03c3e16bdfe5879051", size = 1160895, upload-time = "2026-04-07T11:13:39.278Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/60/a67a7ca7c2532c6c1a4b5cd797917780eed43798b82c98b6df734a086c95/rapidfuzz-3.14.5-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9fff308486bbd2c8c24f25e8e152c7594d3fe8db265a2d6a1ce24d58671127f", size = 1382245, upload-time = "2026-04-07T11:13:41.054Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ff/a42c9ce9f9e90ceb5b51136e0b8e8e6e5113ba0b45d986effbd671e7dddf/rapidfuzz-3.14.5-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dfa552338f51aec280f17b02d28bace1e162d1a84ccd80e3339a57f98aedb56b", size = 3163974, upload-time = "2026-04-07T11:13:42.662Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/3c/11e2d41075e6e48b7dad373631b379b7e40491f71d5412c5a98d3c58f60f/rapidfuzz-3.14.5-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:068b3e965ca9d9ee4debe40001ae7c3938ba646308afd33cf0c66618147db65c", size = 1475540, upload-time = "2026-04-07T11:13:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/29/fa/09be143dcc22c79f09cf90168a574725dbda49f02cbbd55d0447da8bec86/rapidfuzz-3.14.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:88b7d31ff1cc5e9bc0e4406e6b1fa00b6d37163d50bb58091e9b976ff1129faa", size = 2404128, upload-time = "2026-04-07T11:13:46.641Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f9/1aeb504cdcfde42881825e9c86f48238d4e01ba8a1530491e82eb17e5689/rapidfuzz-3.14.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:eacb434410b8d9ca99a8d42352ef085cf423e3c76c1f0b86be2fcba3bff2952c", size = 2508455, upload-time = "2026-04-07T11:13:48.726Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8e/b1b5eed8d887a29b0e18fd3222c46ca60fddfb528e7e1c41267ce42d5522/rapidfuzz-3.14.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:649712823f3abcdc48427147a5384fac15623ba435d0013959b52e6462521397", size = 4274060, upload-time = "2026-04-07T11:13:50.805Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/7e5b0353693d4f47b8b0f96e941efc377cfb2034b67ef92d082ac4441a0f/rapidfuzz-3.14.5-cp310-cp310-win32.whl", hash = "sha256:13cb79c23ef5516e4c4e3830877be8b19aa75203636be1163d690d37803f6504", size = 1727457, upload-time = "2026-04-07T11:13:52.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6e/f530a39b946fa71c009bc9c81fdb6b48a77bbc57ee8572ac0302b3bf6308/rapidfuzz-3.14.5-cp310-cp310-win_amd64.whl", hash = "sha256:f2073495a7f9b75e57e600747ac09510d67683fd64d3228e009740b7ef88f9fe", size = 1544657, upload-time = "2026-04-07T11:13:54.952Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/01/02fa075f9f59ff766d374fecbd042b3ac9782dcd5abc52d909a54f587eeb/rapidfuzz-3.14.5-cp310-cp310-win_arm64.whl", hash = "sha256:8166efddea49fdbc61185559f47593239e4794fd7c9044dd5a789d1a90af852d", size = 816587, upload-time = "2026-04-07T11:13:56.418Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f9/3c41a7be8855803f4f6c713b472226a98d31d41869d98f64f4ca790510d6/rapidfuzz-3.14.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e251126d48615e1f02b4a178f2cd0cd4f0332b8a019c01a2e10480f7552554b4", size = 1952372, upload-time = "2026-04-07T11:13:58.32Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/89/c2557e37531d03465193bff0ab9de70b468420a807d71a26a65100635459/rapidfuzz-3.14.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5ab449c9abd0d4e1f8145dce0798a4c822a1a1933d613c764a641bea88b8bdab", size = 1159782, upload-time = "2026-04-07T11:14:00.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b2/ffeeb7eca1a897d51b998f4c0ef0281696c3b06abcca4f88f9def708ffe1/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb2829fedd672dd7107267189dabe2bbe07972801d636014417c6861eb89e358", size = 1383677, upload-time = "2026-04-07T11:14:01.696Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d0/4539e42a2d596e068f7738f279638a4a74edd1fbb6f8594e2458058979c6/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d50e5861872935fece391351cbb5ba21d1bced277cf5e1143d207a0a35f1925", size = 3168906, upload-time = "2026-04-07T11:14:03.29Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1c/3ec897eb9d8b05308aa8ef6ae4ed64b088ad521a3f9d8ff469e7e97bc2b0/rapidfuzz-3.14.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:7092a216728f80c960bd6b3807275d1ee318b168986bd5dc523349581d4890b8", size = 1478176, upload-time = "2026-04-07T11:14:04.94Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ba/970c03a12ce20a5399e22afe9f8932fd4cd1265b8a8461d0e63b00eb4eae/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9669753caef7fdc6529f6adcc5883ed98d65976445d9322e7dbdb6b697feee13", size = 2402441, upload-time = "2026-04-07T11:14:07.228Z" },
+    { url = "https://files.pythonhosted.org/packages/81/93/61d351cae60c1d0e21ba5ff1a1015ad045539ed215da9d6e302204ed887a/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:823b1b9d9230809d8edcc18872770764bfe8ef4357995e16744047c8ccf0e489", size = 2511628, upload-time = "2026-04-07T11:14:09.234Z" },
+    { url = "https://files.pythonhosted.org/packages/87/52/374d2d4f60fd98155142a869323aa221e30868cfa1f15171a0f64070c247/rapidfuzz-3.14.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f0b2af76b7e7060c09e1a0dfa9410eb19369cbe6164509bff2ef94094b54d2b6", size = 4275480, upload-time = "2026-04-07T11:14:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/04/82e7989bc9ec20a15b720a335c5cb6b0724bf6582013898f90a3280cfccd/rapidfuzz-3.14.5-cp311-cp311-win32.whl", hash = "sha256:c5801a89604c65ab4cc9e91b23bc4076d0ca80efd8c976fb63843d7879a85d7f", size = 1725627, upload-time = "2026-04-07T11:14:13.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b5/eca8ac5609bc9bcb02bb6ff87fa5983cc92b8772d66a431556ab8a8c178f/rapidfuzz-3.14.5-cp311-cp311-win_amd64.whl", hash = "sha256:d7ca16637c0ede8243f84074044bd0b2335a0341421f8227c85756de2d18c819", size = 1545977, upload-time = "2026-04-07T11:14:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e1/dbf318de28f65fa2cdd0a9dfbdee380f8199eb83b19259bc4f8592551b4e/rapidfuzz-3.14.5-cp311-cp311-win_arm64.whl", hash = "sha256:8c90cdf8516d9057e502aa6003cea71cf5ec27cc44699ca52412b502a04761bb", size = 816827, upload-time = "2026-04-07T11:14:16.788Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/aa3ffb3355e62e1bf91f6599b3092e866bc88487a07c524004943c7676df/rapidfuzz-3.14.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1a31cc6d7d03e7318a0974c038959c59e19c752b81115f2e9138b3331cd64d45", size = 1943327, upload-time = "2026-04-07T11:15:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e1/c2141f1840a41e07ad2db6f724945f8f8ff3065463899a22939152dd6e09/rapidfuzz-3.14.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0298d357e2bc59d572da4db0bc631009b6f8f6c9bc8c11e99a12b833f16b6575", size = 1161755, upload-time = "2026-04-07T11:15:28.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/07/66e753eeaa353161d1d331b7dd517bb349b0bacfebe8496d7b26be26f81f/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b3dba758661a318995655435c6ab20a04ade79fa51e75bc8dc107cac8df280", size = 1376571, upload-time = "2026-04-07T11:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/85/9535df0b78ba51f478c9ce7eb6d1f85535cc31fe356773b48fd9d3e563ca/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4900143d82071bdda533b00300c40b14b963ff826b3642cc463b6dd0f036585e", size = 3156468, upload-time = "2026-04-07T11:15:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ee/b667eb93bba6dc4e0de658edd778e1619dc4d6aab68fa5e5c7f075152735/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a", size = 1458311, upload-time = "2026-04-07T11:15:35.557Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ce/479074f5624364a48df3403c538797ef22d3ac49c19dc76c3f79fcdcc70c/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419e4397a36e2665ec992d8d64c20ba4b2a42500c76ecadeca78a4f19cb9cc32", size = 2398228, upload-time = "2026-04-07T11:15:37.669Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/a8982f649150fffbdcd6f17565974501f6ab33b2795267bffbd4a7ba905b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:97131ab2be39043054ee28d99e09efe316e6d53449b7e962dfcf3c2de8b2b246", size = 2497226, upload-time = "2026-04-07T11:15:39.857Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/5267c03ef6759831b7d4625a0c9c06e87baa2fae084b61ac9c388858317b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:593c00dac4e30231c35bf3b4f1da8ec0998762e9e94425586a5d636fcd57f9d0", size = 4262283, upload-time = "2026-04-07T11:15:42.279Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c0/2579f343a97f5254c43bb5853baccc01488357dcb64a27bcb869b7888a4a/rapidfuzz-3.14.5-cp314-cp314-win32.whl", hash = "sha256:0084b687b02b4e569b46d8d6d4ad25659528e6081cd6d067ca453a69035f07e4", size = 1744614, upload-time = "2026-04-07T11:15:44.498Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/8edfed1e80119dc9c35b11df4bc701eea85622ad681fff0263b6961d3224/rapidfuzz-3.14.5-cp314-cp314-win_amd64.whl", hash = "sha256:5dfa89d78f22cd773054caff44827b846161a29f2dcf7e78b8f90d086621e502", size = 1588971, upload-time = "2026-04-07T11:15:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/04/5676df93c85cfa57a3045d8047318df9f3cd58c7b8a99340dd95f874795e/rapidfuzz-3.14.5-cp314-cp314-win_arm64.whl", hash = "sha256:67f3f9d2b444268ab53e47d31bab89954888d23c04c6789f2c727e51fe4b1d13", size = 834985, upload-time = "2026-04-07T11:15:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/4a8988cea658fe335048ddef8c876addff1b6daa3c9ca8ad65a5a2196e69/rapidfuzz-3.14.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:77eac0526899b3c3ad1454bb2b03cdb491d67358ec8ef0c9c48bd61b632b431d", size = 1972517, upload-time = "2026-04-07T11:15:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a3/f5cfd9965a9d9a9e32249159797c47b5d6299ea6d1629f9126b25f1c10a3/rapidfuzz-3.14.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b9c6bd754d11f6e78ac54e3d86b4b11dc1ba2f13e5fc958899574532897f5a99", size = 1196056, upload-time = "2026-04-07T11:15:54.292Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/561c2e40cfd10e6630a7b0ac5a2a813aef50d944bcd1f3d260319d659d5b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:738c96944d076deeaff70e92b65696ab4f7ecb8081d7791c5403a3257dfaf8ff", size = 1374732, upload-time = "2026-04-07T11:15:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/39/123bb94fee40e2fb3b7c49b80827c7ef42d838e18def3fc2fef5a3cf817a/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3", size = 3166902, upload-time = "2026-04-07T11:15:58.768Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/45716fafc9fd2e028cf20b5ac5bc704887081cd312f84edb0e325599414b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:af6a90a4ed2a48fa1a2d17e9d824e6c7c950bea5bad0b707c77fd55751e6bfef", size = 1452130, upload-time = "2026-04-07T11:16:01.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/49/4e96c413114398481c0a5b0086af32c364a18613c9a2ea578d17c4bea4ee/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bf5018938208d4597b2e679a4f8cff9fd252f1df53583130ae56281a21801b64", size = 2396308, upload-time = "2026-04-07T11:16:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b7/49fea9fc6878d59bd259d01dd1972d9b86117992b1c66d9b16f0a65273c3/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c0919d1f89ddf91129906705723118ea09754171e4116f5a5dbc667c7bc9b261", size = 2488210, upload-time = "2026-04-07T11:16:05.871Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/44/a1f732b93ffacbdad077b7c801149549b2938e1bece6addb5ad85ed74df8/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93d8da883a35116d6813432177f35e570db5b0a5e30ecb0cbd7cb39c815735df", size = 4270621, upload-time = "2026-04-07T11:16:08.483Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/ff942d19fce5385054650bb71a58495ddda299d94661ccc4e6e7fa44868b/rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279", size = 1803950, upload-time = "2026-04-07T11:16:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0f/9aafc63f9661222b819b391c187eed29fc90ad5935f9690e5ecc2d2047a4/rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66", size = 1632357, upload-time = "2026-04-07T11:16:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/51fc1b0e61e3326e1c68a61cfd0c6b3c34c843681c4b1eefbf0596f59162/rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813", size = 855409, upload-time = "2026-04-07T11:16:15.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ee/e71853bf82846c5c2174b924b71d8e8099fb05ff87c958a720380b434ba3/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:578e6051f6d5e6200c259b47a103cf06bb875ab5814d17333fc0b5c290b22f4c", size = 1888603, upload-time = "2026-04-07T11:16:18.223Z" },
+    { url = "https://files.pythonhosted.org/packages/36/82/40f67b730f32be2ebad9f62add1571c754f52249254b2e88af094b907eee/rapidfuzz-3.14.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fbf1b8bb2695415b347f3727da1addca2acb82c9b97ac86bebf8b1bead1eb12d", size = 1120599, upload-time = "2026-04-07T11:16:20.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/9f/a3635cc4ec8fc6e14b46e7db1f7f8763d8c4bef33dcc124eea2e6cb2c8f3/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f4a8f5cc84c7ad6bffa0e9947b33eb343ad66e6b53e94fe54378a5508c5ed53", size = 1348524, upload-time = "2026-04-07T11:16:23.451Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1b/2b229520f0b48464cfcd7aa758f74551d12c9bc4ab544022a60210aab064/rapidfuzz-3.14.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:97c6d85283629646fa87acc22c66b30ea9d4de7f6fdf887daa2e30fa041829b5", size = 3099302, upload-time = "2026-04-07T11:16:25.858Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b5/363906b1064fc6fe611783a61764927bbd91919aaaabe8cba82151ca93ef/rapidfuzz-3.14.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:dfef96543ced67d9513a422755db422ae1dc34dade0a1485e0b43e7342ed3ebf", size = 1509889, upload-time = "2026-04-07T11:16:28.487Z" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.14.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
+    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
+    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/97/226c43b7b5d957bc3840ed52ea99eed261f99834c4619be7a4742cbaeafa/rapidfuzz-3.14.6.tar.gz", hash = "sha256:e13a8160d017b499ec7a2fa9d0ce1ae2e7377080815785819f966fb235d4eb60", size = 57955060, upload-time = "2026-08-30T21:45:51.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/09/144d6fcd84fadb124d282f727d197a92dc48ae279e80d4b7d23795ba164d/rapidfuzz-3.14.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c0dd0d765184366b6e213a8af3b0b3bb39dad27943bbfb193515d4ff96ac82a", size = 1975267, upload-time = "2026-08-30T21:41:54.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/8f/17985248f0f651a518b543f802fa706b7810cbe96a434a5a9dc24f99b7d2/rapidfuzz-3.14.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0c61cade182f130c9903231946bd1074539121721693a918e7b70382ae802bd8", size = 1246874, upload-time = "2026-08-30T21:41:57.063Z" },
+    { url = "https://files.pythonhosted.org/packages/de/8f/9cf3b552bb84911add3c86e014e8704d20ea4e274295686106dc010356ae/rapidfuzz-3.14.6-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3781cf14f9fc933d7198c2b25a8bbbd1a62b752746d5cd26de14957edc0e802f", size = 1394531, upload-time = "2026-08-30T21:41:58.745Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7f/c4824d855cb1f89f8db0802b7ae22705187be55e0ab2f9873b574a0a6713/rapidfuzz-3.14.6-cp311-cp311-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:71a5bbfd00da1963f27dd1432068929694cf0e00007ae2b9c1ad2a187ec29a16", size = 1702106, upload-time = "2026-08-30T21:42:00.398Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ff/556d3aefbd1f115fcda6bdf3ea578405fcaa44c233b525fda583943f3692/rapidfuzz-3.14.6-cp311-cp311-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:eabaf06ca4896c59cfd9162480f0d37a15a2304ce2efe83ae2bbcfa1cf13534e", size = 2735203, upload-time = "2026-08-30T21:42:02.115Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ae/a781ec62825990319483c82ef962b509e9ce22a67a9f97d63d70b2b175b9/rapidfuzz-3.14.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d5d90bae3c6fb7ea34da968c9f23070e8440edb827a28b242580e0108110b14", size = 3180952, upload-time = "2026-08-30T21:42:03.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cc/a8cdeaa64db2e914f3475551b19ea2a6187b5458b50eac707e10f1bcf9d7/rapidfuzz-3.14.6-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:d6b58daadbe6974884ec39aee30cfb8bd2e126f8d03503f0069f70d5e84656a3", size = 1485205, upload-time = "2026-08-30T21:42:05.659Z" },
+    { url = "https://files.pythonhosted.org/packages/09/4e/6394e8d79088124bf39a8103ac2ae166a3f62ffc67b51c4e869dfe38b6d1/rapidfuzz-3.14.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ab4386ef7c2cb3e5eb46e815be49715dfcd301bb9f0a431f18da7aa0007de54f", size = 2415347, upload-time = "2026-08-30T21:42:07.847Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2e/92acf13a03c45884aabe9d637c620f5b7806e56bd6f6f8d8016f95614722/rapidfuzz-3.14.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:33a2f7faedaa3608c4876c41b448fc786d54e6cd7c6e732f7de466319b5a73c2", size = 2819438, upload-time = "2026-08-30T21:42:09.788Z" },
+    { url = "https://files.pythonhosted.org/packages/95/54/3ed4286d9ebf0b623b021970a46d7befa053dd09c85cd213bfb2ad2a0bbc/rapidfuzz-3.14.6-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:adb160a100f6122aa45c78d686e198da3f9e815d4182e0c4fe730608479f7f9c", size = 2521065, upload-time = "2026-08-30T21:42:11.923Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ff/ae8ecf60ce25eab3accfe5a0c9ba6499b02c5e2ab03ee9defdf5475eb4e7/rapidfuzz-3.14.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:ad60297c001d15af24338440bca85dfee8710e9e3222733c906b33e89d986166", size = 3319384, upload-time = "2026-08-30T21:42:14.191Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/1d/d39dfc6cdc5c1d0452d4af563c678f2d5821f0df306bc3ab9502f3555690/rapidfuzz-3.14.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3d5b1cfa67bbe6239a643bca1d986f8a07e0a045286c674946e1648c132baa46", size = 4297470, upload-time = "2026-08-30T21:42:16.667Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f6/0a64983c5cf5b2ce8cf2ce4fc54ecd6b5ee6cd6a3af8b870657f28e31a07/rapidfuzz-3.14.6-cp311-cp311-win32.whl", hash = "sha256:46ddb42af4cad3ac9d5e0c97ee1e687500c529a1ad5cbf9c949ce35f6edd4537", size = 1902086, upload-time = "2026-08-30T21:42:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/41/72/638db21d63041ba17c4ed482a8cd1fe6dc4d90bc84b2a28aaccc2611ff84/rapidfuzz-3.14.6-cp311-cp311-win_amd64.whl", hash = "sha256:737a57cbca3e5c16decac86e205727bcd4b99c52f77c48bb44123078c5cd9a7a", size = 1738042, upload-time = "2026-08-30T21:42:20.427Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f7/d0fb82451c1f0c701a742939120b32a092ac64bbacf8bf8fa21d61fc89e7/rapidfuzz-3.14.6-cp311-cp311-win_arm64.whl", hash = "sha256:19c1cda8198cc57ffd4ff69a1c02cbe4297e9ca7b506bca03ec584da0a9fe1ff", size = 1190829, upload-time = "2026-08-30T21:42:22.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/5a7646b185a61400220e4783d23461c1e864a9ee82ba443b18c218e2364b/rapidfuzz-3.14.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b46cecf27025e7a934332ade033e6a394da8a493f19fa1d835e3b2968a4ff7da", size = 1965178, upload-time = "2026-08-30T21:42:24.164Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/72/10fc4e414eeed7963e2f1c315c731cb68196f0478cb244c78a21f5ce8662/rapidfuzz-3.14.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1901414b135afb1a7f4b1ef940b95523b49cc5642aecf02af740f37567e98137", size = 1248230, upload-time = "2026-08-30T21:42:26.088Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e9/0794043c1a0af09cacdbb6a9e8b9b2079cdf73337e7c29b4a9f117415bb9/rapidfuzz-3.14.6-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96a548979cd939b2c69358a0f5088a408524fbf7454f04bf90939fa971e64310", size = 1380396, upload-time = "2026-08-30T21:42:27.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/73/9218cf4424ab86260ee88ebdb612c5ed4d9bfd6b6d1e2f3c3bf4599d13bf/rapidfuzz-3.14.6-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b22ef7e5e2341efc6216b666491022027b984e5aef93446064742f43f3c1d926", size = 1674037, upload-time = "2026-08-30T21:42:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/f5/bad528b6dfc608a48838508f270c79332ab05592703c9a46504ba95e9eab/rapidfuzz-3.14.6-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f0d2d95c787d812b9106cfbcb94ad37a49f59df9287e00a75eb61afc246e8759", size = 2722897, upload-time = "2026-08-30T21:42:31.737Z" },
+    { url = "https://files.pythonhosted.org/packages/13/da/49ab137f788a0e03e872d4c6b3d5c9c6c6bed4e4ccea381f69c4d186341b/rapidfuzz-3.14.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0debb5f43662ea84d2f0228a0c7407ff647f9c3d13f3b692efff0cde46eebce0", size = 3168023, upload-time = "2026-08-30T21:42:33.663Z" },
+    { url = "https://files.pythonhosted.org/packages/59/33/81ca664a15194b8b4a7e863b534e36c057724f9709c7781e9400d0edf024/rapidfuzz-3.14.6-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1d253e1fe44648242a0029b42ba23adf238ed2a7eb3d8ed0a03731a23f074ae0", size = 1474666, upload-time = "2026-08-30T21:42:35.5Z" },
+    { url = "https://files.pythonhosted.org/packages/87/eb/b16f9f8cc255c8dc7c0d7712aa7e7c12a6fd85c8b2b56665f2a24222a941/rapidfuzz-3.14.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e06c6050c9bf6cd72305e3e6a293918b2b92cf2a067007585a53898624902e3c", size = 2402289, upload-time = "2026-08-30T21:42:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/73/eaa1ca89f6ab12c0fe7f943226ce4ad1d2c67eb281dfd706279771fcff5a/rapidfuzz-3.14.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d85a6e9180e53cde95c95dfeb05a2ac94ead4d9d803a8fd186d2719a678b8483", size = 2788332, upload-time = "2026-08-30T21:42:39.412Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ad/db927fbe23f621dd292a6332a19822703084617c0281a88156a8c138d4e0/rapidfuzz-3.14.6-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:35db2670f69fa3a4eb4741055581477ff92f2cf39e7e06f43ebcb97c2192fe7c", size = 2510540, upload-time = "2026-08-30T21:42:41.629Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b2/8e9012968fab837babe1292edcbe1c972605f5b3af19c7fcac2ded731d39/rapidfuzz-3.14.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:f9d93e5424d1e4c103b57906b8beba270e680afda3ffdff7ea3bc6173b37083c", size = 3299876, upload-time = "2026-08-30T21:42:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/19/99/799ce99328ea97fe5d7510048ffea148b8ad4a838366f908691be52342a5/rapidfuzz-3.14.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f9b0a501f37fb852c54469375baa25874246b3bbc8b6e21fb4cd186a32335868", size = 4277032, upload-time = "2026-08-30T21:42:46.08Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8a/995b4746c5bc1f561e64de1fa546927183fec7a369fe988716ef394a6d0a/rapidfuzz-3.14.6-cp312-cp312-win32.whl", hash = "sha256:9e974251a9833791bc557b46f975676a56c2d58946f795cd2964b095496dfdcc", size = 1887051, upload-time = "2026-08-30T21:42:48.265Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c4/12f01df5778227c8655fcd9b429fc001d43270f5d8d154edc9066bab1de3/rapidfuzz-3.14.6-cp312-cp312-win_amd64.whl", hash = "sha256:cfca36e4612208875e08611a779164b6cb8900ab8bbd3d82d4cfdfae9efbfac9", size = 1731992, upload-time = "2026-08-30T21:42:50.211Z" },
+    { url = "https://files.pythonhosted.org/packages/19/8d/92217f0bc81ec458b4134ad53714b1be0cd3be21494227d73510b06467d6/rapidfuzz-3.14.6-cp312-cp312-win_arm64.whl", hash = "sha256:96bbd5a1c67d135334d02fae74f1d933fdda204ea03d544a59dab6b1cbfbf565", size = 1186693, upload-time = "2026-08-30T21:42:52.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ad/4901a37256bc5027f3873ebd538b851349d7627d8aa2e91743c79b500f48/rapidfuzz-3.14.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:55dc9a55924b4ecfcf4a60a701bcfae7d9daf0129c41dc16139270d75be0996c", size = 1961301, upload-time = "2026-08-30T21:42:54.46Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d3/5a56e26db79c00191bc7c5387a04dfa5b6326c2c81c468a976ee2aa8fa15/rapidfuzz-3.14.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bba0e9fad4dbea80227cde9cef3aaa984a934a84aec5f7505532e19838b14769", size = 1244370, upload-time = "2026-08-30T21:42:56.425Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/12/0958686418e596961642c41e9162906363649e70f6a12cfcff212f77ccb3/rapidfuzz-3.14.6-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b34b7ee4f4f760690d6477163aabbec05705b5dd764cb6c3a6ba95aa1fffc42", size = 1377336, upload-time = "2026-08-30T21:42:58.687Z" },
+    { url = "https://files.pythonhosted.org/packages/60/09/a0a70c35996fa5225c8cddca38e2e594c82518aeefa08edb5d875ce0d82b/rapidfuzz-3.14.6-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:abe92a70134c8b40790bb5c78b2a0a790686c26e83b6e99a456127ca141fe06a", size = 1670277, upload-time = "2026-08-30T21:43:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d7/b9deea614b32e933e37d77eecf539ffe2b41c0a922a6fd759993865e7ee5/rapidfuzz-3.14.6-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:659b41570fcc6e02631ac361c47cc8db9ad26d740e4be2177df1b63005a49174", size = 2722260, upload-time = "2026-08-30T21:43:02.655Z" },
+    { url = "https://files.pythonhosted.org/packages/70/42/4bf9dc905df33bb4515895ff87f777d8df25a3617c0bf8f5d4716813d9ea/rapidfuzz-3.14.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6bb896f89a387219c671ebc33c4a636b222010cc3c5c83884a7fc8707bf0bbf9", size = 3165730, upload-time = "2026-08-30T21:43:04.632Z" },
+    { url = "https://files.pythonhosted.org/packages/25/76/454acc3abfa6b958511d6e761f5a95e6c3128936a1eed4f23643c3267d8b/rapidfuzz-3.14.6-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:11d76bb2b2cd038df708ae18f521fb3a50af477cc5a0dffce812da43a2f1beb3", size = 1469515, upload-time = "2026-08-30T21:43:06.612Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f9/29b0f0d7764423573d35db4970dd573b324f4d41abe74d48adca542bcf79/rapidfuzz-3.14.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:28e9ce91bd41a8203185887ef9b1541a891aa61c5c1cb2e46f1689cd4288d372", size = 2401073, upload-time = "2026-08-30T21:43:08.742Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f7/86ac824a7dd2b58729187cc31edebfa7805418f66d97d625010b7383d1de/rapidfuzz-3.14.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:864658e5a10d249a2277374e800f944fe990346d70eea6f3a51b712b6dd01984", size = 2786567, upload-time = "2026-08-30T21:43:11.048Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a6/39fc42e45eb8ee70304862523b2e55cfbd2561c560dd8da1071015fa0ff0/rapidfuzz-3.14.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:3c2444f5cd757ded2c3ba8b1734253b801b9b2ba9ecb3ee40cd505cebbfa7341", size = 2504907, upload-time = "2026-08-30T21:43:13.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ea/61f25272239ffef036eb3de1cc63372dfbff27193ca6f9f259d844f41a9c/rapidfuzz-3.14.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2cc9b5dde0ac89f7856f997ef917cac8e18e9dea473e9b3090a84bd600de6a91", size = 3298728, upload-time = "2026-08-30T21:43:15.518Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/02/f9bfff9e19e852b097afa837a8000592bcd714fe80827a76367b958771b8/rapidfuzz-3.14.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:faebff9b9a287fb673f9a66465a7e03043601c9bfe5e71c3f91b3f2e7b8a37f6", size = 4272030, upload-time = "2026-08-30T21:43:17.785Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d4/5845698661cb23bc7935536c28f5b86b2b3606de1f54722c1cfac39f170a/rapidfuzz-3.14.6-cp313-cp313-win32.whl", hash = "sha256:4406b2517b85febcf9419f8fbcdfbd534872ea32608050f9562224933ca49a4c", size = 1886313, upload-time = "2026-08-30T21:43:20.173Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f1/5b7c56737b9e5af7523ea79e90df732e9e4b2fa66fe2b333ee013ea6e541/rapidfuzz-3.14.6-cp313-cp313-win_amd64.whl", hash = "sha256:c69fb0e064d10c79908dcda76d7ca8ecdf8393a39acbb74dbad3f709f2c60e95", size = 1728638, upload-time = "2026-08-30T21:43:22.169Z" },
+    { url = "https://files.pythonhosted.org/packages/05/5e/fc1da16b7f5245a7cc61dc08f70391ddaa1c538be1cf92681e7c763b77a4/rapidfuzz-3.14.6-cp313-cp313-win_arm64.whl", hash = "sha256:a0c8bef04f6b1d9fdbb319576350af53151a64692d477db7d4844c220bc8e212", size = 1185777, upload-time = "2026-08-30T21:43:24.27Z" },
+    { url = "https://files.pythonhosted.org/packages/67/9e/8f862d2c8d80ee02633f1c9ce3e5121ce955e61efae24a61a05dd8a55fef/rapidfuzz-3.14.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0f8d6718e7edacdb16455c0472e7552fd518decb91e91250c58784fd6163f54f", size = 1964420, upload-time = "2026-08-30T21:43:26.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/28/282e8c76b7dcc91e8f5aa1a594168d2136639f29dfda11384c6d36aabca0/rapidfuzz-3.14.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8fa7d45388dec34a86038f2a38380f4922b74b5dd8991247f629a531178db10f", size = 1246072, upload-time = "2026-08-30T21:43:28.475Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ae/8e0f714c55180667d66346e46a3d680dd9809bcee1c5f03557a58b4f2ef6/rapidfuzz-3.14.6-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:760ee152af5e8b4d241a469f933ba2d7215248618ae19770fec7d80d9e149db6", size = 1381829, upload-time = "2026-08-30T21:43:30.67Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9a/4a106d68033a81c24ab71129e3016cc6a27a668f30f436e729cae79048e5/rapidfuzz-3.14.6-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dbe3378db3ae0453accf6196e2ed943f43d416cfacdcb8883db105bc14a0130f", size = 1676195, upload-time = "2026-08-30T21:43:32.862Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f0/b456a74d8e33051b76b3f156cf4d55f717614d68b44b6312ae1f5d85b31d/rapidfuzz-3.14.6-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ddb0ddf3ee616fdc066add4ef05639c5cf59b58d83779b6023488e5435f6191", size = 2714364, upload-time = "2026-08-30T21:43:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/56/1203b46cedefc3f0c16e10d87123fdd4ec0f2e209f65cd2bf221ec669217/rapidfuzz-3.14.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:08bc63b88048376114d1e66cf8fa6926495d03bb873eb87854fa74cf6848a70b", size = 3167618, upload-time = "2026-08-30T21:43:37.625Z" },
+    { url = "https://files.pythonhosted.org/packages/57/17/fa4a0853979b885ff27488d9b80e7c5c985dfed74c5021ea95a3b54ddfad/rapidfuzz-3.14.6-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:50cd6718bcda7ec5293635a9d0b3fb5906251013d3b99ca403ba9dfa8965f661", size = 1471360, upload-time = "2026-08-30T21:43:39.852Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f2/757615ab88f7922b4477f9c93356c4512d744ea042e3e2b41554aab5ec1e/rapidfuzz-3.14.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:63b0e84faec3c5706cae8ae51246ff103407d54efa32a615a548b7b67392ebcf", size = 2403946, upload-time = "2026-08-30T21:43:42.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c3/1c2670ff528f7e625d7b552e7ebccd5c4dfdcb84dc08ee85d1bcc0cf1465/rapidfuzz-3.14.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9080a730fdcf3cb8a07464c90f9cf40c1b4ffc73a8375b56a8898aba619dda30", size = 2793123, upload-time = "2026-08-30T21:43:44.438Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/92/a01444687bb9a5a2679aa71325c227760e9c475cd02054b45fd8b219cb0c/rapidfuzz-3.14.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:178557c7a50c8c8d65369ede7f3d845bf23590a951c9a368caf166b105d58cf3", size = 2507361, upload-time = "2026-08-30T21:43:46.568Z" },
+    { url = "https://files.pythonhosted.org/packages/98/90/43d80ba73fd297c744f7fe0a949af2a610b4b9be96688799c3e73d002b13/rapidfuzz-3.14.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:44f1cddbc2010700e2d88063d0ab64183efe2578d9b52770ce1cd283dda230c5", size = 3304287, upload-time = "2026-08-30T21:43:48.966Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e9/fd9a160699b72b6857551642fe109a1d0a86b06b7ecc0d2b4bbecbc6b61b/rapidfuzz-3.14.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:17081a0e904c12bb4ed49619a2bbb6528f6af00fe850e7ace22487bfd2aea455", size = 4273338, upload-time = "2026-08-30T21:43:51.574Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/72/3bc42217fadd07ea0ff9d249cc8001d6f285197c253db95d3a03aac8c254/rapidfuzz-3.14.6-cp314-cp314-win32.whl", hash = "sha256:9e00c8c9500aacbc0c52b66369f54533ecbdcb92e5aa87e160fc8e293000a696", size = 1927357, upload-time = "2026-08-30T21:43:53.851Z" },
+    { url = "https://files.pythonhosted.org/packages/57/8d/3ea3bf93a2f22858e1b1298126db35cbf58592d05571ca757f2f16071b17/rapidfuzz-3.14.6-cp314-cp314-win_amd64.whl", hash = "sha256:41ee893c4d7d0fb1844f6cad966540a833784b3bad2c239a0d80195d9231cef4", size = 1783090, upload-time = "2026-08-30T21:43:56.202Z" },
+    { url = "https://files.pythonhosted.org/packages/13/17/4add9d94236b37b6f857a3bf34d696b32304e3debc6830584fda95413ac6/rapidfuzz-3.14.6-cp314-cp314-win_arm64.whl", hash = "sha256:10576c39fe6a49fad0bf1069371a77300ce166a3f36d2900d2d0bae08f297104", size = 1221915, upload-time = "2026-08-30T21:43:58.335Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a4/af0509bffac37645841e2a6b55a4c6c46f7b2fc0757610b0cba0cbcfa900/rapidfuzz-3.14.6-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1b0a9546a7328d3cfc2f1385501db7c4c374fb566dc1a3b22ad56092846c0134", size = 1994141, upload-time = "2026-08-30T21:44:00.931Z" },
+    { url = "https://files.pythonhosted.org/packages/67/da/d46da45e393937509111d4affa4db794fb064341735cfdcffe1f5f13a78a/rapidfuzz-3.14.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9989280902b9c4ecf7de95fbb906e94df0d8c047290ed315c7aa1760cec9b3de", size = 1279969, upload-time = "2026-08-30T21:44:03.253Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/8a/1db5582d5c9684c57b1e292dc88d70177233b570e684fe30736140697658/rapidfuzz-3.14.6-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc166efa4ca2fc9cc52e43784a54cbea95fc0e03e533f8266ef66b1c04c7cb76", size = 1381099, upload-time = "2026-08-30T21:44:05.402Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/a9dba69d174b4436c115fcd877a67745d355a859109e0f59955c14577519/rapidfuzz-3.14.6-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:32352a3ed1aad9c097d31fd4f2eece3030169e2de3dedde7a2fadc2652b768ad", size = 1638869, upload-time = "2026-08-30T21:44:07.51Z" },
+    { url = "https://files.pythonhosted.org/packages/61/34/67915218f5f84ec2cda57560d81425929b8ea97956eb31283bf95768fefc/rapidfuzz-3.14.6-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ecb45d616002751b58914d5b7c2e66acd39e12242be12717a1258148a1b36526", size = 2687831, upload-time = "2026-08-30T21:44:09.709Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/80/07985e10b534dbdd48df0ddf2e42f9d27cf98dc44e09fe047fc4b38471f5/rapidfuzz-3.14.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f9ad513e3a3e045b60b421d5cd3887ae0a33b38fc6c6db3ea5e27c0a2e0412c", size = 3185373, upload-time = "2026-08-30T21:44:12.162Z" },
+    { url = "https://files.pythonhosted.org/packages/91/09/db64291ce5f11c0f79486b435b49f5dc66680f605077cb011d282bf767b4/rapidfuzz-3.14.6-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:f35723caef8cc31b6f34209708fb172fc88bab0077c12e9b36bbb829baaf1b16", size = 1459628, upload-time = "2026-08-30T21:44:14.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/7eeaf6f7f42d4ec8b90db54c73f7c2a727e208b4db6fd5ea807e87133b9c/rapidfuzz-3.14.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:408b2e8e8c1ac71b57f0923cf964d6932539725e07b69e70ec66f22c4a403891", size = 2407348, upload-time = "2026-08-30T21:44:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/db04caff7bf26718e97592f8cc007988ef18eb088ebb0742addcb25f0819/rapidfuzz-3.14.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5667c56fdc902fa1e12449b5c042e8b1c7e9b30040db20c396fbdb3d0a750866", size = 2758630, upload-time = "2026-08-30T21:44:19.196Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/26/962fc396a56ec37146eb5331e55ae53d19dc564fd921f49a6d524c83ee05/rapidfuzz-3.14.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:76a122fc573df603deb5fb827df31bb5efbd0826b50bb7aeca8535a6e8c70cf9", size = 2494519, upload-time = "2026-08-30T21:44:21.687Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0f/d2067e23d9b7fb2aeb70a6b36173f0b2376635483f670aa5c47f17e55135/rapidfuzz-3.14.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:e221366e24709b9d41d5f9cc99053b04cfc575d429e956a82cfbc4c4e9e8860a", size = 3262241, upload-time = "2026-08-30T21:44:24.218Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/bd/05e48e21b1dd722b41c0cb8ab8867996f6e0c0a1b46e42921ace09799b0c/rapidfuzz-3.14.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:36710ff214b7a8049d26a9c81d99948026593cacb47663742c4119072b651ecd", size = 4296246, upload-time = "2026-08-30T21:44:26.911Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ce/f4b355f05b17bdb3a56f1c5e9bd864965dbb810f93d1b5d6044ecfcbd42d/rapidfuzz-3.14.6-cp314-cp314t-win32.whl", hash = "sha256:66ece6f5e2586c742fc3e0b8487e06783d27c6c24adcdcfdd7f306afbd8b5737", size = 1977694, upload-time = "2026-08-30T21:44:29.431Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/15/d2c20c57b357ec4157e74a197b3f622dbda0b2a82d1fc708ed7b262758f9/rapidfuzz-3.14.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cab4a932cec02d09471e2c9f1434049ef5bfe1f6e646ff10939c222dc610ad60", size = 1827262, upload-time = "2026-08-30T21:44:31.683Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e5/c38c19fbc1de82980e05bd3adbe1dc7f3dd0680e38e868646082317572d6/rapidfuzz-3.14.6-cp314-cp314t-win_arm64.whl", hash = "sha256:b056ce19eaea2ea70c6a6fb387a605ca2af8979de5b9d507597e8012820ddb14", size = 1245604, upload-time = "2026-08-30T21:44:34.066Z" },
+    { url = "https://files.pythonhosted.org/packages/08/9a/7d4949406e2d391e160ead12036bba05e7c90e09bba77a782d33e7e6a1b0/rapidfuzz-3.14.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0844066900cdc9909ce4ab4fb5ba1d8e0c021252d770f2ea476f3443df1d22ef", size = 1912210, upload-time = "2026-08-30T21:45:33.653Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/00/a1a077f5cf90c9fa13b28c721f931529ad02748d418d7750590a388832a9/rapidfuzz-3.14.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:1398bd2c197b79bfc40b615999fd3599dc60265fdd5b59edc18156ae048c4cde", size = 1209219, upload-time = "2026-08-30T21:45:36.035Z" },
+    { url = "https://files.pythonhosted.org/packages/48/69/a573c2e5e1b1a4f19e98a8fb3f6a792a44f5b8a067895a2654890ffd35a4/rapidfuzz-3.14.6-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2fc748d1fde4109e5d0dab27f1e61f53b3136a235dfee5a4fb579da44808b6a", size = 1361237, upload-time = "2026-08-30T21:45:38.582Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0b/375ebdfc4ca149e23793bb6b72461954ec64d0acbb826030787e88b90ff3/rapidfuzz-3.14.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b42536675c930cb76b7998bfc4d8e59cb35d8df47f2103020265743b6b2ccd2a", size = 3136631, upload-time = "2026-08-30T21:45:41.426Z" },
+    { url = "https://files.pythonhosted.org/packages/55/56/799accc99532ecaaa2c1d04c7e594d6bb8f1afdddc327389c61196741cb8/rapidfuzz-3.14.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:1e6911e3a14971719ddc35af98f181d2e5369ab273a5a3488ab7685d23c31ad5", size = 1722739, upload-time = "2026-08-30T21:45:44.301Z" },
+]
+
+[[package]]
 name = "redshift-connector"
-version = "2.0.917"
+version = "2.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4", marker = "python_full_version < '3.14'" },
@@ -8946,12 +9155,13 @@ dependencies = [
     { name = "lxml", marker = "python_full_version < '3.14'" },
     { name = "packaging", marker = "python_full_version < '3.14'" },
     { name = "pytz", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version == '3.13.*'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "scramp", marker = "python_full_version < '3.14'" },
     { name = "setuptools", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/70/878c4250a0016c280dc3afe8c0e6ab1336dac6a1ce3fc4a2683512703630/redshift_connector-2.0.917-py3-none-any.whl", hash = "sha256:291b1476acd7e035e98fcd8667c91a8281bf7deed898195eb4dea077bac2d884", size = 124171, upload-time = "2023-11-20T18:09:55.691Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/192a7bf58577dca8fb4e2e40130aacdf9a9e9d6ec5af0c5b150596704013/redshift_connector-2.1.11-py3-none-any.whl", hash = "sha256:25e03ec006e43ef809c5ceb42344ce9f8b6c6c5dd5ee594a8f2848171689bec0", size = 152834, upload-time = "2026-01-27T06:26:29.84Z" },
 ]
 
 [[package]]
@@ -9094,11 +9304,19 @@ wheels = [
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
+    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
+    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
+]
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "charset-normalizer", marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "idna", marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "urllib3", marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -9106,11 +9324,33 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
+    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
+    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
+]
+dependencies = [
+    { name = "certifi", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "charset-normalizer", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "idna", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "urllib3", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "requests-mock"
 version = "1.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
 wheels = [
@@ -9123,7 +9363,8 @@ version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "oauthlib" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
@@ -9135,7 +9376,8 @@ name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests", marker = "python_full_version < '3.13'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
@@ -9447,18 +9689,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/6f/93831a3bfe789542ed0c1d0d74b78b440f055d6dc3ea4640eba2d95e6e23/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c74005a7bb87752acf351c93897ec63ad77a07a0da7ecad9c050e32e7286ba34", size = 557243, upload-time = "2026-05-28T12:02:08.013Z" },
     { url = "https://files.pythonhosted.org/packages/1f/ff/0b3d604614ffc77522c6b288fdbce68957eb583da1002aa65ba38ac0ee40/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8213afbe8a3a906fb9acb2014423fe3359ee783d0bf90995f70623a3217bfa6c", size = 623541, upload-time = "2026-05-28T12:02:09.661Z" },
     { url = "https://files.pythonhosted.org/packages/ea/ea/e7b0251441da9adfeaebcf29601d10f2a1455fcf0772fae9e7e19032bd96/rpds_py-2026.5.1-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8c43a8a973270fd173bf48cdf80bbe66312421cba68d40845034f174f2389049", size = 586326, upload-time = "2026-05-28T12:02:11.47Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1", marker = "python_full_version < '3.14'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
@@ -9809,7 +10039,8 @@ dependencies = [
     { name = "pyjwt", marker = "python_full_version < '3.14'" },
     { name = "pyopenssl", version = "25.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pytz", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version == '3.13.*'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "sortedcontainers", marker = "python_full_version < '3.14'" },
     { name = "tomlkit", marker = "python_full_version < '3.14'" },
     { name = "typing-extensions", marker = "python_full_version < '3.14'" },
@@ -9865,7 +10096,7 @@ dependencies = [
     { name = "pyjwt", marker = "python_full_version >= '3.14'" },
     { name = "pyopenssl", version = "26.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pytz", marker = "python_full_version >= '3.14'" },
-    { name = "requests", marker = "python_full_version >= '3.14'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "sortedcontainers", marker = "python_full_version >= '3.14'" },
     { name = "tomlkit", marker = "python_full_version >= '3.14'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
@@ -9909,8 +10140,9 @@ name = "snowplow-tracker"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests", marker = "python_full_version >= '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/77/1ab6e5bafb9c80d8128f065a355377a04ac5b3c38eb719d920a9909d346e/snowplow_tracker-1.1.0.tar.gz", hash = "sha256:95d8fdc8bd542fd12a0b9a076852239cbaf0599eda8721deaf5f93f7138fe755", size = 34135, upload-time = "2025-02-21T10:58:48.112Z" }
 wheels = [
@@ -9994,8 +10226,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "appdirs" },
     { name = "chardet" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click" },
     { name = "colorama" },
     { name = "diff-cover" },
     { name = "jinja2" },
@@ -10024,31 +10255,8 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "python_full_version < '3.11' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version == '3.13.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.13.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.12.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.12.*' and sys_platform == 'emscripten')",
-    "(python_full_version == '3.11.*' and platform_python_implementation == 'PyPy') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
-    "(python_full_version < '3.11' and platform_python_implementation == 'PyPy') or (python_full_version < '3.11' and sys_platform == 'emscripten')",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
-]
-
-[[package]]
-name = "sqlparse"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten'",
-    "(python_full_version >= '3.14' and platform_python_implementation == 'PyPy') or (python_full_version >= '3.14' and sys_platform == 'emscripten')",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
@@ -10113,8 +10321,7 @@ dependencies = [
     { name = "altair" },
     { name = "blinker" },
     { name = "cachetools" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click" },
     { name = "gitpython" },
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version == '3.13.*'" },
@@ -10123,11 +10330,11 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow", version = "11.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
     { name = "pyarrow" },
     { name = "pydeck" },
-    { name = "requests" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "tenacity" },
     { name = "toml" },
     { name = "tornado" },
@@ -10213,6 +10420,61 @@ name = "thrift"
 version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/c2/db648cc10dd7d15560f2eafd92a27cd280811924696e0b4a87175fb28c94/thrift-0.22.0.tar.gz", hash = "sha256:42e8276afbd5f54fe1d364858b6877bc5e5a4a5ed69f6a005b94ca4918fe1466", size = 62303, upload-time = "2025-05-23T20:49:33.309Z" }
+
+[[package]]
+name = "tiktoken"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/62/167a842aa0429d45f5e797354fd4343a96f6043d67d0513c675c7b8d36e6/tiktoken-0.14.0.tar.gz", hash = "sha256:231dec90efcdccf1b565a1416107736f1e09b1a08fe736ef9d6363e626d03874", size = 38898, upload-time = "2026-08-17T19:49:49.514Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/82/d60a7a5d7bff7b4641d556ea68ea5914ea6edc3774a12eb1c0d444701382/tiktoken-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3b12e54f8bec91433e41aff65d8d1f209a4f678081163747079806e5361f6c91", size = 1095817, upload-time = "2026-08-17T19:48:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/d39ae33d3dc30a0c229ff0cb683df961ebb5e7b8691feb2d08b3ee6ac327/tiktoken-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:94f77b60a8ab23580db19ae822744c9716c1720020d2179ca5605112d12326f1", size = 1043064, upload-time = "2026-08-17T19:48:33.138Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e9/8e18cbee0c3ae8321c7e9696bef6090a24eed99a4a75a4c4a7f5115e5a2f/tiktoken-0.14.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f3d6cf93fbe2e7117eb7bedca684216fbe328a41f0843ce34245451d8eb2df1c", size = 1190381, upload-time = "2026-08-17T19:48:34.386Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c8/051e7b72a816ff50eb34a1c7c5b185cd2429ffdf59a497baea35b2b6b2dd/tiktoken-0.14.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:18a1b651c4b032004bf7b4f1713391a54b2a341a52c6e8a2b59acae9d16e13c7", size = 1206869, upload-time = "2026-08-17T19:48:35.581Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b3/7795db206adb6a57d6137fe48ef2cca6b9707e90b86ee8244671592ddc33/tiktoken-0.14.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4d8d91d68353bd167fdf26467e5ff9e56aaa5f87d6410c0238608629e4dc0d33", size = 1255197, upload-time = "2026-08-17T19:48:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/39/5234783af6b81af645ccdf9438f2f02af472f14e91d876ca2079af641841/tiktoken-0.14.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:10f31e63e40313f2e518d87f7086cfa44e45f64cc14d8ae14103b41220c30a14", size = 1319329, upload-time = "2026-08-17T19:48:37.944Z" },
+    { url = "https://files.pythonhosted.org/packages/88/cf/f2d955c8c5c6c67cc86ba6fb132c47c710465ebe6a6dcec1c3b6e250660e/tiktoken-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:c6cb9896a82b9ee44e15ba0b5c8044072f2e4d48acaa704c8d3feeef5ad9487c", size = 944146, upload-time = "2026-08-17T19:48:39.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c5/9d848b7f408241171e1f843deb8bfa626086452bc9c78beee500829583e3/tiktoken-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:c2edf09b381fafbc014ae8e018ed25087abb9a3dafa8465a0ea63c6558c47a79", size = 1094971, upload-time = "2026-08-17T19:48:40.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/a9/d94302340304328961d6f0c35ca4e60617fbb57a5cf667e2ed1692cb9e57/tiktoken-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cd8ca1305c1c902fe42c486165f2e4808d9997625c98ffb05b9e0366d99d3948", size = 1042916, upload-time = "2026-08-17T19:48:41.541Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b6/31da98ee871383509cae2ba96a9ddef1965e3c4f8cb6dc7bcda3379398db/tiktoken-0.14.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1f83081065ee5833d35b49e9180f3d8d15622a603dd1c435da0da6cc12b3662f", size = 1188650, upload-time = "2026-08-17T19:48:42.729Z" },
+    { url = "https://files.pythonhosted.org/packages/24/65/8c5dddd7cb67f6571d154a58d7c6e2f07da54bf84c49b6a1839965b7c35e/tiktoken-0.14.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f5e7665f6624e052e5e7f6a36919ab69279decdc976d7b16b4fa15e1897d0513", size = 1206378, upload-time = "2026-08-17T19:48:44.013Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/04/522ec59d30dd9a2f3ab837011cd4fc5d1178dc4a2fa07c9fa4b90af6ba9d/tiktoken-0.14.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:144a3fc369f92b7d548995217c5d6e84038d3572157a0f6f34080d65291d0f78", size = 1253694, upload-time = "2026-08-17T19:48:45.597Z" },
+    { url = "https://files.pythonhosted.org/packages/69/84/9019e272bad188a1c61ecf44f25a9ba2368744644e3ac1f3d6516f3c9e80/tiktoken-0.14.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:151d37a150c8f3dfc5f4345597b10e101876bd1bd13494e0185af6b508758d2e", size = 1317873, upload-time = "2026-08-17T19:48:46.792Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7f/fff1217240343c0c11b5938b98aeae0e3a266cacfac25f86f91cdcd748f0/tiktoken-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:c77d4a3e1deb2707819df92046b89aad1ac81d27e07616b797cbff3f62c037da", size = 944395, upload-time = "2026-08-17T19:48:48.028Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/da/e273746b9d24a63c776bc60fba914351573ad9c575b52601eb5e60632564/tiktoken-0.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8e947aefe98ef74cce94923f90e48c98fe34eb1ec0a6bfdfadfc5a96359bfc36", size = 1094408, upload-time = "2026-08-17T19:48:49.269Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9f/fe6b1aca23331aa5271df5a4bd07bf68a7059254d47faee1b8272592a777/tiktoken-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d6cebe67765569df3dafac8474e4eccf5c19d24140492567a5e58a11445732a4", size = 1038499, upload-time = "2026-08-17T19:48:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/35/e9f47647c9e163bd1de30fe1a491669b7248cfc67b7404c35c009a701e1a/tiktoken-0.14.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7db45b98e94adf4173a5cd7422b150999a7ee11ff847783a14f6e1b80cc38cb6", size = 1186355, upload-time = "2026-08-17T19:48:51.93Z" },
+    { url = "https://files.pythonhosted.org/packages/51/11/9976ad86980a00cdef05e730a0127a2578a1bc6d11644d8d47246de2eb26/tiktoken-0.14.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7896eea257fe497a2b7134474d909156c6744ce8da35bce88011a960e008aa0d", size = 1204197, upload-time = "2026-08-17T19:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9c/7035b0bcfaa68d1ee4803fc5be5214ad865669b05bd20e7105ae8a18afc6/tiktoken-0.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b950248272f1b303dc32986396e2dccfa10cf6d1e83ec8f0bba1776660305482", size = 1250635, upload-time = "2026-08-17T19:48:54.392Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1d/69cabf18bed7f4366da076735816abce0d4db3fae491ae338a6612128777/tiktoken-0.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3de75343041a1c57333b1e707ac8a9769738241d7d6a55d39e12cf84548337c6", size = 1316085, upload-time = "2026-08-17T19:48:55.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/bd/a2e884fb1402cba5be08836590320012b2d8ada0e2eef9911a64df4bcd2d/tiktoken-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:087538c080e5ff421abd3a0785ed63c5111d06af98e6cd0d374dbe5969147ca3", size = 941208, upload-time = "2026-08-17T19:48:56.938Z" },
+    { url = "https://files.pythonhosted.org/packages/50/53/ee1453623bf65f019328721ccb6587846d2c5b7b82f34e73ca09101f072e/tiktoken-0.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9c5fe393aab56469f04e432ff851216d3def3436cf5f07e442a240164bf500f", size = 1094198, upload-time = "2026-08-17T19:48:57.955Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5f/6448cfe278c3664ba9ec5b5ac08344341f7dc3d42888476e215a14eda2be/tiktoken-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cbe2cc3bba939bcdaf103e03df9d5039d33887080b315624be28ec69059e5f94", size = 1038820, upload-time = "2026-08-17T19:48:59.015Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3b/d67eac1bcce9dee3abe23aff5e3ded3116bbebaf67b80a0811c06d3806fc/tiktoken-0.14.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:2157f52e4b4d7ac5ecc7457b3716834706e7ef9a46f5144029bfeb7cf71f4e06", size = 1186175, upload-time = "2026-08-17T19:49:00.068Z" },
+    { url = "https://files.pythonhosted.org/packages/37/62/cae690d9783146b0f81f564ada0f8f611de68178c0c9c7e1e969f0516b48/tiktoken-0.14.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:26e60f6a956ee171ab728b37b8439905d7ea1db435c30f9822f291e9861c861d", size = 1203884, upload-time = "2026-08-17T19:49:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/1e/633e30237b94e383cf814145499079f3bb9cdd4aeafc1bc42e01b0f810a6/tiktoken-0.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:380873f330b741c4435574f37edb20813d04603ace2d53e0a63560e1fec83010", size = 1250980, upload-time = "2026-08-17T19:49:02.274Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/56/4c12f07b812f84206f38d723eb1ebfdd34bad9309b5dbc0bee6bbcff4cbf/tiktoken-0.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3fd7c14b1cb45b486c39fc9b3443bb341f3e2fc7e6f31247f3435a5836651632", size = 1315434, upload-time = "2026-08-17T19:49:03.434Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e0/c65603f0c44811def666d3fbf611bf2af3b5e1ef613e06c19411419830b3/tiktoken-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:90a762670c7f968184723769a06ed51f5cf5ce5dcd1e30164f25c72d85c2d1f1", size = 940883, upload-time = "2026-08-17T19:49:04.583Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b0/1cf129f4af8fc513931f931023def596b7c4bfc77026513cd9d851da9e88/tiktoken-0.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e067f4cbcc5d036e8aff7fe7a6b530a8f4de2e4616ad9005a24a1879e24e6450", size = 1096273, upload-time = "2026-08-17T19:49:05.807Z" },
+    { url = "https://files.pythonhosted.org/packages/62/85/2ae74575e321148484147e10b53c3b1717c59ebaa9edb4fe18b1f5c055f8/tiktoken-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f2af4a336ea56d6c14f27741a0e1d8294a35dd0b038bcf990d232ebb54eb994b", size = 1040269, upload-time = "2026-08-17T19:49:06.943Z" },
+    { url = "https://files.pythonhosted.org/packages/89/29/92a1120a12e4bcf2d5464350d1a91b68a433d63ce656bb7f806c27aec09c/tiktoken-0.14.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f702e0aeeb6506e57687e881c59e844ebe8f0a6a097ddafe20e3ab25f387be4e", size = 1186101, upload-time = "2026-08-17T19:49:08.102Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7d/144af98dc5ad68108451a82e2f5a17f80e2663f5115058b8dfd215c1ad02/tiktoken-0.14.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e3442bbb2f0c588cec876061e37ae67b455b9df9978b003c8fe30e45f2ef5b42", size = 1204457, upload-time = "2026-08-17T19:49:09.28Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1f/be7cb06ab2108f612f3e92e7b76cf391e192db0db37a984616f0cc32aafc/tiktoken-0.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:979c1524f753b662b0f3cd261b135afe6659cce33caaa7a5ea00dd1756b3055c", size = 1251716, upload-time = "2026-08-17T19:49:10.509Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/6b/81f158d0f90adb826cd704069c2129a046cb784a2a09861009519fc41cf4/tiktoken-0.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2cc19ac87b41c9493c9778ff5847f0c8bbcf5bd0ec6b87ce06c1c802adc8a771", size = 1315432, upload-time = "2026-08-17T19:49:11.844Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ec/f5fa35ec13f07279fdcaf3cc9c04bbb154ea591d23978651f2b672593e8a/tiktoken-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:eceeff0c62419bc78d4b6e70a4762a4d25df3ae8f2d5946e3853ce93e7a57098", size = 988046, upload-time = "2026-08-17T19:49:13.282Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c9/7756717408d3d0dfea3f046c9466144b28afde39ff69d5808f2475dcd7f5/tiktoken-0.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6eb94895c45f26bb8f5546e5fd8a069efcf6e3f108ea9d5cbe3bf6f7f3983438", size = 1096261, upload-time = "2026-08-17T19:49:14.351Z" },
+    { url = "https://files.pythonhosted.org/packages/79/29/46ad8061f57bd9f8b2ea0aa82bf574e0f2aa040b0857a1582adba9957899/tiktoken-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:86951a971c53979ec857bd8c4a32dc227ab0fd33f6c12a3bd62d3fbf5f0bfcaa", size = 1040183, upload-time = "2026-08-17T19:49:15.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/7c/3184d17b868456f17b60b1a75f5ec0405618a43aa753336df341d8f11781/tiktoken-0.14.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2eca764c53490f8930dbce329e0769f11108d87d908282a80c5c130e26e7037", size = 1186719, upload-time = "2026-08-17T19:49:16.84Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e8/46de4400d5bf859f640feee85bd7e32235f68ddf25db53c63be78e581e3a/tiktoken-0.14.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:26cc4b4840fa0e9f4b72ed489883e12f57e00d1021ca794720e3c29a12f0edef", size = 1204660, upload-time = "2026-08-17T19:49:17.987Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ce/af8964c38bc8226dd8950305b7a255fa33345d5572f78af7275a313d28e0/tiktoken-0.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2fc834fbe3f6a0736905c36ab709537e6840dbd63b982dc9e0216ae7d305ba1a", size = 1250932, upload-time = "2026-08-17T19:49:19.28Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4b/323631116fc986d9cc5bbeb2b8223c7c85e61a8bb94ea5ab4951023b149b/tiktoken-0.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ca4db6ff5c5bf600f9b7761a0070ed44dfe5797a76bd432fb978bc480ef40c58", size = 1315190, upload-time = "2026-08-17T19:49:20.467Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8b/ba48a73729c9270989b36f37ab2ed5525e52690d715097c9fa791aaa5d05/tiktoken-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:7aab286a020660a039097912a088236b985d18a3090d73f136c4413d29d37ca0", size = 987717, upload-time = "2026-08-17T19:49:21.704Z" },
+]
 
 [[package]]
 name = "tokenize-rt"
@@ -10353,13 +10615,21 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
 ]
@@ -10644,8 +10914,7 @@ name = "uvicorn"
 version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -10803,8 +11072,7 @@ dependencies = [
     { name = "deprecation" },
     { name = "grpcio" },
     { name = "httpx" },
-    { name = "protobuf", version = "4.25.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "protobuf" },
     { name = "pydantic" },
     { name = "validators" },
 ]


### PR DESCRIPTION
Adds a job kind whose body is an agent loop. Three terms carry it:

- an **agent definition**, an `AGENT.md` or a decorated function: the system prompt, the inputs and output, the tools, skills and rules the agent uses, and the access it needs (pydantic-ai calls this an `AgentSpec`);
- an **agent job**, `run.agent(...)`: the definition plus the runtime settings that say how it operates: model, token limit, trigger, instructions, loop, identity (what pydantic-ai and claude-agent-sdk call an Agent, and what the web UI lists as one);
- an **agent run**, one execution of the job: inputs in (a job run id, say), output and trace out, with settings a caller may override for that run alone.

Agent jobs run on the same launcher machinery as every other dlt job: locally with `dlthub local run`, remotely by the runner, on a pluggable loop (pydantic-ai or claude-agent-sdk). Part 1 is the user guide, on the job-inspector example. Part 2 is how it works.

# Part 1. User guide

## 1. Write an agent definition

An agent definition is a system prompt plus a declaration of what the agent takes, returns and may touch. It is an `AGENT.md` or a decorated Python function; both make the same agent job.

### 1a. As an `AGENT.md`

Installed with a toolkit (`dlthub ai toolkit install dlthub-platform`) it lives in `.claude/dlthub/agents/<name>/AGENT.md` (`.cursor/...`, `.agents/...` for the other hosts), a folder Claude Code does not scan for subagents, so dlt agents and native subagents never mix. Or keep it anywhere in the workspace as a folder holding an `AGENT.md` and refer to it by path. The frontmatter declares, the markdown body is the system prompt, and only the body is required: a file with no frontmatter is a working agent definition named after its folder.

```yaml
---
name: job-inspector
description: Inspects a failed job run and reports a diagnosis. Read-only.
tools: [telemetry]                          # dlthub MCP feature groups, see §8
skills: [dlthub-platform:debug-deployment]  # loaded natively or inlined, see §9
rules:  [dlthub-platform:job-resources]     # always inlined into the prompt

access:                                     # what the job may touch, see §7
  local:   [read]                           # read | write | execute | network
  data:    [read]                           # read | write, governed by the profile
  context: [read]                           # telemetry, runs, job definitions

inputs:
  type: object
  properties:
    failed_run_id:
      type: string
      description: run id of the job that failed
      entity_type: job-run                  # this input names a workspace entity
    failed_job_ref:
      type: string
      description: job ref of the failed job
      entity_type: job
  required: {}

output:
  type: object
  properties:
    classification: { enum: [config, credentials, code, upstream_data, unknown] }
    confidence:     { enum: [high, medium, low] }
    evidence:       { type: array, items: { type: string } }
  required: [classification, confidence]

defaults:                                   # the runtime may override all of these
  trigger: [job.fail:*]
  model: sonnet
  limits: { max_turns: 30, max_tokens: 1000000 }
  loop_run_args: { retries: 1 }
---
You are a job inspector for a dltHub Platform workspace. You run unattended, seconds
after a job failed. Explain the failure; do not repair it.

Investigate job_ref '{{ failed_job_ref }}' from trigger `{{ run_context.trigger }}`
with failed run id '{{ failed_run_id }}'. Any of the three may be empty.

1. With a run id, read the run and its logs.
2. Without one, resolve it from the job ref or the trigger.
3. With neither, you have nothing to inspect: return `status: aborted` naming what was
   missing.
```

**Inputs.** `inputs` is a JSON Schema, and every property in it is a job configuration key: `-c failed_run_id=...` on the command line, `jobs.<section>.<job>.failed_run_id` in `config.toml` or the environment, or a run argument the trigger carries. The body refers to inputs as `{{ name }}`, and to the run as `{{ run_context.trigger }}` or `{{ run_context.run_id }}`; placeholders are rendered before the first turn. A required input with no value fails the run like any missing job argument. An optional one nobody supplied renders blank, is logged, and is listed in the trace as unresolved; an input the body never mentions is a warning at manifest time. There is no `inputs.prompt`: the task belongs in the body.

**Entities.** An input with `entity_type` names a workspace entity: `job-run`, `job`, `pipeline`, `dataset` or `workspace`. The value the agent receives is the bare id: a run id, a job ref, a pipeline name. Declaring it buys two things. The agent run reports the entity in its result's `object` list, so the run shows up on that entity's page. And the first entity-typed input lands in the manifest as `expose.object_input`, which is how a UI offers the agent job from a failed run's row and knows which key to pass the run id under (§6).

**Outputs.** `output` is optional. `status` and `summary` are always part of it, with descriptions dlt writes so the model knows when to report which outcome; `output` adds the definition's own fields. Descriptions matter: the model reads them when it fills a field. `status` is `succeeded` or `failed` as the prompt defines them, and `aborted` when the task could not be done at all; `aborted` ends the run with an exception that carries `summary`.

### 1b. As a function

No file, no toolkit. The docstring is the system prompt, the parameters are the inputs, the return type is the output; together they are the agent definition, and the decorator arguments are the agent job's settings. The body drives the loop it finds in `run_context["ai_loop"]`.

```python
from typing import Annotated, List, Literal

import dlt
from dlt.common.typing import NotRequired
from dlt.hub import run


class CrashReport(run.TAgentOutput):
    """`status` and `summary` come from the base."""
    classification: Annotated[
        Literal["config", "credentials", "code", "upstream_data", "unknown"],
        run.Doc("What kind of failure it was"),
    ]
    confidence: Literal["high", "medium", "low"]
    evidence: NotRequired[List[str]]


@run.agent(
    access={"local": ["read"], "data": ["read"], "context": ["read"]},
    tools=["telemetry"],
    skills=["dlthub-platform:debug-deployment"],
    trigger="job.fail:*",
    limits={"max_turns": 30},
)
async def crash_inspector(
    failed_run_id: Annotated[str, run.Entity("job-run")] = dlt.config.value,
    depth: int = 2,
    run_context: run.TJobRunContext = None,
) -> CrashReport:
    """Inspects a failed job run and reports a diagnosis.

    You run unattended, seconds after a job failed. Explain the failure; do not repair it.
    Investigate run '{{ failed_run_id }}' from `{{ run_context.trigger }}`, going
    {{ depth }} runs back. Return `aborted` when the inputs give you nothing to inspect.
    """
    loop = run_context["ai_loop"]
    report = await loop.run(inputs={"failed_run_id": failed_run_id, "depth": depth})
    if loop.trace["total_tokens"] > 800_000:
        report["summary"] += "\n\n_Investigation was expensive; consider narrowing the trigger._"
    return report
```

| in Python | in the agent definition |
|---|---|
| function name | `name`, the agent job's name, and with `<module>:` in front the agent definition reference when no `AGENT.md` is behind it |
| docstring | system prompt, placeholders included; its first line is the `description` |
| parameters | `inputs`, and so the job's configuration: `-c failed_run_id=...` fills them, typed |
| `Annotated[str, run.Entity("job-run")]` | an entity-typed input |
| `dlt.config.value` default | a required input |
| `run_context` parameter | the implicit input the launcher passes; in neither `inputs` nor `config_keys` |
| return type deriving from `run.TAgentOutput` | `output`; `run.Doc(...)` on a field is its description |
| `access=`, `tools=`, `skills=`, `rules=` | the matching `AGENT.md` fields of the definition |
| `model=`, `limits=`, `loop_run_args=`, `instructions=`, `trigger=`, `loop=` | the agent job's settings, `defaults` in an `AGENT.md` |

The schemas come from pydantic, `TypeAdapter(func).json_schema()` for the signature and the return type for the output, so `Optional`, `Literal`, `List`, nested models and `NotRequired` behave as they do everywhere else. The return type derives from `TAgentOutput`, the payload, not from the result envelope, so the schema the model sees never contains a launcher-owned key.

The function may be `def` or `async def`. Returning the loop's output as-is is the common case; the body above exists to show that the job owns the run: it can inspect `loop.trace`, run the loop twice, or not run it at all. A function that only drives an installed agent definition is a one-liner, with `agent=` as the base that the decorator arguments and the function override:

```python
@run.agent(agent="dlthub-platform:job-inspector", loop="claude-agent-sdk")
async def inspect(run_context: run.TJobRunContext = None) -> run.TAgentOutput:
    return await run_context["ai_loop"].run()
```

## 2. Declare the agent job

The agent job is the agent definition plus the settings that say how it operates: model, limits, trigger, instructions, loop, and later the identity that grants its access. It is what pydantic-ai and claude-agent-sdk call an Agent, and what the web UI lists as one.

```python
from dlt.hub import run

inspector = run.agent(
    "dlthub-platform:job-inspector",
    trigger="job.fail:tag:ingest",
    model="opus",
    limits={"max_turns": 20},
    instructions="focus on the loader step",
)
```

The job is named after the agent definition (`job-inspector` becomes `job_inspector`) in the declaring module's section. Instead of a `"<toolkit>:<agent>"` reference you can pass a workspace-relative path to a folder holding an `AGENT.md`, or a `TAgentSpec` dict declared inline. Also accepted: `loop=`, `loop_run_args=`, `verbosity=`, `inputs_validator=`, `outputs_validator=`, `name=`, `section=`, plus the usual `trigger`, `execute`, `expose`, `require`, `spec`.

`job.fail:` and `job.success:` take a job ref or any selector dlt already has, the same grammar `--select` and the runtime's trigger API use:

```
job.fail:tag:ingest          every job tagged `ingest`
job.fail:batch:              every batch job
job.fail:jobs.mod.*          every job in section `mod`
job.fail:*                   every job
```

A selector expands at manifest time to one concrete `job.fail:jobs.<section>.<name>` per matching job, because the runtime looks a completion trigger up by exact string. It never expands onto the job that declares it, and interactive jobs are never targets. A job event never becomes a job's `default_trigger`: run by hand, an inspector sees `manual:` and aborts, as its body says it should.

## 3. Start an agent run

Every trigger of the agent job produces an agent run: inputs in, output and trace out. Settings may be overridden for that run alone, the way `Agent.run()` takes overrides in the frameworks:

```bash
dlthub local run job_inspector -c failed_run_id=89826ee6-... -c agent.instructions="explain, do not fix"
```

Locally and on the runner the entry point is the same, `dlt._workspace.deployment.launchers.agent`, and it delegates to the ordinary job launcher: config env vars, profile activation, interval injection, signal interception and result delivery are those of any function job.

- **`agent.instructions`** is the user prompt, the run's first message. The system prompt says who the agent is; instructions say what to do this time. Without any, the loop sends a bare "Go ahead" and the system prompt speaks alone. It resolves like `model`: decorator argument, then configuration, then `loop.run(instructions=...)` for a direct call.
- **`agent.verbosity`** is how much of the transcript goes to stdout: `0` the turns, tool names and results; `1` (default) plus the agent's thoughts and the tool arguments; `2` plus the full rendered system prompt, nothing cut. The user sets it on the agent job; configuration overrides it per run.
- **`agent.model`, `agent.max_turns`, `agent.max_tokens`** raise or lower the job's settings for one run.
- Precedence for every setting: loop default, then `AGENT.md` defaults, then the decorator argument, then configuration, so a runtime value always wins.

Everything resolves through normal dlt config (env, toml, `-c`):

| what | key |
|---|---|
| declared inputs | `jobs.<section>.<name>.<input>`, so `-c failed_run_id=...` |
| loop, instructions, model, limits, `loop_run_args`, verbosity | `jobs.<section>.<name>.agent.*`, so `-c agent.verbosity=2` |
| the model endpoint | `agent.model` / `agent.api_key` / `agent.api_url` / `agent.api_version`, each with a `runtime_*` twin the runtime supplies; one whole set is used, never a mix |
| trace export | `agent.trace_url` / `agent.trace_key` |

An agent job's inputs are its job configuration: they take the type from the schema (`-c depth=3` arrives as `int`), and a required input with no value fails the run like any missing job argument.

## 4. Read the result

The agent run prints its transcript to stdout as it goes, in color whether or not a terminal is attached (`NO_COLOR` turns it off): what the model thinks, says and calls, what each tool handed back, and a finish line with the tools, skills and MCP tools it used. When it ends, the launcher prints and delivers the job result:

```jsonc
{
  "type": "job.background_agent.dlthub-platform:job-inspector",
  "engine_version": 1,
  "job_ref": "jobs.__deployment__.job_inspector",
  "status": "succeeded",
  "summary": "## Root cause: platform runner token conflict ...",
  "result": { "status": "succeeded", "summary": "...", "classification": "transient", "confidence": "high", "evidence": [...] },
  "object": [
    { "type": "job-run", "id": "job-run/89826ee6-ed5d-478e-8ad1-415251f225e0" },
    { "type": "job", "id": "job/jobs.maintenance.compact_delta_tables" }
  ],
  "trace": { "loop_type": "pydantic-ai", "model": "anthropic:claude-sonnet-5", "turn_count": 3, "total_tokens": 13215, ... }
}
```

- **`status`** and **`summary`** are lifted out of the agent output to the top, so a list never opens `result`. `succeeded` and `failed` mean what the prompt says they mean; `aborted` means the task could not be done at all, and raises `JobAbortedException` with `summary` as its text, after the result is delivered.
- **`result`** is the agent output, exactly as the definition's `output` schema declares it.
- **`object`** is the entities the run acted on.
- **`trace`** is what the loop ran with and did: agent and file, loop type, model, limits, `loop_run_args`, the user turn, the resolved inputs, declared `access` with the `local_tools` the loop wired, MCP features, native and inlined skills, unresolved placeholders, turn count and token counts, per-turn tool calls, `tools_used` / `skills_used` / `mcp_tools_used`, and `cost_usd` / `stop_reason` where the loop reports them.

# Part 2. Mechanisms and architecture

## 5. One envelope for every job, shaped like Activity Streams 2.0

Any job can declare a structured result; it names only the payload shape:

```python
run.result({"rows": 10}, type="etl_summary")
```

The launcher completes the envelope when the run ends: `type`, `job_ref`, `object`, and for agents `status`, `summary` and `trace`, then delivers it to the telemetry beacon as payload type `job_result`, synchronously and before an abort is raised, so the trace is on the wire even when the process exits non-zero. The body carries no run id; the beacon knows the run from the token in the DSN, as it does for pipeline traces.

- **`type`** is `job.<category>.<name>`, two discriminators in one string, and it links a result to its shape. The category (`background_agent`, `pipeline`, `batch`, ...) names the envelope: `background_agent` means `status`, `summary` and `trace` are present. The name names the payload schema of `result`. For a plain job it is whatever `run.result(..., type=)` said. For an agent job it is the **agent definition reference**, because the definition's `output` schema is the payload schema: `dlthub-platform:job-inspector` for a toolkit agent, the workspace path for a definition referenced by path, or `<module>:<function>` (`agents:crash_inspector`) for a decorated function with no `AGENT.md` behind it. Every job that runs the same definition produces the same `type`, so one template renders all their results; the schema itself is `output` on the job definition the result's `job_ref` points at. The job never writes the prefix; the launcher adds it, because only the launcher knows the category. The first two segments are closed vocabularies with no dots, so the name may carry dots, colons and slashes.
- **`object`** is derived the same way for every job kind, from its entity-typed inputs and outputs (§6).
- **`result`** is the payload. **`trace`** is agent-specific.

The envelope follows the Activity Streams 2.0 model the dltHub audit log is being designed on: an actor performs a verb on an object, optionally toward a target, and the activity carries a `result` and a `summary`.

| Activity Streams 2.0 | job result |
|---|---|
| `actor` | the agent job, `job_ref`, acting through one run, the beacon token; its kind is the agent definition reference, the name segment of `type` |
| `type`, the verb | implicit and constant: a job ran (`run:job`, `end:run` in the audit vocabulary). The envelope's own `type` is not the verb but the schema discriminator above |
| `object`, `target` | `object`, the entities the run acted on |
| `result` | `result`, and `status` |
| `summary` | `summary` |
| `id`, deduplicated | deduplicated on `job_ref` within the run |

An agent run therefore projects onto the audit log as `run:job` by the agent job, with the inspected run as its object, and an entity's activity view can list job results next to audit events without a second model.

## 6. Entities: from an input to `object` and `expose.object_input`

An input is an entity reference when its schema says so: `entity_type: job-run` in `AGENT.md`, or `Annotated[str, Entity("job-run")]` on a parameter. Known types are `job-run`, `job`, `pipeline`, `dataset`, `workspace`; they are URI path segments, hence the hyphen. The value carries only the unique id; dlt composes `{type}/{id}` when it reports: `job-run/89826ee6-...`, `dataset/duckdb_prod/github_events`, `pipeline/github_actions`, `job/jobs.agents.job_inspector`. At the end of a run, `object` is every entity-typed input the run received, overwritten by an output property of the same name, so an agent that resolves a run id it was not given still reports the run it inspected. The loops hand the model the same schema with `entity_type` moved into `$comment`: strict validators such as the Claude CLI's reject keywords they do not know, and `$comment` is the standard slot a model still reads.

The manifest generator takes the first entity-typed input and writes it to `expose`:

```yaml
expose:
  category: background_agent
  object_input:
    entity_type: job-run
    input: jobs.__deployment__.job_inspector.failed_run_id
```

That is all a UI needs to start an agent run for an entity. On a list of job runs, a failed run's row offers every agent job whose `object_input.entity_type` is `job-run`; choosing one starts a run with the run id under the key `object_input.input` names, plus an optional prompt:

```json
{
  "script_id_or_ref": "jobs.__deployment__.job_inspector",
  "trigger": "manual:",
  "config": {
    "jobs.__deployment__.job_inspector.failed_run_id": "89826ee6-ed5d-478e-8ad1-415251f225e0",
    "jobs.__deployment__.job_inspector.agent.instructions": "explain, do not fix"
  }
}
```

The launcher turns `config` into job configuration under the job's section, the inputs resolve as if typed on the command line, and the result comes back with that run in `object`, closing the loop: offered from the entity, reported on the entity. `object_input` names the primary entity only; `inputs.properties[*].entity_type` lists every entity the job can be pointed at.

## 7. Access: what a job may touch

`access` is a job-level manifest field (`TJobDefinition.access`), not an agent-only one. Agents are the first job kind to declare it and the only producer for now; the field lives where the next job kind can fill it.

| axis | verbs | meaning |
|---|---|---|
| `local` | `read`, `write`, `execute`, `network` | what may be done on the machine the workspace lives on |
| `data` | `read`, `write` | workspace data, governed by the dlt profile |
| `context` | `read` | the context graph: telemetry, runs, job definitions |

`all` is shorthand for every verb on an axis, and a single verb may be written without the list (`data: read`). The type carries a wider `context` ladder (`write`, `execute`, `deploy`) than any runtime serves, so a manifest declaring one is refused at generation with a message saying it is typed but unserved.

**Only `local` depends on the loop.** `data` and `context` are served by the workspace MCP server, started with the declared access, so nothing can be granted beyond it. A loop that lacks a tool for a verb wires less, and the run proceeds narrowed. What it did wire is in the trace as `local_tools` and in the result view, each tool under its verb: `Grep (read), Bash (execute), WebSearch (network)`.

**`access.local` maps to one standard tool set**, named as the Claude Code harness names its tools, so the same declaration means the same thing on both loops:

| verb | tools |
|---|---|
| `read` | `Read`, `Glob`, `Grep` |
| `write` | `Write`, `Edit` |
| `execute` | `Bash` (`PowerShell` on Windows), `RunPython` |
| `network` | `WebFetch`, `WebSearch` |

The tools themselves are `LocalTools` in `deployment/agent/loops/tools.py`: plain methods confined to the workspace root and the system temp folder, tested on their own. The pydantic-ai loop wraps them as function tools, and `network` maps to the provider's own web capabilities. Both loops name the workspace and the temp folder in the system prompt so the model knows where scratch files go; the claude loop also adds the temp folder to the harness's directories and attaches what it has beyond the standard names to the name it extends (`Read` brings `NotebookRead`, `Edit` brings `MultiEdit` and `NotebookEdit`, `Bash` brings `BashOutput` and `KillShell`). The shell is one per platform, as Claude Code offers it: `Bash` everywhere but Windows, `PowerShell` there, run without a profile and non-interactively; on both loops the model is told which one it has, and tool output is UTF-8 whatever the console code page. Paths the tools return are posix and relative to the workspace root on every platform. No verb, no tool: an agent that declares no `access` gets no file tool and no shell, and its MCP server serves only the tools that require nothing, the toolkit catalogue.

Nothing here is an OS sandbox: `execute` runs in the same process tree and virtualenv as the job, so what contains it is the runner the job already runs in. Two things are enforced regardless of the declared access:

- **credential files are never readable by a file tool**: `*secrets.toml`, `.env`, `.env.*`, on both loops (deny rules on the harness, a refusal inside dlt's own tools);
- **`execute_sql_query` runs one read-only statement**, whole-tree checked against mutating statements and host functions after [GHSA-xxqf-4m3r-qx6c](https://github.com/dlt-hub/dlt/security/advisories/GHSA-xxqf-4m3r-qx6c).

## 8. MCP tools: how they are injected

`tools:` names feature groups to request from the dlthub MCP server: `telemetry`, `pipeline`, `jobs`, `logs`, whatever the installed plugins contribute through `plug_mcp`. The loop turns that into a server the agent talks to over stdio:

```
dlthub ai mcp run --stdio --access data:read,context:read --no-default-features --features telemetry
```

Three parts, each doing one job:

1. **`--features`**: exactly the groups the agent asked for. `--no-default-features` keeps the interactive defaults (workspace, pipeline, toolkit, secrets, context) out: an agent that asks for one group does not silently get the rest.
2. **`--access`**: the agent definition's `access`, serialized as `axis:verb` pairs. Server-side it is parsed back and every tool is checked against it before `add_tool`, so a tool the grant does not cover does not exist in the schema the model sees. Of the 17 tools dlt serves, `data:read` leaves 10, `local:write` leaves 3, and a grant of nothing, spelled `local:,data:,context:` (an axis with no verb grants nothing on it), leaves the 2 that need nothing (the toolkit catalogue). An empty `--access` is refused rather than read as anything. A person at a terminal running `dlthub ai mcp run` without `--access` is granted everything explicitly: the command hands the full grant to the server, which always filters against the grant it holds.
3. **the environment**: the workspace directory and `WORKSPACE__PROFILE` the launcher exported, so the server reads the same profile and config as the job.

Tools declare what they require next to what they return, and dlt reads it; pydantic drops metadata it does not recognise, so nothing of it reaches the tool schema:

```python
def list_pipelines() -> Annotated[List[str], RequiresAccess(data=["read"])]: ...
def get_workspace_info() -> Annotated[Dict[str, Any], RequiresAccess(local=["read"])]: ...
def export_schema(...) -> Annotated[str, RequiresAccess(data=["read"], local=["write"])]: ...
```

Silence is not a grant: a tool that declares nothing is assumed to need everything, so it reaches no narrowed caller until someone has decided what it may touch. `RequiresAccess()` is how a tool says it needs nothing.

Wiring differs per loop, the surface does not:

- **pydantic-ai** attaches the server as an `MCPToolset` over `StdioTransport`, id `dlt-workspace-mcp`, booted when the agent enters its context. Tool errors, MCP and local alike, follow `loop_run_args.retries`: at 0 (the default) every error reaches the model as a failed call and the run goes on, as on the claude loop; above 0 pydantic-ai asks the model to correct the call that many times per tool and ends the run when the budget is spent.
- **claude-agent-sdk** passes it as `mcp_servers` with `strict_mcp_config`, and allows `mcp__dlt-workspace-mcp__*`. The project's own `.mcp.json` is never loaded; the loop always spawns its own server.

`tools: []` (or no `tools`) means no server is started at all.

## 9. Loops

`pydantic-ai` (default) and `claude-agent-sdk` ship; `loop="claude-agent-sdk"` on the decorator, overridden by `agent.loop` in config. A third-party loop registers through the `plug_agent_loop` plugin hook and needs no changes here. Each loop maps to a dependency group (`agent-loop-pydantic-ai`, `agent-loop-claude-agent-sdk`) which the job stamps into `require.dependency_groups` and dlt writes into the requirements manifest, so the runner installs only the loop that job needs. claude-agent-sdk ships a bundled Claude Code CLI binary; nothing else is installed.

**What each loop does with the agent definition.** `access` becomes the tool surface (§7), `tools` the MCP server (§8), the rendered body the framework's system prompt, `instructions` the user turn, `output` structured output with `entity_type` moved into `$comment`. Rules are inlined into the system prompt on both loops. Skills follow the loop: pydantic-ai inlines their text; claude-agent-sdk lists the declared skills by name and loads one when the agent invokes it, the way Claude Code does natively. For that it reads the project settings, adds the `Skill` tool to the base tool set only when skills are declared, and keeps everything else in the project out of the agent's context: `.claude/rules/*.md` are excluded through the `--settings` layer (merged with any `settings` in `loop_run_args`) because in a dlthub workspace they name every installed skill, while `CLAUDE.md` and `CLAUDE.local.md` load as in any Claude Code session. The pydantic loop attaches the prompt as a function rather than through `AgentSpec.instructions`, because that field is re-rendered as a Handlebars template when `deps_schema` is set and would drop the `{{ }}` dlt has already resolved.

**Limits are dlt's.** `limits.max_tokens` is counted by dlt itself after each turn, so it means the same on every loop; pydantic-ai's native limit and claude-agent-sdk's lack of one no longer matter, and a run that passes it stops with `AgentTokenLimitExceeded`. `limits.max_turns` is handed to the framework.

**Transcript.** Every loop emits the same events (start, system prompt, prompt, turn, thinks, says, tool call, tool result, finish) and one renderer prints them, with the verbosity levels of §3. On pydantic-ai a tool the loop did not build itself is counted as the MCP server's. Every run ends with the tools, skills and MCP tools it used, on the console and as an INFO line in the log.

## 10. Code map

- **`run.agent` and `AgentJobFactory`** (`deployment/decorators.py`): the agent job. When the job definition is built it resolves the agent definition (referenced, given inline, or read off the function), emits the manifest `agent` block, the job-level `access`, `inputs`, `output` and `expose.object_input`, and synthesizes the job's config spec from the declared inputs.
- **`deployment/agent/reflection.py`**: signature, return type and docstring to `TAgentSpec`, the agent definition, merged over the one the decorator referenced. Pydantic renders both JSON Schemas.
- **`deployment/agent/manifest.py`**: reads `AGENT.md`, resolves `<toolkit>:<agent>` refs through the toolkit index installed in the workspace, renders `{{ }}` placeholders against the run's inputs, inlines rules and skills a loop cannot load natively.
- **`_workspace/access.py`**: the access vocabulary shared by agents, tools and the MCP server: `TWorkspaceAccess`, `RequiresAccess`, and the parse/format helpers.
- **`deployment/agent/loop.py`**: the `AgentLoop` contract: `init(agent_spec)` takes the agent definition, `run(instructions, inputs, model, limits, run_args)` is one agent run: it renders the system prompt against the inputs, builds the framework's Agent and runs it. Settings resolve loop default < `AGENT.md` defaults < decorator argument < configuration.
- **`deployment/agent/loops/{pydantic_ai,claude_sdk}.py`**: one adapter each; **`loops/tools.py`**: `LocalTools` and the MCP server command.
- **`deployment/launchers/agent.py`**: a thin call into `launchers/job.py` with an `invoke` that builds and drives the loop, so all job-launcher setup is shared by construction rather than copied.
- **`deployment/job_result.py`**: `run.result`, the per-run result container, `result_type` / `parse_result_type`, and beacon delivery; **`deployment/entity.py`**: `THubEntity` construction and the `object` merge.
- **`deployment/_run_views.py`**: the transcript and result renderer.
- **Packaging**: the toolkit index under `.dlt/.toolkits` ships with the deployment package so `<toolkit>:<agent>` refs resolve on the runner; the agent definition's files travel as ordinary workspace files.

## 11. Required runtime changes

The runtime imports dlt's `TJobDefinition` into pydantic models with `extra="forbid"` and freezes it into nine generated mirrors (three OpenAPI specs, three attrs clients including `dlthub-client`, two TypeScript schemas). Every item below therefore needs a dlt pin bump plus regeneration before any agent job can deploy.

1. **New job-definition fields.** `engine_version` (the manifest engine the definition is written for, always the manifest's own; `migrate_job_definition` stamps it, so a definition stored on its own can be migrated later), `agent` (the `TAgentDefinition` block: engine_version, `agent_file`, name, description, tools/skills/rules, instructions, model), `access` (`TWorkspaceAccess`, without `toolkits`), `inputs` / `output` (JSON Schema, on every job kind, not just agents), `expose.object_input` (`TJobObjectInput`: `entity_type` and the full config key of the first entity-typed input), and `background_agent` in `TExposeSpec.category`. All are optional; nothing in the runtime reads them yet, so this is a schema move, not a behaviour change. They ride manifest engine 2 (the #4033 bump) and need no migration of their own. Every workspace's manifest hash moves once, because a job that takes arguments now carries `inputs`. The frozen category enum blocks deploying any agent job today; `tests/hub/test_manifest_contract.py` fails until it lands.
2. **Run requests take `config`.** `CreateRunRequest` gains a `config` map of full config keys (`jobs.<section>.<job>.<key>`), carried to the vault and passed as `cli_config` to `build_runtime_entry_point`, stripped of the `<job_ref>.` prefix and nested by the remaining dots. This is what §6 and a "run with prompt" dialog need; the launcher side already works.
3. **Telemetry beacon must accept `job_result`.** Payloads are `PUT` as payload type `job_result` with the envelope of §5. The beacon's payload type enum has `trace` and `state` only and its dedup key falls back to `transaction_id`, so today it answers `ignored` and drops every job result, agent traces included. Add the type, dedup on `job_ref` within the run, store it, and expose `status`, `summary`, `object` on the run response and `result`, `trace` on a detail call.
4. **Loop dependency groups and the MCP server.** The runner installs the groups a job names in `require.dependency_groups`, which it already does by flattening them into the run's requirements. Both loops reach the platform through the workspace MCP server, so the job environment needs the `dlthub` console script and the `hub` extra; the loops spawn `dlthub ai mcp run --stdio` themselves.
5. **Agent credentials, including the API version.** The runtime supplies the model endpoint as `agent.runtime_api_key` / `agent.runtime_api_url` / `agent.runtime_api_version` and `agent.runtime_model` in the job's config section (or workspace-wide `AGENT__RUNTIME_*`). The model id belongs to the endpoint that serves it, so the four are one set: setting any one of `agent.model` / `agent.api_key` / `agent.api_url` / `agent.api_version` makes the run use the user's four and ignore all four runtime values, and the loop logs at INFO which endpoint it picked. Both sets stay readable side by side. dlt maps each to the argument the named provider uses (`azure_endpoint` and `api_version` for Azure, `api_base` for LiteLLM, `api_host` for xAI, `base_url` elsewhere) and refuses an `api_url` on a provider with a fixed endpoint rather than silently calling the wrong host.
6. **Profile.** dlt does not infer a profile from the agent. It exports `WORKSPACE__PROFILE` for the job and the tools read it; the runtime decides the profile from the declared `access.data` (`write` for prod, `read` for access) or from what the user pinned on the job.
7. **`default_trigger` recompute.** The runtime recomputes it with dlt's own `compute_default_trigger`, so the job-event exclusion arrives with the pin bump; jobs already stored keep their column until redeployed. Null is already handled everywhere it is read: an explicitly named job with no default is fired as `manual:<ref>`.
8. **No change needed, verified:** the run repackager passes the deployment tarball through unchanged, so the shipped `.dlt/.toolkits` index and the agent's files reach the runner as-is.

