### PR TITLE
fix(extract): repair the DeletingResourcesNotSupported message

### DIFF
--- a/dlt/extract/exceptions.py
+++ b/dlt/extract/exceptions.py
@@ -275,7 +275,7 @@ class InvalidParentResourceIsAFunction(DltResourceException):
 class DeletingResourcesNotSupported(DltResourceException):
     def __init__(self, source_name: str, resource_name: str) -> None:
         super().__init__(
-            resource_name, f"Resource cannot be removed the the source `{source_name}`"
+            resource_name, f"Resource cannot be removed from the source `{source_name}`"
         )
 
 


### PR DESCRIPTION
The `ValueError` raised by `DeletingResourcesNotSupported` (`dlt/extract/exceptions.py`) read "Resource cannot be removed **the the** source `{source_name}`" — a doubled `the` and a missing `from`. Now reads "cannot be removed from the source". User-visible exception string only.