### PR TITLE
docs: fix two stale docstring parameter names

### DIFF
--- a/dlt/extract/hints.py
+++ b/dlt/extract/hints.py
@@ -468,7 +468,7 @@ class DltResourceHints:
         Args:
             table_name (TTableHintTemplate[str]): name of the table which resource will generate
 
-            parent_table_parent (str, optional): A name of parent table if you want the resource to generate nested table. Please note that if you use merge, you must define `root_key` columns explicitly
+            parent_table_name (str, optional): A name of parent table if you want the resource to generate nested table. Please note that if you use merge, you must define `root_key` columns explicitly
 
             incremental (Incremental, optional): Enables the incremental loading for a resource.
 

--- a/dlt/pipeline/drop.py
+++ b/dlt/pipeline/drop.py
@@ -98,7 +98,7 @@ def prepare_drop_resources(
         state_paths: JSON path(s) relative to the source state to drop.
         drop_all: If True, all resources will be dropped (supersedes `resources`).
         state_only: If True, only modify the pipeline state, not schema
-        sources: Only wipe state for sources matching the name(s) or regex pattern(s) in this list
+        resources: Only wipe state for resources matching the name(s) or regex pattern(s) in this list
             If not set all source states will be modified according to `state_paths` and `resources`
 
     Returns:


### PR DESCRIPTION
- `dlt/pipeline/drop.py` `prepare_drop_resources`: documented `sources` — the parameter is `resources`
- `dlt/extract/hints.py` `apply_hints`: documented `parent_table_parent` — the parameter is `parent_table_name`

Small self-contained docs corrections.