### PR TITLE
docs(dataset): align where/filter docstring params with the signature

### DIFF
--- a/dlt/dataset/relation.py
+++ b/dlt/dataset/relation.py
@@ -918,7 +918,7 @@ class Relation(WithSqlClient):
         This is identical to `Relation.filter()`.
 
         Args:
-            column_name (str): The column to filter on.
+            column_or_expr (str | sqlglot.Expression): The column or SQL expression to filter on.
             operator (TFilterOperation): The operator to use. Available operations are: eq, ne, gt, lt, gte, lte, in, not_in
             value (Any): The value to filter on.
 
@@ -998,7 +998,7 @@ class Relation(WithSqlClient):
         This is identical to `Relation.where()`.
 
         Args:
-            column_name (str): The column to filter on.
+            column_or_expr (str | sqlglot.Expression): The column or SQL expression to filter on.
             operator (TFilterOperation): The operator to use. Available operations are: eq, ne, gt, lt, gte, lte, in, not_in
             value (Any): The value to filter on.
 


### PR DESCRIPTION
`Relation.where()` and `Relation.filter()` (both in `dlt/dataset/relation.py`) document a `column_name (str)` parameter — the actual parameter is `column_or_expr: SqlglotExprOrStr`. The two Args entries now match. Small self-contained docs correction (exempt from the issue requirement per the contributing guide).