### PR TITLE
docs: drop links to the removed examples/ directory

### DIFF
--- a/docs/website/docs/general-usage/credentials/setup.md
+++ b/docs/website/docs/general-usage/credentials/setup.md
@@ -367,7 +367,7 @@ dlt.config.register_provider(provider)
 ```
 
 :::tip
-Check out our [example YAML provider](../../examples/custom_config_provider) that supports switchable configuration profiles.
+Check out our example YAML provider that supports switchable configuration profiles.
 :::
 
 ## Examples

--- a/docs/website/docs/general-usage/customising-pipelines/pseudonymizing_columns.md
+++ b/docs/website/docs/general-usage/customising-pipelines/pseudonymizing_columns.md
@@ -61,4 +61,4 @@ load_info = pipeline.run(source_instance)
 
 For production use cases with SQL database sources, you'll want a reusable masking function that takes column names as parameters, supports multiple masking methods (replace with asterisks or nullify), and works with all `sql_database` backends (PyArrow, Pandas, SQLAlchemy).
 
-See the full [data masking example](../../examples/data_masking.md) for a production-ready implementation using closures.
+See the full data masking for a production-ready implementation using closures.

--- a/docs/website/docs/general-usage/naming-convention.md
+++ b/docs/website/docs/general-usage/naming-convention.md
@@ -225,7 +225,7 @@ dest_ = dlt.destinations.postgres(naming_convention=my_package.sql_cs_latin2)
 :::
 
 
-We include [two examples](../examples/custom_naming) of naming conventions that you may find useful:
+Two naming-convention examples that you may find useful:
 
 1. A variant of `sql_ci` that generates identifier collisions with a low (user-defined) probability by appending a deterministic tag to each name.
 2. A variant of `sql_cs` that allows for LATIN (i.e., umlaut) characters.

--- a/docs/website/docs/hub/notifications/slack.md
+++ b/docs/website/docs/hub/notifications/slack.md
@@ -74,7 +74,7 @@ def my_job():
 The `if hook:` check skips the Slack call when no webhook is configured. The same script works in any profile, whether you've set up notifications or not.
 
 :::tip Notify on schema changes
-You can also notify Slack whenever a load surfaces new tables or columns. The [dlt chess pipeline](../../examples/chess_production.md) shows this pattern by inspecting `schema_update` on each load package and posting a message when new tables or columns appear.
+You can also notify Slack whenever a load surfaces new tables or columns. The dlt chess pipeline shows this pattern by inspecting `schema_update` on each load package and posting a message when new tables or columns appear.
 :::
 
 ## Deploy and trigger


### PR DESCRIPTION
Four docs pages still linked files under `examples/` — that directory no longer exists in the repo (`docs/website/docs/examples/` contains only `index.md`), so the links 404:

- `general-usage/naming-convention.md`: "We include [two examples](../examples/custom_naming)…"
- `general-usage/customising-pipelines/pseudonymizing_columns.md`: `data masking` example link
- `general-usage/credentials/setup.md`: `custom config provider` example link
- `hub/notifications/slack.md`: `chess production` example link

Link markup removed while the feature references stay in the text. Small self-contained docs correction.