### PR TITLE
fix(providers): serialize vault cache resolution

### DIFF
--- a/dlt/common/configuration/providers/vault.py
+++ b/dlt/common/configuration/providers/vault.py
@@ -2,6 +2,7 @@ import abc
 import contextlib
 import re
 import string
+from threading import Lock
 from typing import Any, Dict, Optional, Set, Tuple
 
 from dlt.common import logger
@@ -64,6 +65,7 @@ class VaultDocProvider(BaseDocProvider):
         self.only_secrets = only_secrets
         self.only_toml_fragments = only_toml_fragments
         self.list_secrets = list_secrets
+        self._vault_lock = Lock()
         self._vault_lookups: Dict[str, Any] = {}
         self._available_keys: Optional[Set[str]] = None
         if list_secrets and (only_toml_fragments or only_secrets):
@@ -78,32 +80,35 @@ class VaultDocProvider(BaseDocProvider):
     def get_value(
         self, key: str, hint: type, pipeline_name: str, *sections: str
     ) -> Tuple[Optional[Any], str]:
-        # global settings must be updated first
-        self._update_from_vault(SECRETS_TOML_KEY, None, AnyType, None, ())
-        # then regular keys
-        full_key = self.get_key_name(key, pipeline_name, *sections)
-        value, _ = super().get_value(key, hint, pipeline_name, *sections)
-        if value is None:
-            if self.only_secrets and not is_secret_hint(hint):
-                pass
-            else:
-                # only secrets hints are handled fully
-                self._load_fragments(key, pipeline_name, *sections)
-                value, _ = super().get_value(key, hint, pipeline_name, *sections)
-                # skip checking the exact path if we check only toml fragments
-                if value is None and not self.only_toml_fragments:
-                    # look for key in the vault and update the toml document
-                    self._update_from_vault(full_key, key, hint, pipeline_name, sections)
+        # Fragments share one document, so reads must wait for the entire merge sequence.
+        with self._vault_lock:
+            # global settings must be updated first
+            self._update_from_vault(SECRETS_TOML_KEY, None, AnyType, None, ())
+            # then regular keys
+            full_key = self.get_key_name(key, pipeline_name, *sections)
+            value, _ = super().get_value(key, hint, pipeline_name, *sections)
+            if value is None:
+                if self.only_secrets and not is_secret_hint(hint):
+                    pass
+                else:
+                    # only secrets hints are handled fully
+                    self._load_fragments(key, pipeline_name, *sections)
                     value, _ = super().get_value(key, hint, pipeline_name, *sections)
+                    # skip checking the exact path if we check only toml fragments
+                    if value is None and not self.only_toml_fragments:
+                        # look for key in the vault and update the toml document
+                        self._update_from_vault(full_key, key, hint, pipeline_name, sections)
+                        value, _ = super().get_value(key, hint, pipeline_name, *sections)
 
-        return value, full_key
+            return value, full_key
 
     @property
     def supports_secrets(self) -> bool:
         return True
 
     def clear_lookup_cache(self) -> None:
