### PR TITLE
fix(filesystem): stop using global duckdb instance in read_csv_duckdb

### DIFF
--- a/dlt/sources/filesystem/readers.py
+++ b/dlt/sources/filesystem/readers.py
@@ -127,15 +127,18 @@ def _read_csv_duckdb(
 
     add_filename = duckdb_kwargs.pop("filename", False)
 
-    for item in items:
-        with item.open() as f:
-            file_data = duckdb.from_csv_auto(f, **duckdb_kwargs)
+    # the extractor advances readers in turn and a connection holds a single pending
+    # result, so each generator needs a connection of its own
+    with duckdb.connect() as conn:
+        for item in items:
+            with item.open() as f:
+                file_data = conn.from_csv_auto(f, **duckdb_kwargs)
 
-            for batch in helper(file_data, chunk_size):
-                if add_filename:
-                    for record in batch:
-                        record["filename"] = item["file_name"]  # type: ignore
-                yield batch
+                for batch in helper(file_data, chunk_size):
+                    if add_filename:
+                        for record in batch:
+                            record["filename"] = item["file_name"]  # type: ignore
+                    yield batch
 
 
 if TYPE_CHECKING:

--- a/tests/sources/filesystem/test_readers.py
+++ b/tests/sources/filesystem/test_readers.py
@@ -1,4 +1,5 @@
 import gzip
+import itertools
 import pathlib
 from typing import Any, Dict, Iterator
 
@@ -215,3 +216,27 @@ def test_read_csv_duckdb_use_pyarrow(tmp_path: pathlib.Path, data: list[dict[str
     assert isinstance(read_data[0], pyarrow.RecordBatch)  # batch of records
     assert isinstance(read_data[0][0], pyarrow.Array)  # column
     assert read_data == [pyarrow.RecordBatch.from_pylist(data)]
+
+
+DUCKDB_VECTOR_SIZE = 2048  # duckdb's STANDARD_VECTOR_SIZE
+
+
+@pytest.mark.parametrize("use_pyarrow", (False, True))
+def test_read_csv_duckdb_interleaved_readers(tmp_path: pathlib.Path, use_pyarrow: bool) -> None:
+    # fetchmany() slices out of an already-materialized DataChunk, so a reader only
+    # re-enters the execution pipeline - and only there observes that another reader
+    # invalidated its pending result - after crossing a vector boundary. rows per file
+    # must exceed DUCKDB_VECTOR_SIZE; a smaller chunk_size cannot substitute for it
+    data = [{"a": i} for i in range(2 * DUCKDB_VECTOR_SIZE)]
+    items = [_create_csv_file(data=data, tmp_path=tmp_path)]
+
+    iter_a = _read_csv_duckdb(items, chunk_size=2048, use_pyarrow=use_pyarrow)
+    iter_b = _read_csv_duckdb(items, chunk_size=2048, use_pyarrow=use_pyarrow)
+
+    size_a = size_b = 0
+    for batch_a, batch_b in itertools.zip_longest(iter_a, iter_b):
+        size_a += len(batch_a) if batch_a is not None else 0
+        size_b += len(batch_b) if batch_b is not None else 0
+
+    assert size_a == len(data)
+    assert size_b == len(data)


### PR DESCRIPTION
### Description

`read_csv_duckdb` built every relation on DuckDB's process-wide default connection. A connection holds a single pending result, so as soon as a second reader started a relation, the first reader's result was invalidated — its next `fetchmany` returned `[]`, which is indistinguishable from end of file. Any run with two or more reader generators alive at once silently truncated all but the last one, whether they came from multiple resources or from file pagination within one resource.

Each generator now opens its own `duckdb.connect()`, hoisted outside the file loop — files within a generator are drained strictly sequentially, so it's one connection per generator rather than per file. The default connection is left alone, and the `with` closes ours on exhaustion or abandonment.

### Related Issues

- Fixes #4405

### Additional Context

Truncation always lands at exactly 2048 rows — DuckDB's `STANDARD_VECTOR_SIZE`, not `chunk_size`. `fetchmany` slices out of an already-materialized DataChunk, so a reader only re-enters the execution pipeline, and only there observes the invalidated result, after crossing a vector boundary. A regression test therefore needs more than 2048 rows *per file*; a smaller `chunk_size` cannot substitute for it. The added test round-robins two generators over one file and covers both the JSON and `use_pyarrow` paths. It fails on `devel` with `assert 2048 == 4096` and passes here.