### PR TITLE
fix(filesystem): use per-file DuckDB connection in read_csv_duckdb

### DIFF
--- a/dlt/sources/filesystem/readers.py
+++ b/dlt/sources/filesystem/readers.py
@@ -129,13 +129,20 @@ def _read_csv_duckdb(
 
     for item in items:
         with item.open() as f:
-            file_data = duckdb.from_csv_auto(f, **duckdb_kwargs)
+            # Use a per-file connection so that interleaved generators
+            # (from different pages) don't clobber each other's result
+            # sets on the single global default connection.
+            con = duckdb.connect()
+            try:
+                file_data = con.from_csv_auto(f, **duckdb_kwargs)
 
-            for batch in helper(file_data, chunk_size):
-                if add_filename:
-                    for record in batch:
-                        record["filename"] = item["file_name"]  # type: ignore
-                yield batch
+                for batch in helper(file_data, chunk_size):
+                    if add_filename:
+                        for record in batch:
+                            record["filename"] = item["file_name"]  # type: ignore
+                    yield batch
+            finally:
+                con.close()
 
 
 if TYPE_CHECKING:

--- a/tests/sources/filesystem/test_readers.py
+++ b/tests/sources/filesystem/test_readers.py
@@ -215,3 +215,44 @@ def test_read_csv_duckdb_use_pyarrow(tmp_path: pathlib.Path, data: list[dict[str
     assert isinstance(read_data[0], pyarrow.RecordBatch)  # batch of records
     assert isinstance(read_data[0][0], pyarrow.Array)  # column
     assert read_data == [pyarrow.RecordBatch.from_pylist(data)]
+
+
+def test_read_csv_duckdb_multiple_files_no_truncation(tmp_path: pathlib.Path) -> None:
+    """Regression test for https://github.com/dlt-hub/dlt/issues/4405.
+
+    When multiple _read_csv_duckdb generators are alive simultaneously
+    (interleaved by the extractor across pages), each file must still be
+    read in full. Previously, the shared global DuckDB connection meant
+    that starting a second relation invalidated the first one's pending
+    result, silently truncating every file to its first chunk.
+    """
+    n_files = 5
+    n_rows = 200  # enough rows to span multiple chunks at default chunk_size
+
+    files = []
+    for i in range(n_files):
+        sub = tmp_path / f"dir{i}"
+        sub.mkdir()
+        rows = [{"file_id": i, "row_id": j} for j in range(n_rows)]
+        files.append(_create_csv_file(data=rows, tmp_path=sub))
+
+    # Open all generators (simulates the extractor having multiple pages alive)
+    generators = [_read_csv_duckdb([f], chunk_size=50) for f in files]
+
+    # Round-robin between generators, like PipeIterator does
+    total_rows = {i: 0 for i in range(n_files)}
+    active = list(range(n_files))
+    while active:
+        next_active = []
+        for i in active:
+            batch = next(generators[i], None)
+            if batch is not None:
+                total_rows[i] += len(batch)
+                next_active.append(i)
+        active = next_active
+
+    for i in range(n_files):
+        assert total_rows[i] == n_rows, (
+            f"File {i}: expected {n_rows} rows but got {total_rows[i]} "
+            f"(truncated by interleaved DuckDB connections)"
+        )


### PR DESCRIPTION
## Summary

`read_csv_duckdb` used DuckDB's single global default connection for every file. When the extractor interleaves multiple generators (which happens whenever `files_per_page` is less than the total file count), starting a new relation on the shared connection silently invalidates all other pending results. The next `fetchmany` returns `[]`, which `fetch_json` treats as end-of-file, so each file is truncated to its first chunk.

The failure is entirely silent: no warning, no exception, load package marked complete.

## Fix

Use `duckdb.connect()` per file so each generator gets its own isolated result slot. This is a one-line change in the generator body: instead of `duckdb.from_csv_auto(f, ...)`, we create a per-file connection and call `con.from_csv_auto(f, ...)`.

## Tests

Added `test_read_csv_duckdb_multiple_files_no_truncation` which opens 5 generators simultaneously and round-robins between them (simulating the extractor's page interleaving), verifying every file is read in full. This test would fail on the old code and passes with the fix.

All 4 duckdb reader tests pass.

Fixes #4405