-        self._vault_lookups.clear()
+        with self._vault_lock:
+            self._vault_lookups.clear()
 
     def _load_fragments(self, key: str, pipeline_name: str, *sections: str) -> None:
         """Load known toml fragments from the vault
@@ -182,9 +187,9 @@ class VaultDocProvider(BaseDocProvider):
         # print(f"tries '{key}' {pipeline_name} | {sections} at '{full_key}'")
         logger.debug(f"Vault provider {self.name} will make a request for {full_key}")
         secret = self._look_vault(full_key, hint)
-        self._vault_lookups[full_key] = pendulum.now()
         if secret is not None:
             self.set_fragment(key, secret, pipeline_name, *sections)
+        self._vault_lookups[full_key] = pendulum.now()
 
     @property
     def is_empty(self) -> bool:

--- a/docs/website/docs/general-usage/credentials/vaults.md
+++ b/docs/website/docs/general-usage/credentials/vaults.md
@@ -38,7 +38,11 @@ Fragments are TOML documents and are merged into the in-memory configuration in 
 
 ### Caching
 
-Every successful or failed lookup (including “not found”) is cached for the lifetime of the process. Changes in the vault will not be picked up until the process restarts.
+Retrieved values and completed lookups (including “not found”) are cached by each provider instance. Changes in the vault are normally picked up when the process restarts. `clear_lookup_cache()` clears the lookup markers; it does not clear already loaded values or the list of available keys.
+
+Concurrent `get_value()` calls on the same provider are serialized, including vault requests and fragment merging. A caller waits for an ongoing resolution before reading the shared document, so it cannot mistake a pending lookup for a missing secret or read a partially merged fragment.
+
+Exceptions raised while listing, retrieving, or storing a fragment are propagated and do not mark that lookup as completed. A later call can try again. The shared vault provider does not add automatic retries on top of the backend SDK's retry policy. A backend response treated as “not found” (including permission errors that a provider handles this way) remains cached.
 
 ## Configure the vault provider
 You can tune the provider to reduce the number of vault calls:

--- a/tests/common/configuration/test_vault_provider.py
+++ b/tests/common/configuration/test_vault_provider.py
@@ -1,5 +1,10 @@
 """Tests for VaultDocProvider using an in-memory mock vault."""
 
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from threading import Event
+from typing import Optional, Tuple
+from unittest.mock import Mock
+
 import pytest
 
 from dlt.common.typing import TSecretValue, AnyType
@@ -207,3 +212,154 @@ def test_pipeline_name_flows_through_resolve() -> None:
         explicit_sections=("sources", "my_source"),
     )
     assert value2 is None
+
+
+@pytest.mark.parametrize("list_secrets", [False, True])
+@pytest.mark.parametrize(
+    "vault_key,fragment,pipeline_name,sections",
+    [
+        ("password", "dummy-secret", None, ()),
+        (SECRETS_TOML_KEY, 'password = "dummy-secret"', None, ()),
+        ("sources", '[sources.test]\npassword = "dummy-secret"', None, ("sources", "test")),
+        (
+            "pipe.dlt_secrets_toml",
+            '[pipe]\npassword = "dummy-secret"',
+            "pipe",
+            (),
+        ),
+    ],
+)
+def test_concurrent_resolution_waits_for_publication(
+    monkeypatch: pytest.MonkeyPatch,
+    list_secrets: bool,
+    vault_key: str,
+    fragment: str,
+    pipeline_name: Optional[str],
+    sections: Tuple[str, ...],
+) -> None:
+    provider = _make_provider(list_secrets=list_secrets)
+    provider.set_secret(vault_key, fragment)
+    publishing, release, reading = Event(), Event(), Event()
+    set_fragment = provider.set_fragment
+
+    def paused_fragment(*args, **kwargs):
+        publishing.set()
+        assert release.wait(5)
+        return set_fragment(*args, **kwargs)
+
+    def read():
+        reading.set()
+        return provider.get_value("password", TSecretValue, pipeline_name, *sections)
+
+    monkeypatch.setattr(provider, "set_fragment", paused_fragment)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(provider.get_value, "password", TSecretValue, pipeline_name, *sections)
+        try:
+            assert publishing.wait(5)
+            second = pool.submit(read)
+            assert reading.wait(5)
+            with pytest.raises(FutureTimeoutError):
+                second.result(timeout=0.1)
+        finally:
+            release.set()
+        assert first.result(timeout=5)[0] == "dummy-secret"
+        assert second.result(timeout=5)[0] == "dummy-secret"
+    assert provider._look_vault_calls.count(vault_key) == 1
+
+
+def test_concurrent_resolution_waits_for_specific_fragment(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _make_provider()
+    provider.set_secret("sources", SOURCE_FRAGMENT)
+    provider.set_secret("sources.my_source", SOURCE_NAMED_FRAGMENT)
+    publishing, release, reading = Event(), Event(), Event()
+    set_fragment = provider.set_fragment
+
+    def paused_fragment(key, *args):
+        if key == "my_source":
+            publishing.set()
+            assert release.wait(5)
+        return set_fragment(key, *args)
+
+    def read():
+        reading.set()
+        return provider.get_value("api_key", TSecretValue, None, "sources", "my_source")
+
+    monkeypatch.setattr(provider, "set_fragment", paused_fragment)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(read)
+        try:
+            assert publishing.wait(5)
+            reading.clear()
+            second = pool.submit(read)
+            assert reading.wait(5)
+            with pytest.raises(FutureTimeoutError):
+                second.result(timeout=0.1)
+        finally:
+            release.set()
+        assert first.result(timeout=5)[0] == "SRC_NAMED"
+        assert second.result(timeout=5)[0] == "SRC_NAMED"
+    assert provider._look_vault_calls.count("sources.my_source") == 1
+
+
+@pytest.mark.parametrize("operation", ["_list_vault", "_look_vault", "set_fragment"])
+def test_failed_lookup_can_recover(monkeypatch: pytest.MonkeyPatch, operation: str) -> None:
+    provider = _make_provider(list_secrets=True)
+    provider.set_secret(SECRETS_TOML_KEY, GLOBAL_TOML)
+    failing = Mock(side_effect=RuntimeError("temporary failure"))
+    with monkeypatch.context() as patch:
+        patch.setattr(provider, operation, failing)
+        with pytest.raises(RuntimeError, match="temporary failure"):
+            provider.get_value("api_key", TSecretValue, None, "sources", "my_source")
+    assert failing.call_count == 1
+    assert SECRETS_TOML_KEY not in provider._vault_lookups
+
+    # Resolve on another thread to also check that an exception releases the lock.
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        result = pool.submit(
+            provider.get_value, "api_key", TSecretValue, None, "sources", "my_source"
+        )
+        assert result.result(timeout=5)[0] == "GLOBAL_KEY"
+
+
+@pytest.mark.parametrize("list_secrets", [False, True])
+def test_concurrent_missing_lookup_is_cached(list_secrets: bool) -> None:
+    provider = _make_provider(list_secrets=list_secrets)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(
+            pool.map(lambda _: provider.get_value("missing", TSecretValue, None), range(8))
+        )
+    assert results == [(None, "missing")] * 8
+    assert provider._look_vault_calls.count("missing") == (0 if list_secrets else 1)
+    assert "missing" in provider._vault_lookups
+
+
+def test_clear_lookup_cache_waits_for_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _make_provider()
+    provider.set_secret("password", "dummy-secret")
+    publishing, release, clearing = Event(), Event(), Event()
+    set_fragment = provider.set_fragment
+
+    def paused_fragment(*args, **kwargs):
+        publishing.set()
+        assert release.wait(5)
+        return set_fragment(*args, **kwargs)
+
+    def clear():
+        clearing.set()
+        provider.clear_lookup_cache()
+
+    monkeypatch.setattr(provider, "set_fragment", paused_fragment)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(provider.get_value, "password", TSecretValue, None)
+        try:
+            assert publishing.wait(5)
+            second = pool.submit(clear)
+            assert clearing.wait(5)
+            with pytest.raises(FutureTimeoutError):
+                second.result(timeout=0.1)
+        finally:
+            release.set()
+        assert first.result(timeout=5)[0] == "dummy-secret"
+        second.result(timeout=5)
+    assert provider._vault_lookups == {}
+    assert provider.get_value("password", TSecretValue, None)[0] == "dummy-secret"


### PR DESCRIPTION
Concurrent vault resolutions can report an existing secret as missing or return a general fragment's value before its more specific override is loaded. Serialize resolution and lookup-cache clearing per provider, and mark a lookup complete only after its fragment has been stored. Retrieval, listing, and publication exceptions remain visible and allow a later call to retry; completed missing lookups remain cached.

Add in-memory regression tests for concurrent single values, global and pipeline documents, fragment precedence, cache clearing, missing keys, and failure recovery. Update the vault documentation to describe synchronization, caching, and backend-controlled retries. No backend-specific dependency is required.

Validation: all 27 vault-provider tests pass; the configuration suite has 301 passed and 11 skipped. Running the new cases against the unmodified upstream implementation reproduces 11 failures. Ruff, Black, and mypy for the changed files with silent import following pass. The broader mypy invocation reports three errors in unchanged runtime/storage files.

Fixes dlt-hub/dlt#4443
