### PR TITLE
docs(helpers): drop duplicated 'a' in graphviz/dbml docstrings

### DIFF
--- a/dlt/helpers/dbml.py
+++ b/dlt/helpers/dbml.py
@@ -489,7 +489,7 @@ def export_to_dbml(
     include_root_child_ref: bool = True,
     group_by_resource: bool = False,
 ) -> str:
-    """Convert a `dlt.Schema` to a a DBML string and return its value.
+    """Convert a `dlt.Schema` to a DBML string and return its value.
 
     Args:
         schema: dlt schema to convert

--- a/dlt/helpers/graphviz.py
+++ b/dlt/helpers/graphviz.py
@@ -342,7 +342,7 @@ def schema_to_graphviz(
     include_root_child_ref: bool = True,
     group_by_resource: bool = False,
 ) -> str:
-    """Convert a `dlt.Schema` to a a Graphviz DOT string and return its value.
+    """Convert a `dlt.Schema` to a Graphviz DOT string and return its value.
 
     Args:
         schema: dlt schema to convert


### PR DESCRIPTION
`dlt/helpers/graphviz.py` and `dlt/helpers/dbml.py`: "Convert a `dlt.Schema` to **a a** Graphviz/DBML string" — single `a` in both. Small self-contained docs correction.