### PR TITLE
feat(azure): support azure_storage_token bearer auth for OneLake/ABFS

### DIFF
--- a/dlt/common/configuration/specs/azure_credentials.py
+++ b/dlt/common/configuration/specs/azure_credentials.py
@@ -59,7 +59,13 @@ class AzureCredentialsBase(CredentialsConfiguration, WithObjectStoreRsCredential
         creds.pop("anon", None)
         creds.pop("credential", None)
 
-        if isinstance(self, CredentialsWithDefault) and self.has_default_credentials():
+        # Static bearer token (e.g. Fabric notebookutils) — key/SAS take precedence when present
+        token = getattr(self, "azure_storage_token", None)
+        has_key = getattr(self, "azure_storage_account_key", None)
+        has_sas = getattr(self, "azure_storage_sas_token", None)
+        if token and not has_key and not has_sas:
+            creds["azure_storage_token"] = token
+        elif isinstance(self, CredentialsWithDefault) and self.has_default_credentials():
             if self.is_external_session():
                 # object_store cannot resolve a user-passed credential, so freeze a bearer token.
                 # NOTE: relies on the consumer merging AZURE_* env into the passed options - verified
@@ -69,6 +75,21 @@ class AzureCredentialsBase(CredentialsConfiguration, WithObjectStoreRsCredential
                 )
 
         return creds
+
+
+def _static_azure_token_credential(token: str) -> Any:
+    """Wrap a static bearer token as an azure-identity-compatible TokenCredential for adlfs."""
+    try:
+        from azure.core.credentials import AccessToken
+    except ModuleNotFoundError:
+        raise MissingDependencyException("AzureCredentials", [_AZURE_STORAGE_EXTRA])
+
+    class _StaticTokenCredential:
+        def get_token(self, *scopes: Any, **kwargs: Any) -> Any:
+            # Static token does not refresh; far-future expiry matches object_store freeze semantics
+            return AccessToken(token, 2**31 - 1)
+
+    return _StaticTokenCredential()
 
 
 class _AzureExternalSession:
@@ -122,6 +143,10 @@ class AzureCredentialsWithoutDefaults(AzureCredentialsBase, WithPyicebergConfig)
 
     azure_storage_account_key: Optional[TSecretStrValue] = None
     azure_storage_sas_token: TSecretStrValue = None
+    azure_storage_token: Optional[TSecretStrValue] = None
+    """Optional static bearer token (e.g. Fabric OneLake / notebookutils). Does not auto-refresh.
+    Precedence: account key / SAS > token > default credential chain.
+    """
     azure_sas_token_permissions: str = "racwdl"
     """Permissions to use when generating a SAS token. Ignored when sas token is provided directly"""
     azure_sas_token_expiration_hours: float = 24.0
@@ -129,14 +154,31 @@ class AzureCredentialsWithoutDefaults(AzureCredentialsBase, WithPyicebergConfig)
 
     def to_adlfs_credentials(self) -> Dict[str, Any]:
         """Return a dict that can be passed as kwargs to adlfs"""
-        return dict(
+        kwargs: Dict[str, Any] = dict(
             account_name=self.azure_storage_account_name,
             account_key=self.azure_storage_account_key,
             sas_token=self.azure_storage_sas_token,
             account_host=self.azure_account_host,
         )
+        # key/SAS win; otherwise pass a static TokenCredential for bearer auth
+        if (
+            self.azure_storage_token
+            and not self.azure_storage_account_key
+            and not self.azure_storage_sas_token
+        ):
+            kwargs["credential"] = _static_azure_token_credential(self.azure_storage_token)
+        return kwargs
 
     def to_pyiceberg_fileio_config(self) -> Dict[str, Any]:
+        if (
+            self.azure_storage_token
+            and not self.azure_storage_account_key
+            and not self.azure_storage_sas_token
+        ):
+            raise UnsupportedAuthenticationMethodException(
+                "A static azure_storage_token cannot be used with pyiceberg on Azure. Configure a"
+                " static account key, SAS token or service principal instead."
+            )
         return {
             "adls.account-name": self.azure_storage_account_name,
             "adls.account-key": self.azure_storage_account_key,
@@ -181,6 +223,14 @@ class AzureCredentialsWithoutDefaults(AzureCredentialsBase, WithPyicebergConfig)
         # sas token can be generated from account key
         if self.azure_storage_account_key and not self.azure_storage_sas_token:
             self.create_sas_token()
+        # account name + static bearer resolves without key/sas (sas field stays required otherwise)
+        if (
+            self.azure_storage_account_name
+            and self.azure_storage_token
+            and not self.azure_storage_account_key
+        ):
+            self.resolve()
+            return
         if not self.is_partial():
             self.resolve()
 
@@ -230,7 +280,11 @@ class AzureCredentials(
         except ModuleNotFoundError:
             raise MissingDependencyException(self.__class__.__name__, [_AZURE_STORAGE_EXTRA])
 
-        if not self.azure_storage_account_key and not self.azure_storage_sas_token:
+        if (
+            not self.azure_storage_account_key
+            and not self.azure_storage_sas_token
+            and not self.azure_storage_token
+        ):
             self._set_default_credentials(DefaultAzureCredential())
             if self.azure_storage_account_name:
                 self.resolve()

--- a/dlt/destinations/impl/duckdb/sql_client.py
+++ b/dlt/destinations/impl/duckdb/sql_client.py
@@ -477,12 +477,23 @@ class DuckDbSqlClient(SqlClientBase[duckdb.DuckDBPyConnection], DBTransaction, W
                     )""")
 
             elif isinstance(credentials, AzureCredentialsWithoutDefaults):
-                sql.append(f"""
-                CREATE OR REPLACE {persistent_stmt} SECRET {secret_name} (
-                    TYPE AZURE,
-                    CONNECTION_STRING 'AccountName={credentials.azure_storage_account_name};AccountKey={credentials.azure_storage_account_key}',
-                    SCOPE '{scope}'
-                )""")
+                if credentials.azure_storage_token and not credentials.azure_storage_account_key:
+                    # Static bearer (e.g. Fabric OneLake) — same PROVIDER as frozen external session
+                    sql.append(f"""
+                    CREATE OR REPLACE {persistent_stmt} SECRET {secret_name} (
+                        TYPE AZURE,
+                        PROVIDER access_token,
+                        ACCESS_TOKEN '{credentials.azure_storage_token}',
+                        ACCOUNT_NAME '{credentials.azure_storage_account_name}',
+                        SCOPE '{scope}'
+                    )""")
+                else:
+                    sql.append(f"""
+                    CREATE OR REPLACE {persistent_stmt} SECRET {secret_name} (
+                        TYPE AZURE,
+                        CONNECTION_STRING 'AccountName={credentials.azure_storage_account_name};AccountKey={credentials.azure_storage_account_key}',
+                        SCOPE '{scope}'
+                    )""")
 
             # azure with service principal creds
             elif isinstance(credentials, AzureServicePrincipalCredentialsWithoutDefaults):

--- a/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
+++ b/docs/website/docs/dlt-ecosystem/destinations/filesystem.md
@@ -239,6 +239,18 @@ If you have the correct Azure credentials set up on your machine (e.g., via Azur
 you can omit both `azure_storage_account_key` and `azure_storage_sas_token` and `dlt` will fall back to the available default.
 Note that `azure_storage_account_name` is still required as it can't be inferred from the environment.
 
+#### Bearer token credentials
+
+For environments that already issue a short-lived Azure Storage access token (for example Microsoft Fabric notebooks via `notebookutils.credentials.getToken("storage")`), set `azure_storage_token` together with the account name:
+
+```toml
+[destination.filesystem.credentials]
+azure_storage_account_name = "onelake"  # or your storage account
+azure_storage_token = "access_token"  # please set me up!
+```
+
+The token is static and does not refresh. Prefer account key, SAS, service principal, or default credentials when you need automatic renewal. Bearer tokens are not supported with pyiceberg on Azure.
+
 #### Service principal credentials
 
 Supply a client ID, client secret, and a tenant ID for a service principal authorized to access your container.

--- a/tests/load/filesystem/test_azure_credentials.py
+++ b/tests/load/filesystem/test_azure_credentials.py
@@ -188,6 +188,50 @@ def test_azure_external_session_always_frozen(creds_cls: Any) -> None:
         creds.to_pyiceberg_fileio_config()
 
 
+def test_azure_storage_token_credentials(environment: Dict[str, str]) -> None:
+    """Static azure_storage_token resolves, maps to object_store/adlfs, and is rejected by pyiceberg."""
+    environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"] = "fake_account_name"
+    environment["CREDENTIALS__AZURE_STORAGE_TOKEN"] = "static-bearer-token"
+
+    config = resolve_configuration(AzureCredentialsWithoutDefaults())
+    assert config.azure_storage_account_name == "fake_account_name"
+    assert config.azure_storage_token == "static-bearer-token"
+
+    os_creds = config.to_object_store_rs_credentials()
+    assert os_creds["azure_storage_token"] == "static-bearer-token"
+    assert os_creds["account_name"] == "fake_account_name"
+    assert "credential" not in os_creds
+    assert "account_key" not in os_creds
+
+    adlfs_creds = config.to_adlfs_credentials()
+    assert "credential" in adlfs_creds
+    assert adlfs_creds["credential"].get_token("https://storage.azure.com/.default").token == (
+        "static-bearer-token"
+    )
+    assert adlfs_creds["account_name"] == "fake_account_name"
+
+    with pytest.raises(UnsupportedAuthenticationMethodException):
+        config.to_pyiceberg_fileio_config()
+
+
+def test_azure_storage_token_does_not_override_key() -> None:
+    """Account key / SAS take precedence over azure_storage_token for object_store/adlfs."""
+    config = AzureCredentialsWithoutDefaults(
+        azure_storage_account_name="fake_account_name",
+        azure_storage_account_key="fake_account_key",
+        azure_storage_sas_token="sp=rwdlacx&sig=fake",
+        azure_storage_token="static-bearer-token",
+    )
+
+    os_creds = config.to_object_store_rs_credentials()
+    assert "azure_storage_token" not in os_creds
+    assert os_creds["account_key"] == "fake_account_key"
+
+    adlfs_creds = config.to_adlfs_credentials()
+    assert "credential" not in adlfs_creds
+    assert adlfs_creds["account_key"] == "fake_account_key"
+
+
 def test_azure_service_principal_credentials(environment: Dict[str, str]) -> None:
     environment["CREDENTIALS__AZURE_STORAGE_ACCOUNT_NAME"] = "fake_account_name"
     environment["CREDENTIALS__AZURE_CLIENT_ID"] = "fake_client_id"


### PR DESCRIPTION
## Description

Adds support for a static Azure Storage bearer token via azure_storage_token on Azure account credentials. This enables auth to OneLake / ABFS from environments like Microsoft Fabric notebooks (notebookutils.credentials.getToken("storage")) without requiring a service principal.

New optional azure_storage_token on AzureCredentialsWithoutDefaults
Wired for adlfs (static TokenCredential), object_store / delta-rs (azure_storage_token), and DuckDB (PROVIDER access_token)
Precedence: account key / SAS > bearer token > DefaultAzureCredential
Token is static (no refresh); pyiceberg raises UnsupportedAuthenticationMethodException (same limitation as external sessions)
Docs note under filesystem Azure credentials; unit tests for resolve, object_store/adlfs mapping, precedence, and pyiceberg rejection

## Related Issues
Fixes #3168


##Additional Context
Example config:

```toml
[destination.filesystem.credentials]
azure_storage_account_name = "onelake"
azure_storage_token = "..."  # e.g. from notebookutils.credentials.getToken("storage")
```

Local verification:

uv run pytest tests/load/filesystem/test_azure_credentials.py -q
Files changed: azure_credentials.py, duckdb/sql_client.py, filesystem.md, test_azure_credentials.py.