### PR TITLE
fix(rest-client): fall back to other stop conditions on null total with default total_path

### DIFF
--- a/dlt/sources/helpers/rest_client/paginators.py
+++ b/dlt/sources/helpers/rest_client/paginators.py
@@ -6,7 +6,18 @@ from urllib.parse import urljoin, urlparse
 from requests import Request, Response
 
 from dlt.common import jsonpath
+from dlt.common import logger
 from dlt.common.utils import str2bool
+
+
+_DEFAULT_TOTAL_PATH: Any = object()
+"""Sentinel marking the default `total_path` of range paginators.
+
+Lets `RangePaginator` tell an inherited default apart from an explicitly
+passed path: a response without a total only raises in the latter case.
+The sentinel is normalized to `"total"` in `__init__` and never stored,
+so paginators stay trivially copyable.
+"""
 
 
 class BasePaginator(ABC):
@@ -133,8 +144,14 @@ class RangePaginator(BasePaginator):
                 Defaults to None.
         """
         super().__init__()
+        # An inherited default is not a reliable stop condition: the response
+        # may simply not carry a total. Only an explicitly passed `total_path`
+        # counts as one for the validation below.
+        self._total_path_explicit = total_path is not None and total_path is not _DEFAULT_TOTAL_PATH
+        if total_path is _DEFAULT_TOTAL_PATH:
+            total_path = "total"
         if (
-            total_path is None
+            (total_path is None or not self._total_path_explicit)
             and maximum_value is None
             and has_more_path is None
             and not stop_after_empty_page
@@ -174,12 +191,26 @@ class RangePaginator(BasePaginator):
                 values = jsonpath.find_values(self.total_path, response_json)
                 total = values[0] if values else None
                 if total is None:
-                    self._handle_missing_total(response_json)
-
-                try:
-                    total = int(total)
-                except (ValueError, TypeError):
-                    self._handle_invalid_total(total)
+                    if self._total_path_explicit:
+                        self._handle_missing_total(response_json)
+                    # The default `total_path` was inherited and the response
+                    # carries no total: a null total means "unknown", not
+                    # "broken". Ignore it and let the other stop conditions
+                    # end the walk. Looked up only once to avoid log spam.
+                    logger.warning(
+                        f"`{self.total_path}` not found in the response in"
+                        f" `{self.__class__.__name__}`. The total will be ignored"
+                        " and pagination will rely on the other stop conditions"
+                        " (`stop_after_empty_page`, `maximum_value` or"
+                        " `has_more_path`). If the API returns the total under a"
+                        " different key, pass it explicitly via `total_path`."
+                    )
+                    self.total_path = None
+                else:
+                    try:
+                        total = int(total)
+                    except (ValueError, TypeError):
+                        self._handle_invalid_total(total)
 
             self.current_value += self.value_step
 
@@ -211,7 +242,9 @@ class RangePaginator(BasePaginator):
         raise ValueError(
             f"Total `{self.error_message_items}` not found in the response in"
             f" `{self.__class__.__name__}` .Expected a response with a `{self.total_path}` key, got"
-            f" `{response_json}`."
+            f" `{response_json}`. If the API does not return a total, pass `total_path=None`"
+            " and use another stop condition (`stop_after_empty_page`, `maximum_value`"
+            " or `has_more_path`) instead."
         )
 
     def _handle_invalid_total(self, total: Any) -> None:
@@ -335,7 +368,7 @@ class PageNumberPaginator(RangePaginator):
         base_page: int = 0,
         page: int = None,
         page_param: Optional[str] = None,
-        total_path: Optional[jsonpath.TJsonPath] = "total",
+        total_path: Optional[jsonpath.TJsonPath] = _DEFAULT_TOTAL_PATH,
         maximum_page: Optional[int] = None,
         stop_after_empty_page: Optional[bool] = True,
         *,
@@ -358,7 +391,10 @@ class PageNumberPaginator(RangePaginator):
                 of `page_param` when sending the page number in the request body.
                 Defaults to `None`.
             total_path (jsonpath.TJsonPath): The JSONPath expression for
-                the total number of pages. Defaults to 'total'.
+                the total number of pages. Defaults to 'total'. If left at the
+                default and the response carries no total, pagination falls back
+                to the other stop conditions instead of raising; an explicitly
+                passed path that is missing still raises.
             maximum_page (int): The maximum page number. If provided, pagination
                 will stop once this page is reached or exceeded, even if more
                 data is available. This allows you to limit the maximum number
@@ -377,7 +413,7 @@ class PageNumberPaginator(RangePaginator):
             raise ValueError("Either 'page_param' or 'page_body_path' must be provided, not both.")
 
         if (
-            total_path is None
+            (total_path is None or total_path is _DEFAULT_TOTAL_PATH)
             and maximum_page is None
             and has_more_path is None
             and not stop_after_empty_page
@@ -492,7 +528,7 @@ class OffsetPaginator(RangePaginator):
         offset: int = 0,
         offset_param: Optional[str] = None,
         limit_param: Optional[str] = None,
-        total_path: Optional[jsonpath.TJsonPath] = "total",
+        total_path: Optional[jsonpath.TJsonPath] = _DEFAULT_TOTAL_PATH,
         maximum_offset: Optional[int] = None,
         stop_after_empty_page: Optional[bool] = True,
         *,
@@ -519,7 +555,10 @@ class OffsetPaginator(RangePaginator):
                 If provided, the paginator will use this instead of `limit_param`
                 to send the limit in the request body. Defaults to `None`.
             total_path (jsonpath.TJsonPath): The JSONPath expression for
-                the total number of items.
+                the total number of items. Defaults to 'total'. If left at the
+                default and the response carries no total, pagination falls back
+                to the other stop conditions instead of raising; an explicitly
+                passed path that is missing still raises.
             maximum_offset (int): The maximum offset value. If provided,
                 pagination will stop once this offset is reached or exceeded,
                 even if more data is available. This allows you to limit the
@@ -548,7 +587,7 @@ class OffsetPaginator(RangePaginator):
             )
 
         if (
-            total_path is None
+            (total_path is None or total_path is _DEFAULT_TOTAL_PATH)
             and maximum_offset is None
             and has_more_path is None
             and not stop_after_empty_page

--- a/tests/sources/helpers/rest_client/test_paginators.py
+++ b/tests/sources/helpers/rest_client/test_paginators.py
@@ -414,10 +414,47 @@ class TestOffsetPaginator:
                 paginator.update_state(response, data=NON_EMPTY_PAGE)
 
     def test_update_state_without_total(self):
+        # An explicitly passed `total_path` that is missing still raises ...
+        paginator = OffsetPaginator(0, 10, total_path="total")
+        response = Mock(Response, json=lambda: {})
+        with pytest.raises(ValueError, match="total_path=None"):
+            paginator.update_state(response, data=NON_EMPTY_PAGE)
+
+    def test_update_state_with_null_total_explicit(self):
+        # ... including when the field is present but null: null means
+        # "unknown" only for the inherited default, not for an explicit path.
+        paginator = OffsetPaginator(0, 10, total_path="total")
+        response = Mock(Response, json=lambda: {"total": None})
+        with pytest.raises(ValueError, match="not found in the response"):
+            paginator.update_state(response, data=NON_EMPTY_PAGE)
+
+    def test_update_state_with_null_total_inherited(self):
+        # Issue #4429: with the default `total_path`, a null total means
+        # "unknown" and falls back to the other stop conditions.
+        paginator = OffsetPaginator(0, 10)
+        response = Mock(Response, json=lambda: {"total": None})
+        paginator.update_state(response, data=NON_EMPTY_PAGE)
+        assert paginator.has_next_page is True
+        # the missing total is looked up only once
+        assert paginator.total_path is None
+
+    def test_update_state_without_total_inherited(self):
+        # Same as above when the field is absent entirely.
         paginator = OffsetPaginator(0, 10)
         response = Mock(Response, json=lambda: {})
-        with pytest.raises(ValueError):
-            paginator.update_state(response, data=NON_EMPTY_PAGE)
+        paginator.update_state(response, data=NON_EMPTY_PAGE)
+        assert paginator.has_next_page is True
+
+    def test_update_state_inherited_total_empty_page_stops(self):
+        paginator = OffsetPaginator(0, 10)
+        response = Mock(Response, json=lambda: {"total": None})
+        paginator.update_state(response, data=[])
+        assert paginator.has_next_page is False
+
+    def test_init_without_stop_condition_raises(self):
+        # The inherited default is not a stop condition on its own.
+        with pytest.raises(ValueError, match="must be provided"):
+            OffsetPaginator(0, 10, stop_after_empty_page=False)
 
     def test_update_state_with_has_more(self):
         paginator = OffsetPaginator(0, 10, total_path=None, has_more_path="has_more")
@@ -663,6 +700,13 @@ class TestOffsetPaginator:
 
 @pytest.mark.usefixtures("mock_api_server")
 class TestPageNumberPaginator:
+    def test_update_state_with_null_total_inherited(self):
+        # Issue #4429: inherited default + null total falls back instead of raising.
+        paginator = PageNumberPaginator(base_page=1, page=1)
+        response = Mock(Response, json=lambda: {"total": None})
+        paginator.update_state(response, data=NON_EMPTY_PAGE)
+        assert paginator.has_next_page is True
+
     def test_update_state(self):
         paginator = PageNumberPaginator(base_page=1, page=1, total_path="total_pages")
         response = Mock(Response, json=lambda: {"total_pages": 3})
@@ -737,7 +781,7 @@ class TestPageNumberPaginator:
         assert paginator.has_next_page is True
 
     def test_update_state_with_invalid_total_pages(self):
-        paginator = PageNumberPaginator(base_page=1, page=1)
+        paginator = PageNumberPaginator(base_page=1, page=1, total_path="total_pages")
         response = Mock(Response, json=lambda: {"total_pages": "invalid"})
         with pytest.raises(ValueError):
             paginator.update_state(response, data=NON_EMPTY_PAGE)
@@ -750,7 +794,7 @@ class TestPageNumberPaginator:
                 paginator.update_state(response, data=NON_EMPTY_PAGE)
 
     def test_update_state_without_total_pages(self):
-        paginator = PageNumberPaginator(base_page=1, page=1)
+        paginator = PageNumberPaginator(base_page=1, page=1, total_path="total_pages")
         response = Mock(Response, json=lambda: {})
         with pytest.raises(ValueError):
             paginator.update_state(response, data=NON_EMPTY_PAGE)


### PR DESCRIPTION
Fixes #4429.

A `null` (or absent) total with the default `total_path` no longer raises: following the design agreed in the issue, the default is now a sentinel instead of the literal `"total"`, so `RangePaginator` can tell an inherited default from an explicitly passed path.

- inherited default + missing total: warn once, ignore the total, and let the other stop conditions (`stop_after_empty_page`, `maximum_value`, `has_more_path`) end the walk;
- explicit `total_path` + missing total: still raises on page one (a mistyped path on an API that clamps page numbers must stay loud), and the error now points at `total_path=None` as the escape hatch;
- constructing a range paginator with no usable stop condition at all fails fast in `__init__`.

The sentinel is normalized to `"total"` in `__init__` and never stored, so paginators stay trivially deep-copyable (`client.paginate` deep-copies the paginator).

Tests: new cases in `tests/sources/helpers/rest_client/test_paginators.py` for inherited-null, inherited-missing, explicit-null, explicit-missing, empty-page stop, and fail-fast construction, plus `PageNumberPaginator` coverage. Three existing tests that asserted the old raise for default-constructed paginators now pass `total_path` explicitly. Full file green (109 passed); `black`, `flake8`, and `mypy` clean on both touched files.